### PR TITLE
der: add support for IMPLICIT mode CONTEXT-SPECIFIC

### DIFF
--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -160,6 +160,12 @@ impl<'a> Encodable for Any<'a> {
     }
 }
 
+impl<'a> From<Any<'a>> for ByteSlice<'a> {
+    fn from(any: Any<'a>) -> ByteSlice<'a> {
+        any.value
+    }
+}
+
 impl<'a> TryFrom<&'a [u8]> for Any<'a> {
     type Error = Error;
 

--- a/der/src/asn1/octet_string.rs
+++ b/der/src/asn1/octet_string.rs
@@ -53,7 +53,7 @@ impl<'a> TryFrom<Any<'a>> for OctetString<'a> {
 
     fn try_from(any: Any<'a>) -> Result<OctetString<'a>> {
         any.tag().assert_eq(Tag::OctetString)?;
-        Self::new(any.value())
+        Ok(Self { inner: any.into() })
     }
 }
 

--- a/der/src/error.rs
+++ b/der/src/error.rs
@@ -193,6 +193,9 @@ pub enum ErrorKind {
         byte: u8,
     },
 
+    /// Unknown tag mode.
+    UnknownTagMode,
+
     /// UTF-8 errors.
     Utf8(Utf8Error),
 
@@ -252,6 +255,7 @@ impl fmt::Display for ErrorKind {
             ErrorKind::UnknownTag { byte } => {
                 write!(f, "unknown/unsupported ASN.1 DER tag: 0x{:02x}", byte)
             }
+            ErrorKind::UnknownTagMode => write!(f, "unknown tag mode"),
             ErrorKind::Utf8(e) => write!(f, "{}", e),
             ErrorKind::Value { tag } => write!(f, "malformed ASN.1 DER value for {}", tag),
         }

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -374,7 +374,7 @@ pub use crate::{
     header::Header,
     length::Length,
     message::Message,
-    tag::{Class, Tag, TagNumber, Tagged},
+    tag::{Class, Tag, TagMode, TagNumber, Tagged},
 };
 
 #[cfg(feature = "bigint")]

--- a/der/src/tag.rs
+++ b/der/src/tag.rs
@@ -1,9 +1,10 @@
 //! ASN.1 tags.
 
 mod class;
+mod mode;
 mod number;
 
-pub use self::{class::Class, number::TagNumber};
+pub use self::{class::Class, mode::TagMode, number::TagNumber};
 
 use crate::{Decodable, Decoder, Encodable, Encoder, Error, ErrorKind, Length, Result};
 use core::{convert::TryFrom, fmt};
