### PR TITLE
spki: rename `From/ToPublicKey` => `DecodePublicKey`/`EncodePublicKey`

### DIFF
--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -141,12 +141,12 @@ pub use crate::{
     version::Version,
 };
 pub use der::{self, asn1::ObjectIdentifier};
-pub use spki::{AlgorithmIdentifier, FromPublicKey, SubjectPublicKeyInfo};
+pub use spki::{AlgorithmIdentifier, DecodePublicKey, SubjectPublicKeyInfo};
 
 #[cfg(feature = "alloc")]
 pub use {
     crate::{document::private_key::PrivateKeyDocument, traits::ToPrivateKey},
-    spki::{PublicKeyDocument, ToPublicKey},
+    spki::{EncodePublicKey, PublicKeyDocument},
 };
 
 #[cfg(feature = "pem")]

--- a/pkcs8/tests/public_key.rs
+++ b/pkcs8/tests/public_key.rs
@@ -8,10 +8,10 @@ use pkcs8::SubjectPublicKeyInfo;
 use der::Encodable;
 
 #[cfg(feature = "pem")]
-use pkcs8::ToPublicKey;
+use pkcs8::EncodePublicKey;
 
 #[cfg(feature = "std")]
-use pkcs8::FromPublicKey;
+use pkcs8::DecodePublicKey;
 
 #[cfg(any(feature = "pem", feature = "std"))]
 use pkcs8::PublicKeyDocument;

--- a/spki/src/document.rs
+++ b/spki/src/document.rs
@@ -1,6 +1,6 @@
 //! SPKI public key document.
 
-use crate::{FromPublicKey, SubjectPublicKeyInfo, ToPublicKey};
+use crate::{DecodePublicKey, EncodePublicKey, SubjectPublicKeyInfo};
 use alloc::{borrow::ToOwned, vec::Vec};
 use core::{
     convert::{TryFrom, TryInto},
@@ -38,7 +38,7 @@ impl PublicKeyDocument {
     }
 }
 
-impl FromPublicKey for PublicKeyDocument {
+impl DecodePublicKey for PublicKeyDocument {
     fn from_spki(spki: SubjectPublicKeyInfo<'_>) -> Result<Self> {
         Ok(Self(spki.to_vec()?))
     }
@@ -77,7 +77,7 @@ impl FromPublicKey for PublicKeyDocument {
     }
 }
 
-impl ToPublicKey for PublicKeyDocument {
+impl EncodePublicKey for PublicKeyDocument {
     fn to_public_key_der(&self) -> Result<PublicKeyDocument> {
         Ok(self.clone())
     }

--- a/spki/src/lib.rs
+++ b/spki/src/lib.rs
@@ -52,9 +52,9 @@ mod traits;
 mod document;
 
 pub use crate::{
-    algorithm::AlgorithmIdentifier, spki::SubjectPublicKeyInfo, traits::FromPublicKey,
+    algorithm::AlgorithmIdentifier, spki::SubjectPublicKeyInfo, traits::DecodePublicKey,
 };
 pub use der::{self, asn1::ObjectIdentifier};
 
 #[cfg(feature = "alloc")]
-pub use crate::{document::PublicKeyDocument, traits::ToPublicKey};
+pub use crate::{document::PublicKeyDocument, traits::EncodePublicKey};

--- a/spki/src/traits.rs
+++ b/spki/src/traits.rs
@@ -14,7 +14,7 @@ use {alloc::string::String, der::pem::LineEnding};
 use std::path::Path;
 
 /// Parse a public key object from an encoded SPKI document.
-pub trait FromPublicKey: Sized {
+pub trait DecodePublicKey: Sized {
     /// Parse [`SubjectPublicKeyInfo`] into a public key object.
     fn from_spki(spki: SubjectPublicKeyInfo<'_>) -> Result<Self>;
 
@@ -66,7 +66,7 @@ pub trait FromPublicKey: Sized {
 /// Serialize a public key object to a SPKI-encoded document.
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-pub trait ToPublicKey {
+pub trait EncodePublicKey {
     /// Serialize a [`PublicKeyDocument`] containing a SPKI-encoded public key.
     fn to_public_key_der(&self) -> Result<PublicKeyDocument>;
 

--- a/spki/tests/spki.rs
+++ b/spki/tests/spki.rs
@@ -9,7 +9,7 @@ use spki::der::Encodable;
 #[cfg(feature = "fingerprint")]
 use spki::SubjectPublicKeyInfo;
 #[cfg(feature = "pem")]
-use spki::{PublicKeyDocument, ToPublicKey};
+use spki::{EncodePublicKey, PublicKeyDocument};
 
 #[cfg(feature = "fingerprint")]
 // Taken from pkcs8/tests/public_key.rs


### PR DESCRIPTION
Renames the traits for decoding/encoding SPKI public keys, emphasizing that they're encoding related and not just `From/`To` conversions.