### PR TITLE
const-oid v0.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "hex-literal",
 ]

--- a/const-oid/CHANGELOG.md
+++ b/const-oid/CHANGELOG.md
@@ -4,13 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.6.1 (2021-09-14)
+## 0.6.2 (2021-10-14)
+### Fixed
+- Off-by-one error parsing large BER arcs ([#84])
+
+[#84]: https://github.com/RustCrypto/formats/pull/84
+
+## 0.6.1 (2021-09-14) [YANKED]
 ### Changed
 - Moved to `formats` repo ([#2])
 
 [#2]: https://github.com/RustCrypto/formats/pull/2
 
-## 0.6.0 (2021-06-03)
+## 0.6.0 (2021-06-03) [YANKED]
 ### Changed
 - Modernize and remove deprecations; MSRV 1.51+
 

--- a/const-oid/Cargo.toml
+++ b/const-oid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "const-oid"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"

--- a/const-oid/src/lib.rs
+++ b/const-oid/src/lib.rs
@@ -56,7 +56,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/const-oid/0.6.1"
+    html_root_url = "https://docs.rs/const-oid/0.6.2"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms)]


### PR DESCRIPTION
### Fixed
- Off-by-one error parsing large BER arcs ([#84])

[#84]: https://github.com/RustCrypto/formats/pull/84