### PR TITLE
Refactor Error and Result usage for pkcs5 crate

### DIFF
--- a/pkcs5/src/error.rs
+++ b/pkcs5/src/error.rs
@@ -1,0 +1,56 @@
+//! Error types
+
+use core::fmt;
+use der::asn1::ObjectIdentifier;
+
+/// Result type
+pub type Result<T> = core::result::Result<T, Error>;
+
+/// Error type
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum Error {
+    /// Given parameters are invalid for this algorithm
+    AlgorithmParametersInvalid {
+        /// OID for algorithm for which the parameters were invalid
+        oid: ObjectIdentifier,
+    },
+
+    /// Decryption Failed
+    DecryptFailed,
+
+    /// Encryption Failed
+    EncryptFailed,
+
+    /// Pbes1 support is limited to parsing; encryption/decryption is not supported (won't fix)
+    #[cfg(feature = "pbes2")]
+    NoPbes1CryptSupport,
+
+    /// Algorithm is not supported
+    ///
+    /// This may be due to a disabled crate feature
+    /// Or the algorithm is not supported at all.
+    UnsupportedAlgorithm {
+        /// OID of unsupported algorithm
+        oid: ObjectIdentifier,
+    },
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::AlgorithmParametersInvalid { oid } => {
+                write!(f, "PKCS#5 parameters for algorithm {} are invalid", oid)
+            }
+            Error::DecryptFailed => f.write_str("PKCS#5 decryption failed"),
+            Error::EncryptFailed => f.write_str("PKCS#5 encryption failed"),
+            #[cfg(feature = "pbes2")]
+            Error::NoPbes1CryptSupport => {
+                f.write_str("PKCS#5 encryption/decryption unsupported for PBES1 (won't fix)")
+            }
+            Error::UnsupportedAlgorithm { oid } => {
+                write!(f, "PKCS#5 algorithm {} is unsupported", oid)
+            }
+        }
+    }
+}

--- a/pkcs5/src/pbes1.rs
+++ b/pkcs5/src/pbes1.rs
@@ -2,7 +2,7 @@
 //!
 //! [RFC 8018 Section 6.1]: https://tools.ietf.org/html/rfc8018#section-6.1
 
-use crate::{AlgorithmIdentifier, Error};
+use crate::AlgorithmIdentifier;
 use core::convert::{TryFrom, TryInto};
 use der::{
     asn1::{ObjectIdentifier, OctetString},
@@ -105,7 +105,7 @@ impl Tagged for Parameters {
 }
 
 impl<'a> TryFrom<AlgorithmIdentifier<'a>> for Parameters {
-    type Error = Error;
+    type Error = der::Error;
 
     fn try_from(alg: AlgorithmIdentifier<'a>) -> der::Result<Self> {
         // Ensure that we have a supported PBES1 algorithm identifier
@@ -155,7 +155,7 @@ pub enum EncryptionScheme {
 }
 
 impl TryFrom<ObjectIdentifier> for EncryptionScheme {
-    type Error = Error;
+    type Error = der::Error;
 
     fn try_from(oid: ObjectIdentifier) -> der::Result<Self> {
         match oid {


### PR DESCRIPTION
- introduce Error enum with one and only existing error value
- introduce specialized Result type for crate
- rewrite references to der crate Error & Result types