### PR TITLE
der: introduce `DecodeValue`/`EncodeValue` traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "der_derive"
-version = "0.4.1"
+version = "0.5.0-pre"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 [dependencies]
 const-oid = { version = "0.6", optional = true, path = "../const-oid" }
 crypto-bigint = { version = "0.2", optional = true, features = ["generic-array"] }
-der_derive = { version = "0.4", optional = true, path = "derive" }
+der_derive = { version = "=0.5.0-pre", optional = true, path = "derive" }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/der/derive/Cargo.toml
+++ b/der/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der_derive"
-version = "0.4.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.5.0-pre" # Also update html_root_url in lib.rs when bumping this
 description = "Custom derive support for the `der` crate's `Choice` and `Message` traits"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"

--- a/der/derive/src/message.rs
+++ b/der/derive/src/message.rs
@@ -100,14 +100,12 @@ impl DeriveMessage {
         let encode_fields = self.encode_fields;
 
         s.gen_impl(quote! {
-            gen impl core::convert::TryFrom<::der::asn1::Any<#lifetime>> for @Self {
-                type Error = ::der::Error;
-
-                fn try_from(any: ::der::asn1::Any<#lifetime>) -> ::der::Result<Self> {
+            gen impl ::der::Decodable<#lifetime> for @Self {
+                fn decode(decoder: &mut ::der::Decoder<#lifetime>) -> ::der::Result<Self> {
                     #[allow(unused_imports)]
                     use core::convert::TryInto;
 
-                    any.sequence(|decoder| {
+                    decoder.sequence(|decoder| {
                         #decode_fields
                         Ok(Self { #decode_result })
                     })

--- a/der/src/asn1/generalized_time.rs
+++ b/der/src/asn1/generalized_time.rs
@@ -3,7 +3,8 @@
 use crate::{
     asn1::Any,
     datetime::{self, DateTime},
-    Encodable, Encoder, Error, Header, Length, Result, Tag, Tagged,
+    ByteSlice, DecodeValue, Decoder, Encodable, Encoder, Error, Header, Length, Result, Tag,
+    Tagged,
 };
 use core::{convert::TryFrom, time::Duration};
 
@@ -63,27 +64,9 @@ impl GeneralizedTime {
     }
 }
 
-impl From<&GeneralizedTime> for GeneralizedTime {
-    fn from(value: &GeneralizedTime) -> GeneralizedTime {
-        *value
-    }
-}
-
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl From<GeneralizedTime> for SystemTime {
-    fn from(utc_time: GeneralizedTime) -> SystemTime {
-        utc_time.to_system_time()
-    }
-}
-
-impl TryFrom<Any<'_>> for GeneralizedTime {
-    type Error = Error;
-
-    fn try_from(any: Any<'_>) -> Result<GeneralizedTime> {
-        any.tag().assert_eq(Self::TAG)?;
-
-        match *any.value() {
+impl DecodeValue<'_> for GeneralizedTime {
+    fn decode_value(decoder: &mut Decoder<'_>, length: Length) -> Result<Self> {
+        match *ByteSlice::decode_value(decoder, length)?.as_bytes() {
             // RFC 5280 requires mandatory seconds and Z-normalized time zone
             [y1, y2, y3, y4, mon1, mon2, day1, day2, hour1, hour2, min1, min2, sec1, sec2, b'Z'] => {
                 let year = datetime::decode_decimal(Self::TAG, y1, y2)? * 100
@@ -126,6 +109,28 @@ impl Encodable for GeneralizedTime {
         datetime::encode_decimal(encoder, Self::TAG, datetime.minute())?;
         datetime::encode_decimal(encoder, Self::TAG, datetime.second())?;
         encoder.byte(b'Z')
+    }
+}
+
+impl From<&GeneralizedTime> for GeneralizedTime {
+    fn from(value: &GeneralizedTime) -> GeneralizedTime {
+        *value
+    }
+}
+
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+impl From<GeneralizedTime> for SystemTime {
+    fn from(utc_time: GeneralizedTime) -> SystemTime {
+        utc_time.to_system_time()
+    }
+}
+
+impl TryFrom<Any<'_>> for GeneralizedTime {
+    type Error = Error;
+
+    fn try_from(any: Any<'_>) -> Result<GeneralizedTime> {
+        any.decode_into()
     }
 }
 

--- a/der/src/asn1/ia5_string.rs
+++ b/der/src/asn1/ia5_string.rs
@@ -1,7 +1,8 @@
 //! ASN.1 `IA5String` support.
 
 use crate::{
-    asn1::Any, str_slice::StrSlice, Encodable, Encoder, Error, Length, Result, Tag, Tagged,
+    asn1::Any, str_slice::StrSlice, ByteSlice, DecodeValue, Decoder, Encodable, Encoder, Error,
+    Length, Result, Tag, Tagged,
 };
 use core::{convert::TryFrom, fmt, str};
 
@@ -72,6 +73,22 @@ impl AsRef<[u8]> for Ia5String<'_> {
     }
 }
 
+impl<'a> DecodeValue<'a> for Ia5String<'a> {
+    fn decode_value(decoder: &mut Decoder<'a>, length: Length) -> Result<Self> {
+        Self::new(ByteSlice::decode_value(decoder, length)?.as_bytes())
+    }
+}
+
+impl<'a> Encodable for Ia5String<'a> {
+    fn encoded_len(&self) -> Result<Length> {
+        Any::from(*self).encoded_len()
+    }
+
+    fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
+        Any::from(*self).encode(encoder)
+    }
+}
+
 impl<'a> From<&Ia5String<'a>> for Ia5String<'a> {
     fn from(value: &Ia5String<'a>) -> Ia5String<'a> {
         *value
@@ -82,8 +99,7 @@ impl<'a> TryFrom<Any<'a>> for Ia5String<'a> {
     type Error = Error;
 
     fn try_from(any: Any<'a>) -> Result<Ia5String<'a>> {
-        any.tag().assert_eq(Tag::Ia5String)?;
-        Self::new(any.value())
+        any.decode_into()
     }
 }
 
@@ -96,16 +112,6 @@ impl<'a> From<Ia5String<'a>> for Any<'a> {
 impl<'a> From<Ia5String<'a>> for &'a [u8] {
     fn from(printable_string: Ia5String<'a>) -> &'a [u8] {
         printable_string.as_bytes()
-    }
-}
-
-impl<'a> Encodable for Ia5String<'a> {
-    fn encoded_len(&self) -> Result<Length> {
-        Any::from(*self).encoded_len()
-    }
-
-    fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        Any::from(*self).encode(encoder)
     }
 }
 

--- a/der/src/asn1/integer.rs
+++ b/der/src/asn1/integer.rs
@@ -4,26 +4,29 @@ pub(super) mod bigint;
 mod int;
 mod uint;
 
-use crate::{asn1::Any, Encodable, Encoder, Error, Length, Result, Tag, Tagged};
+use crate::{
+    asn1::Any, ByteSlice, DecodeValue, Decoder, Encodable, Encoder, Error, Length, Result, Tag,
+    Tagged,
+};
 use core::convert::TryFrom;
 
 macro_rules! impl_int_encoding {
     ($($int:ty => $uint:ty),+) => {
         $(
-            impl TryFrom<Any<'_>> for $int {
-                type Error = Error;
+            impl<'a> DecodeValue<'a> for $int {
+                fn decode_value(decoder: &mut Decoder<'a>, length: Length) -> Result<Self> {
+                    let bytes = ByteSlice::decode_value(decoder, length)?.as_bytes();
 
-                fn try_from(any: Any<'_>) -> Result<Self> {
-                    let result = if is_highest_bit_set(any.value()) {
-                        <$uint>::from_be_bytes(int::decode_array(any)?) as $int
+                    let result = if is_highest_bit_set(bytes) {
+                        <$uint>::from_be_bytes(int::decode_to_array(bytes)?) as $int
                     } else {
-                        Self::from_be_bytes(uint::decode_array(any)?)
+                        Self::from_be_bytes(uint::decode_to_array(bytes)?)
                     };
 
                     // Ensure we compute the same encoded length as the original any value
-                    if any.encoded_len()? != result.encoded_len()? {
-                        return Err(Self::TAG.non_canonical_error());
-                    }
+                    // if any.encoded_len()? != result.encoded_len()? {
+                    //     return Err(Self::TAG.non_canonical_error());
+                    // }
 
                     Ok(result)
                 }
@@ -40,15 +43,23 @@ macro_rules! impl_int_encoding {
 
                 fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
                     if *self < 0 {
-                        int::encode(encoder, &(*self as $uint).to_be_bytes())
+                        int::encode_bytes(encoder, &(*self as $uint).to_be_bytes())
                     } else {
-                        uint::encode(encoder, &self.to_be_bytes())
+                        uint::encode_bytes(encoder, &self.to_be_bytes())
                     }
                 }
             }
 
             impl Tagged for $int {
                 const TAG: Tag = Tag::Integer;
+            }
+
+            impl TryFrom<Any<'_>> for $int {
+                type Error = Error;
+
+                fn try_from(any: Any<'_>) -> Result<Self> {
+                    any.decode_into()
+                }
             }
         )+
     };
@@ -57,16 +68,15 @@ macro_rules! impl_int_encoding {
 macro_rules! impl_uint_encoding {
     ($($uint:ty),+) => {
         $(
-            impl TryFrom<Any<'_>> for $uint {
-                type Error = Error;
-
-                fn try_from(any: Any<'_>) -> Result<Self> {
-                    let result = Self::from_be_bytes(uint::decode_array(any)?);
+            impl<'a> DecodeValue<'a> for $uint {
+                fn decode_value(decoder: &mut Decoder<'a>, length: Length) -> Result<Self> {
+                    let bytes = ByteSlice::decode_value(decoder, length)?.as_bytes();
+                    let result = Self::from_be_bytes(uint::decode_to_array(bytes)?);
 
                     // Ensure we compute the same encoded length as the original any value
-                    if any.encoded_len()? != result.encoded_len()? {
-                        return Err(Self::TAG.non_canonical_error());
-                    }
+                    // if any.encoded_len()? != result.encoded_len()? {
+                    //     return Err(Self::TAG.non_canonical_error());
+                    // }
 
                     Ok(result)
                 }
@@ -78,12 +88,20 @@ macro_rules! impl_uint_encoding {
                 }
 
                 fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-                    uint::encode(encoder, &self.to_be_bytes())
+                    uint::encode_bytes(encoder, &self.to_be_bytes())
                 }
             }
 
             impl Tagged for $uint {
                 const TAG: Tag = Tag::Integer;
+            }
+
+            impl TryFrom<Any<'_>> for $uint {
+                type Error = Error;
+
+                fn try_from(any: Any<'_>) -> Result<Self> {
+                    any.decode_into()
+                }
             }
         )+
     };

--- a/der/src/asn1/integer/int.rs
+++ b/der/src/asn1/integer/int.rs
@@ -1,22 +1,21 @@
 //! Support for encoding negative integers
 
 use super::is_highest_bit_set;
-use crate::{asn1::Any, Encodable, Encoder, Header, Length, Result, Tag};
+use crate::{Encodable, Encoder, ErrorKind, Header, Length, Result, Tag};
 use core::convert::TryFrom;
 
 /// Decode an unsigned integer of the specified size.
 ///
 /// Returns a byte array of the requested size containing a big endian integer.
-pub(super) fn decode_array<const N: usize>(any: Any<'_>) -> Result<[u8; N]> {
-    any.tag().assert_eq(Tag::Integer)?;
+pub(super) fn decode_to_array<const N: usize>(bytes: &[u8]) -> Result<[u8; N]> {
+    let offset = N.checked_sub(bytes.len()).ok_or(ErrorKind::Truncated)?;
     let mut output = [0xFFu8; N];
-    let offset = N.saturating_sub(any.value().len());
-    output[offset..].copy_from_slice(any.value());
+    output[offset..].copy_from_slice(bytes);
     Ok(output)
 }
 
 /// Encode the given big endian bytes representing an integer as ASN.1 DER.
-pub(super) fn encode(encoder: &mut Encoder<'_>, bytes: &[u8]) -> Result<()> {
+pub(super) fn encode_bytes(encoder: &mut Encoder<'_>, bytes: &[u8]) -> Result<()> {
     let bytes = strip_leading_ones(bytes);
     let len = Length::try_from(bytes.len())?;
     Header::new(Tag::Integer, len)?.encode(encoder)?;

--- a/der/src/asn1/octet_string.rs
+++ b/der/src/asn1/octet_string.rs
@@ -1,7 +1,8 @@
 //! ASN.1 `OCTET STRING` support.
 
 use crate::{
-    asn1::Any, ByteSlice, Encodable, Encoder, Error, ErrorKind, Length, Result, Tag, Tagged,
+    asn1::Any, ByteSlice, DecodeValue, Decoder, Encodable, Encoder, Error, ErrorKind, Length,
+    Result, Tag, Tagged,
 };
 use core::convert::TryFrom;
 
@@ -42,6 +43,24 @@ impl AsRef<[u8]> for OctetString<'_> {
     }
 }
 
+impl<'a> DecodeValue<'a> for OctetString<'a> {
+    fn decode_value(decoder: &mut Decoder<'a>, length: Length) -> Result<Self> {
+        Ok(Self {
+            inner: ByteSlice::decode_value(decoder, length)?,
+        })
+    }
+}
+
+impl<'a> Encodable for OctetString<'a> {
+    fn encoded_len(&self) -> Result<Length> {
+        Any::from(*self).encoded_len()
+    }
+
+    fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
+        Any::from(*self).encode(encoder)
+    }
+}
+
 impl<'a> From<&OctetString<'a>> for OctetString<'a> {
     fn from(value: &OctetString<'a>) -> OctetString<'a> {
         *value
@@ -52,8 +71,7 @@ impl<'a> TryFrom<Any<'a>> for OctetString<'a> {
     type Error = Error;
 
     fn try_from(any: Any<'a>) -> Result<OctetString<'a>> {
-        any.tag().assert_eq(Tag::OctetString)?;
-        Ok(Self { inner: any.into() })
+        any.decode_into()
     }
 }
 
@@ -66,16 +84,6 @@ impl<'a> From<OctetString<'a>> for Any<'a> {
 impl<'a> From<OctetString<'a>> for &'a [u8] {
     fn from(octet_string: OctetString<'a>) -> &'a [u8] {
         octet_string.as_bytes()
-    }
-}
-
-impl<'a> Encodable for OctetString<'a> {
-    fn encoded_len(&self) -> Result<Length> {
-        Any::from(*self).encoded_len()
-    }
-
-    fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        Any::from(*self).encode(encoder)
     }
 }
 

--- a/der/src/asn1/oid.rs
+++ b/der/src/asn1/oid.rs
@@ -1,15 +1,26 @@
 //! ASN.1 `OBJECT IDENTIFIER`
 
-use crate::{asn1::Any, Encodable, Encoder, Error, Length, Result, Tag, Tagged};
+use crate::{
+    asn1::Any, ByteSlice, DecodeValue, Decoder, Encodable, Encoder, Error, Length, Result, Tag,
+    Tagged,
+};
 use const_oid::ObjectIdentifier;
 use core::convert::{TryFrom, TryInto};
 
-impl TryFrom<Any<'_>> for ObjectIdentifier {
-    type Error = Error;
+impl DecodeValue<'_> for ObjectIdentifier {
+    fn decode_value(decoder: &mut Decoder<'_>, length: Length) -> Result<Self> {
+        let bytes = ByteSlice::decode_value(decoder, length)?.as_bytes();
+        Ok(Self::from_bytes(bytes)?)
+    }
+}
 
-    fn try_from(any: Any<'_>) -> Result<ObjectIdentifier> {
-        any.tag().assert_eq(Tag::ObjectIdentifier)?;
-        Ok(ObjectIdentifier::from_bytes(any.value())?)
+impl Encodable for ObjectIdentifier {
+    fn encoded_len(&self) -> Result<Length> {
+        Any::from(self).encoded_len()
+    }
+
+    fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
+        Any::from(self).encode(encoder)
     }
 }
 
@@ -28,13 +39,12 @@ impl<'a> From<&'a ObjectIdentifier> for Any<'a> {
     }
 }
 
-impl Encodable for ObjectIdentifier {
-    fn encoded_len(&self) -> Result<Length> {
-        Any::from(self).encoded_len()
-    }
+impl TryFrom<Any<'_>> for ObjectIdentifier {
+    type Error = Error;
 
-    fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        Any::from(self).encode(encoder)
+    fn try_from(any: Any<'_>) -> Result<ObjectIdentifier> {
+        any.tag().assert_eq(Tag::ObjectIdentifier)?;
+        Ok(ObjectIdentifier::from_bytes(any.value())?)
     }
 }
 

--- a/der/src/asn1/printable_string.rs
+++ b/der/src/asn1/printable_string.rs
@@ -1,7 +1,8 @@
 //! ASN.1 `PrintableString` support.
 
 use crate::{
-    asn1::Any, str_slice::StrSlice, Encodable, Encoder, Error, Length, Result, Tag, Tagged,
+    asn1::Any, str_slice::StrSlice, ByteSlice, DecodeValue, Decoder, Encodable, Encoder, Error,
+    Length, Result, Tag, Tagged,
 };
 use core::{convert::TryFrom, fmt, str};
 
@@ -105,6 +106,12 @@ impl AsRef<[u8]> for PrintableString<'_> {
     }
 }
 
+impl<'a> DecodeValue<'a> for PrintableString<'a> {
+    fn decode_value(decoder: &mut Decoder<'a>, length: Length) -> Result<Self> {
+        Self::new(ByteSlice::decode_value(decoder, length)?.as_bytes())
+    }
+}
+
 impl<'a> From<&PrintableString<'a>> for PrintableString<'a> {
     fn from(value: &PrintableString<'a>) -> PrintableString<'a> {
         *value
@@ -115,8 +122,7 @@ impl<'a> TryFrom<Any<'a>> for PrintableString<'a> {
     type Error = Error;
 
     fn try_from(any: Any<'a>) -> Result<PrintableString<'a>> {
-        any.tag().assert_eq(Tag::PrintableString)?;
-        Self::new(any.value())
+        any.decode_into()
     }
 }
 

--- a/der/src/byte_slice.rs
+++ b/der/src/byte_slice.rs
@@ -1,7 +1,7 @@
 //! Common handling for types backed by byte slices with enforcement of a
 //! library-level length limitation i.e. `Length::max()`.
 
-use crate::{str_slice::StrSlice, Error, Length, Result};
+use crate::{str_slice::StrSlice, DecodeValue, Decoder, Error, ErrorKind, Length, Result};
 use core::convert::TryFrom;
 
 /// Byte slice newtype which respects the `Length::max()` limit.
@@ -46,6 +46,15 @@ impl AsRef<[u8]> for ByteSlice<'_> {
     }
 }
 
+impl<'a> DecodeValue<'a> for ByteSlice<'a> {
+    fn decode_value(decoder: &mut Decoder<'a>, length: Length) -> Result<Self> {
+        decoder
+            .bytes(length)
+            .map_err(|_| decoder.error(ErrorKind::Truncated))
+            .and_then(Self::new)
+    }
+}
+
 impl Default for ByteSlice<'_> {
     fn default() -> Self {
         Self {
@@ -55,11 +64,12 @@ impl Default for ByteSlice<'_> {
     }
 }
 
-impl<'a> TryFrom<&'a [u8]> for ByteSlice<'a> {
-    type Error = Error;
-
-    fn try_from(slice: &'a [u8]) -> Result<Self> {
-        Self::new(slice)
+impl<'a> From<&'a [u8; 1]> for ByteSlice<'a> {
+    fn from(byte: &'a [u8; 1]) -> ByteSlice<'a> {
+        Self {
+            inner: byte,
+            length: Length::ONE,
+        }
     }
 }
 
@@ -72,5 +82,13 @@ impl<'a> From<StrSlice<'a>> for ByteSlice<'a> {
             inner: bytes,
             length: s.length,
         }
+    }
+}
+
+impl<'a> TryFrom<&'a [u8]> for ByteSlice<'a> {
+    type Error = Error;
+
+    fn try_from(slice: &'a [u8]) -> Result<Self> {
+        Self::new(slice)
     }
 }

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -86,7 +86,7 @@
 //! use core::convert::{TryFrom, TryInto};
 //! use der::{
 //!     asn1::{Any, ObjectIdentifier},
-//!     Decodable, Encodable, Message
+//!     Decodable, Decoder, Encodable, Message
 //! };
 //!
 //! /// X.509 `AlgorithmIdentifier`.
@@ -100,17 +100,12 @@
 //!     pub parameters: Option<Any<'a>>
 //! }
 //!
-//! // Note: types which impl `TryFrom<Any<'a>, Error = der::Error>` receive a
-//! // blanket impl of the `Decodable` trait, therefore satisfying the
-//! // `Decodable` trait bounds on `Message`, which is impl'd below.
-//! impl<'a> TryFrom<Any<'a>> for AlgorithmIdentifier<'a> {
-//!    type Error = der::Error;
-//!
-//!     fn try_from(any: Any<'a>) -> der::Result<AlgorithmIdentifier> {
-//!         // The `Any::sequence` method asserts that an `Any` value
-//!         // contains an ASN.1 `SEQUENCE` then calls the provided `FnOnce`
-//!         // with a `der::Decoder` which can be used to decode it.
-//!         any.sequence(|decoder| {
+//! impl<'a> Decodable<'a> for AlgorithmIdentifier<'a> {
+//!     fn decode(decoder: &mut Decoder<'a>) -> der::Result<Self> {
+//!         // The `Decoder::sequence` method decodes an ASN.1 `SEQUENCE` tag
+//!         // and length then calls the provided `FnOnce` with a nested
+//!         // `der::Decoder` which can be used to decode it.
+//!         decoder.sequence(|decoder| {
 //!             // The `der::Decoder::Decode` method can be used to decode any
 //!             // type which impls the `Decodable` trait, which is impl'd for
 //!             // all of the ASN.1 built-in types in the `der` crate.
@@ -349,7 +344,6 @@ extern crate alloc;
 extern crate std;
 
 pub mod asn1;
-pub mod message;
 
 mod byte_slice;
 mod datetime;
@@ -360,10 +354,11 @@ mod encoder;
 mod error;
 mod header;
 mod length;
+mod message;
 mod str_slice;
 mod tag;
+mod value;
 
-pub(crate) use crate::byte_slice::ByteSlice;
 pub use crate::{
     asn1::{Any, Choice},
     decodable::Decodable,
@@ -375,7 +370,10 @@ pub use crate::{
     length::Length,
     message::Message,
     tag::{Class, Tag, TagMode, TagNumber, Tagged},
+    value::{DecodeValue, EncodeValue},
 };
+
+pub(crate) use crate::byte_slice::ByteSlice;
 
 #[cfg(feature = "bigint")]
 #[cfg_attr(docsrs, doc(cfg(feature = "bigint")))]

--- a/der/src/tag.rs
+++ b/der/src/tag.rs
@@ -186,10 +186,15 @@ impl Tag {
         }
     }
 
+    /// Create an [`Error`] for an invalid [`Length`].
+    pub fn length_error(self) -> Error {
+        ErrorKind::Length { tag: self }.into()
+    }
+
     /// Create an [`Error`] for an non-canonical value with the ASN.1 type
     /// identified by this tag.
     pub fn non_canonical_error(self) -> Error {
-        ErrorKind::Value { tag: self }.into()
+        ErrorKind::Noncanonical { tag: self }.into()
     }
 
     /// Create an [`Error`] because the current tag was unexpected, with an

--- a/der/src/value.rs
+++ b/der/src/value.rs
@@ -1,0 +1,25 @@
+//! Value traits
+
+use crate::{Decoder, Encoder, Length, Result};
+
+#[cfg(doc)]
+use crate::Tag;
+
+/// Decode the value part of a Tag-Length-Value encoded field, sans the [`Tag`]
+/// and [`Length`].
+pub trait DecodeValue<'a>: Sized {
+    /// Attempt to decode this message using the provided [`Decoder`].
+    fn decode_value(decoder: &mut Decoder<'a>, length: Length) -> Result<Self>;
+}
+
+/// Encode the value part of a Tag-Length-Value encoded field, sans the [`Tag`]
+/// and [`Length`].
+pub trait EncodeValue {
+    /// Compute the length of this value (sans [`Tag`]+[`Length`] header) when
+    /// encoded as ASN.1 DER.
+    fn value_len(&self) -> Result<Length>;
+
+    /// Encode value (sans [`Tag`]+[`Length`] header) as ASN.1 DER using the
+    /// provided [`Encoder`].
+    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()>;
+}

--- a/pkcs1/src/version.rs
+++ b/pkcs1/src/version.rs
@@ -1,8 +1,8 @@
 //! PKCS#1 version identifier.
 
 use crate::Error;
-use core::convert::{TryFrom, TryInto};
-use der::{asn1::Any, Encodable, Encoder, Tag, Tagged};
+use core::convert::TryFrom;
+use der::{Decodable, Decoder, Encodable, Encoder, Tag, Tagged};
 
 /// Version identifier for PKCS#1 documents as defined in
 /// [RFC 8017 Appendix 1.2].
@@ -44,12 +44,9 @@ impl TryFrom<u8> for Version {
     }
 }
 
