### PR TITLE
pem-rfc7468 v0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,7 +190,7 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "base64ct",
 ]

--- a/pem-rfc7468/CHANGELOG.md
+++ b/pem-rfc7468/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.2 (2021-09-16)
+### Changed
+- Allow for data before PEM encapsulation boundary ([#40])
+
+[#40]: https://github.com/RustCrypto/formats/pull/40
+
 ## 0.2.1 (2021-09-14)
 ### Added
 - `decode_label` ([#22])

--- a/pem-rfc7468/Cargo.toml
+++ b/pem-rfc7468/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pem-rfc7468"
-version = "0.2.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.2" # Also update html_root_url in lib.rs when bumping this
 description = """
 PEM Encoding (RFC 7468) for PKIX, PKCS, and CMS Structures, implementing a
 strict subset of the original Privacy-Enhanced Mail encoding intended

--- a/pem-rfc7468/src/lib.rs
+++ b/pem-rfc7468/src/lib.rs
@@ -95,7 +95,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/pem-rfc7468/0.2.1"
+    html_root_url = "https://docs.rs/pem-rfc7468/0.2.2"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Changed
- Allow for data before PEM encapsulation boundary ([#40])

[#40]: https://github.com/RustCrypto/formats/pull/40