### PR TITLE
Downgrade MSRV to 1.51 for select crates

### DIFF
--- a/.github/workflows/base64ct.yml
+++ b/.github/workflows/base64ct.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.55.0 # MSRV
+          - 1.51.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.55.0 # MSRV
+          - 1.51.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/const-oid.yml
+++ b/.github/workflows/const-oid.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.55.0 # MSRV
+          - 1.51.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.55.0 # MSRV
+          - 1.51.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/pem-rfc7468.yml
+++ b/.github/workflows/pem-rfc7468.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.55.0 # MSRV
+          - 1.51.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -44,7 +44,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.55.0 # MSRV
+          - 1.51.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/tls_codec.yml
+++ b/.github/workflows/tls_codec.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.55.0 # MSRV
+          - 1.51.0 # MSRV
           - stable
         target:
           - wasm32-unknown-unknown
@@ -47,7 +47,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.55.0 # MSRV
+            rust: 1.51.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -55,7 +55,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.55.0 # MSRV
+            rust: 1.51.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
     steps:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RustCrypto: Formats [![Project Chat][chat-image]][chat-link] ![MSRV][msrv-image] [![dependency status][deps-image]][deps-link] 
+# RustCrypto: Formats [![Project Chat][chat-image]][chat-link] [![dependency status][deps-image]][deps-link] 
 
 Cryptography-related format encoders/decoders: PKCS, PKIX.
 
@@ -38,7 +38,6 @@ dual licensed as above, without any additional terms or conditions.
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 [deps-image]: https://deps.rs/repo/github/RustCrypto/formats/status.svg
 [deps-link]: https://deps.rs/repo/github/RustCrypto/formats
-[msrv-image]: https://img.shields.io/badge/rustc-1.55+-blue.svg
 
 [//]: # (links)
 

--- a/base64ct/README.md
+++ b/base64ct/README.md
@@ -65,7 +65,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/formats/actions/workflows/base64ct.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/formats/actions/workflows/base64ct.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.55+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 

--- a/const-oid/README.md
+++ b/const-oid/README.md
@@ -77,7 +77,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/const-oid/badge.svg
 [docs-link]: https://docs.rs/const-oid/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.55+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 [build-image]: https://github.com/RustCrypto/formats/workflows/const-oid/badge.svg?branch=master&event=push

--- a/pem-rfc7468/README.md
+++ b/pem-rfc7468/README.md
@@ -81,7 +81,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/formats/actions/workflows/pem-rfc7468.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/formats/actions/workflows/pem-rfc7468.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.55+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 

--- a/tls_codec/README.md
+++ b/tls_codec/README.md
@@ -50,4 +50,4 @@ serialization/deserialization
 [tls_codec_derive-link]: https://crates.io/crates/tls_codec_derive
 [tls_codec_derive_docs]: https://img.shields.io/docsrs/tls_codec_derive/latest?style=for-the-badge
 [tls_codec_derive_docs-link]: https://docs.rs/tls_codec_derive/
-[rustc-image]: https://img.shields.io/badge/rustc-1.55+-blue.svg?style=for-the-badge
+[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg?style=for-the-badge


### PR DESCRIPTION
In PR #91, MSRV was accidentally bumped for crates which don't directly
depend on `der`. This includes:

- `base64ct`
- `const-oid`
- `pem-rfc7468`
- `tls_codec`

Since these crates don't depend on `der`, they can retain their previous original MSRV of 1.51.

This PR bumps the MSRV back for these crates, both as used by GitHub Actions CI as well as in documentation.