### PR TITLE
feat: add support for constructed bit

### DIFF
--- a/der/src/decoder.rs
+++ b/der/src/decoder.rs
@@ -141,7 +141,7 @@ impl<'a> Decoder<'a> {
     pub fn context_specific(&mut self, tag: TagNumber) -> Result<Option<Any<'a>>> {
         loop {
             match self.peek().map(Tag::try_from).transpose()? {
-                Some(Tag::ContextSpecific(actual_tag)) => {
+                Some(Tag::ContextSpecific(actual_tag, _)) => {
                     match actual_tag.cmp(&tag) {
                         Ordering::Less => {
                             // Decode and ignore lower-numbered fields if

--- a/der/src/tag/number.rs
+++ b/der/src/tag/number.rs
@@ -37,18 +37,18 @@ impl TagNumber {
     }
 
     /// Create an `APPLICATION` tag with this tag number.
-    pub fn application(self) -> Tag {
-        Tag::Application(self)
+    pub fn application(self, constructed: bool) -> Tag {
+        Tag::Application(self, constructed)
     }
 
     /// Create a `CONTEXT-SPECIFIC` tag with this tag number.
-    pub fn context_specific(self) -> Tag {
-        Tag::ContextSpecific(self)
+    pub fn context_specific(self, constructed: bool) -> Tag {
+        Tag::ContextSpecific(self, constructed)
     }
 
     /// Create a `PRIVATE` tag with this tag number.
-    pub fn private(self) -> Tag {
-        Tag::Private(self)
+    pub fn private(self, constructed: bool) -> Tag {
+        Tag::Private(self, constructed)
     }
 
     /// Get the inner value.


### PR DESCRIPTION
- Previously, DER outputted by the Application, ContextSpecific,
  and Private types were assumed to have their constructed bit
  (0b100000) set
- This PR adds a parameter when decoding/encoding Application,
  ContextSpecific, and Private types that allows these types to
  not have their constructed bit (0b100000) set