### PR TITLE
base64ct v1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
 
 [[package]]
 name = "base64ct"
-version = "1.0.1"
+version = "1.1.0"
 
 [[package]]
 name = "block-buffer"

--- a/base64ct/CHANGELOG.md
+++ b/base64ct/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.1.0 (2021-09-14)
+### Changed
+- Moved to `formats` repo; MSRV 1.51+ ([#2])
+
+[#2]: https://github.com/RustCrypto/formats/pull/2
+
 ## 1.0.1 (2021-08-14)
 ### Fixed
 - Make `Encoding::decode` reject invalid padding

--- a/base64ct/Cargo.toml
+++ b/base64ct/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base64ct"
-version = "1.0.1" # Also update html_root_url in lib.rs when bumping this
+version = "1.1.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Base64 (RFC 4648) which avoids any usages of
 data-dependent branches/LUTs and thereby provides portable "best effort"
@@ -9,10 +9,10 @@ constant-time operation and embedded-friendly no_std support
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"
-documentation = "https://docs.rs/pkcs8"
+documentation = "https://docs.rs/base64ct"
 repository = "https://github.com/RustCrypto/formats/tree/master/base64ct"
 categories = ["cryptography", "encoding", "no-std", "parser-implementations"]
-keywords = ["base64", "phc"]
+keywords = ["crypto", "base64", "pem", "phc"]
 readme = "README.md"
 
 [features]

--- a/base64ct/src/lib.rs
+++ b/base64ct/src/lib.rs
@@ -76,7 +76,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/base64ct/1.0.1"
+    html_root_url = "https://docs.rs/base64ct/1.1.0"
 )]
 #![warn(missing_docs, rust_2018_idioms)]
 


### PR DESCRIPTION
### Changed
- Moved to `formats` repo; MSRV 1.51+ ([#2])

[#2]: https://github.com/RustCrypto/formats/pull/2