### PR TITLE
Update Util::Lookup paper references

### DIFF
--- a/base64ct/README.md
+++ b/base64ct/README.md
@@ -17,6 +17,16 @@ Supports `no_std` environments and avoids heap allocations in the core API
 
 [Documentation][docs-link]
 
+## About
+
+This is a Base64 library designed for sidechannel resistance, aimed at purposes
+like encoding/decoding the "PEM" format used to store things like cryptographic
+private keys.
+
+The paper [Util::Lookup: Exploiting key decoding in cryptographic libraries][Util::Lookup]
+demonstrates how the leakage from non-constant-time Base64 parsers can be used
+to practically extract RSA private keys from SGX enclaves.
+
 ## Supported Base64 variants
 
 - Standard Base64: `[A-Z]`, `[a-z]`, `[0-9]`, `+`, `/`
@@ -63,3 +73,4 @@ dual licensed as above, without any additional terms or conditions.
 
 [RustCrypto]: https://github.com/rustcrypto
 [RFC 4648]: https://tools.ietf.org/html/rfc4648
+[Util::Lookup]: https://arxiv.org/pdf/2108.04600.pdf

--- a/base64ct/src/lib.rs
+++ b/base64ct/src/lib.rs
@@ -3,7 +3,14 @@
 //!
 //! # About
 //!
-//! This crate implements several Base64 variants in constant-time.
+//! This crate implements several Base64 variants in constant-time for
+//! sidechannel resistance, aimed at purposes like encoding/decoding the
+//! "PEM" format used to store things like cryptographic
+//! private keys.
+//!
+//! The paper [Util::Lookup: Exploiting key decoding in cryptographic libraries][Util::Lookup]
+//! demonstrates how the leakage from non-constant-time Base64 parsers can be used
+//! to practically extract RSA private keys from SGX enclaves.
 //!
 //! The padded variants require (`=`) padding. Unpadded variants expressly
 //! reject such padding.
@@ -70,6 +77,7 @@
 //! Derived code is dual licensed MIT + Apache 2 (with permission from Sc00bz).
 //!
 //! [RFC 4648, section 4]: https://tools.ietf.org/html/rfc4648#section-4
+//! [Util::Lookup]: https://arxiv.org/pdf/2108.04600.pdf
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/pem-rfc7468/README.md
+++ b/pem-rfc7468/README.md
@@ -53,7 +53,7 @@ Section 3 Figure 3.
   In the happy path, only 1-byte of secret data is potentially
   branched upon.
 
-Note: a forthcoming paper [Util::Lookup: Exploiting key decoding in cryptographic libraries][Util::Lookup]
+The paper [Util::Lookup: Exploiting key decoding in cryptographic libraries][Util::Lookup]
 demonstrates how the leakage from non-constant-time PEM parsers can be used
 to practically extract RSA private keys from SGX enclaves.
 
@@ -91,4 +91,4 @@ dual licensed as above, without any additional terms or conditions.
 [RFC 1421]: https://datatracker.ietf.org/doc/html/rfc1421
 [RFC 7468]: https://datatracker.ietf.org/doc/html/rfc7468
 [`base64ct`]: https://github.com/RustCrypto/formats/tree/master/base64ct
-[Util::Lookup]: https://twitter.com/JanWichelmann/status/1418532480081145857
+[Util::Lookup]: https://arxiv.org/pdf/2108.04600.pdf

--- a/pem-rfc7468/src/lib.rs
+++ b/pem-rfc7468/src/lib.rs
@@ -42,7 +42,7 @@
 //!   possible. In the happy path, only 1-byte of secret data is potentially
 //!   branched upon.
 //!
-//! Note: a forthcoming paper [Util::Lookup: Exploiting key decoding in cryptographic libraries][Util::Lookup]
+//! The paper [Util::Lookup: Exploiting key decoding in cryptographic libraries][Util::Lookup]
 //! demonstrates how the leakage from non-constant-time PEM parsers can be used
 //! to practically extract RSA private keys from SGX enclaves.
 //!
@@ -88,7 +88,7 @@
 //! [RFC 1421]: https://datatracker.ietf.org/doc/html/rfc1421
 //! [RFC 7468]: https://datatracker.ietf.org/doc/html/rfc7468
 //! [RFC 7468 p6]: https://datatracker.ietf.org/doc/html/rfc7468#page-6
-//! [Util::Lookup]: https://twitter.com/JanWichelmann/status/1418532480081145857
+//! [Util::Lookup]: https://arxiv.org/pdf/2108.04600.pdf
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]


### PR DESCRIPTION
This updates references to the paper:

"Util::Lookup: Exploiting key decoding in cryptographic libraries"

https://arxiv.org/pdf/2108.04600.pdf

The paper was previously unpublished, and the references to it in the documentation provided a summary of the described attack.

Now that the paper is published it's possible to link to it.