### PR TITLE
pkcs1: rename `From/ToRsa*Key` => `DecodeRsa*Key`/`EncodeRsa*Key`

### DIFF
--- a/der/src/document.rs
+++ b/der/src/document.rs
@@ -98,7 +98,7 @@ pub trait Document<'a>: AsRef<[u8]> + Sized + TryFrom<Vec<u8>, Error = Error> {
     /// Write ASN.1 DER document to a file.
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    fn write_der_file(&self, path: &Path) -> Result<()> {
+    fn write_der_file(&self, path: impl AsRef<Path>) -> Result<()> {
         fs::write(path, self.as_ref())?;
         Ok(())
     }
@@ -106,7 +106,7 @@ pub trait Document<'a>: AsRef<[u8]> + Sized + TryFrom<Vec<u8>, Error = Error> {
     /// Write PEM-encoded ASN.1 DER document to a file.
     #[cfg(all(feature = "pem", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(all(feature = "pem", feature = "std"))))]
-    fn write_pem_file(&self, path: &Path, line_ending: pem::LineEnding) -> Result<()>
+    fn write_pem_file(&self, path: impl AsRef<Path>, line_ending: pem::LineEnding) -> Result<()>
     where
         Self: pem::PemLabel,
     {

--- a/pkcs1/src/lib.rs
+++ b/pkcs1/src/lib.rs
@@ -53,7 +53,7 @@ pub use self::{
     error::{Error, Result},
     private_key::RsaPrivateKey,
     public_key::RsaPublicKey,
-    traits::{FromRsaPrivateKey, FromRsaPublicKey},
+    traits::{DecodeRsaPrivateKey, DecodeRsaPublicKey},
     version::Version,
 };
 
@@ -63,7 +63,7 @@ pub use crate::{
         document::RsaPrivateKeyDocument, other_prime_info::OtherPrimeInfo, OtherPrimeInfos,
     },
     public_key::document::RsaPublicKeyDocument,
-    traits::{ToRsaPrivateKey, ToRsaPublicKey},
+    traits::{EncodeRsaPrivateKey, EncodeRsaPublicKey},
 };
 
 #[cfg(feature = "pem")]

--- a/pkcs1/src/private_key/document.rs
+++ b/pkcs1/src/private_key/document.rs
@@ -1,6 +1,6 @@
 //! PKCS#1 RSA private key document.
 
-use crate::{error, Error, FromRsaPrivateKey, Result, RsaPrivateKey, ToRsaPrivateKey};
+use crate::{error, DecodeRsaPrivateKey, EncodeRsaPrivateKey, Error, Result, RsaPrivateKey};
 use alloc::{borrow::ToOwned, vec::Vec};
 use core::{
     convert::{TryFrom, TryInto},
@@ -40,7 +40,7 @@ impl RsaPrivateKeyDocument {
     }
 }
 
-impl FromRsaPrivateKey for RsaPrivateKeyDocument {
+impl DecodeRsaPrivateKey for RsaPrivateKeyDocument {
     fn from_pkcs1_private_key(private_key: RsaPrivateKey<'_>) -> Result<Self> {
         Ok(Self(Zeroizing::new(private_key.to_vec()?)))
     }
@@ -67,19 +67,19 @@ impl FromRsaPrivateKey for RsaPrivateKeyDocument {
 
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    fn read_pkcs1_der_file(path: &Path) -> Result<Self> {
+    fn read_pkcs1_der_file(path: impl AsRef<Path>) -> Result<Self> {
         fs::read(path)?.try_into()
     }
 
     #[cfg(all(feature = "pem", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    fn read_pkcs1_pem_file(path: &Path) -> Result<Self> {
+    fn read_pkcs1_pem_file(path: impl AsRef<Path>) -> Result<Self> {
         Self::from_pkcs1_pem(&Zeroizing::new(fs::read_to_string(path)?))
     }
 }
 
-impl ToRsaPrivateKey for RsaPrivateKeyDocument {
+impl EncodeRsaPrivateKey for RsaPrivateKeyDocument {
     fn to_pkcs1_der(&self) -> Result<RsaPrivateKeyDocument> {
         Ok(self.clone())
     }
@@ -93,14 +93,14 @@ impl ToRsaPrivateKey for RsaPrivateKeyDocument {
 
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    fn write_pkcs1_der_file(&self, path: &Path) -> Result<()> {
+    fn write_pkcs1_der_file(&self, path: impl AsRef<Path>) -> Result<()> {
         write_secret_file(path, self.as_der())
     }
 
     #[cfg(all(feature = "pem", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    fn write_pkcs1_pem_file(&self, path: &Path, line_ending: LineEnding) -> Result<()> {
+    fn write_pkcs1_pem_file(&self, path: impl AsRef<Path>, line_ending: LineEnding) -> Result<()> {
         let pem_doc = self.to_pkcs1_pem(line_ending)?;
         write_secret_file(path, pem_doc.as_bytes())
     }

--- a/pkcs1/src/public_key/document.rs
+++ b/pkcs1/src/public_key/document.rs
@@ -1,6 +1,6 @@
 //! PKCS#1 RSA public key document.
 
-use crate::{error, Error, FromRsaPublicKey, Result, RsaPublicKey, ToRsaPublicKey};
+use crate::{error, DecodeRsaPublicKey, EncodeRsaPublicKey, Error, Result, RsaPublicKey};
 use alloc::vec::Vec;
 use core::{
     convert::{TryFrom, TryInto},
@@ -31,7 +31,7 @@ impl<'a> Document<'a> for RsaPublicKeyDocument {
     type Message = RsaPublicKey<'a>;
 }
 
-impl FromRsaPublicKey for RsaPublicKeyDocument {
+impl DecodeRsaPublicKey for RsaPublicKeyDocument {
     fn from_pkcs1_public_key(public_key: RsaPublicKey<'_>) -> Result<Self> {
         Ok(Self::from_msg(&public_key)?)
     }
@@ -48,19 +48,19 @@ impl FromRsaPublicKey for RsaPublicKeyDocument {
 
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    fn read_pkcs1_der_file(path: &Path) -> Result<Self> {
+    fn read_pkcs1_der_file(path: impl AsRef<Path>) -> Result<Self> {
         Ok(Self::read_der_file(path)?)
     }
 
     #[cfg(all(feature = "pem", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    fn read_pkcs1_pem_file(path: &Path) -> Result<Self> {
+    fn read_pkcs1_pem_file(path: impl AsRef<Path>) -> Result<Self> {
         Ok(Self::read_pem_file(path)?)
     }
 }
 
-impl ToRsaPublicKey for RsaPublicKeyDocument {
+impl EncodeRsaPublicKey for RsaPublicKeyDocument {
     fn to_pkcs1_der(&self) -> Result<RsaPublicKeyDocument> {
         Ok(self.clone())
     }
@@ -73,14 +73,14 @@ impl ToRsaPublicKey for RsaPublicKeyDocument {
 
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    fn write_pkcs1_der_file(&self, path: &Path) -> Result<()> {
+    fn write_pkcs1_der_file(&self, path: impl AsRef<Path>) -> Result<()> {
         Ok(self.write_der_file(path)?)
     }
 
     #[cfg(all(feature = "pem", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    fn write_pkcs1_pem_file(&self, path: &Path, line_ending: LineEnding) -> Result<()> {
+    fn write_pkcs1_pem_file(&self, path: impl AsRef<Path>, line_ending: LineEnding) -> Result<()> {
         Ok(self.write_pem_file(path, line_ending)?)
     }
 }

--- a/pkcs1/src/traits.rs
+++ b/pkcs1/src/traits.rs
@@ -16,7 +16,7 @@ use std::path::Path;
 use {der::Document, zeroize::Zeroizing};
 
 /// Parse an [`RsaPrivateKey`] from a PKCS#1-encoded document.
-pub trait FromRsaPrivateKey: Sized {
+pub trait DecodeRsaPrivateKey: Sized {
     /// Parse the [`RsaPrivateKey`] from a PKCS#1-encoded document.
     fn from_pkcs1_private_key(private_key: RsaPrivateKey<'_>) -> Result<Self>;
 
@@ -44,7 +44,7 @@ pub trait FromRsaPrivateKey: Sized {
     /// filesystem (binary format).
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    fn read_pkcs1_der_file(path: &Path) -> Result<Self> {
+    fn read_pkcs1_der_file(path: impl AsRef<Path>) -> Result<Self> {
         RsaPrivateKeyDocument::read_pkcs1_der_file(path)
             .and_then(|doc| Self::from_pkcs1_private_key(doc.private_key()))
     }
@@ -53,14 +53,14 @@ pub trait FromRsaPrivateKey: Sized {
     #[cfg(all(feature = "pem", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    fn read_pkcs1_pem_file(path: &Path) -> Result<Self> {
+    fn read_pkcs1_pem_file(path: impl AsRef<Path>) -> Result<Self> {
         RsaPrivateKeyDocument::read_pkcs1_pem_file(path)
             .and_then(|doc| Self::from_pkcs1_private_key(doc.private_key()))
     }
 }
 
 /// Parse a [`RsaPublicKey`] from a PKCS#1-encoded document.
-pub trait FromRsaPublicKey: Sized {
+pub trait DecodeRsaPublicKey: Sized {
     /// Parse [`RsaPublicKey`] into a [`RsaPublicKey`].
     fn from_pkcs1_public_key(public_key: RsaPublicKey<'_>) -> Result<Self>;
 
@@ -88,7 +88,7 @@ pub trait FromRsaPublicKey: Sized {
     /// filesystem (binary format).
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    fn read_pkcs1_der_file(path: &Path) -> Result<Self> {
+    fn read_pkcs1_der_file(path: impl AsRef<Path>) -> Result<Self> {
         RsaPublicKeyDocument::read_pkcs1_der_file(path)
             .and_then(|doc| Self::from_pkcs1_public_key(doc.decode()))
     }
@@ -97,7 +97,7 @@ pub trait FromRsaPublicKey: Sized {
     #[cfg(all(feature = "pem", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    fn read_pkcs1_pem_file(path: &Path) -> Result<Self> {
+    fn read_pkcs1_pem_file(path: impl AsRef<Path>) -> Result<Self> {
         RsaPublicKeyDocument::read_pkcs1_pem_file(path)
             .and_then(|doc| Self::from_pkcs1_public_key(doc.decode()))
     }
@@ -106,7 +106,7 @@ pub trait FromRsaPublicKey: Sized {
 /// Serialize a [`RsaPrivateKey`] to a PKCS#1 encoded document.
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-pub trait ToRsaPrivateKey {
+pub trait EncodeRsaPrivateKey {
     /// Serialize a [`RsaPrivateKeyDocument`] containing a PKCS#1-encoded private key.
     fn to_pkcs1_der(&self) -> Result<RsaPrivateKeyDocument>;
 
@@ -120,15 +120,14 @@ pub trait ToRsaPrivateKey {
     /// Write ASN.1 DER-encoded PKCS#1 private key to the given path.
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    fn write_pkcs1_der_file(&self, path: &Path) -> Result<()> {
+    fn write_pkcs1_der_file(&self, path: impl AsRef<Path>) -> Result<()> {
         self.to_pkcs1_der()?.write_pkcs1_der_file(path)
     }
 
     /// Write ASN.1 DER-encoded PKCS#1 private key to the given path.
     #[cfg(all(feature = "pem", feature = "std"))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    fn write_pkcs1_pem_file(&self, path: &Path, line_ending: LineEnding) -> Result<()> {
+    #[cfg_attr(docsrs, doc(cfg(feature = "pem", feature = "std")))]
+    fn write_pkcs1_pem_file(&self, path: impl AsRef<Path>, line_ending: LineEnding) -> Result<()> {
         self.to_pkcs1_der()?.write_pkcs1_pem_file(path, line_ending)
     }
 }
@@ -136,7 +135,7 @@ pub trait ToRsaPrivateKey {
 /// Serialize a [`RsaPublicKey`] to a PKCS#1-encoded document.
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-pub trait ToRsaPublicKey {
+pub trait EncodeRsaPublicKey {
     /// Serialize a [`RsaPublicKeyDocument`] containing a PKCS#1-encoded public key.
     fn to_pkcs1_der(&self) -> Result<RsaPublicKeyDocument>;
 
@@ -150,15 +149,14 @@ pub trait ToRsaPublicKey {
     /// Write ASN.1 DER-encoded public key to the given path.
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    fn write_pkcs1_der_file(&self, path: &Path) -> Result<()> {
+    fn write_pkcs1_der_file(&self, path: impl AsRef<Path>) -> Result<()> {
         self.to_pkcs1_der()?.write_pkcs1_der_file(path)
     }
 
     /// Write ASN.1 DER-encoded public key to the given path.
     #[cfg(all(feature = "pem", feature = "std"))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    fn write_pkcs1_pem_file(&self, path: &Path, line_ending: LineEnding) -> Result<()> {
+    #[cfg_attr(docsrs, doc(cfg(feature = "pem", feature = "std")))]
+    fn write_pkcs1_pem_file(&self, path: impl AsRef<Path>, line_ending: LineEnding) -> Result<()> {
         self.to_pkcs1_der()?.write_pkcs1_pem_file(path, line_ending)
     }
 }

--- a/pkcs8/src/traits.rs
+++ b/pkcs8/src/traits.rs
@@ -162,7 +162,7 @@ pub trait ToPrivateKey {
 
 #[cfg(feature = "pkcs1")]
 #[cfg_attr(docsrs, doc(cfg(feature = "pkcs1")))]
-impl<K: pkcs1::FromRsaPrivateKey> FromPrivateKey for K {
+impl<K: pkcs1::DecodeRsaPrivateKey> FromPrivateKey for K {
     fn from_pkcs8_private_key_info(pkcs8_key: PrivateKeyInfo<'_>) -> Result<Self> {
         pkcs8_key.algorithm.assert_algorithm_oid(PKCS1_OID)?;
 
@@ -178,7 +178,7 @@ impl<K: pkcs1::FromRsaPrivateKey> FromPrivateKey for K {
 #[cfg(all(feature = "alloc", feature = "pkcs1"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[cfg_attr(docsrs, doc(cfg(feature = "pkcs1")))]
-impl<K: pkcs1::ToRsaPrivateKey> ToPrivateKey for K {
+impl<K: pkcs1::EncodeRsaPrivateKey> ToPrivateKey for K {
     fn to_pkcs8_der(&self) -> Result<PrivateKeyDocument> {
         let pkcs1_der = self.to_pkcs1_der()?;
 

--- a/spki/src/traits.rs
+++ b/spki/src/traits.rs
@@ -55,8 +55,7 @@ pub trait DecodePublicKey: Sized {
 
     /// Load public key object from a PEM-encoded file on the local filesystem.
     #[cfg(all(feature = "pem", feature = "std"))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "pem", feature = "std")))]
     fn read_public_key_pem_file(path: impl AsRef<Path>) -> Result<Self> {
         PublicKeyDocument::read_public_key_pem_file(path)
             .and_then(|doc| Self::from_public_key_doc(&doc))


### PR DESCRIPTION
Following suit with the changes to the `spki` crate in #119, renames the traits for decoding/encoding RSA keys, emphasizing that they're encoding-related and not just `From/`To` conversions.