### PR TITLE
pem-rfc7468: rename `Error::HeaderDisallowed`

### DIFF
--- a/pem-rfc7468/src/decoder.rs
+++ b/pem-rfc7468/src/decoder.rs
@@ -34,7 +34,7 @@ fn decode_encapsulated_text<'i, 'o>(
                 // and we error, then attribute the error to an unsupported header
                 // if a colon char is present in the line
                 if *out_len == 0 && line.iter().any(|&b| b == grammar::CHAR_COLON) {
-                    return Err(Error::HeaderDetected);
+                    return Err(Error::HeaderDisallowed);
                 } else {
                     return Err(error.into());
                 }
@@ -212,7 +212,7 @@ impl<'a> Iterator for Lines<'a> {
                 // then it may be a unsupported header
                 Some(Err(
                     if self.is_start && line.iter().any(|&b| b == grammar::CHAR_COLON) {
-                        Error::HeaderDetected
+                        Error::HeaderDisallowed
                     } else {
                         Error::EncapsulatedText
                     },

--- a/pem-rfc7468/src/error.rs
+++ b/pem-rfc7468/src/error.rs
@@ -19,7 +19,7 @@ pub enum Error {
     EncapsulatedText,
 
     /// Header detected in the encapsulated text
-    HeaderDetected,
+    HeaderDisallowed,
 
     /// Invalid label.
     Label,
@@ -40,7 +40,7 @@ impl fmt::Display for Error {
             Error::Base64 => "PEM Base64 error",
             Error::CharacterEncoding => "PEM character encoding error",
             Error::EncapsulatedText => "PEM error in encapsulated text",
-            Error::HeaderDetected => "PEM header (disallowed) detected in encapsulated text",
+            Error::HeaderDisallowed => "PEM headers disallowed by RFC7468",
             Error::Label => "PEM type label invalid",
             Error::Length => "PEM length invalid",
             Error::PreEncapsulationBoundary => "PEM error in pre-encapsulation boundary",

--- a/pem-rfc7468/tests/decode.rs
+++ b/pem-rfc7468/tests/decode.rs
@@ -14,7 +14,7 @@ fn pkcs1_enc_example() {
     let pem = include_bytes!("examples/ssh_rsa_pem_password.pem");
     let mut buf = [0u8; 2048];
     match pem_rfc7468::decode(pem, &mut buf) {
-        Err(pem_rfc7468::Error::HeaderDetected) => (),
+        Err(pem_rfc7468::Error::HeaderDisallowed) => (),
         _ => panic!("Expected HeaderDetected error"),
     }
 }
@@ -24,7 +24,7 @@ fn pkcs1_enc_example() {
 fn pkcs1_enc_example_with_vec() {
     let pem = include_bytes!("examples/ssh_rsa_pem_password.pem");
     match pem_rfc7468::decode_vec(pem) {
-        Err(pem_rfc7468::Error::HeaderDetected) => (),
+        Err(pem_rfc7468::Error::HeaderDisallowed) => (),
         _ => panic!("Expected HeaderDetected error"),
     }
 }
@@ -34,7 +34,7 @@ fn header_of_length_64() {
     let pem = include_bytes!("examples/chosen_header.pem");
     let mut buf = [0u8; 2048];
     match pem_rfc7468::decode(pem, &mut buf) {
-        Err(pem_rfc7468::Error::HeaderDetected) => (),
+        Err(pem_rfc7468::Error::HeaderDisallowed) => (),
         _ => panic!("Expected HeaderDetected error"),
     }
 }
@@ -44,7 +44,7 @@ fn header_of_length_64() {
 fn header_of_length_64_with_vec() {
     let pem = include_bytes!("examples/chosen_header.pem");
     match pem_rfc7468::decode_vec(pem) {
-        Err(pem_rfc7468::Error::HeaderDetected) => (),
+        Err(pem_rfc7468::Error::HeaderDisallowed) => (),
         res => panic!("Expected HeaderDetected error; Found {:?}", res),
     }
 }


### PR DESCRIPTION
It was previously `Error::HeaderDetected`, however that doesn't really indicate why it's an error.

The new error message notes that headers are explicitly disallowed in the RFC7468 interpretation of PEM.

cc @dwhjames 