### PR TITLE
Bump `der`-dependent crates to prerelease versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.4.3"
+version = "0.5.0-pre"
 dependencies = [
  "const-oid",
  "crypto-bigint",
@@ -197,7 +197,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs1"
-version = "0.2.4"
+version = "0.3.0-pre"
 dependencies = [
  "der",
  "hex-literal",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs5"
-version = "0.3.2"
+version = "0.4.0-pre"
 dependencies = [
  "aes",
  "block-modes",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.7.6"
+version = "0.8.0-pre"
 dependencies = [
  "der",
  "hex-literal",
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "der",
  "generic-array",
@@ -321,7 +321,7 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.4.1"
+version = "0.5.0-pre"
 dependencies = [
  "base64ct",
  "der",

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der"
-version = "0.4.3" # Also update html_root_url in lib.rs when bumping this
+version = "0.5.0-pre" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust embedded-friendly implementation of the Distinguished Encoding Rules
 (DER) for Abstract Syntax Notation One (ASN.1) as described in ITU X.690 with

--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs1"
-version = "0.2.4" # Also update html_root_url in lib.rs when bumping this
+version = "0.3.0-pre" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #1:
 RSA Cryptography Specifications Version 2.2 (RFC 8017)
@@ -14,7 +14,7 @@ keywords = ["crypto", "key", "pem", "pkcs", "rsa"]
 readme = "README.md"
 
 [dependencies]
-der = { version = "0.4", features = ["bigint", "oid"], path = "../der" }
+der = { version = "=0.5.0-pre", features = ["bigint", "oid"], path = "../der" }
 
 # optional dependencies
 pem-rfc7468 = { version = "0.2", optional = true, path = "../pem-rfc7468" }

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs5"
-version = "0.3.2" # Also update html_root_url in lib.rs when bumping this
+version = "0.4.0-pre" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #5:
 Password-Based Cryptography Specification Version 2.1 (RFC 8018)
@@ -14,8 +14,8 @@ keywords = ["crypto", "key", "pkcs", "password"]
 readme = "README.md"
 
 [dependencies]
-der = { version = "0.4", features = ["oid"], path = "../der" }
-spki = { version = "0.4", path = "../spki" }
+der = { version = "=0.5.0-pre", features = ["oid"], path = "../der" }
+spki = { version = "=0.5.0-pre", path = "../spki" }
 
 # optional dependencies
 aes = { version = "0.7", optional = true }

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs8"
-version = "0.7.6" # Also update html_root_url in lib.rs when bumping this
+version = "0.8.0-pre" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #8:
 Private-Key Information Syntax Specification (RFC 5208), with additional
@@ -15,13 +15,13 @@ keywords = ["crypto", "key", "pkcs", "private"]
 readme = "README.md"
 
 [dependencies]
-der = { version = "0.4", features = ["oid"], path = "../der" }
-spki = { version = "0.4", path = "../spki" }
+der = { version = "=0.5.0-pre", features = ["oid"], path = "../der" }
+spki = { version = "=0.5.0-pre", path = "../spki" }
 
 # optional dependencies
 rand_core = { version = "0.6", optional = true, default-features = false }
-pkcs1 = { version = "0.2", optional = true, features = ["alloc"], path = "../pkcs1" }
-pkcs5 = { version = "0.3", optional = true, path = "../pkcs5" }
+pkcs1 = { version = "=0.3.0-pre", optional = true, features = ["alloc"], path = "../pkcs1" }
+pkcs5 = { version = "=0.4.0-pre", optional = true, path = "../pkcs5" }
 pem-rfc7468 = { version = "0.2", optional = true, path = "../pem-rfc7468" }
 zeroize = { version = "1", optional = true, default-features = false, features = ["alloc"] }
 

--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sec1"
-version = "0.1.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of SEC1: Elliptic Curve Cryptography encoding formats
 including ASN.1 DER-serialized private keys as well as the
@@ -15,7 +15,7 @@ keywords = ["crypto", "key", "elliptic-curve", "secg"]
 readme = "README.md"
 
 [dependencies]
-der = { version = "0.4", features = ["oid"], path = "../der" }
+der = { version = "=0.5.0-pre", features = ["oid"], path = "../der" }
 generic-array = { version = "0.14", default-features = false }
 
 # optional dependencies

--- a/spki/Cargo.toml
+++ b/spki/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spki"
-version = "0.4.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.5.0-pre" # Also update html_root_url in lib.rs when bumping this
 description = """
 X.509 Subject Public Key Info (RFC5280) describing public keys as well as their
 associated AlgorithmIdentifiers (i.e. OIDs)
@@ -14,7 +14,7 @@ keywords = ["crypto", "x509"]
 readme = "README.md"
 
 [dependencies]
-der = { version = "0.4", features = ["oid"], path = "../der" }
+der = { version = "=0.5.0-pre", features = ["oid"], path = "../der" }
 
 # Optional dependencies
 sha2 = { version = "0.9.8", optional = true, default-features = false }

--- a/x509/Cargo.toml
+++ b/x509/Cargo.toml
@@ -14,8 +14,8 @@ keywords   = ["crypto", "x.509"]
 readme     = "README.md"
 
 [dependencies]
-der = { version = "0.4", features = ["derive"], path = "../der" }
-spki = { version = "0.4", path = "../spki" }
+der = { version = "=0.5.0-pre", features = ["derive"], path = "../der" }
+spki = { version = "=0.5.0-pre", path = "../spki" }
 
 [features]
 std = []


### PR DESCRIPTION
RustCrypto/formats#61 contained breaking changes to the public API.

As such, this commit bumps `der` and all of the crates which depend on it to prerelease versions to reflect that