### PR TITLE
der: replace `SetOfRef` with `SetOfArray`; MSRV 1.55+

### DIFF
--- a/.github/workflows/base64ct.yml
+++ b/.github/workflows/base64ct.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.55.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.55.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/const-oid.yml
+++ b/.github/workflows/const-oid.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.55.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.55.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/der.yml
+++ b/.github/workflows/der.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.55.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -48,7 +48,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.51.0 # MSRV
+            rust: 1.55.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -56,7 +56,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.51.0 # MSRV
+            rust: 1.55.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
     steps:

--- a/.github/workflows/pem-rfc7468.yml
+++ b/.github/workflows/pem-rfc7468.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.55.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -44,7 +44,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.55.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/pkcs1.yml
+++ b/.github/workflows/pkcs1.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.55.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.55.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/pkcs5.yml
+++ b/.github/workflows/pkcs5.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.55.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.55.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/pkcs8.yml
+++ b/.github/workflows/pkcs8.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.55.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -57,7 +57,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.55.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/sec1.yml
+++ b/.github/workflows/sec1.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.55.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.55.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/spki.yml
+++ b/.github/workflows/spki.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.55.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -45,7 +45,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.55.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/tls_codec.yml
+++ b/.github/workflows/tls_codec.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.55.0 # MSRV
           - stable
         target:
           - wasm32-unknown-unknown
@@ -47,7 +47,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.51.0 # MSRV
+            rust: 1.55.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -55,7 +55,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.51.0 # MSRV
+            rust: 1.55.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
     steps:

--- a/.github/workflows/x509.yml
+++ b/.github/workflows/x509.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.55.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -44,7 +44,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.55.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ dual licensed as above, without any additional terms or conditions.
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 [deps-image]: https://deps.rs/repo/github/RustCrypto/formats/status.svg
 [deps-link]: https://deps.rs/repo/github/RustCrypto/formats
