### PR TITLE
der: use `EncodeValue` for ASN.1 types

### DIFF
--- a/der/src/asn1/boolean.rs
+++ b/der/src/asn1/boolean.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `BOOLEAN` support.
 
 use crate::{
-    asn1::Any, ByteSlice, DecodeValue, Decoder, Encodable, Encoder, Error, ErrorKind, Header,
-    Length, Result, Tag, Tagged,
+    asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, ErrorKind, Length,
+    Result, Tag, Tagged,
 };
 use core::convert::{TryFrom, TryInto};
 
@@ -29,15 +29,13 @@ impl<'a> DecodeValue<'a> for bool {
     }
 }
 
-impl Encodable for bool {
-    fn encoded_len(&self) -> Result<Length> {
-        Length::ONE.for_tlv()
+impl EncodeValue for bool {
+    fn value_len(&self) -> Result<Length> {
+        Ok(Length::ONE)
     }
 
-    fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        Header::new(Self::TAG, Length::ONE)?.encode(encoder)?;
-        let byte = if *self { TRUE_OCTET } else { FALSE_OCTET };
-        encoder.byte(byte)
+    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
+        encoder.byte(if *self { TRUE_OCTET } else { FALSE_OCTET })
     }
 }
 

--- a/der/src/asn1/generalized_time.rs
+++ b/der/src/asn1/generalized_time.rs
@@ -3,8 +3,7 @@
 use crate::{
     asn1::Any,
     datetime::{self, DateTime},
-    ByteSlice, DecodeValue, Decoder, Encodable, Encoder, Error, Header, Length, Result, Tag,
-    Tagged,
+    ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, Length, Result, Tag, Tagged,
 };
 use core::{convert::TryFrom, time::Duration};
 
@@ -87,14 +86,12 @@ impl DecodeValue<'_> for GeneralizedTime {
     }
 }
 
