### PR TITLE
der: add `SequenceOf` type

### DIFF
--- a/der/src/arrayvec.rs
+++ b/der/src/arrayvec.rs
@@ -3,9 +3,10 @@
 // See: https://github.com/rust-lang/rfcs/pull/2990
 
 use crate::{ErrorKind, Result};
+use core::convert::TryInto;
 
 /// Array-backed append-only vector type.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub(crate) struct ArrayVec<T, const N: usize> {
     /// Elements of the set.
     elements: [Option<T>; N],
@@ -55,10 +56,64 @@ impl<T, const N: usize> ArrayVec<T, N> {
     pub fn last(&self) -> Option<&T> {
         self.length.checked_sub(1).and_then(|n| self.get(n))
     }
+
+    /// Iterate over the elements in this [`ArrayVec`].
+    pub fn iter(&self) -> impl Iterator<Item = &T> {
+        Iter::new(&self.elements)
+    }
+
+    /// Try to convert this [`ArrayVec`] into a `[T; N]`.
+    ///
+    /// Returns `None` if the [`ArrayVec`] does not contain `N` elements.
+    pub fn try_into_array(self) -> Result<[T; N]> {
+        if self.length != N {
+            return Err(ErrorKind::Underlength {
+                expected: N.try_into()?,
+                actual: self.length.try_into()?,
+            }
+            .into());
+        }
+
+        Ok(self.elements.map(|elem| match elem {
+            Some(e) => e,
+            None => unreachable!(),
+        }))
+    }
 }
 
 impl<T, const N: usize> Default for ArrayVec<T, N> {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Iterator over the elements of an [`ArrayVec`].
+pub struct Iter<'a, T> {
+    /// Decoder which iterates over the elements of the message.
+    elements: &'a [Option<T>],
+
+    /// Position within the iterator.
+    position: usize,
+}
+
+impl<'a, T> Iter<'a, T> {
+    pub(crate) fn new(elements: &'a [Option<T>]) -> Self {
+        Self {
+            elements,
+            position: 0,
+        }
+    }
+}
+
+impl<'a, T> Iterator for Iter<'a, T> {
+    type Item = &'a T;
+
+    fn next(&mut self) -> Option<&'a T> {
+        if let Some(Some(res)) = self.elements.get(self.position) {
+            self.position = self.position.checked_add(1)?;
+            Some(res)
+        } else {
+            None
+        }
     }
 }

--- a/der/src/asn1.rs
+++ b/der/src/asn1.rs
@@ -30,7 +30,7 @@ pub use self::{
     null::Null,
     octet_string::OctetString,
     printable_string::PrintableString,
-    sequence::{iter::SequenceIter, Sequence},
+    sequence::{iter::SequenceIter, Sequence, SequenceOf},
     set_of::{SetOf, SetOfArray},
     utc_time::UtcTime,
     utf8_string::Utf8String,

--- a/der/src/asn1/set_of.rs
+++ b/der/src/asn1/set_of.rs
@@ -42,7 +42,7 @@ where
 /// and does not depend on `alloc` support.
 // TODO(tarcieri): use `ArrayVec` when/if it's merged into `core`
 // See: https://github.com/rust-lang/rfcs/pull/2990
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct SetOfArray<T, const N: usize>
 where
     T: Clone + Ord,

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -26,12 +26,12 @@
 //! The traits are impl'd for the following Rust core types:
 //!
 //! - `()`: ASN.1 `NULL` (see also [`Null`])
+//! - `[T; N]`: ASN.1 `SEQUENCE OF`
 //! - [`bool`]: ASN.1 `BOOLEAN`
 //! - [`i8`], [`i16`], [`i32`], [`i64`], [`i128`]: ASN.1 `INTEGER`
 //! - [`u8`], [`u16`], [`u32`], [`u64`], [`u128`]: ASN.1 `INTEGER`
 //! - [`str`], [`String`][`alloc::string::String`]: ASN.1 `UTF8String`
 //!   (see also [`Utf8String`]. `String` requires `alloc` feature)
-//! - `[T; N]`: ASN.1 `SEQUENCE OF`
 //! - [`BTreeSet`][`alloc::collections::BTreeSet`]: ASN.1 `SET OF` (requires `alloc` feature)
 //! - [`Option`]: ASN.1 `OPTIONAL`
 //! - [`SystemTime`][`std::time::SystemTime`]: ASN.1 `GeneralizedTime` (requires `std` feature)
@@ -47,7 +47,8 @@
 //! - [`OctetString`]: ASN.1 `OCTET STRING`
 //! - [`PrintableString`]: ASN.1 `PrintableString` (ASCII subset)
 //! - [`Sequence`]: ASN.1 `SEQUENCE`
-//! - [`SetOfRef`]: ASN.1 `SET OF`
+//! - [`SequenceOf`]: ASN.1 `SEQUENCE OF`
+//! - [`SetOfArray`]: ASN.1 `SET OF`
 //! - [`UIntBytes`]: ASN.1 unsigned `INTEGER` with raw access to encoded bytes
 //! - [`UtcTime`]: ASN.1 `UTCTime`
 //! - [`Utf8String`]: ASN.1 `UTF8String`
@@ -325,7 +326,8 @@
 //! [`OctetString`]: asn1::OctetString
 //! [`PrintableString`]: asn1::PrintableString
 //! [`Sequence`]: asn1::Sequence
-//! [`SetOfRef`]: asn1::SetOfRef
+//! [`SequenceOf`]: asn1::SequenceOf
+//! [`SetOfArray`]: asn1::SetOfArray
 //! [`UtcTime`]: asn1::UtcTime
 //! [`Utf8String`]: asn1::Utf8String
 


### PR DESCRIPTION
Adds a type for `SequenceOf`, backed by the internal `ArrayVec` type.

This allows for array-backed storage of an ASN.1 SEQUENCE OF, where the array size acts as a maximum, rather than an exact length requirement.

Support for modeling `[T; N]` as a SEQUENCE OF is retained, and now implemented using `SequenceOf` to handle decoding.