### PR TITLE
der: add support for hardened `Document` file permissions

### DIFF
--- a/.github/workflows/der.yml
+++ b/.github/workflows/der.yml
@@ -45,23 +45,35 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --release --features alloc,bigint,derive,oid,pem
 
   test:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
+            platform: ubuntu-latest
             rust: 1.55.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
+            platform: ubuntu-latest
             rust: stable
             deps: sudo apt update && sudo apt install gcc-multilib
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
+            platform: ubuntu-latest
             rust: 1.55.0 # MSRV
           - target: x86_64-unknown-linux-gnu
+            platform: ubuntu-latest
             rust: stable
+
+          # 64-bit Windows
+          - target: x86_64-pc-windows-msvc
+            platform: windows-latest
+            rust: 1.55.0 # MSRV
+          - target: x86_64-pc-windows-msvc
+            platform: windows-latest
+            rust: stable
+    runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
@@ -74,4 +86,5 @@ jobs:
       - run: cargo test --target ${{ matrix.target }} --release
       - run: cargo test --target ${{ matrix.target }} --release --features bigint
       - run: cargo test --target ${{ matrix.target }} --release --features oid
+      - run: cargo test --target ${{ matrix.target }} --release --features pem
       - run: cargo test --target ${{ matrix.target }} --release --all-features

--- a/pkcs1/src/public_key/document.rs
+++ b/pkcs1/src/public_key/document.rs
@@ -74,14 +74,14 @@ impl EncodeRsaPublicKey for RsaPublicKeyDocument {
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn write_pkcs1_der_file(&self, path: impl AsRef<Path>) -> Result<()> {
-        Ok(self.write_der_file(path)?)
+        Ok(self.write_der_file(path, false)?)
     }
 
     #[cfg(all(feature = "pem", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn write_pkcs1_pem_file(&self, path: impl AsRef<Path>, line_ending: LineEnding) -> Result<()> {
-        Ok(self.write_pem_file(path, line_ending)?)
+        Ok(self.write_pem_file(path, false, line_ending)?)
     }
 }
 


### PR DESCRIPTION
When persisting `der::Document` as either DER or PEM, and the document contains a secret (e.g. cryptographic key), this commit adds support for using hardened file permissions on Unix platforms to prevent accidental leakage to other users on the same host.

The `pkcs1`, `pkcs8`, and `sec1` crates already use such permissions, however this change allows the file permission handling to be implemented in a single place, so adding support for hardened permissions on other OSes (Windows would be desirable) can happen in a single location.

The aforementioned crates have not yet been updated to use this new API, but it is at least now possible.