-impl Encodable for GeneralizedTime {
-    fn encoded_len(&self) -> Result<Length> {
-        Self::LENGTH.for_tlv()
+impl EncodeValue for GeneralizedTime {
+    fn value_len(&self) -> Result<Length> {
+        Ok(Self::LENGTH)
     }
 
-    fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        Header::new(Self::TAG, Self::LENGTH)?.encode(encoder)?;
-
+    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
         let datetime = DateTime::from_unix_duration(self.0).map_err(|_| Self::TAG.value_error())?;
         let year_hi = datetime.year() / 100;
         let year_lo = datetime.year() % 100;
@@ -148,13 +145,13 @@ impl<'a> TryFrom<Any<'a>> for SystemTime {
 
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl Encodable for SystemTime {
-    fn encoded_len(&self) -> Result<Length> {
-        GeneralizedTime::from_system_time(*self)?.encoded_len()
+impl EncodeValue for SystemTime {
+    fn value_len(&self) -> Result<Length> {
+        GeneralizedTime::from_system_time(*self)?.value_len()
     }
 
-    fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        GeneralizedTime::from_system_time(*self)?.encode(encoder)
+    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
+        GeneralizedTime::from_system_time(*self)?.encode_value(encoder)
     }
 }
 

--- a/der/src/asn1/ia5_string.rs
+++ b/der/src/asn1/ia5_string.rs
@@ -1,7 +1,7 @@
 //! ASN.1 `IA5String` support.
 
 use crate::{
-    asn1::Any, str_slice::StrSlice, ByteSlice, DecodeValue, Decoder, Encodable, Encoder, Error,
+    asn1::Any, str_slice::StrSlice, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error,
     Length, Result, Tag, Tagged,
 };
 use core::{convert::TryFrom, fmt, str};
@@ -79,13 +79,13 @@ impl<'a> DecodeValue<'a> for Ia5String<'a> {
     }
 }
 
-impl<'a> Encodable for Ia5String<'a> {
-    fn encoded_len(&self) -> Result<Length> {
-        Any::from(*self).encoded_len()
+impl<'a> EncodeValue for Ia5String<'a> {
+    fn value_len(&self) -> Result<Length> {
+        self.inner.value_len()
     }
 
-    fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        Any::from(*self).encode(encoder)
+    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
+        self.inner.encode_value(encoder)
     }
 }
 

--- a/der/src/asn1/integer.rs
+++ b/der/src/asn1/integer.rs
@@ -5,7 +5,7 @@ mod int;
 mod uint;
 
 use crate::{
-    asn1::Any, ByteSlice, DecodeValue, Decoder, Encodable, Encoder, Error, Length, Result, Tag,
+    asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, Length, Result, Tag,
     Tagged,
 };
 use core::convert::TryFrom;
@@ -32,16 +32,16 @@ macro_rules! impl_int_encoding {
                 }
             }
 
-            impl Encodable for $int {
-                fn encoded_len(&self) -> Result<Length> {
+            impl EncodeValue for $int {
+                fn value_len(&self) -> Result<Length> {
                     if *self < 0 {
-                        int::encoded_len(&(*self as $uint).to_be_bytes())?.for_tlv()
+                        int::encoded_len(&(*self as $uint).to_be_bytes())
                     } else {
-                        uint::encoded_len(&self.to_be_bytes())?.for_tlv()
+                        uint::encoded_len(&self.to_be_bytes())
                     }
                 }
 
-                fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
+                fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
                     if *self < 0 {
                         int::encode_bytes(encoder, &(*self as $uint).to_be_bytes())
                     } else {
@@ -82,12 +82,12 @@ macro_rules! impl_uint_encoding {
                 }
             }
 
-            impl Encodable for $uint {
-                fn encoded_len(&self) -> Result<Length> {
-                    uint::encoded_len(&self.to_be_bytes())?.for_tlv()
+            impl EncodeValue for $uint {
+                fn value_len(&self) -> Result<Length> {
+                    uint::encoded_len(&self.to_be_bytes())
                 }
 
-                fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
+                fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
                     uint::encode_bytes(encoder, &self.to_be_bytes())
                 }
             }

--- a/der/src/asn1/integer/int.rs
+++ b/der/src/asn1/integer/int.rs
@@ -1,7 +1,7 @@
 //! Support for encoding negative integers
 
 use super::is_highest_bit_set;
-use crate::{Encodable, Encoder, ErrorKind, Header, Length, Result, Tag};
+use crate::{Encoder, ErrorKind, Length, Result};
 use core::convert::TryFrom;
 
 /// Decode an unsigned integer of the specified size.
@@ -16,10 +16,7 @@ pub(super) fn decode_to_array<const N: usize>(bytes: &[u8]) -> Result<[u8; N]> {
 
 /// Encode the given big endian bytes representing an integer as ASN.1 DER.
 pub(super) fn encode_bytes(encoder: &mut Encoder<'_>, bytes: &[u8]) -> Result<()> {
-    let bytes = strip_leading_ones(bytes);
-    let len = Length::try_from(bytes.len())?;
-    Header::new(Tag::Integer, len)?.encode(encoder)?;
-    encoder.bytes(bytes)
+    encoder.bytes(strip_leading_ones(bytes))
 }
 
 /// Get the encoded length for the given unsigned integer serialized as bytes.

--- a/der/src/asn1/integer/uint.rs
+++ b/der/src/asn1/integer/uint.rs
@@ -1,6 +1,6 @@
 //! Unsigned integer decoders/encoders.
 
-use crate::{Encodable, Encoder, Header, Length, Result, Tag};
+use crate::{Encoder, Length, Result, Tag};
 use core::convert::TryFrom;
 
 /// Decode an unsigned integer into a big endian byte slice with all leading
@@ -38,11 +38,8 @@ pub(super) fn decode_to_array<const N: usize>(bytes: &[u8]) -> Result<[u8; N]> {
 /// Encode the given big endian bytes representing an integer as ASN.1 DER.
 pub(super) fn encode_bytes(encoder: &mut Encoder<'_>, bytes: &[u8]) -> Result<()> {
     let bytes = strip_leading_zeroes(bytes);
-    let leading_zero = needs_leading_zero(bytes);
-    let len = (Length::try_from(bytes.len())? + leading_zero as u8)?;
-    Header::new(Tag::Integer, len)?.encode(encoder)?;
 
-    if leading_zero {
+    if needs_leading_zero(bytes) {
         encoder.byte(0)?;
     }
 

--- a/der/src/asn1/null.rs
+++ b/der/src/asn1/null.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `NULL` support.
 
 use crate::{
-    asn1::Any, ByteSlice, DecodeValue, Decoder, Encodable, Encoder, Error, ErrorKind, Length,
-    Result, Tag, Tagged,
+    asn1::Any, ByteSlice, DecodeValue, Decoder, Encodable, EncodeValue, Encoder, Error, ErrorKind,
+    Length, Result, Tag, Tagged,
 };
 use core::convert::TryFrom;
 
@@ -20,13 +20,13 @@ impl DecodeValue<'_> for Null {
     }
 }
 
-impl Encodable for Null {
-    fn encoded_len(&self) -> Result<Length> {
-        Any::from(*self).encoded_len()
+impl EncodeValue for Null {
+    fn value_len(&self) -> Result<Length> {
+        Ok(Length::ZERO)
     }
 
-    fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        Any::from(*self).encode(encoder)
+    fn encode_value(&self, _encoder: &mut Encoder<'_>) -> Result<()> {
+        Ok(())
     }
 }
 

--- a/der/src/asn1/printable_string.rs
+++ b/der/src/asn1/printable_string.rs
@@ -1,7 +1,7 @@
 //! ASN.1 `PrintableString` support.
 
 use crate::{
-    asn1::Any, str_slice::StrSlice, ByteSlice, DecodeValue, Decoder, Encodable, Encoder, Error,
+    asn1::Any, str_slice::StrSlice, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error,
     Length, Result, Tag, Tagged,
 };
 use core::{convert::TryFrom, fmt, str};
@@ -112,6 +112,16 @@ impl<'a> DecodeValue<'a> for PrintableString<'a> {
     }
 }
 
+impl<'a> EncodeValue for PrintableString<'a> {
+    fn value_len(&self) -> Result<Length> {
+        self.inner.value_len()
+    }
+
+    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
+        self.inner.encode_value(encoder)
+    }
+}
+
 impl<'a> From<&PrintableString<'a>> for PrintableString<'a> {
     fn from(value: &PrintableString<'a>) -> PrintableString<'a> {
         *value
@@ -135,16 +145,6 @@ impl<'a> From<PrintableString<'a>> for Any<'a> {
 impl<'a> From<PrintableString<'a>> for &'a [u8] {
     fn from(printable_string: PrintableString<'a>) -> &'a [u8] {
         printable_string.as_bytes()
-    }
-}
-
-impl<'a> Encodable for PrintableString<'a> {
-    fn encoded_len(&self) -> Result<Length> {
-        Any::from(*self).encoded_len()
-    }
-
-    fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        Any::from(*self).encode(encoder)
     }
 }
 

--- a/der/src/asn1/sequence.rs
+++ b/der/src/asn1/sequence.rs
@@ -4,7 +4,7 @@ pub(super) mod iter;
 
 use self::iter::SequenceIter;
 use crate::{
-    asn1::Any, ByteSlice, Decodable, DecodeValue, Decoder, Encodable, Encoder, Error, ErrorKind,
+    asn1::Any, ByteSlice, Decodable, DecodeValue, Decoder, EncodeValue, Encoder, Error, ErrorKind,
     Length, Result, Tag, Tagged,
 };
 use core::convert::TryFrom;
@@ -59,13 +59,13 @@ impl<'a> DecodeValue<'a> for Sequence<'a> {
     }
 }
 
-impl<'a> Encodable for Sequence<'a> {
-    fn encoded_len(&self) -> Result<Length> {
-        Any::from(*self).encoded_len()
+impl<'a> EncodeValue for Sequence<'a> {
+    fn value_len(&self) -> Result<Length> {
+        self.inner.value_len()
     }
 
-    fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        Any::from(*self).encode(encoder)
+    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
+        self.inner.encode_value(encoder)
     }
 }
 

--- a/der/src/asn1/set_of.rs
+++ b/der/src/asn1/set_of.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `SET OF` support.
 
 use crate::{
-    asn1::Any, ByteSlice, Decodable, DecodeValue, Decoder, Encodable, Encoder, Error, ErrorKind,
-    Length, Result, Tag, Tagged,
+    asn1::Any, ByteSlice, Decodable, DecodeValue, Decoder, Encodable, EncodeValue, Encoder, Error,
+    ErrorKind, Length, Result, Tag, Tagged,
 };
 use core::{convert::TryFrom, marker::PhantomData};
 
@@ -104,16 +104,16 @@ where
     }
 }
 
-impl<'a, T> Encodable for SetOfRef<'a, T>
+impl<'a, T> EncodeValue for SetOfRef<'a, T>
 where
     T: Clone + Decodable<'a> + Encodable + Ord,
 {
-    fn encoded_len(&self) -> Result<Length> {
-        Any::from(self.clone()).encoded_len()
+    fn value_len(&self) -> Result<Length> {
+        self.inner.value_len()
     }
 
-    fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        Any::from(self.clone()).encode(encoder)
+    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
+        self.inner.encode_value(encoder)
     }
 }
 

--- a/der/src/asn1/utc_time.rs
+++ b/der/src/asn1/utc_time.rs
@@ -3,8 +3,7 @@
 use crate::{
     asn1::Any,
     datetime::{self, DateTime},
-    ByteSlice, DecodeValue, Decoder, Encodable, Encoder, Error, Header, Length, Result, Tag,
-    Tagged,
+    ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, Length, Result, Tag, Tagged,
 };
 use core::{convert::TryFrom, time::Duration};
 
@@ -96,14 +95,12 @@ impl DecodeValue<'_> for UtcTime {
     }
 }
 
-impl Encodable for UtcTime {
-    fn encoded_len(&self) -> Result<Length> {
-        Self::LENGTH.for_tlv()
+impl EncodeValue for UtcTime {
+    fn value_len(&self) -> Result<Length> {
+        Ok(Self::LENGTH)
     }
 
-    fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        Header::new(Self::TAG, Self::LENGTH)?.encode(encoder)?;
-
+    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
         let datetime = DateTime::from_unix_duration(self.0).map_err(|_| Self::TAG.value_error())?;
         debug_assert!((1950..2050).contains(&datetime.year()));
 

--- a/der/src/asn1/utf8_string.rs
+++ b/der/src/asn1/utf8_string.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `UTF8String` support.
 
 use crate::{
-    asn1::Any, str_slice::StrSlice, ByteSlice, DecodeValue, Decoder, Encodable, Encoder, Error,
-    Length, Result, Tag, Tagged,
+    asn1::Any, str_slice::StrSlice, ByteSlice, DecodeValue, Decoder, Encodable, EncodeValue,
+    Encoder, Error, Length, Result, Tag, Tagged,
 };
 use core::{convert::TryFrom, fmt, str};
 
@@ -75,13 +75,13 @@ impl<'a> DecodeValue<'a> for Utf8String<'a> {
     }
 }
 
-impl<'a> Encodable for Utf8String<'a> {
-    fn encoded_len(&self) -> Result<Length> {
-        Any::from(*self).encoded_len()
+impl<'a> EncodeValue for Utf8String<'a> {
+    fn value_len(&self) -> Result<Length> {
+        self.inner.value_len()
     }
 
-    fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        Any::from(*self).encode(encoder)
+    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
+        self.inner.encode_value(encoder)
     }
 }
 

--- a/der/src/str_slice.rs
+++ b/der/src/str_slice.rs
@@ -1,7 +1,7 @@
 //! Common handling for types backed by `str` slices with enforcement of a
 //! library-level length limitation i.e. `Length::max()`.
 
-use crate::{Length, Result};
+use crate::{ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Length, Result};
 use core::{convert::TryFrom, str};
 
 /// String slice newtype which respects the [`Length::max`] limit.
@@ -59,5 +59,21 @@ impl AsRef<str> for StrSlice<'_> {
 impl AsRef<[u8]> for StrSlice<'_> {
     fn as_ref(&self) -> &[u8] {
         self.as_bytes()
+    }
+}
+
+impl<'a> DecodeValue<'a> for StrSlice<'a> {
+    fn decode_value(decoder: &mut Decoder<'a>, length: Length) -> Result<Self> {
+        Self::from_bytes(ByteSlice::decode_value(decoder, length)?.as_bytes())
+    }
+}
+
+impl<'a> EncodeValue for StrSlice<'a> {
+    fn value_len(&self) -> Result<Length> {
+        Ok(self.length)
+    }
+
+    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
+        encoder.bytes(self.as_ref())
     }
 }


### PR DESCRIPTION
Types which impl this trait are more flexible (can be used in `IMPLICIT` fields) and this also eliminates some of the complexity of encoding these types via a blanket impl of `Encodable`.