### PR TITLE
Bump clippy to use Rust 1.55

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.51.0
+        toolchain: 1.55.0
         components: clippy
         override: true
         profile: minimal

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"
 repository = "https://github.com/RustCrypto/formats/tree/master/der"
-categories = ["cryptography", "data-structures", "encoding", "no-std", "parser-implementations"]
+categories = ["cryptography", "data-structures", "encoding", "no-std", "parsing"]
 keywords = ["asn1", "crypto", "itu", "pkcs"]
 readme = "README.md"
 

--- a/der/derive/src/choice.rs
+++ b/der/derive/src/choice.rs
@@ -61,8 +61,8 @@ impl DeriveChoice {
             match variant_info.bindings().len() {
                 // TODO(tarcieri): handle 0 bindings for ASN.1 NULL
                 1 => {
-                    state.derive_variant_encoder(&variant_info, asn1_type);
-                    state.derive_variant_encoded_len(&variant_info);
+                    state.derive_variant_encoder(variant_info, asn1_type);
+                    state.derive_variant_encoded_len(variant_info);
                 }
                 other => panic!(
                     "unsupported number of ASN.1 variant bindings for {}: {}",

--- a/der/derive/src/lib.rs
+++ b/der/derive/src/lib.rs
@@ -177,8 +177,5 @@ fn derive_message(s: Structure<'_>) -> TokenStream {
 ///
 /// Returns `None` if there is no first lifetime.
 fn parse_lifetime(generics: &Generics) -> Option<&Lifetime> {
-    generics
-        .lifetimes()
-        .next()
-        .map(|ref lt_ref| &lt_ref.lifetime)
+    generics.lifetimes().next().map(|lt_ref| &lt_ref.lifetime)
 }

--- a/der/src/asn1/integer/int.rs
+++ b/der/src/asn1/integer/int.rs
@@ -17,7 +17,7 @@ pub(super) fn decode_array<const N: usize>(any: Any<'_>) -> Result<[u8; N]> {
 
 /// Encode the given big endian bytes representing an integer as ASN.1 DER.
 pub(super) fn encode(encoder: &mut Encoder<'_>, bytes: &[u8]) -> Result<()> {
-    let bytes = strip_leading_ones(&bytes);
+    let bytes = strip_leading_ones(bytes);
     let len = Length::try_from(bytes.len())?;
     Header::new(Tag::Integer, len)?.encode(encoder)?;
     encoder.bytes(bytes)
@@ -26,7 +26,7 @@ pub(super) fn encode(encoder: &mut Encoder<'_>, bytes: &[u8]) -> Result<()> {
 /// Get the encoded length for the given unsigned integer serialized as bytes.
 #[inline]
 pub(super) fn encoded_len(bytes: &[u8]) -> Result<Length> {
-    Length::try_from(strip_leading_ones(&bytes).len())
+    Length::try_from(strip_leading_ones(bytes).len())
 }
 
 /// Strip the leading all-ones bytes from the given byte slice.

--- a/der/src/asn1/integer/uint.rs
+++ b/der/src/asn1/integer/uint.rs
@@ -21,7 +21,7 @@ pub(super) fn decode_slice(any: Any<'_>) -> Result<&[u8]> {
         [] => Err(tag.non_canonical_error()),
         [0] => Ok(bytes),
         [0, byte, ..] if *byte < 0x80 => Err(tag.non_canonical_error()),
-        [0, rest @ ..] => Ok(&rest),
+        [0, rest @ ..] => Ok(rest),
         [byte, ..] if *byte >= 0x80 => Err(tag.value_error()),
         _ => Ok(bytes),
     }
@@ -40,7 +40,7 @@ pub(super) fn decode_array<const N: usize>(any: Any<'_>) -> Result<[u8; N]> {
 
 /// Encode the given big endian bytes representing an integer as ASN.1 DER.
 pub(super) fn encode(encoder: &mut Encoder<'_>, bytes: &[u8]) -> Result<()> {
-    let bytes = strip_leading_zeroes(&bytes);
+    let bytes = strip_leading_zeroes(bytes);
     let leading_zero = needs_leading_zero(bytes);
     let len = (Length::try_from(bytes.len())? + leading_zero as u8)?;
     Header::new(Tag::Integer, len)?.encode(encoder)?;
@@ -55,7 +55,7 @@ pub(super) fn encode(encoder: &mut Encoder<'_>, bytes: &[u8]) -> Result<()> {
 /// Get the encoded length for the given unsigned integer serialized as bytes.
 #[inline]
 pub(super) fn encoded_len(bytes: &[u8]) -> Result<Length> {
-    let bytes = strip_leading_zeroes(&bytes);
+    let bytes = strip_leading_zeroes(bytes);
     Length::try_from(bytes.len())? + needs_leading_zero(bytes) as u8
 }
 

--- a/pkcs5/src/pbes2/encryption.rs
+++ b/pkcs5/src/pbes2/encryption.rs
@@ -157,7 +157,7 @@ impl EncryptionKey {
                 Ok(key)
             }
             Kdf::Scrypt(scrypt_params) => {
-                EncryptionKey::derive_with_scrypt(password, &scrypt_params, key_size)
+                EncryptionKey::derive_with_scrypt(password, scrypt_params, key_size)
             }
         }
     }

--- a/pkcs8/src/encrypted_private_key_info.rs
+++ b/pkcs8/src/encrypted_private_key_info.rs
@@ -61,7 +61,7 @@ impl<'a> EncryptedPrivateKeyInfo<'a> {
     #[cfg_attr(docsrs, doc(cfg(feature = "encryption")))]
     pub fn decrypt(&self, password: impl AsRef<[u8]>) -> Result<PrivateKeyDocument> {
         self.encryption_algorithm
-            .decrypt(password, &self.encrypted_data)
+            .decrypt(password, self.encrypted_data)
             .map_err(|_| Error::Crypto)
             .and_then(TryInto::try_into)
     }


### PR DESCRIPTION
Uses the latest stable version of clippy

Fixes the warnings which occur under it