### PR TITLE
der: expose `DateTime` through public API

### DIFF
--- a/der/src/asn1/generalized_time.rs
+++ b/der/src/asn1/generalized_time.rs
@@ -79,7 +79,7 @@ impl DecodeValue<'_> for GeneralizedTime {
 
                 DateTime::new(year, month, day, hour, minute, second)
                     .and_then(|dt| dt.unix_duration())
-                    .ok_or_else(|| Self::TAG.value_error())
+                    .map_err(|_| Self::TAG.value_error())
                     .and_then(Self::new)
             }
             _ => Err(Self::TAG.value_error()),
@@ -95,9 +95,7 @@ impl Encodable for GeneralizedTime {
     fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
         Header::new(Self::TAG, Self::LENGTH)?.encode(encoder)?;
 
-        let datetime =
-            DateTime::from_unix_duration(self.0).ok_or_else(|| Self::TAG.value_error())?;
-
+        let datetime = DateTime::from_unix_duration(self.0).map_err(|_| Self::TAG.value_error())?;
         let year_hi = datetime.year() / 100;
         let year_lo = datetime.year() % 100;
 
@@ -106,8 +104,8 @@ impl Encodable for GeneralizedTime {
         datetime::encode_decimal(encoder, Self::TAG, datetime.month())?;
         datetime::encode_decimal(encoder, Self::TAG, datetime.day())?;
         datetime::encode_decimal(encoder, Self::TAG, datetime.hour())?;
-        datetime::encode_decimal(encoder, Self::TAG, datetime.minute())?;
-        datetime::encode_decimal(encoder, Self::TAG, datetime.second())?;
+        datetime::encode_decimal(encoder, Self::TAG, datetime.minutes())?;
+        datetime::encode_decimal(encoder, Self::TAG, datetime.seconds())?;
         encoder.byte(b'Z')
     }
 }

--- a/der/src/asn1/utc_time.rs
+++ b/der/src/asn1/utc_time.rs
@@ -88,7 +88,7 @@ impl DecodeValue<'_> for UtcTime {
 
                 DateTime::new(year, month, day, hour, minute, second)
                     .and_then(|dt| dt.unix_duration())
-                    .ok_or_else(|| Self::TAG.value_error())
+                    .map_err(|_| Self::TAG.value_error())
                     .and_then(Self::new)
             }
             _ => Err(Self::TAG.value_error()),
@@ -104,9 +104,7 @@ impl Encodable for UtcTime {
     fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
         Header::new(Self::TAG, Self::LENGTH)?.encode(encoder)?;
 
-        let datetime =
-            DateTime::from_unix_duration(self.0).ok_or_else(|| Self::TAG.value_error())?;
-
+        let datetime = DateTime::from_unix_duration(self.0).map_err(|_| Self::TAG.value_error())?;
         debug_assert!((1950..2050).contains(&datetime.year()));
 
         let year = match datetime.year() {
@@ -119,8 +117,8 @@ impl Encodable for UtcTime {
         datetime::encode_decimal(encoder, Self::TAG, datetime.month())?;
         datetime::encode_decimal(encoder, Self::TAG, datetime.day())?;
         datetime::encode_decimal(encoder, Self::TAG, datetime.hour())?;
-        datetime::encode_decimal(encoder, Self::TAG, datetime.minute())?;
-        datetime::encode_decimal(encoder, Self::TAG, datetime.second())?;
+        datetime::encode_decimal(encoder, Self::TAG, datetime.minutes())?;
+        datetime::encode_decimal(encoder, Self::TAG, datetime.seconds())?;
         encoder.byte(b'Z')
     }
 }

--- a/der/src/error.rs
+++ b/der/src/error.rs
@@ -103,6 +103,9 @@ impl std::error::Error for ErrorKind {}
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum ErrorKind {
+    /// Date-and-time related errors.
+    DateTime,
+
     /// Indicates a field which is duplicated when only one is expected.
     DuplicateField {
         /// Tag of the duplicated field.
@@ -217,6 +220,7 @@ impl ErrorKind {
 impl fmt::Display for ErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            ErrorKind::DateTime => write!(f, "date/time error"),
             ErrorKind::DuplicateField { tag } => write!(f, "duplicate field for {}", tag),
             ErrorKind::Failed => write!(f, "operation failed"),
             ErrorKind::Length { tag } => write!(f, "incorrect length for {}", tag),

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -361,6 +361,7 @@ mod value;
 
 pub use crate::{
     asn1::{Any, Choice},
+    datetime::DateTime,
     decodable::Decodable,
     decoder::Decoder,
     encodable::Encodable,


### PR DESCRIPTION
Debatably we should switch to something like `chrono`, but since we have a rich built-in `no_std`-friendly date-and-time type we might as well expose it.