### PR TITLE
tls_codec: implement derivation for a simple enum pattern common in the MLS spec

### DIFF
--- a/tls_codec/derive/src/lib.rs
+++ b/tls_codec/derive/src/lib.rs
@@ -445,8 +445,6 @@ fn impl_serialize(parsed_ast: TlsStruct) -> TokenStream2 {
                         enum_value.tls_serialize(writer)
                     }
                 }
-                // This can probably be optimised such that we only have one
-                // `match` statement.
                 EnumStyle::TupleStruct => {
                     let type_mapping: Vec<TokenStream2> = variants
                         .iter()

--- a/tls_codec/derive/src/lib.rs
+++ b/tls_codec/derive/src/lib.rs
@@ -46,7 +46,7 @@ struct Enum {
     variants: Punctuated<Variant, Comma>,
 }
 
-const ENUM_TYPE_POSTFIX: &'static str = "Type";
+const ENUM_TYPE_POSTFIX: &str = "Type";
 
 #[derive(Clone)]
 enum TlsStruct {

--- a/tls_codec/derive/src/lib.rs
+++ b/tls_codec/derive/src/lib.rs
@@ -167,11 +167,7 @@ fn parse_ast(ast: DeriveInput) -> Result<TlsStruct> {
                 syn::Fields::Unnamed(ref fields_unnamed) => {
                     if fields_unnamed.unnamed.len() == 1 {
                         let field_type = fields_unnamed.unnamed.first().unwrap().ty.clone();
-                        if let syn::Type::Path(_) = field_type {
-                            false
-                        } else {
-                            true
-                        }
+                        !matches!(field_type, syn::Type::Path(_))
                     } else {
                         true
                     }

--- a/tls_codec/derive/tests/decode.rs
+++ b/tls_codec/derive/tests/decode.rs
@@ -66,8 +66,21 @@ fn tuple_struct() {
     );
 }
 
+#[derive(TlsDeserialize, TlsSize, Clone, PartialEq, Debug)]
+#[repr(u8)]
+enum SimpleEnumType {
+    One = 1u8,
+    Two = 2u8,
+}
+
+#[derive(TlsDeserialize, TlsSize, Clone, PartialEq)]
+enum SimpleEnum {
+    One(Credential),
+    Two(BasicCredential),
+}
+
 #[test]
-fn simple_enum() {
+fn simple_enums() {
     let mut b = &[0u8, 5] as &[u8];
     let deserialized = ExtensionType::tls_deserialize(&mut b).unwrap();
     assert_eq!(ExtensionType::RatchetTree, deserialized);
@@ -82,6 +95,19 @@ fn simple_enum() {
         let deserialized = ExtensionType::tls_deserialize(&mut b).unwrap();
         assert_eq!(variant, &deserialized);
     }
+
+    let mut one_serialized = &[1u8, 0, 0, 0, 0, 0, 0, 0, 0] as &[u8];
+    let mut two_serialized = &[2u8, 0, 0, 0, 0, 0, 0] as &[u8];
+
+    let one = SimpleEnum::tls_deserialize(&mut one_serialized).expect("Error deserializing.");
+    let two = SimpleEnum::tls_deserialize(&mut two_serialized).expect("Error deserializing.");
+
+    if let SimpleEnum::Two(_) = one {
+        panic!("Enum wrongly deserialized.")
+    };
+    if let SimpleEnum::One(_) = two {
+        panic!("Enum wrongly deserialized.")
+    };
 }
 
 #[test]

--- a/tls_codec/derive/tests/encode.rs
+++ b/tls_codec/derive/tests/encode.rs
@@ -113,10 +113,14 @@ fn simple_enum() {
         credential: basic_credential.clone(),
     };
     let one = SimpleEnum::One(credential);
-    let _one_serialized: Vec<u8> = one.tls_serialize_detached().unwrap();
+    let _one_serialized: Vec<u8> = one
+        .tls_serialize_detached()
+        .expect("Error serializing simple enum");
 
     let two = SimpleEnum::Two(basic_credential);
-    let _two_serialized: Vec<u8> = two.tls_serialize_detached().unwrap();
+    let _two_serialized: Vec<u8> = two
+        .tls_serialize_detached()
+        .expect("Error serializing simple enum");
 }
 
 #[test]

--- a/tls_codec/derive/tests/encode.rs
+++ b/tls_codec/derive/tests/encode.rs
@@ -62,6 +62,38 @@ fn lifetime_struct() {
     );
 }
 
+#[derive(TlsSerialize, TlsSize, Clone, PartialEq)]
+struct CredentialType(u16);
+
+#[derive(TlsSerialize, TlsSize, Clone, PartialEq)]
+struct SignatureScheme(u16);
+
+#[derive(TlsSerialize, TlsSize, Clone, PartialEq)]
+struct BasicCredential {
+    identity: TlsVecU16<u8>,
+    signature_scheme: SignatureScheme,
+    signature_key: TlsVecU16<u8>,
+}
+
+#[derive(TlsSerialize, TlsSize, Clone, PartialEq, Debug)]
+#[repr(u8)]
+enum SimpleEnumType {
+    One = 1u8,
+    Two = 2u8,
+}
+
+#[derive(TlsSerialize, TlsSize, Clone, PartialEq)]
+enum SimpleEnum {
+    One(Credential),
+    Two(BasicCredential),
+}
+
+#[derive(TlsSerialize, TlsSize, Clone, PartialEq)]
+struct Credential {
+    credential_type: CredentialType,
+    credential: BasicCredential,
+}
+
 #[test]
 fn simple_enum() {
     let serialized = ExtensionType::KeyId.tls_serialize_detached().unwrap();
@@ -70,6 +102,21 @@ fn simple_enum() {
         .tls_serialize_detached()
         .unwrap();
     assert_eq!(vec![1, 244], serialized);
+
+    let basic_credential = BasicCredential {
+        identity: vec![].into(),
+        signature_scheme: SignatureScheme(0u16),
+        signature_key: vec![].into(),
+    };
+    let credential = Credential {
+        credential_type: CredentialType(0u16),
+        credential: basic_credential.clone(),
+    };
+    let one = SimpleEnum::One(credential);
+    let _one_serialized: Vec<u8> = one.tls_serialize_detached().unwrap();
+
+    let two = SimpleEnum::Two(basic_credential);
+    let _two_serialized: Vec<u8> = two.tls_serialize_detached().unwrap();
 }
 
 #[test]


### PR DESCRIPTION
This PR allows derivation of the `tls_codec` serialization and deserialization traits for a simple enum pattern that is commonly used in the MLS spec.

In particular, it allows derivation for enums for which a `...Type` exists. Consider the following example enum:
```
enum SimpleEnumType {
    One = 1u8,
    Two = 2u8,
}

enum SimpleEnum {
    One(CredentialOne),
    Two(CredentialTwo),
}
```
We can now derive `TlsSerialize, TlsDeserialize` and `TlsSize` for `SimpleEnum`. Here, `tls_serialize` of an instance of `SimpleEnum::One(cred)` results in the serialization of `SimpleEnumType::One`, concatenated with the serialization of `cred` (which of course needs to implement `TlsSerialize` itself. Or put differently, it results in the serialization of.
```
struct MlsCredential {
    type: SimpleEnumType,
    cred: CredentialOne/Two,
}
```