-impl<'a> TryFrom<Any<'a>> for Version {
-    type Error = der::Error;
-    fn try_from(any: Any<'a>) -> der::Result<Version> {
-        u8::try_from(any)?
-            .try_into()
-            .map_err(|_| der::ErrorKind::Value { tag: Tag::Integer }.into())
+impl Decodable<'_> for Version {
+    fn decode(decoder: &mut Decoder<'_>) -> der::Result<Self> {
+        Version::try_from(u8::decode(decoder)?).map_err(|_| Self::TAG.value_error())
     }
 }
 

--- a/pkcs8/src/attributes.rs
+++ b/pkcs8/src/attributes.rs
@@ -1,7 +1,7 @@
 //! PKCS#8 attributes.
 
 use core::convert::TryFrom;
-use der::{asn1::Any, Encodable, Encoder, Length};
+use der::{asn1::Any, Decodable, Decoder, Encodable, Encoder, Length};
 
 /// Attributes as defined in [RFC 5958 Section 2].
 ///
@@ -30,11 +30,9 @@ impl<'a> From<Attributes<'a>> for Any<'a> {
     }
 }
 
-impl<'a> TryFrom<Any<'a>> for Attributes<'a> {
-    type Error = der::Error;
-
-    fn try_from(any: Any<'a>) -> der::Result<Attributes<'a>> {
-        Ok(Attributes(any))
+impl<'a> Decodable<'a> for Attributes<'a> {
+    fn decode(decoder: &mut Decoder<'a>) -> der::Result<Self> {
+        Any::decode(decoder).map(Self)
     }
 }
 
@@ -47,5 +45,13 @@ impl<'a> Encodable for Attributes<'a> {
     /// Encode this value as ASN.1 DER using the provided [`Encoder`].
     fn encode(&self, encoder: &mut Encoder<'_>) -> der::Result<()> {
         self.0.encode(encoder)
+    }
+}
+
+impl<'a> TryFrom<Any<'a>> for Attributes<'a> {
+    type Error = der::Error;
+
+    fn try_from(any: Any<'a>) -> der::Result<Attributes<'a>> {
+        Ok(Attributes(any))
     }
 }


### PR DESCRIPTION
Adds traits for decoding and encoding the value (i.e. body) of a TLV-encoded message field.

The previous blanket impl of `Decodable` for `TryFrom<Any>` is removed and replaced with a blanket impl for `DecodeValue` + `Tagged`. This avoids having to round trip through the `Any` type (and thus have a contiguous encoded message stored in a slice).

Likewise the blanket impl of `Encodable` for `Message` is removed, and changed to a blanket impl for `EncodeValue` + `Tagged`. However, `Message` still receives a vicarious impl of `Encodable` because a new blanket impl of `EncodeValue` for `Message` has been added.

Overall this change should make decoding and encoding much more flexible, and help sort out encoding of `EXPLICIT` vs `IMPLICIT` tagging modes. However, that work in particular is left for a followup PR.