### PR TITLE
pkcs8 v0.7.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "der",
  "hex-literal",

--- a/pkcs8/CHANGELOG.md
+++ b/pkcs8/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.6 (2021-09-14)
+### Added
+- `3des` and `des-insecure` features
+- `sha1` feature
+- Support for AES-192-CBC
+
+### Changed
+- Moved to `formats` repo ([#2])
+
+[#2]: https://github.com/RustCrypto/formats/pull/2
+
 ## 0.7.5 (2021-07-26)
 ### Added
 - Support for customizing PEM `LineEnding`

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs8"
-version = "0.7.5" # Also update html_root_url in lib.rs when bumping this
+version = "0.7.6" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #8:
 Private-Key Information Syntax Specification (RFC 5208), with additional
@@ -29,13 +29,13 @@ zeroize = { version = "1", optional = true, default-features = false, features =
 hex-literal = "0.3"
 
 [features]
-encryption = ["alloc", "pkcs5/alloc", "pkcs5/pbes2", "rand_core"]
-std = ["alloc", "der/std"]
 alloc = ["der/alloc", "zeroize"]
+3des = ["encryption", "pkcs5/3des"]
+des-insecure = ["encryption", "pkcs5/des-insecure"]
+encryption = ["alloc", "pkcs5/alloc", "pkcs5/pbes2", "rand_core"]
 pem = ["alloc", "pem-rfc7468/alloc"]
 sha1 = ["encryption", "pkcs5/sha1"]
-des-insecure = ["encryption", "pkcs5/des-insecure"]
-3des = ["encryption", "pkcs5/3des"]
+std = ["alloc", "der/std"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -79,20 +79,19 @@
 //!     - PBKDF2 ([RFC 8018](https://datatracker.ietf.org/doc/html/rfc8018#section-5.2))
 //!       - SHA-2 based PRF with HMAC-SHA224, HMAC-SHA256, HMAC-SHA384, or HMAC-SHA512
 //!       - SHA-1 based PRF with HMAC-SHA1, when the `sha1` feature of this crate is enabled.
-//!   - Symmetric encryption: AES-128-CBC, AES-192-CBC, or AES-256-CBC (best available options for PKCS#5v2)
+//!   - Symmetric encryption: AES-128-CBC, AES-192-CBC, or AES-256-CBC
+//!     (best available options for PKCS#5v2)
 //!  
-//! # DES-CBC and DES-EDE3-CBC (3DES) Support
-//! When the `des-insecure` and `3des` features are enabled this crate provides support for Private Keys encrypted
-//! with DES-CBC and DES-EDE3-CBC (3DES or Triple DES) symmetric encryption, respectively.
+//! ## Legacy DES-CBC and DES-EDE3-CBC (3DES) support (optional)
+//! When the `des-insecure` and/or `3des` features are enabled this crate provides support for
+//! private keys encrypted with with DES-CBC and DES-EDE3-CBC (3DES or Triple DES) symmetric
+//! encryption, respectively.
 //!
-//! **WARNING**
+//! ⚠️ WARNING ⚠️
 //!
-//! DES support is implemented to allow for decryption of legacy files. DES is considered insecure due to
-//! its short key size and SHOULD NOT be used for new keys. The algorithms implemented under the `encryption`
-//! feature should be used where possible.
+//! DES support is implemented to allow for decryption of legacy files.
 //!
-//! **WARNING**
-//!
+//! DES is considered insecure due to its short key size. New keys should use AES instead.
 //!
 //! # PKCS#1 support (optional)
 //! When the `pkcs1` feature of this crate is enabled, this crate provides
@@ -113,7 +112,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/pkcs8/0.7.5"
+    html_root_url = "https://docs.rs/pkcs8/0.7.6"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Added
- `3des` and `des-insecure` features
- `sha1` feature
- Support for AES-192-CBC

### Changed
- Moved to `formats` repo ([#2])

[#2]: https://github.com/RustCrypto/formats/pull/2