### PR TITLE
sec1: rename `From/ToEcPrivateKey` => `DecodeEcPrivateKey`/`EncodeEcPrivateKey`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.2.0"
+version = "0.2.0-pre"
 dependencies = [
  "der",
  "generic-array",

--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sec1"
-version = "0.2.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.0-pre" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of SEC1: Elliptic Curve Cryptography encoding formats
 including ASN.1 DER-serialized private keys as well as the

--- a/sec1/src/lib.rs
+++ b/sec1/src/lib.rs
@@ -13,7 +13,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/sec1/0.1.0"
+    html_root_url = "https://docs.rs/sec1/0.2.0-pre"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
@@ -37,13 +37,13 @@ pub use self::{
     parameters::EcParameters,
     point::EncodedPoint,
     private_key::EcPrivateKey,
-    traits::FromEcPrivateKey,
+    traits::DecodeEcPrivateKey,
 };
 
 pub use generic_array::typenum::consts;
 
 #[cfg(feature = "alloc")]
-pub use crate::{private_key::document::EcPrivateKeyDocument, traits::ToEcPrivateKey};
+pub use crate::{private_key::document::EcPrivateKeyDocument, traits::EncodeEcPrivateKey};
 
 #[cfg(feature = "pem")]
 #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]

--- a/sec1/src/private_key/document.rs
+++ b/sec1/src/private_key/document.rs
@@ -1,6 +1,6 @@
 //! SEC1 EC private key document.
 
-use crate::{EcPrivateKey, Error, FromEcPrivateKey, Result, ToEcPrivateKey};
+use crate::{DecodeEcPrivateKey, EcPrivateKey, EncodeEcPrivateKey, Error, Result};
 use alloc::{borrow::ToOwned, vec::Vec};
 use core::{convert::TryFrom, fmt};
 use der::{Decodable, Encodable};
@@ -40,7 +40,7 @@ impl EcPrivateKeyDocument {
     }
 }
 
-impl FromEcPrivateKey for EcPrivateKeyDocument {
+impl DecodeEcPrivateKey for EcPrivateKeyDocument {
     fn from_sec1_der(bytes: &[u8]) -> Result<Self> {
         // Ensure document is well-formed
         EcPrivateKey::from_der(bytes)?;
@@ -63,19 +63,19 @@ impl FromEcPrivateKey for EcPrivateKeyDocument {
 
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    fn read_sec1_der_file(path: &Path) -> Result<Self> {
+    fn read_sec1_der_file(path: impl AsRef<Path>) -> Result<Self> {
         fs::read(path)?.try_into()
     }
 
     #[cfg(all(feature = "pem", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    fn read_sec1_pem_file(path: &Path) -> Result<Self> {
+    fn read_sec1_pem_file(path: impl AsRef<Path>) -> Result<Self> {
         Self::from_sec1_pem(&Zeroizing::new(fs::read_to_string(path)?))
     }
 }
 
-impl ToEcPrivateKey for EcPrivateKeyDocument {
+impl EncodeEcPrivateKey for EcPrivateKeyDocument {
     fn to_sec1_der(&self) -> Result<EcPrivateKeyDocument> {
         Ok(self.clone())
     }
@@ -89,14 +89,14 @@ impl ToEcPrivateKey for EcPrivateKeyDocument {
 
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    fn write_sec1_der_file(&self, path: &Path) -> Result<()> {
+    fn write_sec1_der_file(&self, path: impl AsRef<Path>) -> Result<()> {
         write_secret_file(path, self.as_der())
     }
 
     #[cfg(all(feature = "pem", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    fn write_sec1_pem_file(&self, path: &Path, line_ending: LineEnding) -> Result<()> {
+    fn write_sec1_pem_file(&self, path: impl AsRef<Path>, line_ending: LineEnding) -> Result<()> {
         let pem_doc = self.to_sec1_pem(line_ending)?;
         write_secret_file(path, pem_doc.as_bytes())
     }

--- a/sec1/src/traits.rs
+++ b/sec1/src/traits.rs
@@ -17,7 +17,7 @@ use std::path::Path;
 use zeroize::Zeroizing;
 
 /// Parse an [`EcPrivateKey`] from a SEC1-encoded document.
-pub trait FromEcPrivateKey: for<'a> TryFrom<EcPrivateKey<'a>, Error = Error> + Sized {
+pub trait DecodeEcPrivateKey: for<'a> TryFrom<EcPrivateKey<'a>, Error = Error> + Sized {
     /// Deserialize SEC1 private key from ASN.1 DER-encoded data
     /// (binary format).
     fn from_sec1_der(bytes: &[u8]) -> Result<Self> {
@@ -41,7 +41,7 @@ pub trait FromEcPrivateKey: for<'a> TryFrom<EcPrivateKey<'a>, Error = Error> + S
     /// filesystem (binary format).
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    fn read_sec1_der_file(path: &Path) -> Result<Self> {
+    fn read_sec1_der_file(path: impl AsRef<Path>) -> Result<Self> {
         EcPrivateKeyDocument::read_sec1_der_file(path)
             .and_then(|doc| Self::try_from(doc.private_key()))
     }
@@ -50,7 +50,7 @@ pub trait FromEcPrivateKey: for<'a> TryFrom<EcPrivateKey<'a>, Error = Error> + S
     #[cfg(all(feature = "pem", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    fn read_sec1_pem_file(path: &Path) -> Result<Self> {
+    fn read_sec1_pem_file(path: impl AsRef<Path>) -> Result<Self> {
         EcPrivateKeyDocument::read_sec1_pem_file(path)
             .and_then(|doc| Self::try_from(doc.private_key()))
     }
@@ -59,7 +59,7 @@ pub trait FromEcPrivateKey: for<'a> TryFrom<EcPrivateKey<'a>, Error = Error> + S
 /// Serialize a [`EcPrivateKey`] to a SEC1 encoded document.
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-pub trait ToEcPrivateKey {
+pub trait EncodeEcPrivateKey {
     /// Serialize a [`EcPrivateKeyDocument`] containing a SEC1-encoded private key.
     fn to_sec1_der(&self) -> Result<EcPrivateKeyDocument>;
 
@@ -75,7 +75,7 @@ pub trait ToEcPrivateKey {
     /// Write ASN.1 DER-encoded SEC1 private key to the given path.
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    fn write_sec1_der_file(&self, path: &Path) -> Result<()> {
+    fn write_sec1_der_file(&self, path: impl AsRef<Path>) -> Result<()> {
         self.to_sec1_der()?.write_sec1_der_file(path)
     }
 
@@ -83,7 +83,7 @@ pub trait ToEcPrivateKey {
     #[cfg(all(feature = "pem", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    fn write_sec1_pem_file(&self, path: &Path, line_ending: LineEnding) -> Result<()> {
+    fn write_sec1_pem_file(&self, path: impl AsRef<Path>, line_ending: LineEnding) -> Result<()> {
         self.to_sec1_der()?.write_sec1_pem_file(path, line_ending)
     }
 }


### PR DESCRIPTION
Following suit with the changes in #119, #120, and #121, renames the traits for decoding/encoding SEC1 private keys, emphasizing that they're encoding-related and not just `From/`To` conversions.