### PR TITLE
pem-rfc7468 v0.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "base64ct",
 ]

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -18,7 +18,7 @@ readme = "README.md"
 const-oid = { version = "0.6", optional = true, path = "../const-oid" }
 crypto-bigint = { version = "0.2", optional = true, features = ["generic-array"] }
 der_derive = { version = "=0.5.0-pre.1", optional = true, path = "derive" }
-pem-rfc7468 = { version = "0.2", optional = true, path = "../pem-rfc7468" }
+pem-rfc7468 = { version = "0.2.3", optional = true, path = "../pem-rfc7468" }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/pem-rfc7468/CHANGELOG.md
+++ b/pem-rfc7468/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.3 (2021-10-17)
+### Added
+- `PemLabel` trait ([#117])
+
+[#117]: https://github.com/RustCrypto/formats/pull/117
+
 ## 0.2.2 (2021-09-16)
 ### Changed
 - Allow for data before PEM encapsulation boundary ([#40])

--- a/pem-rfc7468/Cargo.toml
+++ b/pem-rfc7468/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pem-rfc7468"
-version = "0.2.2" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.3" # Also update html_root_url in lib.rs when bumping this
 description = """
 PEM Encoding (RFC 7468) for PKIX, PKCS, and CMS Structures, implementing a
 strict subset of the original Privacy-Enhanced Mail encoding intended

--- a/pem-rfc7468/src/lib.rs
+++ b/pem-rfc7468/src/lib.rs
@@ -48,7 +48,7 @@
 //!
 //! # Minimum Supported Rust Version
 //!
-//! This crate requires **Rust 1.55** at a minimum.
+//! This crate requires **Rust 1.51** at a minimum.
 //!
 //! # Usage
 //!
@@ -95,7 +95,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/pem-rfc7468/0.2.2"
+    html_root_url = "https://docs.rs/pem-rfc7468/0.2.3"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Added
- `PemLabel` trait ([#117])

[#117]: https://github.com/RustCrypto/formats/pull/117