@@ -35,53 +36,71 @@ pub trait Tagged {
 #[derive(Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum Tag {
-    /// `BOOLEAN` tag: 0x01
+    /// `BOOLEAN` tag: `0x01`.
     Boolean,
 
-    /// `INTEGER` tag: 0x02
+    /// `INTEGER` tag: `0x02`.
     Integer,
 
-    /// `BIT STRING` tag: 0x03
+    /// `BIT STRING` tag: `0x03`.
     BitString,
 
-    /// `OCTET STRING` tag: 0x04
+    /// `OCTET STRING` tag: `0x04`.
     OctetString,
 
-    /// `NULL` tag: 0x05
+    /// `NULL` tag: `0x05`.
     Null,
 
-    /// `OBJECT IDENTIFIER` tag: 0x06
+    /// `OBJECT IDENTIFIER` tag: `0x06`.
     ObjectIdentifier,
 
-    /// `UTF8String` tag: 0x0C
+    /// `UTF8String` tag: `0x0C`.
     Utf8String,
 
-    /// `SEQUENCE` tag: 0x10
+    /// `SEQUENCE` tag: `0x10`.
     Sequence,
 
-    /// `SET` and `SET OF` tag: 0x11
+    /// `SET` and `SET OF` tag: `0x11`.
     Set,
 
-    /// `PrintableString` tag: 0x13
+    /// `PrintableString` tag: `0x13`.
     PrintableString,
 
-    /// `IA5String` tag: 0x16
+    /// `IA5String` tag: `0x16`.
     Ia5String,
 
-    /// `UTCTime` tag: 0x17
+    /// `UTCTime` tag: `0x17`.
     UtcTime,
 
-    /// `GeneralizedTime` tag: 0x18
+    /// `GeneralizedTime` tag: `0x18`.
     GeneralizedTime,
 
     /// Application tag.
-    Application(TagNumber),
+    Application {
+        /// Is this tag constructed? (vs primitive).
+        constructed: bool,
+
+        /// Tag number.
+        number: TagNumber,
+    },
 
     /// Context-specific tag.
-    ContextSpecific(TagNumber),
+    ContextSpecific {
+        /// Is this tag constructed? (vs primitive).
+        constructed: bool,
+
+        /// Tag number.
+        number: TagNumber,
+    },
 
     /// Private tag number.
-    Private(TagNumber),
+    Private {
+        /// Is this tag constructed? (vs primitive).
+        constructed: bool,
+
+        /// Tag number.
+        number: TagNumber,
+    },
 }
 
 impl Tag {
@@ -99,11 +118,41 @@ impl Tag {
     /// Get the [`Class`] that corresponds to this [`Tag`].
     pub fn class(self) -> Class {
         match self {
-            Tag::Application(_) => Class::Application,
-            Tag::ContextSpecific(_) => Class::ContextSpecific,
-            Tag::Private(_) => Class::Private,
+            Tag::Application { .. } => Class::Application,
+            Tag::ContextSpecific { .. } => Class::ContextSpecific,
+            Tag::Private { .. } => Class::Private,
             _ => Class::Universal,
         }
+    }
+
+    /// Get the [`TagNumber`] (lower 6-bits) for this tag.
+    pub fn number(self) -> TagNumber {
+        TagNumber(self.octet() & TagNumber::MASK)
+    }
+
+    /// Does this tag represent a constructed (as opposed to primitive) field?
+    pub fn is_constructed(self) -> bool {
+        self.octet() & CONSTRUCTED_FLAG != 0
+    }
+
+    /// Is this an application tag?
+    pub fn is_application(self) -> bool {
+        self.class() == Class::Application
+    }
+
+    /// Is this a context-specific tag?
+    pub fn is_context_specific(self) -> bool {
+        self.class() == Class::ContextSpecific
+    }
+
+    /// Is this a private tag?
+    pub fn is_private(self) -> bool {
+        self.class() == Class::Private
+    }
+
+    /// Is this a universal tag?
+    pub fn is_universal(self) -> bool {
+        self.class() == Class::Universal
     }
 
     /// Get the octet encoding for this [`Tag`].
@@ -122,9 +171,18 @@ impl Tag {
             Tag::Ia5String => 0x16,
             Tag::UtcTime => 0x17,
             Tag::GeneralizedTime => 0x18,
-            Tag::Application(number) | Tag::ContextSpecific(number) | Tag::Private(number) => {
-                self.class().octet(number, true)
+            Tag::Application {
+                constructed,
+                number,
             }
+            | Tag::ContextSpecific {
+                constructed,
+                number,
+            }
+            | Tag::Private {
+                constructed,
+                number,
+            } => self.class().octet(constructed, number),
         }
     }
 
@@ -155,6 +213,9 @@ impl TryFrom<u8> for Tag {
     type Error = Error;
 
     fn try_from(byte: u8) -> Result<Tag> {
+        let constructed = byte & CONSTRUCTED_FLAG != 0;
+        let number = TagNumber::try_from(byte & TagNumber::MASK)?;
+
         match byte {
             0x01 => Ok(Tag::Boolean),
             0x02 => Ok(Tag::Integer),
@@ -169,9 +230,18 @@ impl TryFrom<u8> for Tag {
             0x18 => Ok(Tag::GeneralizedTime),
             0x30 => Ok(Tag::Sequence), // constructed
             0x31 => Ok(Tag::Set),      // constructed
-            0x60..=0x7E => Ok(Tag::Application(TagNumber(byte & 0b11111))), // constructed
-            0xA0..=0xBE => Ok(Tag::ContextSpecific(TagNumber(byte & 0b11111))), // constructed
-            0xE0..=0xFE => Ok(Tag::Private(TagNumber(byte & 0b11111))), // constructed
+            0x40..=0x7E => Ok(Tag::Application {
+                constructed,
+                number,
+            }),
+            0x80..=0xBE => Ok(Tag::ContextSpecific {
+                constructed,
+                number,
+            }),
+            0xC0..=0xFE => Ok(Tag::Private {
+                constructed,
+                number,
+            }),
             _ => Err(ErrorKind::UnknownTag { byte }.into()),
         }
     }
@@ -207,6 +277,8 @@ impl Encodable for Tag {
 
 impl fmt::Display for Tag {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        const FIELD_TYPE: [&str; 2] = ["primitive", "constructed"];
+
         match self {
             Tag::Boolean => f.write_str("BOOLEAN"),
             Tag::Integer => f.write_str("INTEGER"),
@@ -221,9 +293,30 @@ impl fmt::Display for Tag {
             Tag::UtcTime => f.write_str("UTCTime"),
             Tag::GeneralizedTime => f.write_str("GeneralizedTime"),
             Tag::Sequence => f.write_str("SEQUENCE"),
-            Tag::Application(n) => write!(f, "APPLICATION {}", n),
-            Tag::ContextSpecific(n) => write!(f, "CONTEXT-SPECIFIC {}", n),
-            Tag::Private(n) => write!(f, "PRIVATE {}", n),
+            Tag::Application {
+                constructed,
+                number,
+            } => write!(
+                f,
+                "APPLICATION [{}] ({})",
+                number, FIELD_TYPE[*constructed as usize]
+            ),
+            Tag::ContextSpecific {
+                constructed,
+                number,
+            } => write!(
+                f,
+                "CONTEXT-SPECIFIC [{}] ({})",
+                number, FIELD_TYPE[*constructed as usize]
+            ),
+            Tag::Private {
+                constructed,
+                number,
+            } => write!(
+                f,
+                "PRIVATE [{}] ({})",
+                number, FIELD_TYPE[*constructed as usize]
+            ),
         }
     }
 }
@@ -256,13 +349,36 @@ mod tests {
         assert_eq!(Tag::Sequence.class(), Class::Universal);
 
         for num in 0..=30 {
-            let tag_num = TagNumber::new(num);
-            assert_eq!(Tag::Application(tag_num).class(), Class::Application);
-            assert_eq!(
-                Tag::ContextSpecific(tag_num).class(),
-                Class::ContextSpecific
-            );
-            assert_eq!(Tag::Private(tag_num).class(), Class::Private);
+            for &constructed in &[false, true] {
+                let number = TagNumber::new(num);
+
+                assert_eq!(
+                    Tag::Application {
+                        constructed,
+                        number
+                    }
+                    .class(),
+                    Class::Application
+                );
+
+                assert_eq!(
+                    Tag::ContextSpecific {
+                        constructed,
+                        number
+                    }
+                    .class(),
+                    Class::ContextSpecific
+                );
+
+                assert_eq!(
+                    Tag::Private {
+                        constructed,
+                        number
+                    }
+                    .class(),
+                    Class::Private
+                );
+            }
         }
     }
 }

--- a/der/src/tag/class.rs
+++ b/der/src/tag/class.rs
@@ -32,7 +32,7 @@ pub enum Class {
 
 impl Class {
     /// Compute the identifier octet for a tag number of this class.
-    pub(super) fn octet(self, number: TagNumber, constructed: bool) -> u8 {
+    pub(super) fn octet(self, constructed: bool, number: TagNumber) -> u8 {
         self as u8 | number.value() | (constructed as u8 * CONSTRUCTED_FLAG)
     }
 }

--- a/der/src/tag/mode.rs
+++ b/der/src/tag/mode.rs
@@ -1,0 +1,45 @@
+//! Tag modes.
+
+use crate::{Error, ErrorKind, Result};
+use core::{fmt, str::FromStr};
+
+/// Tagging modes: `EXPLICIT` versus `IMPLICIT`.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub enum TagMode {
+    /// `EXPLICIT` tagging.
+    ///
+    /// Tag is added in addition to the inner tag of the type.
+    Explicit,
+
+    /// `IMPLICIT` tagging.
+    ///
+    /// Tag replaces the existing tag of the inner type.
+    Implicit,
+}
+
+impl Default for TagMode {
+    fn default() -> TagMode {
+        TagMode::Explicit
+    }
+}
+
+impl FromStr for TagMode {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        match s {
+            "EXPLICIT" | "explicit" => Ok(TagMode::Explicit),
+            "IMPLICIT" | "implicit" => Ok(TagMode::Implicit),
+            _ => Err(ErrorKind::UnknownTagMode.into()),
+        }
+    }
+}
+
+impl fmt::Display for TagMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TagMode::Explicit => f.write_str("EXPLICIT"),
+            TagMode::Implicit => f.write_str("IMPLICIT"),
+        }
+    }
+}

--- a/der/src/tag/number.rs
+++ b/der/src/tag/number.rs
@@ -25,6 +25,9 @@ impl TagNumber {
     /// Maximum tag number supported (inclusive).
     pub const MAX: u8 = 30;
 
+    /// Mask value used to obtain the tag number from a tag octet.
+    pub(super) const MASK: u8 = 0b11111;
+
     /// Create a new tag number (const-friendly).
     ///
     /// Panics if the tag number is greater than [`TagNumber::MAX`]. For a fallible
@@ -37,18 +40,27 @@ impl TagNumber {
     }
 
     /// Create an `APPLICATION` tag with this tag number.
-    pub fn application(self) -> Tag {
-        Tag::Application(self)
+    pub fn application(self, constructed: bool) -> Tag {
+        Tag::Application {
+            constructed,
+            number: self,
+        }
     }
 
     /// Create a `CONTEXT-SPECIFIC` tag with this tag number.
-    pub fn context_specific(self) -> Tag {
-        Tag::ContextSpecific(self)
+    pub fn context_specific(self, constructed: bool) -> Tag {
+        Tag::ContextSpecific {
+            constructed,
+            number: self,
+        }
     }
 
     /// Create a `PRIVATE` tag with this tag number.
-    pub fn private(self) -> Tag {
-        Tag::Private(self)
+    pub fn private(self, constructed: bool) -> Tag {
+        Tag::Private {
+            constructed,
+            number: self,
+        }
     }
 
     /// Get the inner value.

--- a/pkcs8/src/private_key_info.rs
+++ b/pkcs8/src/private_key_info.rs
@@ -190,14 +190,17 @@ impl<'a> TryFrom<Any<'a>> for PrivateKeyInfo<'a> {
             let version = Version::decode(decoder)?;
             let algorithm = decoder.decode()?;
             let private_key = decoder.octet_string()?.into();
-            let attributes = decoder.context_specific(ATTRIBUTES_TAG)?;
+            let attributes = decoder.context_specific_explicit(ATTRIBUTES_TAG)?;
 
             let public_key = decoder
-                .context_specific::<BitString<'_>>(PUBLIC_KEY_TAG)?
+                .context_specific_explicit::<BitString<'_>>(PUBLIC_KEY_TAG)?
                 .map(|bs| bs.as_bytes());
 
             if version.has_public_key() != public_key.is_some() {
-                return Err(decoder.value_error(der::Tag::ContextSpecific(PUBLIC_KEY_TAG)));
+                return Err(decoder.value_error(der::Tag::ContextSpecific {
+                    constructed: true,
+                    number: PUBLIC_KEY_TAG,
+                }));
             }
 
             // Ignore any remaining extension fields

--- a/sec1/src/private_key.rs
+++ b/sec1/src/private_key.rs
@@ -88,9 +88,9 @@ impl<'a> TryFrom<Any<'a>> for EcPrivateKey<'a> {
             }
 
             let private_key = decoder.octet_string()?.as_bytes();
-            let parameters = decoder.context_specific(EC_PARAMETERS_TAG)?;
+            let parameters = decoder.context_specific_explicit(EC_PARAMETERS_TAG)?;
             let public_key = decoder
-                .context_specific::<BitString<'_>>(PUBLIC_KEY_TAG)?
+                .context_specific_explicit::<BitString<'_>>(PUBLIC_KEY_TAG)?
                 .map(|bs| bs.as_bytes());
 
             Ok(EcPrivateKey {


### PR DESCRIPTION
Adds preliminary support for `IMPLICIT`, splitting `Decoder::context_specific` into separate `_explicit` and `_implicit`
versions.

Two functions are necessary for now because they have different trait bounds, and furthermore, support for `IMPLICIT` fields is highly restricted for now: it requires an `Into<Any>` bound.

Some refactoring of the encoding traits will be necessary to support more types.