### PR TITLE
pkcs8: impl `From*Key`/`To*Key` traits on `Document` types

### DIFF
--- a/.github/workflows/pkcs8.yml
+++ b/.github/workflows/pkcs8.yml
@@ -69,12 +69,13 @@ jobs:
       - run: cargo test --release --no-default-features
       - run: cargo test --release
       - run: cargo test --release --features alloc
+      - run: cargo test --release --features 3des
+      - run: cargo test --release --features des-insecure
       - run: cargo test --release --features encryption
       - run: cargo test --release --features pem
       - run: cargo test --release --features pkcs1
       - run: cargo test --release --features pkcs1,alloc
       - run: cargo test --release --features pkcs5
       - run: cargo test --release --features sha1
-      - run: cargo test --release --features 3des
-      - run: cargo test --release --features des-insecure
+      - run: cargo test --release --features std
       - run: cargo test --release --all-features

--- a/pkcs8/tests/private_key.rs
+++ b/pkcs8/tests/private_key.rs
@@ -7,6 +7,9 @@ use pkcs8::{PrivateKeyInfo, Version};
 #[cfg(any(feature = "pem", feature = "std"))]
 use pkcs8::PrivateKeyDocument;
 
+#[cfg(feature = "std")]
+use pkcs8::FromPrivateKey;
+
 /// Elliptic Curve (P-256) PKCS#8 private key encoded as ASN.1 DER
 const EC_P256_DER_EXAMPLE: &[u8] = include_bytes!("examples/p256-priv.der");
 
@@ -224,13 +227,15 @@ fn encode_rsa_2048_pem() {
 #[test]
 #[cfg(feature = "std")]
 fn read_der_file() {
-    let pkcs8_doc = PrivateKeyDocument::read_der_file("tests/examples/p256-priv.der").unwrap();
+    let pkcs8_doc =
+        PrivateKeyDocument::read_pkcs8_der_file("tests/examples/p256-priv.der").unwrap();
     assert_eq!(pkcs8_doc.as_ref(), EC_P256_DER_EXAMPLE);
 }
 
 #[test]
 #[cfg(all(feature = "pem", feature = "std"))]
 fn read_pem_file() {
-    let pkcs8_doc = PrivateKeyDocument::read_pem_file("tests/examples/p256-priv.pem").unwrap();
+    let pkcs8_doc =
+        PrivateKeyDocument::read_pkcs8_pem_file("tests/examples/p256-priv.pem").unwrap();
     assert_eq!(pkcs8_doc.as_ref(), EC_P256_DER_EXAMPLE);
 }

--- a/pkcs8/tests/public_key.rs
+++ b/pkcs8/tests/public_key.rs
@@ -7,6 +7,12 @@ use pkcs8::SubjectPublicKeyInfo;
 #[cfg(feature = "alloc")]
 use der::Encodable;
 
+#[cfg(feature = "pem")]
+use pkcs8::ToPublicKey;
+
+#[cfg(feature = "std")]
+use pkcs8::FromPublicKey;
+
 #[cfg(any(feature = "pem", feature = "std"))]
 use pkcs8::PublicKeyDocument;
 
@@ -129,7 +135,7 @@ fn encode_ec_p256_pem() {
     let pk = SubjectPublicKeyInfo::try_from(EC_P256_DER_EXAMPLE).unwrap();
     let pk_encoded = PublicKeyDocument::try_from(pk)
         .unwrap()
-        .to_pem(Default::default())
+        .to_public_key_pem(Default::default())
         .unwrap();
 
     assert_eq!(EC_P256_PEM_EXAMPLE, pk_encoded);
@@ -141,7 +147,7 @@ fn encode_ed25519_pem() {
     let pk = SubjectPublicKeyInfo::try_from(ED25519_DER_EXAMPLE).unwrap();
     let pk_encoded = PublicKeyDocument::try_from(pk)
         .unwrap()
-        .to_pem(Default::default())
+        .to_public_key_pem(Default::default())
         .unwrap();
 
     assert_eq!(ED25519_PEM_EXAMPLE, pk_encoded);
@@ -153,7 +159,7 @@ fn encode_rsa_2048_pem() {
     let pk = SubjectPublicKeyInfo::try_from(RSA_2048_DER_EXAMPLE).unwrap();
     let pk_encoded = PublicKeyDocument::try_from(pk)
         .unwrap()
-        .to_pem(Default::default())
+        .to_public_key_pem(Default::default())
         .unwrap();
 
     assert_eq!(RSA_2048_PEM_EXAMPLE, pk_encoded);
@@ -162,13 +168,17 @@ fn encode_rsa_2048_pem() {
 #[test]
 #[cfg(feature = "std")]
 fn read_der_file() {
-    let pkcs8_doc = PublicKeyDocument::read_der_file("tests/examples/p256-pub.der").unwrap();
+    let pkcs8_doc =
+        PublicKeyDocument::read_public_key_der_file("tests/examples/p256-pub.der").unwrap();
+
     assert_eq!(pkcs8_doc.as_ref(), EC_P256_DER_EXAMPLE);
 }
 
 #[test]
 #[cfg(all(feature = "pem", feature = "std"))]
 fn read_pem_file() {
-    let pkcs8_doc = PublicKeyDocument::read_pem_file("tests/examples/p256-pub.pem").unwrap();
+    let pkcs8_doc =
+        PublicKeyDocument::read_public_key_pem_file("tests/examples/p256-pub.pem").unwrap();
+
     assert_eq!(pkcs8_doc.as_ref(), EC_P256_DER_EXAMPLE);
 }


### PR DESCRIPTION
These types previously had similarly "shaped" inherent methods.

This commit impls the traits instead, providing a common API, and better consistency with the `pkcs1` and `sec1` crates which work this way.