### PR TITLE
pkcs5: remove DES encryption support

### DIFF
--- a/pkcs5/src/pbes2/encryption.rs
+++ b/pkcs5/src/pbes2/encryption.rs
@@ -51,18 +51,14 @@ pub fn encrypt_in_place<'b>(
                 .map_err(|_| CryptoError)?;
             cipher.encrypt(buffer, pos).map_err(|_| CryptoError)
         }
-        #[cfg(feature = "des-insecure")]
-        EncryptionScheme::DesCbc { iv } => {
-            let cipher =
-                DesCbc::new_from_slices(encryption_key.as_slice(), iv).map_err(|_| CryptoError)?;
-            cipher.encrypt(buffer, pos).map_err(|_| CryptoError)
-        }
         #[cfg(feature = "3des")]
         EncryptionScheme::DesEde3Cbc { iv } => {
             let cipher = DesEde3Cbc::new_from_slices(encryption_key.as_slice(), iv)
                 .map_err(|_| CryptoError)?;
             cipher.encrypt(buffer, pos).map_err(|_| CryptoError)
         }
+        #[cfg(feature = "des-insecure")]
+        EncryptionScheme::DesCbc { .. } => Err(CryptoError),
     }
 }
 


### PR DESCRIPTION
Removes support for encrypting keys using 56-bit DES, which is trivially broken due to its small key size.

This functionality is already gated under the off-by-default `des-insecure` feature, however there is little reason why anyone should be encrypting DES keys today, and is a potential sharp edge if someone accidentally configure this setting.