### PR TITLE
fix typo in docs

### DIFF
--- a/der/src/asn1/set_of.rs
+++ b/der/src/asn1/set_of.rs
@@ -18,8 +18,7 @@ use {
 /// When encoded as DER, `SET OF` is lexicographically ordered. To implement
 /// that requirement, types `T` which are elements of [`SetOf`] MUST provide
 /// an impl of `Ord` which ensures that the corresponding DER encodings of
-/// a given type are ordffvkjnkjnlvceubbngtirurinkbvfditfnihengdigvl
-/// ered.
+/// a given type are ordered.
 pub trait SetOf<'a, 'b, T>: Decodable<'a> + Encodable
 where
     T: Clone + Decodable<'a> + Encodable + Ord + Tagged,


### PR DESCRIPTION
- introduced in https://github.com/RustCrypto/formats/commit/566abc5ef466a6b85d37ec8a779500f906dff8ce#diff-1881a4036b1e4d7639041e44cda3f8bbbf2051ae14e274736c04417ccb3acf8bR21