### PR TITLE
spki: move `PublicKeyDocument` from `pkcs8` crate

### DIFF
--- a/.github/workflows/spki.yml
+++ b/.github/workflows/spki.yml
@@ -40,7 +40,9 @@ jobs:
           override: true
       - run: cargo build --release --target ${{ matrix.target }}
       - run: cargo build --release --target ${{ matrix.target }} --features alloc
-      - run: cargo build --release --target ${{ matrix.target }} --features alloc,fingerprint
+      - run: cargo build --release --target ${{ matrix.target }} --features fingerprint
+      - run: cargo build --release --target ${{ matrix.target }} --features pem
+      - run: cargo build --release --target ${{ matrix.target }} --features alloc,fingerprint,pem
 
   test:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,7 +465,6 @@ version = "0.3.0-pre"
 dependencies = [
  "der",
  "hex-literal",
- "pem-rfc7468",
  "zeroize",
 ]
 
@@ -492,7 +491,6 @@ version = "0.8.0-pre"
 dependencies = [
  "der",
  "hex-literal",
- "pem-rfc7468",
  "pkcs1",
  "pkcs5",
  "rand_core",
@@ -657,7 +655,6 @@ dependencies = [
  "der",
  "generic-array",
  "hex-literal",
- "pem-rfc7468",
  "subtle",
  "zeroize",
 ]

--- a/der/src/document.rs
+++ b/der/src/document.rs
@@ -5,7 +5,7 @@ use alloc::{boxed::Box, vec::Vec};
 use core::convert::{TryFrom, TryInto};
 
 #[cfg(feature = "pem")]
-use {alloc::string::String, pem_rfc7468 as pem};
+use {crate::pem, alloc::string::String};
 
 #[cfg(feature = "std")]
 use std::{fs, path::Path};

--- a/der/src/error.rs
+++ b/der/src/error.rs
@@ -9,7 +9,7 @@ use core::{convert::Infallible, fmt};
 use crate::asn1::ObjectIdentifier;
 
 #[cfg(feature = "pem")]
-use pem_rfc7468 as pem;
+use crate::pem;
 
 /// Result type.
 pub type Result<T> = core::result::Result<T, Error>;

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -390,4 +390,8 @@ pub use crypto_bigint as bigint;
 #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
 pub use der_derive::{Choice, Sequence};
 
+#[cfg(feature = "pem")]
+#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
+pub use pem_rfc7468 as pem;
+
 pub(crate) use crate::{arrayvec::ArrayVec, byte_slice::ByteSlice, str_slice::StrSlice};

--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -17,7 +17,6 @@ readme = "README.md"
 der = { version = "=0.5.0-pre.1", features = ["bigint", "oid"], path = "../der" }
 
 # optional dependencies
-pem-rfc7468 = { version = "0.2", optional = true, path = "../pem-rfc7468" }
 zeroize = { version = "1", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
@@ -25,7 +24,7 @@ hex-literal = "0.3"
 
 [features]
 alloc = ["der/alloc", "zeroize"]
-pem = ["alloc", "der/pem", "pem-rfc7468/alloc"]
+pem = ["alloc", "der/pem"]
 std = ["der/std"]
 
 [package.metadata.docs.rs]

--- a/pkcs1/src/error.rs
+++ b/pkcs1/src/error.rs
@@ -68,21 +68,21 @@ impl fmt::Display for Error {
     }
 }
 
+impl From<der::Error> for Error {
+    fn from(err: der::Error) -> Error {
+        Error::Asn1(err)
+    }
+}
+
 #[cfg(feature = "pem")]
-impl From<pem_rfc7468::Error> for Error {
-    fn from(err: pem_rfc7468::Error) -> Error {
+impl From<pem::Error> for Error {
+    fn from(err: pem::Error) -> Error {
         Error::Pem(err)
     }
 }
 
 #[cfg(feature = "std")]
 impl std::error::Error for Error {}
-
-impl From<der::Error> for Error {
-    fn from(err: der::Error) -> Error {
-        Error::Asn1(err)
-    }
-}
 
 #[cfg(feature = "std")]
 impl From<std::io::Error> for Error {

--- a/pkcs1/src/lib.rs
+++ b/pkcs1/src/lib.rs
@@ -57,10 +57,6 @@ pub use self::{
     version::Version,
 };
 
-#[cfg(feature = "pem")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-pub use pem_rfc7468::LineEnding;
-
 #[cfg(feature = "alloc")]
 pub use crate::{
     private_key::{
@@ -71,4 +67,5 @@ pub use crate::{
 };
 
 #[cfg(feature = "pem")]
-use pem_rfc7468 as pem;
+#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
+pub use der::pem::{self, LineEnding};

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -22,7 +22,6 @@ spki = { version = "=0.5.0-pre", path = "../spki" }
 rand_core = { version = "0.6", optional = true, default-features = false }
 pkcs1 = { version = "=0.3.0-pre", optional = true, features = ["alloc"], path = "../pkcs1" }
 pkcs5 = { version = "=0.4.0-pre", optional = true, path = "../pkcs5" }
-pem-rfc7468 = { version = "0.2", optional = true, path = "../pem-rfc7468" }
 subtle = { version = "2", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false, features = ["alloc"] }
 
@@ -30,13 +29,13 @@ zeroize = { version = "1", optional = true, default-features = false, features =
 hex-literal = "0.3"
 
 [features]
-alloc = ["der/alloc", "zeroize"]
+alloc = ["der/alloc", "spki/alloc", "zeroize"]
 3des = ["encryption", "pkcs5/3des"]
 des-insecure = ["encryption", "pkcs5/des-insecure"]
 encryption = ["alloc", "pkcs5/alloc", "pkcs5/pbes2", "rand_core"]
-pem = ["alloc", "pem-rfc7468/alloc"]
+pem = ["alloc", "der/pem", "spki/pem"]
 sha1 = ["encryption", "pkcs5/sha1"]
-std = ["alloc", "der/std"]
+std = ["alloc", "der/std", "spki/std"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/pkcs8/src/document.rs
+++ b/pkcs8/src/document.rs
@@ -4,4 +4,3 @@
 #[cfg(feature = "pkcs5")]
 pub(crate) mod encrypted_private_key;
 pub(crate) mod private_key;
-pub(crate) mod public_key;

--- a/pkcs8/src/document/encrypted_private_key.rs
+++ b/pkcs8/src/document/encrypted_private_key.rs
@@ -83,7 +83,7 @@ impl EncryptedPrivateKeyDocument {
     pub fn to_pem(&self, line_ending: LineEnding) -> Result<Zeroizing<String>> {
         pem::encode_string(PEM_TYPE_LABEL, line_ending, &self.0)
             .map(Zeroizing::new)
-            .map_err(|_| Error::Pem)
+            .map_err(Error::Pem)
     }
 
     /// Load [`EncryptedPrivateKeyDocument`] from an ASN.1 DER-encoded file on

--- a/pkcs8/src/encrypted_private_key_info.rs
+++ b/pkcs8/src/encrypted_private_key_info.rs
@@ -77,7 +77,7 @@ impl<'a> EncryptedPrivateKeyInfo<'a> {
     pub fn to_pem(&self, line_ending: LineEnding) -> Result<Zeroizing<alloc::string::String>> {
         pem::encode_string(PEM_TYPE_LABEL, line_ending, self.to_der()?.as_ref())
             .map(Zeroizing::new)
-            .map_err(|_| Error::Pem)
+            .map_err(Error::Pem)
     }
 }
 

--- a/pkcs8/src/error.rs
+++ b/pkcs8/src/error.rs
@@ -2,6 +2,9 @@
 
 use core::fmt;
 
+#[cfg(feature = "pem")]
+use crate::pem;
+
 /// Result type
 pub type Result<T> = core::result::Result<T, Error>;
 
@@ -40,9 +43,8 @@ pub enum Error {
     ParametersMalformed,
 
     /// PEM encoding errors.
-    // TODO(tarcieri): propagate `pem_rfc7468::Error`
     #[cfg(feature = "pem")]
-    Pem,
+    Pem(pem::Error),
 
     /// Permission denied reading file.
     #[cfg(feature = "std")]
@@ -67,7 +69,7 @@ impl fmt::Display for Error {
             Error::Io => f.write_str("I/O error"),
             Error::ParametersMalformed => f.write_str("PKCS#8 algorithm parameters malformed"),
             #[cfg(feature = "pem")]
-            Error::Pem => f.write_str("PKCS#8 PEM error"),
+            Error::Pem(err) => write!(f, "PKCS8 {}", err),
             #[cfg(feature = "std")]
             Error::PermissionDenied => f.write_str("permission denied"),
             #[cfg(feature = "pkcs1")]
@@ -92,10 +94,9 @@ impl From<der::ErrorKind> for Error {
 }
 
 #[cfg(feature = "pem")]
-impl From<pem_rfc7468::Error> for Error {
-    fn from(_: pem_rfc7468::Error) -> Error {
-        // TODO(tarcieri): propagate `pem_rfc7468::Error`
-        Error::Pem
+impl From<pem::Error> for Error {
+    fn from(err: pem::Error) -> Error {
+        Error::Pem(err)
     }
 }
 

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -137,21 +137,21 @@ pub(crate) mod encrypted_private_key_info;
 pub use crate::{
     error::{Error, Result},
     private_key_info::PrivateKeyInfo,
-    traits::{FromPrivateKey, FromPublicKey},
+    traits::FromPrivateKey,
     version::Version,
 };
 pub use der::{self, asn1::ObjectIdentifier};
-pub use spki::{AlgorithmIdentifier, SubjectPublicKeyInfo};
+pub use spki::{AlgorithmIdentifier, FromPublicKey, SubjectPublicKeyInfo};
 
 #[cfg(feature = "alloc")]
-pub use crate::{
-    document::{private_key::PrivateKeyDocument, public_key::PublicKeyDocument},
-    traits::{ToPrivateKey, ToPublicKey},
+pub use {
+    crate::{document::private_key::PrivateKeyDocument, traits::ToPrivateKey},
+    spki::{PublicKeyDocument, ToPublicKey},
 };
 
 #[cfg(feature = "pem")]
 #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-pub use pem_rfc7468::LineEnding;
+pub use der::pem::{self, LineEnding};
 
 #[cfg(feature = "pkcs5")]
 pub use encrypted_private_key_info::EncryptedPrivateKeyInfo;
@@ -164,6 +164,3 @@ pub use pkcs5;
 
 #[cfg(all(feature = "alloc", feature = "pkcs5"))]
 pub use crate::document::encrypted_private_key::EncryptedPrivateKeyDocument;
-
-#[cfg(feature = "pem")]
-use pem_rfc7468 as pem;

--- a/pkcs8/src/private_key_info.rs
+++ b/pkcs8/src/private_key_info.rs
@@ -158,7 +158,7 @@ impl<'a> PrivateKeyInfo<'a> {
     pub fn to_pem(&self, line_ending: LineEnding) -> Result<Zeroizing<String>> {
         pem::encode_string(PEM_TYPE_LABEL, line_ending, self.to_der()?.as_ref())
             .map(Zeroizing::new)
-            .map_err(|_| Error::Pem)
+            .map_err(Error::Pem)
     }
 }
 

--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -19,8 +19,7 @@ der = { version = "=0.5.0-pre.1", features = ["oid"], path = "../der" }
 generic-array = { version = "0.14", default-features = false }
 
 # optional dependencies
-pem-rfc7468 = { version = "0.2", optional = true, path = "../pem-rfc7468" }
-subtle = { version = ">=2, <2.5", optional = true, default-features = false }
+subtle = { version = "2", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
@@ -28,8 +27,8 @@ hex-literal = "0.3"
 
 [features]
 alloc = ["der/alloc", "zeroize"]
-pem = ["alloc", "pem-rfc7468/alloc"]
-std = []
+pem = ["alloc", "der/pem"]
+std = ["der/std"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/sec1/src/error.rs
+++ b/sec1/src/error.rs
@@ -70,8 +70,8 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "pem")]
-impl From<pem_rfc7468::Error> for Error {
-    fn from(err: pem_rfc7468::Error) -> Error {
+impl From<pem::Error> for Error {
+    fn from(err: pem::Error) -> Error {
         Error::Pem(err)
     }
 }

--- a/sec1/src/lib.rs
+++ b/sec1/src/lib.rs
@@ -42,12 +42,9 @@ pub use self::{
 
 pub use generic_array::typenum::consts;
 
-#[cfg(feature = "pem")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-pub use pem_rfc7468::LineEnding;
-
 #[cfg(feature = "alloc")]
 pub use crate::{private_key::document::EcPrivateKeyDocument, traits::ToEcPrivateKey};
 
 #[cfg(feature = "pem")]
-use pem_rfc7468 as pem;
+#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
+pub use der::pem::{self, LineEnding};

--- a/spki/Cargo.toml
+++ b/spki/Cargo.toml
@@ -24,8 +24,9 @@ base64ct = { version = "1", path = "../base64ct", optional = true, default-featu
 hex-literal = "0.3"
 
 [features]
-alloc = ["base64ct/alloc"]
+alloc = ["base64ct/alloc", "der/alloc"]
 fingerprint = ["sha2"]
+pem = ["alloc", "der/pem"]
 std = ["der/std"]
 
 [package.metadata.docs.rs]

--- a/spki/src/document.rs
+++ b/spki/src/document.rs
@@ -1,21 +1,21 @@
 //! SPKI public key document.
 
-use crate::{Error, FromPublicKey, Result, SubjectPublicKeyInfo, ToPublicKey};
+use crate::{FromPublicKey, SubjectPublicKeyInfo, ToPublicKey};
 use alloc::{borrow::ToOwned, vec::Vec};
 use core::{
     convert::{TryFrom, TryInto},
     fmt,
 };
-use der::Encodable;
+use der::{Encodable, Error, Result};
 
 #[cfg(feature = "std")]
 use std::{fs, path::Path};
 
 #[cfg(feature = "pem")]
 use {
-    crate::{pem, LineEnding},
     alloc::string::String,
     core::str::FromStr,
+    der::pem::{self, LineEnding},
 };
 
 /// Type label for PEM-encoded private keys.
@@ -166,4 +166,10 @@ impl FromStr for PublicKeyDocument {
     fn from_str(s: &str) -> Result<Self> {
         Self::from_public_key_pem(s)
     }
+}
+
+#[cfg(feature = "pem")]
+#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
+impl pem::PemLabel for PublicKeyDocument {
+    const TYPE_LABEL: &'static str = "PUBLIC KEY";
 }

--- a/spki/src/lib.rs
+++ b/spki/src/lib.rs
@@ -39,11 +39,22 @@
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
-#[cfg(all(feature = "alloc", feature = "fingerprint"))]
+#[cfg(feature = "alloc")]
 extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
 
 mod algorithm;
 mod spki;
+mod traits;
 
-pub use crate::{algorithm::AlgorithmIdentifier, spki::SubjectPublicKeyInfo};
+#[cfg(feature = "alloc")]
+mod document;
+
+pub use crate::{
+    algorithm::AlgorithmIdentifier, spki::SubjectPublicKeyInfo, traits::FromPublicKey,
+};
 pub use der::{self, asn1::ObjectIdentifier};
+
+#[cfg(feature = "alloc")]
+pub use crate::{document::PublicKeyDocument, traits::ToPublicKey};

--- a/spki/src/spki.rs
+++ b/spki/src/spki.rs
@@ -35,17 +35,18 @@ pub struct SubjectPublicKeyInfo<'a> {
 }
 
 impl<'a> SubjectPublicKeyInfo<'a> {
+    /// Calculate the SHA-256 fingerprint of this [`SubjectPublicKeyInfo`].
     #[cfg(feature = "fingerprint")]
     #[cfg_attr(docsrs, doc(cfg(feature = "fingerprint")))]
-    /// Calculate the SHA-256 fingerprint of this SubjectPublicKeyInfo
     pub fn fingerprint(&self) -> Result<digest::Output<Sha256>> {
         let mut buf = [0u8; 4096];
         Ok(Sha256::digest(self.encode_to_slice(&mut buf)?))
     }
 
+    /// Calculate the SHA-256 fingerprint of this [`SubjectPublicKeyInfo`] and
+    /// encode it as a Base64 string.
     #[cfg(all(feature = "fingerprint", feature = "alloc"))]
     #[cfg_attr(docsrs, doc(cfg(all(feature = "fingerprint", feature = "alloc"))))]
-    /// Calculate the SHA-256 fingerprint of this SubjectPublicKeyInfo and encode it as a Base64 string
     pub fn fingerprint_base64(&self) -> Result<String> {
         Ok(Base64::encode_string(self.fingerprint()?.as_slice()))
     }

--- a/spki/src/traits.rs
+++ b/spki/src/traits.rs
@@ -1,0 +1,98 @@
+//! Traits for encoding/decoding SPKI public keys.
+
+use crate::SubjectPublicKeyInfo;
+use core::convert::TryFrom;
+use der::Result;
+
+#[cfg(feature = "alloc")]
+use crate::PublicKeyDocument;
+
+#[cfg(feature = "pem")]
+use {alloc::string::String, der::pem::LineEnding};
+
+#[cfg(feature = "std")]
+use std::path::Path;
+
+/// Parse a public key object from an encoded SPKI document.
+pub trait FromPublicKey: Sized {
+    /// Parse [`SubjectPublicKeyInfo`] into a public key object.
+    fn from_spki(spki: SubjectPublicKeyInfo<'_>) -> Result<Self>;
+
+    /// Deserialize object from ASN.1 DER-encoded [`SubjectPublicKeyInfo`]
+    /// (binary format).
+    fn from_public_key_der(bytes: &[u8]) -> Result<Self> {
+        Self::from_spki(SubjectPublicKeyInfo::try_from(bytes)?)
+    }
+
+    /// Deserialize PKCS#8 private key from a [`PrivateKeyDocument`].
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    fn from_public_key_doc(doc: &PublicKeyDocument) -> Result<Self> {
+        Self::from_spki(doc.spki())
+    }
+
+    /// Deserialize PEM-encoded [`SubjectPublicKeyInfo`].
+    ///
+    /// Keys in this format begin with the following delimiter:
+    ///
+    /// ```text
+    /// -----BEGIN PUBLIC KEY-----
+    /// ```
+    #[cfg(feature = "pem")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
+    fn from_public_key_pem(s: &str) -> Result<Self> {
+        PublicKeyDocument::from_public_key_pem(s).and_then(|doc| Self::from_public_key_doc(&doc))
+    }
+
+    /// Load public key object from an ASN.1 DER-encoded file on the local
+    /// filesystem (binary format).
+    #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    fn read_public_key_der_file(path: impl AsRef<Path>) -> Result<Self> {
+        PublicKeyDocument::read_public_key_der_file(path)
+            .and_then(|doc| Self::from_public_key_doc(&doc))
+    }
+
+    /// Load public key object from a PEM-encoded file on the local filesystem.
+    #[cfg(all(feature = "pem", feature = "std"))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    fn read_public_key_pem_file(path: impl AsRef<Path>) -> Result<Self> {
+        PublicKeyDocument::read_public_key_pem_file(path)
+            .and_then(|doc| Self::from_public_key_doc(&doc))
+    }
+}
+
+/// Serialize a public key object to a SPKI-encoded document.
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+pub trait ToPublicKey {
+    /// Serialize a [`PublicKeyDocument`] containing a SPKI-encoded public key.
+    fn to_public_key_der(&self) -> Result<PublicKeyDocument>;
+
+    /// Serialize this public key as PEM-encoded SPKI with the given [`LineEnding`].
+    #[cfg(feature = "pem")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
+    fn to_public_key_pem(&self, line_ending: LineEnding) -> Result<String> {
+        self.to_public_key_der()?.to_public_key_pem(line_ending)
+    }
+
+    /// Write ASN.1 DER-encoded public key to the given path
+    #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    fn write_public_key_der_file(&self, path: impl AsRef<Path>) -> Result<()> {
+        self.to_public_key_der()?.write_public_key_der_file(path)
+    }
+
+    /// Write ASN.1 DER-encoded public key to the given path
+    #[cfg(all(feature = "pem", feature = "std"))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "pem", feature = "std"))))]
+    fn write_public_key_pem_file(
+        &self,
+        path: impl AsRef<Path>,
+        line_ending: LineEnding,
+    ) -> Result<()> {
+        self.to_public_key_der()?
+            .write_public_key_pem_file(path, line_ending)
+    }
+}

--- a/spki/tests/examples/ed25519-pub.pem
+++ b/spki/tests/examples/ed25519-pub.pem
@@ -1,0 +1,3 @@
+-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEATSkWfz8ZEqb3rfopOgUaFcBexnuPFyZ7HFVQ3OhTvQ0=
+-----END PUBLIC KEY-----


### PR DESCRIPTION
This type provides heap-backed storage for `SubjectPublicKeyInfo`.

It was placed in the `pkcs8` crate instead of the `spki` crate because that's where PEM support used to live.

Now that PEM support has been extracted into the `pem-rfc7468` crate, this type can move to the `spki` crate.

To provide backwards compatibility, it's re-exported from the `pkcs8` crate (where it's effectively the associated "public key type").