### PR TITLE
der: add `Document` trait

### DIFF
--- a/.github/workflows/der.yml
+++ b/.github/workflows/der.yml
@@ -37,9 +37,12 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - run: cargo build --target ${{ matrix.target }} --release
+      - run: cargo build --target ${{ matrix.target }} --release --features alloc
       - run: cargo build --target ${{ matrix.target }} --release --features bigint
+      - run: cargo build --target ${{ matrix.target }} --release --features derive
       - run: cargo build --target ${{ matrix.target }} --release --features oid
-      - run: cargo build --target ${{ matrix.target }} --release --features bigint,oid
+      - run: cargo build --target ${{ matrix.target }} --release --features pem
+      - run: cargo build --target ${{ matrix.target }} --release --features alloc,bigint,derive,oid,pem
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/spki.yml
+++ b/.github/workflows/spki.yml
@@ -39,6 +39,8 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - run: cargo build --release --target ${{ matrix.target }}
+      - run: cargo build --release --target ${{ matrix.target }} --features alloc
+      - run: cargo build --release --target ${{ matrix.target }} --features alloc,fingerprint
 
   test:
     runs-on: ubuntu-latest
@@ -55,6 +57,4 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
       - run: cargo test --release
-      - run: cargo test --release --features fingerprint
-      - run: cargo test --release --features fingerprint,alloc
       - run: cargo test --release --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,6 +272,7 @@ dependencies = [
  "crypto-bigint",
  "der_derive",
  "hex-literal",
+ "pem-rfc7468",
 ]
 
 [[package]]

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -18,6 +18,7 @@ readme = "README.md"
 const-oid = { version = "0.6", optional = true, path = "../const-oid" }
 crypto-bigint = { version = "0.2", optional = true, features = ["generic-array"] }
 der_derive = { version = "=0.5.0-pre.1", optional = true, path = "derive" }
+pem-rfc7468 = { version = "0.2", optional = true, path = "../pem-rfc7468" }
 
 [dev-dependencies]
 hex-literal = "0.3"
@@ -27,6 +28,7 @@ alloc = []
 derive = ["der_derive"]
 bigint = ["crypto-bigint"]
 oid = ["const-oid"]
+pem = ["alloc", "pem-rfc7468/alloc"]
 std = ["alloc"]
 
 [package.metadata.docs.rs]

--- a/der/src/asn1/generalized_time.rs
+++ b/der/src/asn1/generalized_time.rs
@@ -28,12 +28,12 @@ impl GeneralizedTime {
     /// Length of an RFC 5280-flavored ASN.1 DER-encoded [`GeneralizedTime`].
     pub const LENGTH: Length = Length::new(15);
 
-    /// Create a [`UtcTime`] from a [`DateTime`].
+    /// Create a [`GeneralizedTime`] from a [`DateTime`].
     pub fn from_date_time(datetime: DateTime) -> Self {
         Self(datetime)
     }
 
-    /// Convert this [`UtcTime`] into a [`DateTime`].
+    /// Convert this [`GeneralizedTime`] into a [`DateTime`].
     pub fn to_date_time(&self) -> DateTime {
         self.0
     }

--- a/der/src/decoder.rs
+++ b/der/src/decoder.rs
@@ -238,6 +238,11 @@ impl<'a> Decoder<'a> {
         Ok(result)
     }
 
+    /// Get the number of bytes still remaining in the buffer.
+    pub(crate) fn remaining_len(&self) -> Result<Length> {
+        self.remaining()?.len().try_into()
+    }
+
     /// Create a nested decoder which operates over the provided [`Length`].
     ///
     /// The nested decoder is passed to the provided callback function which is
@@ -273,11 +278,6 @@ impl<'a> Decoder<'a> {
         self.bytes
             .and_then(|b| b.get(pos..))
             .ok_or_else(|| ErrorKind::Truncated.at(self.position))
-    }
-
-    /// Get the number of bytes still remaining in the buffer.
-    fn remaining_len(&self) -> Result<Length> {
-        self.remaining()?.len().try_into()
     }
 }
 

