### PR TITLE
sec1: use manual impl of `(Partial)Ord` on EncodedPoint

### DIFF
--- a/sec1/src/point.rs
+++ b/sec1/src/point.rs
@@ -6,6 +6,7 @@
 
 use crate::{Error, Result};
 use core::{
+    cmp::Ordering,
     fmt::{self, Debug},
     ops::Add,
 };
@@ -60,7 +61,7 @@ impl_modulus_size!(U28, U32, U48, U66);
 /// This type is an enum over the compressed and uncompressed encodings,
 /// useful for cases where either encoding can be supported, or conversions
 /// between the two forms.
-#[derive(Clone, Default, PartialOrd, Ord)]
+#[derive(Clone, Default)]
 pub struct EncodedPoint<Size>
 where
     Size: ModulusSize,
@@ -278,6 +279,8 @@ where
     }
 }
 
+impl<Size: ModulusSize> Eq for EncodedPoint<Size> {}
+
 impl<Size> PartialEq for EncodedPoint<Size>
 where
     Size: ModulusSize,
@@ -287,7 +290,23 @@ where
     }
 }
 
-impl<Size: ModulusSize> Eq for EncodedPoint<Size> {}
+impl<Size: ModulusSize> PartialOrd for EncodedPoint<Size>
+where
+    Size: ModulusSize,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<Size: ModulusSize> Ord for EncodedPoint<Size>
+where
+    Size: ModulusSize,
+{
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.as_bytes().cmp(other.as_bytes())
+    }
+}
 
 #[cfg(feature = "zeroize")]
 impl<Size> Zeroize for EncodedPoint<Size>

--- a/sec1/src/private_key.rs
+++ b/sec1/src/private_key.rs
@@ -24,11 +24,13 @@ pub(crate) const PEM_TYPE_LABEL: &str = "EC PRIVATE KEY";
 
 /// `ECPrivateKey` version.
 ///
-/// From RFC5913 Section 3:
+/// From [RFC5913 Section 3]:
 /// > version specifies the syntax version number of the elliptic curve
 /// > private key structure.  For this version of the document, it SHALL
 /// > be set to ecPrivkeyVer1, which is of type INTEGER and whose value
 /// > is one (1).
+///
+/// [RFC5915 Section 3]: https://datatracker.ietf.org/doc/html/rfc5915#section-3
 const VERSION: u8 = 1;
 
 /// Context-specific tag number for the elliptic curve parameters.


### PR DESCRIPTION
The derived versions aren't working because they are attempting to compare values on the generic typenum, which doesn't impl the proper traits to allow the derive to work.