-[msrv-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
+[msrv-image]: https://img.shields.io/badge/rustc-1.55+-blue.svg
 
 [//]: # (links)
 

--- a/base64ct/README.md
+++ b/base64ct/README.md
@@ -36,7 +36,7 @@ to practically extract RSA private keys from SGX enclaves.
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.51** at a minimum.
+This crate requires **Rust 1.55** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -65,7 +65,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/formats/actions/workflows/base64ct.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/formats/actions/workflows/base64ct.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.55+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 

--- a/base64ct/src/lib.rs
+++ b/base64ct/src/lib.rs
@@ -19,7 +19,7 @@
 //!
 //! # Minimum Supported Rust Version
 //!
-//! This crate requires **Rust 1.51** at a minimum.
+//! This crate requires **Rust 1.55** at a minimum.
 //!
 //! We may change the MSRV in the future, but it will be accompanied by a minor
 //! version bump.

--- a/const-oid/README.md
+++ b/const-oid/README.md
@@ -77,7 +77,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/const-oid/badge.svg
 [docs-link]: https://docs.rs/const-oid/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.55+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 [build-image]: https://github.com/RustCrypto/formats/workflows/const-oid/badge.svg?branch=master&event=push

--- a/const-oid/src/lib.rs
+++ b/const-oid/src/lib.rs
@@ -44,7 +44,7 @@
 //!
 //! # Minimum Supported Rust Version
 //!
-//! This crate requires **Rust 1.51** at a minimum.
+//! This crate requires **Rust 1.55** at a minimum.
 //!
 //! Minimum supported Rust version may be changed in the future, but it will be
 //! accompanied with a minor version bump.

--- a/der/README.md
+++ b/der/README.md
@@ -45,7 +45,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/formats/actions/workflows/der.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/formats/actions/workflows/der.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.55+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 

--- a/der/derive/README.md
+++ b/der/derive/README.md
@@ -35,7 +35,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/formats/actions/workflows/der.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/formats/actions/workflows/der.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.55+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 

--- a/der/src/asn1.rs
+++ b/der/src/asn1.rs
@@ -31,7 +31,7 @@ pub use self::{
     octet_string::OctetString,
     printable_string::PrintableString,
     sequence::{iter::SequenceIter, Sequence},
-    set_of::{SetOf, SetOfRef, SetOfRefIter},
+    set_of::{SetOf, SetOfArray},
     utc_time::UtcTime,
     utf8_string::Utf8String,
 };

--- a/der/src/error.rs
+++ b/der/src/error.rs
@@ -134,6 +134,9 @@ pub enum ErrorKind {
     /// Malformed OID
     MalformedOid,
 
+    /// Ordering error
+    Ordering,
+
     /// Integer overflow occurred (library bug!).
     Overflow,
 
@@ -228,6 +231,7 @@ impl fmt::Display for ErrorKind {
                 write!(f, "ASN.1 {} not canonically encoded as DER", tag)
             }
             ErrorKind::MalformedOid => write!(f, "malformed OID"),
+            ErrorKind::Ordering => write!(f, "ordering error"),
             ErrorKind::Overflow => write!(f, "integer overflow"),
             ErrorKind::Overlength => write!(f, "DER message is too long"),
             ErrorKind::TrailingData { decoded, remaining } => {

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -11,7 +11,7 @@
 //! that allocate gated under the off-by-default `alloc` feature).
 //!
 //! # Minimum Supported Rust Version
-//! This crate requires **Rust 1.51** at a minimum.
+//! This crate requires **Rust 1.55** at a minimum.
 //!
 //! We may change the MSRV in the future, but it will be accompanied by a minor
 //! version bump.

--- a/pem-rfc7468/README.md
+++ b/pem-rfc7468/README.md
@@ -81,7 +81,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/formats/actions/workflows/pem-rfc7468.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/formats/actions/workflows/pem-rfc7468.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.55+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 

--- a/pem-rfc7468/src/lib.rs
+++ b/pem-rfc7468/src/lib.rs
@@ -48,7 +48,7 @@
 //!
 //! # Minimum Supported Rust Version
 //!
-//! This crate requires **Rust 1.51** at a minimum.
+//! This crate requires **Rust 1.55** at a minimum.
 //!
 //! # Usage
 //!

--- a/pkcs1/README.md
+++ b/pkcs1/README.md
@@ -51,7 +51,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/pkcs1/badge.svg
 [docs-link]: https://docs.rs/pkcs1/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.55+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 [build-image]: https://github.com/RustCrypto/formats/workflows/pkcs1/badge.svg?branch=master&event=push

--- a/pkcs1/src/lib.rs
+++ b/pkcs1/src/lib.rs
@@ -19,7 +19,7 @@
 //! ```
 //!
 //! # Minimum Supported Rust Version
-//! This crate requires **Rust 1.51** at a minimum.
+//! This crate requires **Rust 1.55** at a minimum.
 //!
 //! [RFC 8017]: https://tools.ietf.org/html/rfc8017
 #![no_std]

--- a/pkcs5/README.md
+++ b/pkcs5/README.md
@@ -36,7 +36,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/formats/actions/workflows/pkcs5.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/formats/actions/workflows/pkcs5.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.55+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 

--- a/pkcs5/src/lib.rs
+++ b/pkcs5/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! # Minimum Supported Rust Version
 //!
-//! This crate requires **Rust 1.51** at a minimum.
+//! This crate requires **Rust 1.55** at a minimum.
 //!
 //! # Usage
 //!

--- a/pkcs8/README.md
+++ b/pkcs8/README.md
@@ -34,7 +34,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/pkcs8/badge.svg
 [docs-link]: https://docs.rs/pkcs8/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.55+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 [build-image]: https://github.com/RustCrypto/formats/workflows/pkcs8/badge.svg?branch=master&event=push

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -100,7 +100,7 @@
 //! [`pkcs1`] crate (e.g. `FromRsaPrivateKey`, `ToRsaPrivateKey`).
 //!
 //! # Minimum Supported Rust Version
-//! This crate requires **Rust 1.51** at a minimum.
+//! This crate requires **Rust 1.55** at a minimum.
 //!
 //! [RFC 5208]: https://tools.ietf.org/html/rfc5208
 //! [RFC 5958]: https://tools.ietf.org/html/rfc5958

--- a/sec1/README.md
+++ b/sec1/README.md
@@ -37,7 +37,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/sec1/badge.svg
 [docs-link]: https://docs.rs/sec1/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.55+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 [build-image]: https://github.com/RustCrypto/formats/workflows/sec1/badge.svg?branch=master&event=push

--- a/sec1/src/lib.rs
+++ b/sec1/src/lib.rs
@@ -4,7 +4,7 @@
 //! `Octet-String-to-Elliptic-Curve-Point` encoding algorithms.
 //!
 //! # Minimum Supported Rust Version
-//! This crate requires **Rust 1.51** at a minimum.
+//! This crate requires **Rust 1.55** at a minimum.
 //!
 //! [SEC1: Elliptic Curve Cryptography]: https://www.secg.org/sec1-v2.pdf
 //! [RFC5915]: https://datatracker.ietf.org/doc/html/rfc5915

--- a/spki/README.md
+++ b/spki/README.md
@@ -38,7 +38,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/formats/actions/workflows/spki.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/formats/actions/workflows/spki.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.55+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 

--- a/spki/src/lib.rs
+++ b/spki/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! # Minimum Supported Rust Version
 //!
-//! This crate requires **Rust 1.51** at a minimum.
+//! This crate requires **Rust 1.55** at a minimum.
 //!
 //! # Usage
 //!

--- a/tls_codec/Readme.md
+++ b/tls_codec/Readme.md
@@ -50,4 +50,4 @@ serialization/deserialization
 [tls_codec_derive-link]: https://crates.io/crates/tls_codec_derive
 [tls_codec_derive_docs]: https://img.shields.io/docsrs/tls_codec_derive/latest?style=for-the-badge
 [tls_codec_derive_docs-link]: https://docs.rs/tls_codec_derive/
-[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg?style=for-the-badge
+[rustc-image]: https://img.shields.io/badge/rustc-1.55+-blue.svg?style=for-the-badge

--- a/x509/README.md
+++ b/x509/README.md
@@ -43,7 +43,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/formats/actions/workflows/x509.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/formats/actions/workflows/x509.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.55+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 


### PR DESCRIPTION
Replaces the previous `SET OF` decoder that operated over a serialized slice of ASN.1 DER with one that decodes to a fix-sized append-only set of owned values.

This type leverages const generics to provide a stack-allocated value which allows for representation of owned fixed-size sets on stable Rust.