### PR TITLE
der: add `SEQUENCE OF` support for `[T; N]`

### DIFF
--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -31,6 +31,7 @@
 //! - [`u8`], [`u16`], [`u32`], [`u64`], [`u128`]: ASN.1 `INTEGER`
 //! - [`str`], [`String`][`alloc::string::String`]: ASN.1 `UTF8String`
 //!   (see also [`Utf8String`]. `String` requires `alloc` feature)
+//! - `[T; N]`: ASN.1 `SEQUENCE OF`
 //! - [`BTreeSet`][`alloc::collections::BTreeSet`]: ASN.1 `SET OF` (requires `alloc` feature)
 //! - [`Option`]: ASN.1 `OPTIONAL`
 //! - [`SystemTime`][`std::time::SystemTime`]: ASN.1 `GeneralizedTime` (requires `std` feature)


### PR DESCRIPTION
Uses const generic arrays to model ASN.1 `SEQUENCE OF`.

Unfortunately this currently requires `Copy` + `Default` bounds in order to safely initialize the array.

There are two ways to work around these bounds:

1. Remove `forbid(unsafe_code)` and use `core::mem::zeroed`. The decoder iterates over and initializes every element in the array, so this is sound, but unsafe.
2. Use the newly landed `core::array::try_from_fn` to construct the array. Unfortunately this just landed on nightly and is not yet stable.

If the `Copy` + `Default` bounds are too restrictive for immediate use cases we can try the first option. The second seems good to add whenever the API has been stabilized.

cc @carl-wallace 