### PR TITLE
pkcs8: rename `From/ToPrivateKey` => `DecodePrivateKey`/`EncodePrivateKey`

### DIFF
--- a/pkcs1/src/traits.rs
+++ b/pkcs1/src/traits.rs
@@ -126,7 +126,7 @@ pub trait EncodeRsaPrivateKey {
 
     /// Write ASN.1 DER-encoded PKCS#1 private key to the given path.
     #[cfg(all(feature = "pem", feature = "std"))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem", feature = "std")))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "pem", feature = "std"))))]
     fn write_pkcs1_pem_file(&self, path: impl AsRef<Path>, line_ending: LineEnding) -> Result<()> {
         self.to_pkcs1_der()?.write_pkcs1_pem_file(path, line_ending)
     }
@@ -155,7 +155,7 @@ pub trait EncodeRsaPublicKey {
 
     /// Write ASN.1 DER-encoded public key to the given path.
     #[cfg(all(feature = "pem", feature = "std"))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem", feature = "std")))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "pem", feature = "std"))))]
     fn write_pkcs1_pem_file(&self, path: impl AsRef<Path>, line_ending: LineEnding) -> Result<()> {
         self.to_pkcs1_der()?.write_pkcs1_pem_file(path, line_ending)
     }

--- a/pkcs8/src/document/private_key.rs
+++ b/pkcs8/src/document/private_key.rs
@@ -1,6 +1,6 @@
 //! PKCS#8 private key document.
 
-use crate::{Error, FromPrivateKey, PrivateKeyInfo, Result, ToPrivateKey};
+use crate::{DecodePrivateKey, EncodePrivateKey, Error, PrivateKeyInfo, Result};
 use alloc::{borrow::ToOwned, vec::Vec};
 use core::{convert::TryFrom, fmt};
 use der::Encodable;
@@ -91,7 +91,7 @@ impl PrivateKeyDocument {
     }
 }
 
-impl FromPrivateKey for PrivateKeyDocument {
+impl DecodePrivateKey for PrivateKeyDocument {
     fn from_pkcs8_private_key_info(private_key: PrivateKeyInfo<'_>) -> Result<Self> {
         Ok(Self(Zeroizing::new(private_key.to_vec()?)))
     }
@@ -130,7 +130,7 @@ impl FromPrivateKey for PrivateKeyDocument {
     }
 }
 
-impl ToPrivateKey for PrivateKeyDocument {
+impl EncodePrivateKey for PrivateKeyDocument {
     fn to_pkcs8_der(&self) -> Result<PrivateKeyDocument> {
         Ok(self.clone())
     }

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -137,7 +137,7 @@ pub(crate) mod encrypted_private_key_info;
 pub use crate::{
     error::{Error, Result},
     private_key_info::PrivateKeyInfo,
-    traits::FromPrivateKey,
+    traits::DecodePrivateKey,
     version::Version,
 };
 pub use der::{self, asn1::ObjectIdentifier};
@@ -145,7 +145,7 @@ pub use spki::{AlgorithmIdentifier, DecodePublicKey, SubjectPublicKeyInfo};
 
 #[cfg(feature = "alloc")]
 pub use {
-    crate::{document::private_key::PrivateKeyDocument, traits::ToPrivateKey},
+    crate::{document::private_key::PrivateKeyDocument, traits::EncodePrivateKey},
     spki::{EncodePublicKey, PublicKeyDocument},
 };
 

--- a/pkcs8/src/traits.rs
+++ b/pkcs8/src/traits.rs
@@ -31,7 +31,7 @@ use crate::AlgorithmIdentifier;
 const PKCS1_OID: ObjectIdentifier = ObjectIdentifier::new("1.2.840.113549.1.1.1");
 
 /// Parse a private key object from a PKCS#8 encoded document.
-pub trait FromPrivateKey: Sized {
+pub trait DecodePrivateKey: Sized {
     /// Parse the [`PrivateKeyInfo`] from a PKCS#8-encoded document.
     fn from_pkcs8_private_key_info(private_key_info: PrivateKeyInfo<'_>) -> Result<Self>;
 
@@ -108,7 +108,7 @@ pub trait FromPrivateKey: Sized {
 /// Serialize a private key object to a PKCS#8 encoded document.
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-pub trait ToPrivateKey {
+pub trait EncodePrivateKey {
     /// Serialize a [`PrivateKeyDocument`] containing a PKCS#8-encoded private key.
     fn to_pkcs8_der(&self) -> Result<PrivateKeyDocument>;
 
@@ -162,7 +162,7 @@ pub trait ToPrivateKey {
 
 #[cfg(feature = "pkcs1")]
 #[cfg_attr(docsrs, doc(cfg(feature = "pkcs1")))]
-impl<K: pkcs1::DecodeRsaPrivateKey> FromPrivateKey for K {
+impl<K: pkcs1::DecodeRsaPrivateKey> DecodePrivateKey for K {
     fn from_pkcs8_private_key_info(pkcs8_key: PrivateKeyInfo<'_>) -> Result<Self> {
         pkcs8_key.algorithm.assert_algorithm_oid(PKCS1_OID)?;
 
@@ -178,7 +178,7 @@ impl<K: pkcs1::DecodeRsaPrivateKey> FromPrivateKey for K {
 #[cfg(all(feature = "alloc", feature = "pkcs1"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[cfg_attr(docsrs, doc(cfg(feature = "pkcs1")))]
-impl<K: pkcs1::EncodeRsaPrivateKey> ToPrivateKey for K {
+impl<K: pkcs1::EncodeRsaPrivateKey> EncodePrivateKey for K {
     fn to_pkcs8_der(&self) -> Result<PrivateKeyDocument> {
         let pkcs1_der = self.to_pkcs1_der()?;
 

--- a/pkcs8/tests/private_key.rs
+++ b/pkcs8/tests/private_key.rs
@@ -8,7 +8,7 @@ use pkcs8::{PrivateKeyInfo, Version};
 use pkcs8::PrivateKeyDocument;
 
 #[cfg(feature = "std")]
-use pkcs8::FromPrivateKey;
+use pkcs8::DecodePrivateKey;
 
 /// Elliptic Curve (P-256) PKCS#8 private key encoded as ASN.1 DER
 const EC_P256_DER_EXAMPLE: &[u8] = include_bytes!("examples/p256-priv.der");


### PR DESCRIPTION
Following suit with the changes to the `spki` and `pkcs1` crates in #119 and #120, renames the traits for decoding/encoding PKCS#8 private keys, emphasizing that they're encoding-related and not just `From/`To` conversions.