### PR TITLE
pkcs1+pkcs8: remove `*_with_le` PEM encoding methods

### DIFF
--- a/pkcs1/src/document/private_key.rs
+++ b/pkcs1/src/document/private_key.rs
@@ -86,7 +86,7 @@ impl ToRsaPrivateKey for RsaPrivateKeyDocument {
 
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    fn to_pkcs1_pem_with_le(&self, line_ending: LineEnding) -> Result<Zeroizing<String>> {
+    fn to_pkcs1_pem(&self, line_ending: LineEnding) -> Result<Zeroizing<String>> {
         let pem_doc = pem::encode_string(PEM_TYPE_LABEL, line_ending, self.as_der())?;
         Ok(Zeroizing::new(pem_doc))
     }
@@ -100,8 +100,8 @@ impl ToRsaPrivateKey for RsaPrivateKeyDocument {
     #[cfg(all(feature = "pem", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    fn write_pkcs1_pem_file(&self, path: &Path) -> Result<()> {
-        let pem_doc = self.to_pkcs1_pem()?;
+    fn write_pkcs1_pem_file(&self, path: &Path, line_ending: LineEnding) -> Result<()> {
+        let pem_doc = self.to_pkcs1_pem(line_ending)?;
         write_secret_file(path, pem_doc.as_bytes())
     }
 }

--- a/pkcs1/src/document/public_key.rs
+++ b/pkcs1/src/document/public_key.rs
@@ -85,7 +85,7 @@ impl ToRsaPublicKey for RsaPublicKeyDocument {
 
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    fn to_pkcs1_pem_with_le(&self, line_ending: LineEnding) -> Result<String> {
+    fn to_pkcs1_pem(&self, line_ending: LineEnding) -> Result<String> {
         Ok(pem::encode_string(PEM_TYPE_LABEL, line_ending, &self.0)?)
     }
 
@@ -99,8 +99,8 @@ impl ToRsaPublicKey for RsaPublicKeyDocument {
     #[cfg(all(feature = "pem", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    fn write_pkcs1_pem_file(&self, path: &Path) -> Result<()> {
-        fs::write(path, self.to_pkcs1_pem()?.as_bytes())?;
+    fn write_pkcs1_pem_file(&self, path: &Path, line_ending: LineEnding) -> Result<()> {
+        fs::write(path, self.to_pkcs1_pem(line_ending)?.as_bytes())?;
         Ok(())
     }
 }

--- a/pkcs1/src/private_key.rs
+++ b/pkcs1/src/private_key.rs
@@ -84,18 +84,11 @@ impl<'a> RsaPrivateKey<'a> {
         self.into()
     }
 
-    /// Encode this [`RsaPrivateKey`] as PEM-encoded ASN.1 DER.
-    #[cfg(feature = "pem")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    pub fn to_pem(&self) -> Result<Zeroizing<String>> {
-        self.to_pem_with_le(LineEnding::default())
-    }
-
     /// Encode this [`RsaPrivateKey`] as PEM-encoded ASN.1 DER using the given
     /// [`LineEnding`].
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    pub fn to_pem_with_le(&self, line_ending: LineEnding) -> Result<Zeroizing<String>> {
+    pub fn to_pem(&self, line_ending: LineEnding) -> Result<Zeroizing<String>> {
         let pem_doc = pem::encode_string(PEM_TYPE_LABEL, line_ending, self.to_der().as_ref())?;
         Ok(Zeroizing::new(pem_doc))
     }

--- a/pkcs1/src/public_key.rs
+++ b/pkcs1/src/public_key.rs
@@ -46,18 +46,11 @@ impl<'a> RsaPublicKey<'a> {
         self.into()
     }
 
-    /// Encode this [`RsaPublicKey`] as PEM-encoded ASN.1 DER.
-    #[cfg(feature = "pem")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    pub fn to_pem(self) -> Result<String> {
-        self.to_pem_with_le(LineEnding::default())
-    }
-
     /// Encode this [`RsaPublicKey`] as PEM-encoded ASN.1 DER with the given
     /// [`LineEnding`].
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    pub fn to_pem_with_le(self, line_ending: LineEnding) -> Result<String> {
+    pub fn to_pem(self, line_ending: LineEnding) -> Result<String> {
         Ok(pem::encode_string(
             PEM_TYPE_LABEL,
             line_ending,

--- a/pkcs1/src/traits.rs
+++ b/pkcs1/src/traits.rs
@@ -110,18 +110,11 @@ pub trait ToRsaPrivateKey {
     /// Serialize a [`RsaPrivateKeyDocument`] containing a PKCS#1-encoded private key.
     fn to_pkcs1_der(&self) -> Result<RsaPrivateKeyDocument>;
 
-    /// Serialize this private key as PEM-encoded PKCS#1.
-    #[cfg(feature = "pem")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    fn to_pkcs1_pem(&self) -> Result<Zeroizing<String>> {
-        self.to_pkcs1_pem_with_le(LineEnding::default())
-    }
-
     /// Serialize this private key as PEM-encoded PKCS#1 with the given [`LineEnding`].
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    fn to_pkcs1_pem_with_le(&self, line_ending: LineEnding) -> Result<Zeroizing<String>> {
-        self.to_pkcs1_der()?.to_pkcs1_pem_with_le(line_ending)
+    fn to_pkcs1_pem(&self, line_ending: LineEnding) -> Result<Zeroizing<String>> {
+        self.to_pkcs1_der()?.to_pkcs1_pem(line_ending)
     }
 
     /// Write ASN.1 DER-encoded PKCS#1 private key to the given path.
@@ -135,8 +128,8 @@ pub trait ToRsaPrivateKey {
     #[cfg(all(feature = "pem", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    fn write_pkcs1_pem_file(&self, path: &Path) -> Result<()> {
-        self.to_pkcs1_der()?.write_pkcs1_pem_file(path)
+    fn write_pkcs1_pem_file(&self, path: &Path, line_ending: LineEnding) -> Result<()> {
+        self.to_pkcs1_der()?.write_pkcs1_pem_file(path, line_ending)
     }
 }
 
@@ -147,18 +140,11 @@ pub trait ToRsaPublicKey {
     /// Serialize a [`RsaPublicKeyDocument`] containing a PKCS#1-encoded public key.
     fn to_pkcs1_der(&self) -> Result<RsaPublicKeyDocument>;
 
-    /// Serialize this public key as PEM-encoded PKCS#1.
-    #[cfg(feature = "pem")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    fn to_pkcs1_pem(&self) -> Result<String> {
-        self.to_pkcs1_pem_with_le(LineEnding::default())
-    }
-
     /// Serialize this public key as PEM-encoded PKCS#1 with the given line ending.
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    fn to_pkcs1_pem_with_le(&self, line_ending: LineEnding) -> Result<String> {
-        self.to_pkcs1_der()?.to_pkcs1_pem_with_le(line_ending)
+    fn to_pkcs1_pem(&self, line_ending: LineEnding) -> Result<String> {
+        self.to_pkcs1_der()?.to_pkcs1_pem(line_ending)
     }
 
     /// Write ASN.1 DER-encoded public key to the given path.
@@ -172,7 +158,7 @@ pub trait ToRsaPublicKey {
     #[cfg(all(feature = "pem", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    fn write_pkcs1_pem_file(&self, path: &Path) -> Result<()> {
-        self.to_pkcs1_der()?.write_pkcs1_pem_file(path)
+    fn write_pkcs1_pem_file(&self, path: &Path, line_ending: LineEnding) -> Result<()> {
+        self.to_pkcs1_der()?.write_pkcs1_pem_file(path, line_ending)
     }
 }

--- a/pkcs8/src/document/encrypted_private_key.rs
+++ b/pkcs8/src/document/encrypted_private_key.rs
@@ -77,18 +77,10 @@ impl EncryptedPrivateKeyDocument {
     }
 
     /// Serialize [`EncryptedPrivateKeyDocument`] as self-zeroizing PEM-encoded
-    /// PKCS#8 string.
-    #[cfg(feature = "pem")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    pub fn to_pem(&self) -> Result<Zeroizing<String>> {
-        self.to_pem_with_le(LineEnding::default())
-    }
-
-    /// Serialize [`EncryptedPrivateKeyDocument`] as self-zeroizing PEM-encoded
     /// PKCS#8 string with the given [`LineEnding`].
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    pub fn to_pem_with_le(&self, line_ending: LineEnding) -> Result<Zeroizing<String>> {
+    pub fn to_pem(&self, line_ending: LineEnding) -> Result<Zeroizing<String>> {
         pem::encode_string(PEM_TYPE_LABEL, line_ending, &self.0)
             .map(Zeroizing::new)
             .map_err(|_| Error::Pem)
@@ -122,8 +114,8 @@ impl EncryptedPrivateKeyDocument {
     #[cfg(all(feature = "pem", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    pub fn write_pem_file(&self, path: impl AsRef<Path>) -> Result<()> {
-        write_secret_file(path, self.to_pem()?.as_bytes())
+    pub fn write_pem_file(&self, path: impl AsRef<Path>, line_ending: LineEnding) -> Result<()> {
+        write_secret_file(path, self.to_pem(line_ending)?.as_bytes())
     }
 }
 

--- a/pkcs8/src/document/private_key.rs
+++ b/pkcs8/src/document/private_key.rs
@@ -65,18 +65,11 @@ impl PrivateKeyDocument {
         Self::from_der(&*der_bytes)
     }
 
-    /// Serialize [`PrivateKeyDocument`] as self-zeroizing PEM-encoded PKCS#8 string.
-    #[cfg(feature = "pem")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    pub fn to_pem(&self) -> Result<Zeroizing<String>> {
-        self.to_pem_with_le(LineEnding::default())
-    }
-
     /// Serialize [`PrivateKeyDocument`] as self-zeroizing PEM-encoded PKCS#8 string
     /// with the given [`LineEnding`].
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    pub fn to_pem_with_le(&self, line_ending: LineEnding) -> Result<Zeroizing<String>> {
+    pub fn to_pem(&self, line_ending: LineEnding) -> Result<Zeroizing<String>> {
         pem::encode_string(PEM_TYPE_LABEL, line_ending, &self.0)
             .map(Zeroizing::new)
             .map_err(|_| Error::Pem)
@@ -109,8 +102,8 @@ impl PrivateKeyDocument {
     #[cfg(all(feature = "pem", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    pub fn write_pem_file(&self, path: impl AsRef<Path>) -> Result<()> {
-        write_secret_file(path, self.to_pem()?.as_bytes())
+    pub fn write_pem_file(&self, path: impl AsRef<Path>, line_ending: LineEnding) -> Result<()> {
+        write_secret_file(path, self.to_pem(line_ending)?.as_bytes())
     }
 
     /// Encrypt this private key using a symmetric encryption key derived

--- a/pkcs8/src/document/public_key.rs
+++ b/pkcs8/src/document/public_key.rs
@@ -61,18 +61,11 @@ impl PublicKeyDocument {
         Self::from_der(&*der_bytes)
     }
 
-    /// Serialize [`PublicKeyDocument`] as PEM-encoded PKCS#8 (SPKI) string.
-    #[cfg(feature = "pem")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    pub fn to_pem(&self) -> Result<String> {
-        self.to_pem_with_le(LineEnding::default())
-    }
-
     /// Serialize [`PublicKeyDocument`] as PEM-encoded PKCS#8 (SPKI) string
     /// with the given [`LineEnding`].
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    pub fn to_pem_with_le(&self, line_ending: LineEnding) -> Result<String> {
+    pub fn to_pem(&self, line_ending: LineEnding) -> Result<String> {
         pem::encode_string(PEM_TYPE_LABEL, line_ending, &self.0).map_err(|_| Error::Pem)
     }
 
@@ -104,8 +97,8 @@ impl PublicKeyDocument {
     #[cfg(all(feature = "pem", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    pub fn write_pem_file(&self, path: impl AsRef<Path>) -> Result<()> {
-        fs::write(path, self.to_pem()?.as_bytes())?;
+    pub fn write_pem_file(&self, path: impl AsRef<Path>, line_ending: LineEnding) -> Result<()> {
+        fs::write(path, self.to_pem(line_ending)?.as_bytes())?;
         Ok(())
     }
 }

--- a/pkcs8/src/encrypted_private_key_info.rs
+++ b/pkcs8/src/encrypted_private_key_info.rs
@@ -70,21 +70,11 @@ impl<'a> EncryptedPrivateKeyInfo<'a> {
         self.try_into()
     }
 
-    /// Encode this [`EncryptedPrivateKeyInfo`] as PEM-encoded ASN.1 DER.
-    #[cfg(feature = "pem")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    pub fn to_pem(&self) -> Result<Zeroizing<alloc::string::String>> {
-        self.to_pem_with_le(LineEnding::default())
-    }
-
     /// Encode this [`EncryptedPrivateKeyInfo`] as PEM-encoded ASN.1 DER with
     /// the given [`LineEnding`].
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    pub fn to_pem_with_le(
-        &self,
-        line_ending: LineEnding,
-    ) -> Result<Zeroizing<alloc::string::String>> {
+    pub fn to_pem(&self, line_ending: LineEnding) -> Result<Zeroizing<alloc::string::String>> {
         pem::encode_string(PEM_TYPE_LABEL, line_ending, self.to_der()?.as_ref())
             .map(Zeroizing::new)
             .map_err(|_| Error::Pem)

--- a/pkcs8/src/private_key_info.rs
+++ b/pkcs8/src/private_key_info.rs
@@ -151,18 +151,11 @@ impl<'a> PrivateKeyInfo<'a> {
         self.try_into()
     }
 
-    /// Encode this [`PrivateKeyInfo`] as PEM-encoded ASN.1 DER.
-    #[cfg(feature = "pem")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    pub fn to_pem(&self) -> Result<Zeroizing<String>> {
-        self.to_pem_with_le(LineEnding::default())
-    }
-
     /// Encode this [`PrivateKeyInfo`] as PEM-encoded ASN.1 DER with the given
     /// [`LineEnding`].
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    pub fn to_pem_with_le(&self, line_ending: LineEnding) -> Result<Zeroizing<String>> {
+    pub fn to_pem(&self, line_ending: LineEnding) -> Result<Zeroizing<String>> {
         pem::encode_string(PEM_TYPE_LABEL, line_ending, self.to_der()?.as_ref())
             .map(Zeroizing::new)
             .map_err(|_| Error::Pem)

--- a/pkcs8/src/traits.rs
+++ b/pkcs8/src/traits.rs
@@ -175,18 +175,11 @@ pub trait ToPrivateKey {
         self.to_pkcs8_der()?.encrypt(rng, password)
     }
 
-    /// Serialize this private key as PEM-encoded PKCS#8.
-    #[cfg(feature = "pem")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    fn to_pkcs8_pem(&self) -> Result<Zeroizing<String>> {
-        self.to_pkcs8_pem_with_le(LineEnding::default())
-    }
-
     /// Serialize this private key as PEM-encoded PKCS#8 with the given [`LineEnding`].
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    fn to_pkcs8_pem_with_le(&self, line_ending: LineEnding) -> Result<Zeroizing<String>> {
-        self.to_pkcs8_der()?.to_pem_with_le(line_ending)
+    fn to_pkcs8_pem(&self, line_ending: LineEnding) -> Result<Zeroizing<String>> {
+        self.to_pkcs8_der()?.to_pem(line_ending)
     }
 
     /// Serialize this private key as an encrypted PEM-encoded PKCS#8 private
@@ -198,8 +191,10 @@ pub trait ToPrivateKey {
         &self,
         rng: impl CryptoRng + RngCore,
         password: impl AsRef<[u8]>,
+        line_ending: LineEnding,
     ) -> Result<Zeroizing<String>> {
-        self.to_pkcs8_encrypted_der(rng, password)?.to_pem()
+        self.to_pkcs8_encrypted_der(rng, password)?
+            .to_pem(line_ending)
     }
 
     /// Write ASN.1 DER-encoded PKCS#8 private key to the given path
@@ -213,8 +208,8 @@ pub trait ToPrivateKey {
     #[cfg(all(feature = "pem", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    fn write_pkcs8_pem_file(&self, path: impl AsRef<Path>) -> Result<()> {
-        self.to_pkcs8_der()?.write_pem_file(path)
+    fn write_pkcs8_pem_file(&self, path: impl AsRef<Path>, line_ending: LineEnding) -> Result<()> {
+        self.to_pkcs8_der()?.write_pem_file(path, line_ending)
     }
 }
 
@@ -225,18 +220,11 @@ pub trait ToPublicKey {
     /// Serialize a [`PublicKeyDocument`] containing a SPKI-encoded public key.
     fn to_public_key_der(&self) -> Result<PublicKeyDocument>;
 
-    /// Serialize this public key as PEM-encoded SPKI.
-    #[cfg(feature = "pem")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    fn to_public_key_pem(&self) -> Result<String> {
-        self.to_public_key_pem_with_le(LineEnding::default())
-    }
-
     /// Serialize this public key as PEM-encoded SPKI with the given [`LineEnding`].
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    fn to_public_key_pem_with_le(&self, line_ending: LineEnding) -> Result<String> {
-        self.to_public_key_der()?.to_pem_with_le(line_ending)
+    fn to_public_key_pem(&self, line_ending: LineEnding) -> Result<String> {
+        self.to_public_key_der()?.to_pem(line_ending)
     }
 
     /// Write ASN.1 DER-encoded public key to the given path
@@ -250,8 +238,12 @@ pub trait ToPublicKey {
     #[cfg(all(feature = "pem", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    fn write_public_key_pem_file(&self, path: impl AsRef<Path>) -> Result<()> {
-        self.to_public_key_der()?.write_pem_file(path)
+    fn write_public_key_pem_file(
+        &self,
+        path: impl AsRef<Path>,
+        line_ending: LineEnding,
+    ) -> Result<()> {
+        self.to_public_key_der()?.write_pem_file(path, line_ending)
     }
 }
 

--- a/pkcs8/tests/encrypted_private_key.rs
+++ b/pkcs8/tests/encrypted_private_key.rs
@@ -229,7 +229,7 @@ fn encode_ed25519_encpriv_aes256_pbkdf2_sha256_pem() {
     let pk = EncryptedPrivateKeyInfo::try_from(ED25519_DER_AES256_PBKDF2_SHA256_EXAMPLE).unwrap();
     assert_eq!(
         ED25519_PEM_AES256_PBKDF2_SHA256_EXAMPLE,
-        &*pk.to_pem().unwrap()
+        &*pk.to_pem(Default::default()).unwrap()
     );
 }
 

--- a/pkcs8/tests/private_key.rs
+++ b/pkcs8/tests/private_key.rs
@@ -195,21 +195,30 @@ fn encode_rsa_2048_der() {
 #[cfg(feature = "pem")]
 fn encode_ec_p256_pem() {
     let pk = PrivateKeyInfo::try_from(EC_P256_DER_EXAMPLE).unwrap();
-    assert_eq!(EC_P256_PEM_EXAMPLE, &*pk.to_pem().unwrap());
+    assert_eq!(
+        EC_P256_PEM_EXAMPLE,
+        &*pk.to_pem(Default::default()).unwrap()
+    );
 }
 
 #[test]
 #[cfg(feature = "pem")]
 fn encode_ed25519_pem() {
     let pk = PrivateKeyInfo::try_from(ED25519_DER_V1_EXAMPLE).unwrap();
-    assert_eq!(ED25519_PEM_V1_EXAMPLE, &*pk.to_pem().unwrap());
+    assert_eq!(
+        ED25519_PEM_V1_EXAMPLE,
+        &*pk.to_pem(Default::default()).unwrap()
+    );
 }
 
 #[test]
 #[cfg(feature = "pem")]
 fn encode_rsa_2048_pem() {
     let pk = PrivateKeyInfo::try_from(RSA_2048_DER_EXAMPLE).unwrap();
-    assert_eq!(RSA_2048_PEM_EXAMPLE, &*pk.to_pem().unwrap());
+    assert_eq!(
+        RSA_2048_PEM_EXAMPLE,
+        &*pk.to_pem(Default::default()).unwrap()
+    );
 }
 
 #[test]

--- a/pkcs8/tests/public_key.rs
+++ b/pkcs8/tests/public_key.rs
@@ -127,7 +127,11 @@ fn encode_rsa_2048_der() {
 #[cfg(feature = "pem")]
 fn encode_ec_p256_pem() {
     let pk = SubjectPublicKeyInfo::try_from(EC_P256_DER_EXAMPLE).unwrap();
-    let pk_encoded = PublicKeyDocument::try_from(pk).unwrap().to_pem().unwrap();
+    let pk_encoded = PublicKeyDocument::try_from(pk)
+        .unwrap()
+        .to_pem(Default::default())
+        .unwrap();
+
     assert_eq!(EC_P256_PEM_EXAMPLE, pk_encoded);
 }
 
@@ -135,7 +139,11 @@ fn encode_ec_p256_pem() {
 #[cfg(feature = "pem")]
 fn encode_ed25519_pem() {
     let pk = SubjectPublicKeyInfo::try_from(ED25519_DER_EXAMPLE).unwrap();
-    let pk_encoded = PublicKeyDocument::try_from(pk).unwrap().to_pem().unwrap();
+    let pk_encoded = PublicKeyDocument::try_from(pk)
+        .unwrap()
+        .to_pem(Default::default())
+        .unwrap();
+
     assert_eq!(ED25519_PEM_EXAMPLE, pk_encoded);
 }
 
@@ -143,7 +151,11 @@ fn encode_ed25519_pem() {
 #[cfg(feature = "pem")]
 fn encode_rsa_2048_pem() {
     let pk = SubjectPublicKeyInfo::try_from(RSA_2048_DER_EXAMPLE).unwrap();
-    let pk_encoded = PublicKeyDocument::try_from(pk).unwrap().to_pem().unwrap();
+    let pk_encoded = PublicKeyDocument::try_from(pk)
+        .unwrap()
+        .to_pem(Default::default())
+        .unwrap();
+
     assert_eq!(RSA_2048_PEM_EXAMPLE, pk_encoded);
 }
 


### PR DESCRIPTION
All PEM encoding methods now take an explicit `LineEnding` parameter.

In cases where the OS default line ending is desired, `Default::default()` can be supplied.