### PR TITLE
der: remove `SetOf` trait; rename `SetOfArray` => `SetOf`

### DIFF
--- a/der/src/arrayvec.rs
+++ b/der/src/arrayvec.rs
@@ -39,11 +39,6 @@ impl<T, const N: usize> ArrayVec<T, N> {
         }
     }
 
-    /// Borrow the elements of this [`ArrayVec`].
-    pub fn elements(&self) -> &[Option<T>; N] {
-        &self.elements
-    }
-
     /// Get an element from this [`ArrayVec`].
     pub fn get(&self, index: usize) -> Option<&T> {
         match self.elements.get(index) {
@@ -58,7 +53,7 @@ impl<T, const N: usize> ArrayVec<T, N> {
     }
 
     /// Iterate over the elements in this [`ArrayVec`].
-    pub fn iter(&self) -> impl Iterator<Item = &T> {
+    pub fn iter(&self) -> Iter<'_, T> {
         Iter::new(&self.elements)
     }
 
@@ -88,6 +83,7 @@ impl<T, const N: usize> Default for ArrayVec<T, N> {
 }
 
 /// Iterator over the elements of an [`ArrayVec`].
+#[derive(Clone, Debug)]
 pub struct Iter<'a, T> {
     /// Decoder which iterates over the elements of the message.
     elements: &'a [Option<T>],

--- a/der/src/asn1.rs
+++ b/der/src/asn1.rs
@@ -30,8 +30,8 @@ pub use self::{
     null::Null,
     octet_string::OctetString,
     printable_string::PrintableString,
-    sequence::{iter::SequenceIter, Sequence, SequenceOf},
-    set_of::{SetOf, SetOfArray},
+    sequence::{iter::SequenceIter, Sequence, SequenceOf, SequenceOfIter},
+    set_of::SetOf,
     utc_time::UtcTime,
     utf8_string::Utf8String,
 };

--- a/der/src/asn1/sequence.rs
+++ b/der/src/asn1/sequence.rs
@@ -4,8 +4,8 @@ pub(super) mod iter;
 
 use self::iter::SequenceIter;
 use crate::{
-    asn1::Any, ArrayVec, ByteSlice, Decodable, DecodeValue, Decoder, Encodable, EncodeValue,
-    Encoder, Error, ErrorKind, Length, Result, Tag, Tagged,
+    arrayvec, asn1::Any, ArrayVec, ByteSlice, Decodable, DecodeValue, Decoder, Encodable,
+    EncodeValue, Encoder, Error, ErrorKind, Length, Result, Tag, Tagged,
 };
 use core::convert::TryFrom;
 
@@ -120,8 +120,10 @@ impl<T, const N: usize> SequenceOf<T, N> {
     }
 
     /// Iterate over the elements in this [`SequenceOf`].
-    pub fn iter(&self) -> impl Iterator<Item = &T> {
-        self.inner.iter()
+    pub fn iter(&self) -> SequenceOfIter<'_, T> {
+        SequenceOfIter {
+            inner: self.inner.iter(),
+        }
     }
 }
 
@@ -171,6 +173,21 @@ where
 
 impl<'a, T, const N: usize> Tagged for SequenceOf<T, N> {
     const TAG: Tag = Tag::Sequence;
+}
+
+/// Iterator over the elements of an [`SequenceOf`].
+#[derive(Clone, Debug)]
+pub struct SequenceOfIter<'a, T> {
+    /// Inner iterator.
+    inner: arrayvec::Iter<'a, T>,
+}
+
+impl<'a, T> Iterator for SequenceOfIter<'a, T> {
+    type Item = &'a T;
+
+    fn next(&mut self) -> Option<&'a T> {
+        self.inner.next()
+    }
 }
 
 impl<'a, T, const N: usize> DecodeValue<'a> for [T; N]

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -25,17 +25,18 @@
 //!
 //! The traits are impl'd for the following Rust core types:
 //!