--- a/der/src/document.rs
+++ b/der/src/document.rs
@@ -1,0 +1,116 @@
+//! ASN.1 DER-encoded documents stored on the heap.
+
+use crate::{Decodable, Encodable, Error, Result};
+use alloc::{boxed::Box, vec::Vec};
+use core::convert::{TryFrom, TryInto};
+
+#[cfg(feature = "pem")]
+use {alloc::string::String, pem_rfc7468 as pem};
+
+#[cfg(feature = "std")]
+use std::{fs, path::Path};
+
+/// ASN.1 DER-encoded document.
+///
+/// This trait is intended to impl on types which contain an ASN.1 DER-encoded
+/// document which is guaranteed to encode as the associated `Message` type.
+///
+/// It implements common functionality related to encoding/decoding such
+/// documents, such as PEM encapsulation as well as reading/writing documents
+/// from/to the filesystem.
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+pub trait Document<'a>: AsRef<[u8]> + Sized + TryFrom<Vec<u8>, Error = Error> {
+    /// ASN.1 message type this document decodes to.
+    type Message: Decodable<'a> + Encodable + Sized;
+
+    /// Borrow the inner serialized bytes of this document.
+    fn as_der(&self) -> &[u8] {
+        self.as_ref()
+    }
+
+    /// Return an allocated ASN.1 DER serialization as a boxed slice.
+    fn to_der(&self) -> Box<[u8]> {
+        self.as_ref().to_vec().into_boxed_slice()
+    }
+
+    /// Decode this document as ASN.1 DER.
+    fn decode(&'a self) -> Self::Message {
+        Self::Message::from_der(self.as_ref()).expect("ASN.1 DER document malformed")
+    }
+
+    /// Create a new document from the provided ASN.1 DER bytes.
+    fn from_der(bytes: &[u8]) -> Result<Self> {
+        bytes.to_vec().try_into()
+    }
+
+    /// Encode the provided type as ASN.1 DER.
+    fn from_msg(msg: &Self::Message) -> Result<Self> {
+        msg.to_vec()?.try_into()
+    }
+
+    /// Decode ASN.1 DER document from PEM.
+    #[cfg(feature = "pem")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
+    fn from_pem(s: &str) -> Result<Self>
+    where
+        Self: pem::PemLabel,
+    {
+        let (label, der_bytes) = pem::decode_vec(s.as_bytes())?;
+
+        if label != Self::TYPE_LABEL {
+            return Err(pem::Error::Label.into());
+        }
+
+        der_bytes.try_into()
+    }
+
+    /// Encode ASN.1 DER document as a PEM string.
+    #[cfg(feature = "pem")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
+    fn to_pem(&self, line_ending: pem::LineEnding) -> Result<String>
+    where
+        Self: pem::PemLabel,
+    {
+        Ok(pem::encode_string(
+            Self::TYPE_LABEL,
+            line_ending,
+            self.as_ref(),
+        )?)
+    }
+
+    /// Read ASN.1 DER document from a file.
+    #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    fn read_der_file(path: impl AsRef<Path>) -> Result<Self> {
+        fs::read(path)?.try_into()
+    }
+
+    /// Read PEM-encoded ASN.1 DER document from a file.
+    #[cfg(all(feature = "pem", feature = "std"))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "pem", feature = "std"))))]
+    fn read_pem_file(path: impl AsRef<Path>) -> Result<Self>
+    where
+        Self: pem::PemLabel,
+    {
+        Self::from_pem(&fs::read_to_string(path)?)
+    }
+
+    /// Write ASN.1 DER document to a file.
+    #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    fn write_der_file(&self, path: &Path) -> Result<()> {
+        fs::write(path, self.as_ref())?;
+        Ok(())
+    }
+
+    /// Write PEM-encoded ASN.1 DER document to a file.
+    #[cfg(all(feature = "pem", feature = "std"))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "pem", feature = "std"))))]
+    fn write_pem_file(&self, path: &Path, line_ending: pem::LineEnding) -> Result<()>
+    where
+        Self: pem::PemLabel,
+    {
+        fs::write(path, self.to_pem(line_ending)?.as_bytes())?;
+        Ok(())
+    }
+}

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -362,6 +362,9 @@ mod str_slice;
 mod tag;
 mod value;
 
