### PR TITLE
detect PEM headers in decode_vec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/target/
+target/
 **/*.rs.bk

--- a/pem-rfc7468/tests/decode.rs
+++ b/pem-rfc7468/tests/decode.rs
@@ -20,12 +20,32 @@ fn pkcs1_enc_example() {
 }
 
 #[test]
+#[cfg(feature = "alloc")]
+fn pkcs1_enc_example_with_vec() {
+    let pem = include_bytes!("examples/ssh_rsa_pem_password.pem");
+    match pem_rfc7468::decode_vec(pem) {
+        Err(pem_rfc7468::Error::HeaderDetected) => (),
+        _ => panic!("Expected HeaderDetected error"),
+    }
+}
+
+#[test]
 fn header_of_length_64() {
     let pem = include_bytes!("examples/chosen_header.pem");
     let mut buf = [0u8; 2048];
     match pem_rfc7468::decode(pem, &mut buf) {
         Err(pem_rfc7468::Error::HeaderDetected) => (),
         _ => panic!("Expected HeaderDetected error"),
+    }
+}
+
+#[test]
+#[cfg(feature = "alloc")]
+fn header_of_length_64_with_vec() {
+    let pem = include_bytes!("examples/chosen_header.pem");
+    match pem_rfc7468::decode_vec(pem) {
+        Err(pem_rfc7468::Error::HeaderDetected) => (),
+        res => panic!("Expected HeaderDetected error; Found {:?}", res),
     }
 }
 


### PR DESCRIPTION
Missed in PR https://github.com/RustCrypto/formats/pull/13

- add test coverage for new cases
- refactor out decoding of encapsulated text
- compromise here on estimating buffer size
  - slightly more overestimation, due to counting whitespace
  - faster due to no two-pass
  - required to ensure that we attempt a base64 decode of the first line
    before chopping the second line