-//! - `()`: ASN.1 `NULL` (see also [`Null`])
-//! - [`bool`]: ASN.1 `BOOLEAN`
-//! - [`i8`], [`i16`], [`i32`], [`i64`], [`i128`]: ASN.1 `INTEGER`
-//! - [`u8`], [`u16`], [`u32`], [`u64`], [`u128`]: ASN.1 `INTEGER`
-//! - [`str`], [`String`][`alloc::string::String`]: ASN.1 `UTF8String`
-//!   (see also [`Utf8String`]. `String` requires `alloc` feature)
-//! - [`BTreeSet`][`alloc::collections::BTreeSet`]: ASN.1 `SET OF` (requires `alloc` feature)
-//! - [`Option`]: ASN.1 `OPTIONAL`
-//! - [`SystemTime`][`std::time::SystemTime`]: ASN.1 `GeneralizedTime` (requires `std` feature)
-//! - [`Vec`][`alloc::vec::Vec`]: ASN.1 `SEQUENCE OF` (requires `alloc` feature)
-//! - `[T; N]`: ASN.1 `SEQUENCE OF`
+//! - `()`: ASN.1 `NULL`. See also [`Null`].
+//! - [`bool`]: ASN.1 `BOOLEAN`.
+//! - [`i8`], [`i16`], [`i32`], [`i64`], [`i128`]: ASN.1 `INTEGER`.
+//! - [`u8`], [`u16`], [`u32`], [`u64`], [`u128`]: ASN.1 `INTEGER`.
+//! - [`str`], [`String`][`alloc::string::String`]: ASN.1 `UTF8String`.
+//!   `String` requires `alloc` feature. See also [`Utf8String`].
+//! - [`BTreeSet`][`alloc::collections::BTreeSet`]: ASN.1 `SET OF`.
+//!   Requires `alloc` feature. See also [`SetOf`].
+//! - [`Option`]: ASN.1 `OPTIONAL`.
+//! - [`SystemTime`][`std::time::SystemTime`]: ASN.1 `GeneralizedTime`. Requires `std` feature.
+//! - [`Vec`][`alloc::vec::Vec`]: ASN.1 `SEQUENCE OF`. Requires `alloc` feature.
+//! - `[T; N]`: ASN.1 `SEQUENCE OF`. See also [`SequenceOf`].
 //!
 //! The following ASN.1 types provided by this crate also impl these traits:
 //!
@@ -49,7 +50,7 @@
 //! - [`PrintableString`]: ASN.1 `PrintableString` (ASCII subset)
 //! - [`Sequence`]: ASN.1 `SEQUENCE`
 //! - [`SequenceOf`]: ASN.1 `SEQUENCE OF`
-//! - [`SetOfArray`]: ASN.1 `SET OF`
+//! - [`SetOf`]: ASN.1 `SET OF`
 //! - [`UIntBytes`]: ASN.1 unsigned `INTEGER` with raw access to encoded bytes
 //! - [`UtcTime`]: ASN.1 `UTCTime`
 //! - [`Utf8String`]: ASN.1 `UTF8String`
@@ -328,7 +329,7 @@
 //! [`PrintableString`]: asn1::PrintableString
 //! [`Sequence`]: asn1::Sequence
 //! [`SequenceOf`]: asn1::SequenceOf
-//! [`SetOfArray`]: asn1::SetOfArray
+//! [`SetOf`]: asn1::SetOf
 //! [`UtcTime`]: asn1::UtcTime
 //! [`Utf8String`]: asn1::Utf8String
 
@@ -349,7 +350,7 @@ extern crate std;
 
 pub mod asn1;
 
-mod arrayvec;
+pub(crate) mod arrayvec;
 mod byte_slice;
 mod datetime;
 mod decodable;


### PR DESCRIPTION
The `der` crate now has SET OF types which cover all cases:

- `SetOf(Array)`: heapless use case
- `BTreeSet`: heap-allocated use case

The `SetOf` trait was intended to provide a way to write generic code that wasn't concerned with the actual storage of a decoded SET OF, with the idea that a heapless crate user would impl it on their own data structures.

Now that `der` provides a heapless data structure, users can simply pick whether they want to use `SetOf` or use `BTreeSet`.