### PR TITLE
Allow for data before PEM (RFC 7468) encapsulation boundary

### DIFF
--- a/pem-rfc7468/src/error.rs
+++ b/pem-rfc7468/src/error.rs
@@ -12,6 +12,9 @@ pub enum Error {
     /// Base64-related errors.
     Base64,
 
+    /// Contents of document is not valid text (contains NUL char)
+    InvalidText,
+
     /// Character encoding-related errors.
     CharacterEncoding,
 
@@ -38,6 +41,7 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
             Error::Base64 => "PEM Base64 error",
+            Error::InvalidText => "PEM is not valid text as NUL char was found",
             Error::CharacterEncoding => "PEM character encoding error",
             Error::EncapsulatedText => "PEM error in encapsulated text",
             Error::HeaderDisallowed => "PEM headers disallowed by RFC7468",

--- a/pem-rfc7468/src/grammar.rs
+++ b/pem-rfc7468/src/grammar.rs
@@ -7,6 +7,9 @@
 use crate::{Error, Result};
 use core::str;
 
+/// NUL char
+pub(crate) const CHAR_NUL: u8 = 0x00;
+
 /// Horizontal tab
 pub(crate) const CHAR_HT: u8 = 0x09;
 

--- a/pem-rfc7468/tests/decode.rs
+++ b/pem-rfc7468/tests/decode.rs
@@ -10,6 +10,16 @@ fn pkcs1_example() {
 }
 
 #[test]
+fn binary_example() {
+    let der = include_bytes!("examples/pkcs1.der");
+    let mut buf = [0u8; 2048];
+    match pem_rfc7468::decode(der, &mut buf) {
+        Err(pem_rfc7468::Error::InvalidText) => (),
+        _ => panic!("Expected InvalidText error"),
+    }
+}
+
+#[test]
 fn pkcs1_example_with_preceeding_junk() {
     let pem = include_bytes!("examples/pkcs1_with_preceeding_junk.pem");
     let mut buf = [0u8; 2048];

--- a/pem-rfc7468/tests/decode.rs
+++ b/pem-rfc7468/tests/decode.rs
@@ -10,6 +10,15 @@ fn pkcs1_example() {
 }
 
 #[test]
+fn pkcs1_example_with_preceeding_junk() {
+    let pem = include_bytes!("examples/pkcs1_with_preceeding_junk.pem");
+    let mut buf = [0u8; 2048];
+    let (label, decoded) = pem_rfc7468::decode(pem, &mut buf).unwrap();
+    assert_eq!(label, "RSA PRIVATE KEY");
+    assert_eq!(decoded, include_bytes!("examples/pkcs1.der"));
+}
+
+#[test]
 fn pkcs1_enc_example() {
     let pem = include_bytes!("examples/ssh_rsa_pem_password.pem");
     let mut buf = [0u8; 2048];

--- a/pem-rfc7468/tests/examples/pkcs1_with_preceeding_junk.pem
+++ b/pem-rfc7468/tests/examples/pkcs1_with_preceeding_junk.pem
@@ -1,0 +1,44 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+Vestibulum lacinia euismod gravida.
+Sed non suscipit mauris.
+Sed ac purus sem.
+Cras ipsum velit, egestas eu lorem at, viverra pellentesque nulla.
+Cras posuere commodo tortor, id viverra velit pellentesque sit amet.
+Suspendisse bibendum eleifend lacus, ac venenatis elit commodo vulputate.
+Maecenas dapibus libero a nulla aliquet pulvinar.
+Vivamus scelerisque elit ac ex rhoncus, ac lacinia enim iaculis.
+Vivamus ultrices, sapien vel sodales rhoncus, augue turpis congue turpis, ut laoreet orci tellus sed augue.
+Mauris mi tellus, sollicitudin at placerat eu, malesuada nec est.
+Curabitur semper ex massa, et laoreet mauris scelerisque non.
+In posuere mauris non urna efficitur, id mattis nisi consectetur.
+Sed dapibus, ante eget laoreet cursus, risus ante mattis neque, a convallis urna lorem eu tortor.
+Curabitur tincidunt justo vitae eros venenatis tincidunt semper vel tellus.
+
+
+-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAtsQsUV8QpqrygsY+2+JCQ6Fw8/omM71IM2N/R8pPbzbgOl0p
+78MZGsgPOQ2HSznjD0FPzsH8oO2B5Uftws04LHb2HJAYlz25+lN5cqfHAfa3fgmC
+38FfwBkn7l582UtPWZ/wcBOnyCgb3yLcvJrXyrt8QxHJgvWO23ITrUVYszImbXQ6
+7YGS0YhMrbixRzmo2tpm3JcIBtnHrEUMsT0NfFdfsZhTT8YbxBvA8FdODgEwx7u/
+vf3J9qbi4+Kv8cvqyJuleIRSjVXPsIMnoejIn04APPKIjpMyQdnWlby7rNyQtE4+
+CV+jcFjqJbE/Xilcvqxt6DirjFCvYeKYl1uHLwIDAQABAoIBAH7Mg2LA7bB0EWQh
+XiL3SrnZG6BpAHAM9jaQ5RFNjua9z7suP5YUaSpnegg/FopeUuWWjmQHudl8bg5A
+ZPgtoLdYoU8XubfUH19I4o1lUXBPVuaeeqn6Yw/HZCjAbSXkVdz8VbesK092ZD/e
+0/4V/3irsn5lrMSq0L322yfvYKaRDFxKCF7UMnWrGcHZl6Msbv/OffLRk19uYB7t
+4WGhK1zCfKIfgdLJnD0eoI6Q4wU6sJvvpyTe8NDDo8HpdAwNn3YSahSewKp9gHgg
+VIQlTZUdsHxM+R+2RUwJZYj9WSTbq+s1nKICUmjQBPnWbrPW963BE5utQPFt3mOe
+EWRzdsECgYEA3MBhJC1Okq+u5yrFE8plufdwNvm9fg5uYUYafvdlQiXsFTx+XDGm
+FXpuWhP/bheOh1jByzPZ1rvjF57xiZjkIuzcvtePTs/b5fT82K7CydDchkc8qb0W
+2dI40h+13e++sUPKYdC9aqjZHzOgl3kOlkDbyRCF3F8mNDujE49rLWcCgYEA0/MU
+dX5A6VSDb5K+JCNq8vDaBKNGU8GAr2fpYAhtk/3mXLI+/Z0JN0di9ZgeNhhJr2jN
+11OU/2pOButpsgnkIo2y36cOQPf5dQpSgXZke3iNDld3osuLIuPNJn/3C087AtOq
++w4YxZClZLAxiLCqX8SBVrB2IiFCQ70SJ++n8vkCgYEAzmi3rBsNEA1jblVIh1PF
+wJhD/bOQ4nBd92iUV8m9jZdl4wl4YX4u/IBI9MMkIG24YIe2VOl7s9Rk5+4/jNg/
+4QQ2998Y6aljxOZJEdZ+3jQELy4m49OhrTRq2ta5t/Z3CMsJTmLe6f9NXWZpr5iK
+8iVdHOjtMXxqfYaR2jVNEtsCgYAl9uWUQiAoa037v0I1wO5YQ9IZgJGJUSDWynsg
+C4JtPs5zji4ASY+sCipsqWnH8MPKGrC8QClxMr51ONe+30yw78a5jvfbpU9Wqpmq
+vOU0xJwnlH1GeMUcY8eMfOFocjG0yOtYeubvBIDLr0/AFzz9WHp+Z69RX7m53nUR
+GDlyKQKBgDGZVAbUBiB8rerqNbONBAxfipoa4IJ+ntBrFT2DtoIZNbSzaoK+nVbH
+kbWMJycaV5PVOh1lfAiZeWCxQz5RcZh/RS8USnxyMG1j4dP/wLcbdasI8uRaSC6Y
+hFHL5HjhLrIo0HRWySS2b2ztBI2FP1M+MaaGFPHDzm2OyZg85yr3
+-----END RSA PRIVATE KEY-----


### PR DESCRIPTION
[RFC 7468 § 2. General Considerations](https://datatracker.ietf.org/doc/html/rfc7468#section-2)
>  Data before the encapsulation boundaries are permitted, and parsers MUST NOT malfunction when processing such data.

fixes TODO