### PR TITLE
der: add `Tag::unexpected_error`

### DIFF
--- a/der/src/asn1/context_specific.rs
+++ b/der/src/asn1/context_specific.rs
@@ -1,8 +1,7 @@
 //! Context-specific field.
 
 use crate::{
-    asn1::Any, Choice, Decodable, Encodable, Encoder, Error, ErrorKind, Header, Length, Result,
-    Tag, TagNumber,
+    asn1::Any, Choice, Decodable, Encodable, Encoder, Error, Header, Length, Result, Tag, TagNumber,
 };
 use core::convert::TryFrom;
 
@@ -58,11 +57,7 @@ impl<'a> TryFrom<Any<'a>> for ContextSpecific<'a> {
                 tag_number,
                 value: Any::from_der(any.as_bytes())?,
             }),
-            actual => Err(ErrorKind::UnexpectedTag {
-                expected: None,
-                actual,
-            }
-            .into()),
+            tag => Err(tag.unexpected_error(None)),
         }
     }
 }

--- a/der/src/tag.rs
+++ b/der/src/tag.rs
@@ -92,11 +92,7 @@ impl Tag {
         if self == expected {
             Ok(self)
         } else {
-            Err(ErrorKind::UnexpectedTag {
-                expected: Some(expected),
-                actual: self,
-            }
-            .into())
+            Err(self.unexpected_error(Some(expected)))
         }
     }
 
@@ -136,6 +132,16 @@ impl Tag {
     /// identified by this tag.
     pub fn non_canonical_error(self) -> Error {
         ErrorKind::Value { tag: self }.into()
+    }
+
+    /// Create an [`Error`] because the current tag was unexpected, with an
+    /// optional expected tag.
+    pub fn unexpected_error(self, expected: Option<Self>) -> Error {
+        ErrorKind::UnexpectedTag {
+            expected,
+            actual: self,
+        }
+        .into()
     }
 
     /// Create an [`Error`] for an invalid value with the ASN.1 type identified


### PR DESCRIPTION
Adds a helper method for constructing `der::Error::UnexpectedTag` from a tag value and an optional expected tag value.