+#[cfg(feature = "alloc")]
+mod document;
+
 pub use crate::{
     asn1::{Any, Choice, Sequence},
     datetime::DateTime,
@@ -375,6 +378,9 @@ pub use crate::{
     tag::{Class, Tag, TagMode, TagNumber, Tagged},
     value::{DecodeValue, EncodeValue},
 };
+
+#[cfg(feature = "alloc")]
+pub use document::Document;
 
 #[cfg(feature = "bigint")]
 #[cfg_attr(docsrs, doc(cfg(feature = "bigint")))]

--- a/pem-rfc7468/src/lib.rs
+++ b/pem-rfc7468/src/lib.rs
@@ -143,3 +143,9 @@ const ENCAPSULATION_BOUNDARY_DELIMITER: &[u8] = b"-----";
 /// > boundary), and they MUST NOT emit extraneous whitespace.  Parsers MAY
 /// > handle other line sizes.
 const BASE64_WRAP_WIDTH: usize = 64;
+
+/// Marker trait for types with an associated PEM type label.
+pub trait PemLabel {
+    /// Expected PEM type label for a given document, e.g. `"PRIVATE KEY"`
+    const TYPE_LABEL: &'static str;
+}

--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -25,8 +25,8 @@ hex-literal = "0.3"
 
 [features]
 alloc = ["der/alloc", "zeroize"]
-pem = ["alloc", "pem-rfc7468/alloc"]
-std = []
+pem = ["alloc", "der/pem", "pem-rfc7468/alloc"]
+std = ["der/std"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/pkcs1/src/public_key/document.rs
+++ b/pkcs1/src/public_key/document.rs
@@ -1,22 +1,22 @@
 //! PKCS#1 RSA public key document.
 
 use crate::{error, Error, FromRsaPublicKey, Result, RsaPublicKey, ToRsaPublicKey};
-use alloc::{borrow::ToOwned, vec::Vec};
+use alloc::vec::Vec;
 use core::{
     convert::{TryFrom, TryInto},
     fmt,
 };
-use der::Encodable;
-
-#[cfg(feature = "std")]
-use std::{fs, path::Path, str};
+use der::{Decodable, Document, Encodable};
 
 #[cfg(feature = "pem")]
 use {
-    crate::{pem, public_key::PEM_TYPE_LABEL, LineEnding},
+    crate::{pem, LineEnding},
     alloc::string::String,
     core::str::FromStr,
 };
+
+#[cfg(feature = "std")]
+use std::path::Path;
 
 /// PKCS#1 `RSA PUBLIC KEY` document.
 ///
@@ -27,54 +27,36 @@ use {
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub struct RsaPublicKeyDocument(Vec<u8>);
 
-impl RsaPublicKeyDocument {
-    /// Parse the [`RsaPublicKey`] contained in this [`RsaPublicKeyDocument`]
-    pub fn public_key(&self) -> RsaPublicKey<'_> {
-        RsaPublicKey::try_from(self.0.as_slice()).expect("malformed PublicKeyDocument")
-    }
-
-    /// Borrow the inner DER encoded bytes.
-    pub fn as_der(&self) -> &[u8] {
-        self.0.as_ref()
-    }
+impl<'a> Document<'a> for RsaPublicKeyDocument {
+    type Message = RsaPublicKey<'a>;
 }
 
 impl FromRsaPublicKey for RsaPublicKeyDocument {
     fn from_pkcs1_public_key(public_key: RsaPublicKey<'_>) -> Result<Self> {
-        Ok(Self(public_key.to_vec()?))
+        Ok(Self::from_msg(&public_key)?)
     }
 
     fn from_pkcs1_der(bytes: &[u8]) -> Result<Self> {
-        // Ensure document is well-formed
-        RsaPublicKey::try_from(bytes)?;
-        Ok(Self(bytes.to_owned()))
+        Ok(Self::from_der(bytes)?)
     }
 
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     fn from_pkcs1_pem(s: &str) -> Result<Self> {
-        let (label, der_bytes) = pem::decode_vec(s.as_bytes())?;
-
-        if label != PEM_TYPE_LABEL {
-            return Err(pem::Error::Label.into());
-        }
-
-        // Ensure document is well-formed
-        RsaPublicKey::try_from(der_bytes.as_slice())?;
-        Ok(Self(der_bytes))
+        Ok(Self::from_pem(s)?)
     }
 
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn read_pkcs1_der_file(path: &Path) -> Result<Self> {
-        fs::read(path)?.try_into()
+        Ok(Self::read_der_file(path)?)
     }
 
     #[cfg(all(feature = "pem", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn read_pkcs1_pem_file(path: &Path) -> Result<Self> {
-        Self::from_pkcs1_pem(&fs::read_to_string(path)?)
+        Ok(Self::read_pem_file(path)?)
     }
 }
 
@@ -86,28 +68,26 @@ impl ToRsaPublicKey for RsaPublicKeyDocument {
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     fn to_pkcs1_pem(&self, line_ending: LineEnding) -> Result<String> {
-        Ok(pem::encode_string(PEM_TYPE_LABEL, line_ending, &self.0)?)
+        Ok(self.to_pem(line_ending)?)
     }
 
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn write_pkcs1_der_file(&self, path: &Path) -> Result<()> {
-        fs::write(path, self.as_ref())?;
-        Ok(())
+        Ok(self.write_der_file(path)?)
     }
 
     #[cfg(all(feature = "pem", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn write_pkcs1_pem_file(&self, path: &Path, line_ending: LineEnding) -> Result<()> {
-        fs::write(path, self.to_pkcs1_pem(line_ending)?.as_bytes())?;
-        Ok(())
+        Ok(self.write_pem_file(path, line_ending)?)
     }
 }
 
 impl AsRef<[u8]> for RsaPublicKeyDocument {
     fn as_ref(&self) -> &[u8] {
-        self.as_der()
+        self.0.as_ref()
     }
 }
 
@@ -136,11 +116,11 @@ impl TryFrom<&[u8]> for RsaPublicKeyDocument {
 }
 
 impl TryFrom<Vec<u8>> for RsaPublicKeyDocument {
-    type Error = Error;
+    type Error = der::Error;
 
-    fn try_from(bytes: Vec<u8>) -> Result<Self> {
+    fn try_from(bytes: Vec<u8>) -> der::Result<Self> {
         // Ensure document is well-formed
-        RsaPublicKey::try_from(bytes.as_slice())?;
+        RsaPublicKey::from_der(bytes.as_slice())?;
         Ok(Self(bytes))
     }
 }
@@ -148,7 +128,7 @@ impl TryFrom<Vec<u8>> for RsaPublicKeyDocument {
 impl fmt::Debug for RsaPublicKeyDocument {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_tuple("RsaPublicKeyDocument")
-            .field(&self.public_key())
+            .field(&self.decode())
             .finish()
     }
 }
@@ -161,4 +141,10 @@ impl FromStr for RsaPublicKeyDocument {
     fn from_str(s: &str) -> Result<Self> {
         Self::from_pkcs1_pem(s)
     }
+}
+
+#[cfg(feature = "pem")]
+#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
+impl pem::PemLabel for RsaPublicKeyDocument {
+    const TYPE_LABEL: &'static str = "RSA PUBLIC KEY";
 }

--- a/pkcs1/src/traits.rs
+++ b/pkcs1/src/traits.rs
@@ -13,7 +13,7 @@ use {crate::LineEnding, alloc::string::String};
 use std::path::Path;
 
 #[cfg(any(feature = "pem", feature = "std"))]
-use zeroize::Zeroizing;
+use {der::Document, zeroize::Zeroizing};
 
 /// Parse an [`RsaPrivateKey`] from a PKCS#1-encoded document.
 pub trait FromRsaPrivateKey: Sized {
@@ -81,7 +81,7 @@ pub trait FromRsaPublicKey: Sized {
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     fn from_pkcs1_pem(s: &str) -> Result<Self> {
         RsaPublicKeyDocument::from_pkcs1_pem(s)
-            .and_then(|doc| Self::from_pkcs1_public_key(doc.public_key()))
+            .and_then(|doc| Self::from_pkcs1_public_key(doc.decode()))
     }
 
     /// Load [`RsaPublicKey`] from an ASN.1 DER-encoded file on the local
@@ -90,7 +90,7 @@ pub trait FromRsaPublicKey: Sized {
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn read_pkcs1_der_file(path: &Path) -> Result<Self> {
         RsaPublicKeyDocument::read_pkcs1_der_file(path)
-            .and_then(|doc| Self::from_pkcs1_public_key(doc.public_key()))
+            .and_then(|doc| Self::from_pkcs1_public_key(doc.decode()))
     }
 
     /// Load [`RsaPublicKey`] from a PEM-encoded file on the local filesystem.
@@ -99,7 +99,7 @@ pub trait FromRsaPublicKey: Sized {
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn read_pkcs1_pem_file(path: &Path) -> Result<Self> {
         RsaPublicKeyDocument::read_pkcs1_pem_file(path)
-            .and_then(|doc| Self::from_pkcs1_public_key(doc.public_key()))
+            .and_then(|doc| Self::from_pkcs1_public_key(doc.decode()))
     }
 }
 

--- a/pkcs1/tests/public_key.rs
+++ b/pkcs1/tests/public_key.rs
@@ -5,7 +5,7 @@ use hex_literal::hex;
 use pkcs1::RsaPublicKey;
 
 #[cfg(feature = "pem")]
-use pkcs1::RsaPublicKeyDocument;
+use pkcs1::{der::Document, RsaPublicKeyDocument};
 
 /// RSA-2048 PKCS#1 public key encoded as ASN.1 DER.
 ///
@@ -52,10 +52,7 @@ fn decode_rsa_2048_pem() {
 
     // Ensure `RsaPublicKeyDocument` parses successfully
     let pk = RsaPublicKey::try_from(RSA_2048_DER_EXAMPLE).unwrap();
-    assert_eq!(
-        pkcs1_doc.public_key().modulus.as_bytes(),
-        pk.modulus.as_bytes()
-    );
+    assert_eq!(pkcs1_doc.decode().modulus.as_bytes(), pk.modulus.as_bytes());
 }
 
 #[test]
@@ -66,8 +63,5 @@ fn decode_rsa_4096_pem() {
 
     // Ensure `RsaPublicKeyDocument` parses successfully
     let pk = RsaPublicKey::try_from(RSA_4096_DER_EXAMPLE).unwrap();
-    assert_eq!(
-        pkcs1_doc.public_key().modulus.as_bytes(),
-        pk.modulus.as_bytes()
-    );
+    assert_eq!(pkcs1_doc.decode().modulus.as_bytes(), pk.modulus.as_bytes());
 }

--- a/spki/Cargo.toml
+++ b/spki/Cargo.toml
@@ -24,9 +24,9 @@ base64ct = { version = "1", path = "../base64ct", optional = true, default-featu
 hex-literal = "0.3"
 
 [features]
-std = ["der/std"]
-fingerprint = ["sha2"]
 alloc = ["base64ct/alloc"]
+fingerprint = ["sha2"]
+std = ["der/std"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/spki/src/lib.rs
+++ b/spki/src/lib.rs
@@ -39,7 +39,7 @@
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", feature = "fingerprint"))]
 extern crate alloc;
 
 mod algorithm;

--- a/spki/src/spki.rs
+++ b/spki/src/spki.rs
@@ -4,14 +4,14 @@ use crate::AlgorithmIdentifier;
 use core::convert::TryFrom;
 use der::{asn1::BitString, Decodable, Decoder, Encodable, Error, Result, Sequence};
 
-#[cfg(feature = "alloc")]
-use alloc::string::String;
-
 #[cfg(feature = "fingerprint")]
 use sha2::{digest, Digest, Sha256};
 
-#[cfg(all(feature = "fingerprint", feature = "alloc"))]
-use base64ct::{Base64, Encoding};
+#[cfg(all(feature = "alloc", feature = "fingerprint"))]
+use {
+    alloc::string::String,
+    base64ct::{Base64, Encoding},
+};
 
 /// X.509 `SubjectPublicKeyInfo` (SPKI) as defined in [RFC 5280 Section 4.1.2.7].
 ///


### PR DESCRIPTION
Adds a trait for representing ASN.1 DER-encoded documents, including generalized support for PEM encoding as well as reading/writing such documents from/to the underlying filesystem.

The intended usage is to DRY out the `*Document` types that exist in the `pkcs1`, `pkcs8`, and `sec1` crates.

As a prototype/POC, this commit also impls the trait for `RsaPublicKey` in the `pkcs1` crate. The rest are left as a followup exercise.