### PR TITLE
const-oid v0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "hex-literal",
 ]

--- a/const-oid/CHANGELOG.md
+++ b/const-oid/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.1 (2021-09-13)
+### Changed
+- Moved to `formats` repo ([#2])
+
+[#2]: https://github.com/RustCrypto/formats/pull/2
+
 ## 0.6.0 (2021-06-03)
 ### Changed
 - Modernize and remove deprecations; MSRV 1.51+

--- a/const-oid/Cargo.toml
+++ b/const-oid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "const-oid"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"
@@ -10,7 +10,7 @@ as defined in ITU X.660, with support for BER/DER encoding/decoding as well as
 heapless no_std (i.e. embedded) support
 """
 documentation = "https://docs.rs/const-oid"
-repository = "https://github.com/RustCrypto/formats"
+repository = "https://github.com/RustCrypto/formats/tree/master/const-oid"
 categories = ["cryptography", "data-structures", "encoding", "no-std", "parser-implementations"]
 keywords = ["iso", "iec", "itu", "oid"]
 readme = "README.md"

--- a/const-oid/README.md
+++ b/const-oid/README.md
@@ -1,4 +1,4 @@
-# RustCrypto: Object Identifiers (OIDs)
+# [RustCrypto]: Object Identifiers (OIDs)
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
@@ -85,4 +85,5 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (links)
 
+[RustCrypto]: https://github.com/rustcrypto
 [X.660]: https://www.itu.int/rec/T-REC-X.660

--- a/const-oid/src/lib.rs
+++ b/const-oid/src/lib.rs
@@ -56,7 +56,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/const-oid/0.6.0"
+    html_root_url = "https://docs.rs/const-oid/0.6.1"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms)]


### PR DESCRIPTION
### Changed
- Moved to `formats` repo ([#2])

[#2]: https://github.com/RustCrypto/formats/pull/2