### PR TITLE
pkcs8: remove PKCS#1 support

### DIFF
--- a/.github/workflows/pkcs8.yml
+++ b/.github/workflows/pkcs8.yml
@@ -46,7 +46,6 @@ jobs:
       - run: cargo build --release --target ${{ matrix.target }} --no-default-features --features des-insecure
       - run: cargo build --release --target ${{ matrix.target }} --no-default-features --features encryption
       - run: cargo build --release --target ${{ matrix.target }} --no-default-features --features pem
-      - run: cargo build --release --target ${{ matrix.target }} --no-default-features --features pkcs1
       - run: cargo build --release --target ${{ matrix.target }} --no-default-features --features pkcs5
       - run: cargo build --release --target ${{ matrix.target }} --no-default-features --features sha1
       - run: cargo build --release --target ${{ matrix.target }} --no-default-features --features subtle
@@ -73,8 +72,6 @@ jobs:
       - run: cargo test --release --features des-insecure
       - run: cargo test --release --features encryption
       - run: cargo test --release --features pem
-      - run: cargo test --release --features pkcs1
-      - run: cargo test --release --features pkcs1,alloc
       - run: cargo test --release --features pkcs5
       - run: cargo test --release --features sha1
       - run: cargo test --release --features std

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,7 +491,6 @@ version = "0.8.0-pre"
 dependencies = [
  "der",
  "hex-literal",
- "pkcs1",
  "pkcs5",
  "rand_core",
  "spki",

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -20,7 +20,6 @@ spki = { version = "=0.5.0-pre", path = "../spki" }
 
 # optional dependencies
 rand_core = { version = "0.6", optional = true, default-features = false }
-pkcs1 = { version = "=0.3.0-pre", optional = true, features = ["alloc"], path = "../pkcs1" }
 pkcs5 = { version = "=0.4.0-pre", optional = true, path = "../pkcs5" }
 subtle = { version = "2", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false, features = ["alloc"] }

--- a/pkcs8/src/error.rs
+++ b/pkcs8/src/error.rs
@@ -50,11 +50,6 @@ pub enum Error {
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     PermissionDenied,
-
-    /// PKCS#1 errors.
-    #[cfg(feature = "pkcs1")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pkcs1")))]
-    Pkcs1(pkcs1::Error),
 }
 
 impl fmt::Display for Error {
@@ -72,8 +67,6 @@ impl fmt::Display for Error {
             Error::Pem(err) => write!(f, "PKCS8 {}", err),
             #[cfg(feature = "std")]
             Error::PermissionDenied => f.write_str("permission denied"),
-            #[cfg(feature = "pkcs1")]
-            Error::Pkcs1(err) => write!(f, "{}", err),
         }
     }
 }
@@ -97,13 +90,6 @@ impl From<der::ErrorKind> for Error {
 impl From<pem::Error> for Error {
     fn from(err: pem::Error) -> Error {
         Error::Pem(err)
-    }
-}
-
-#[cfg(feature = "pkcs1")]
-impl From<pkcs1::Error> for Error {
-    fn from(err: pkcs1::Error) -> Error {
-        Error::Pkcs1(err)
     }
 }
 

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -91,13 +91,8 @@
 //! ⚠️ WARNING ⚠️
 //!
 //! DES support is implemented to allow for decryption of legacy files.
-//!
-//! DES is considered insecure due to its short key size. New keys should use AES instead.
-//!
-//! # PKCS#1 support (optional)
-//! When the `pkcs1` feature of this crate is enabled, this crate provides
-//! a blanket impl of PKCS#8 support for types which impl the traits from the
-//! [`pkcs1`] crate (e.g. `FromRsaPrivateKey`, `ToRsaPrivateKey`).
+//! Such keys should be considered *INSECURE* due to their short key size.
+//! New keys should use AES instead.
 //!
 //! # Minimum Supported Rust Version
 //! This crate requires **Rust 1.55** at a minimum.
@@ -154,13 +149,7 @@ pub use {
 pub use der::pem::{self, LineEnding};
 
 #[cfg(feature = "pkcs5")]
-pub use encrypted_private_key_info::EncryptedPrivateKeyInfo;
-
-#[cfg(feature = "pkcs1")]
-pub use pkcs1;
-
-#[cfg(feature = "pkcs5")]
-pub use pkcs5;
+pub use {crate::encrypted_private_key_info::EncryptedPrivateKeyInfo, pkcs5};
 
 #[cfg(all(feature = "alloc", feature = "pkcs5"))]
 pub use crate::document::encrypted_private_key::EncryptedPrivateKeyDocument;


### PR DESCRIPTION
Previously the `pkcs8` crate provided a blanket impl of the `pkcs1` crate's traits.

However implementing support in this direction can only be done once and means we can't do something similar for the `sec1` crate. See #38.

Removing `pkcs1` support in this direction is the first step towards addressing #38.