### PR TITLE
pkcs5 v0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs5"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "aes",
  "block-modes",

--- a/pkcs5/CHANGELOG.md
+++ b/pkcs5/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.2 (2021-09-14)
+### Added
+- `3des` and `des-insecure` features
+- `sha1` feature
+- Support for AES-192-CBC
+
+### Changed
+- Moved to `formats` repo ([#2])
+
+[#2]: https://github.com/RustCrypto/formats/pull/2
+
 ## 0.3.1 (2021-08-30)
 ### Changed
 - Bump `scrypt` dependency to 0.8

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs5"
-version = "0.3.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.3.2" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #5:
 Password-Based Cryptography Specification Version 2.1 (RFC 8018)
@@ -32,10 +32,10 @@ hex-literal = "0.3"
 
 [features]
 alloc = []
+3des = ["pbes2", "des"]
+des-insecure = ["pbes2", "des"]
 pbes2 = ["aes", "block-modes", "hmac", "pbkdf2", "scrypt", "sha2"]
 sha1 = ["pbes2", "sha-1"]
-des-insecure = ["pbes2", "des"]
-3des = ["pbes2", "des"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/pkcs5/src/lib.rs
+++ b/pkcs5/src/lib.rs
@@ -20,7 +20,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/pkcs5/0.3.1"
+    html_root_url = "https://docs.rs/pkcs5/0.3.2"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Added
- `3des` and `des-insecure` features
- `sha1` feature
- Support for AES-192-CBC

### Changed
- Moved to `formats` repo ([#2])

[#2]: https://github.com/RustCrypto/formats/pull/2