### PR TITLE
Add pem_rfc7468::decode_label

### DIFF
--- a/pem-rfc7468/src/decoder.rs
+++ b/pem-rfc7468/src/decoder.rs
@@ -44,6 +44,12 @@ fn decode_encapsulated_text<'i, 'o>(
     }
     Ok(())
 }
+/// Decode the encapsulation boundaries of a PEM document according to RFC 7468's "Strict" grammar.
+///
+/// On success, returning the decoded label.
+pub fn decode_label(pem: &[u8]) -> Result<&str> {
+    Ok(Encapsulation::try_from(pem)?.label())
+}
 
 /// Decode a PEM document according to RFC 7468's "Strict" grammar.
 ///

--- a/pem-rfc7468/src/lib.rs
+++ b/pem-rfc7468/src/lib.rs
@@ -112,7 +112,7 @@ mod error;
 mod grammar;
 
 pub use crate::{
-    decoder::decode,
+    decoder::{decode, decode_label},
     encoder::{encode, encoded_len, LineEnding},
     error::{Error, Result},
 };

--- a/pem-rfc7468/tests/decode.rs
+++ b/pem-rfc7468/tests/decode.rs
@@ -17,6 +17,8 @@ fn pkcs1_enc_example() {
         Err(pem_rfc7468::Error::HeaderDetected) => (),
         _ => panic!("Expected HeaderDetected error"),
     }
+    let label = pem_rfc7468::decode_label(pem).unwrap();
+    assert_eq!(label, "RSA PRIVATE KEY");
 }
 
 #[test]
@@ -37,6 +39,8 @@ fn header_of_length_64() {
         Err(pem_rfc7468::Error::HeaderDetected) => (),
         _ => panic!("Expected HeaderDetected error"),
     }
+    let label = pem_rfc7468::decode_label(pem).unwrap();
+    assert_eq!(label, "RSA PRIVATE KEY");
 }
 
 #[test]


### PR DESCRIPTION
Decode the encapsulation boundaries of a PEM document, returning the label.

The motivation is to capture the document label in the case of an error
(by repeating the decoding only to extract the label)