### PR TITLE
der: use `proptest` for `DateTime`/`UtcTime` tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,21 @@ name = "base64ct"
 version = "1.1.1"
 
 [[package]]
+name = "bit-set"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,6 +288,7 @@ dependencies = [
  "der_derive",
  "hex-literal",
  "pem-rfc7468",
+ "proptest",
 ]
 
 [[package]]
@@ -312,6 +328,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "generic-array"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,6 +341,17 @@ checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -527,6 +560,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3ca011bd0129ff4ae15cd04c4eef202cadf6c51c21e47aba319b4e0501db741"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,6 +573,38 @@ checksum = "edc3358ebc67bc8b7fa0c007f945b0b18226f78437d61bec735a9eb96b61ee70"
 dependencies = [
  "unicode-xid",
 ]
+
+[[package]]
+name = "proptest"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0d9cc07f18492d879586c92b485def06bc850da3118075cd45d50e9c95b0e5"
+dependencies = [
+ "bit-set",
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "num-traits",
+ "quick-error 2.0.1",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -545,10 +616,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "rayon"
@@ -576,6 +690,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,12 +720,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -771,6 +915,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rand",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -834,6 +992,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -843,6 +1010,12 @@ dependencies = [
  "winapi",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -22,6 +22,7 @@ pem-rfc7468 = { version = "0.2.3", optional = true, path = "../pem-rfc7468" }
 
 [dev-dependencies]
 hex-literal = "0.3"
+proptest = "1"
 
 [features]
 alloc = []

--- a/der/src/asn1/utc_time.rs
+++ b/der/src/asn1/utc_time.rs
@@ -182,7 +182,7 @@ impl Tagged for UtcTime {
 
 #[cfg(test)]
 mod tests {
-    use super::{DateTime, UtcTime};
+    use super::UtcTime;
     use crate::{Decodable, Encodable, Encoder};
     use hex_literal::hex;
 
@@ -196,30 +196,5 @@ mod tests {
         let mut encoder = Encoder::new(&mut buf);
         utc_time.encode(&mut encoder).unwrap();
         assert_eq!(example_bytes, encoder.finish().unwrap());
-    }
-
-    #[test]
-    fn round_trip_examples() {
-        for year in 1970..=2049 {
-            for month in 1..=12 {
-                let max_day = if month == 2 { 28 } else { 30 };
-
-                for day in 1..=max_day {
-                    for hour in 0..=23 {
-                        let datetime1 = DateTime::new(year, month, day, hour, 0, 0).unwrap();
-                        let utc_time1 =
-                            UtcTime::from_unix_duration(datetime1.unix_duration()).unwrap();
-
-                        let mut buf = [0u8; 128];
-                        let mut encoder = Encoder::new(&mut buf);
-                        utc_time1.encode(&mut encoder).unwrap();
-                        let der_bytes = encoder.finish().unwrap();
-
-                        let utc_time2 = UtcTime::from_der(der_bytes).unwrap();
-                        assert_eq!(utc_time1, utc_time2);
-                    }
-                }
-            }
-        }
     }
 }

--- a/der/src/datetime.rs
+++ b/der/src/datetime.rs
@@ -382,22 +382,4 @@ mod tests {
         let datetime = DateTime::new(2001, 01, 02, 12, 13, 14).unwrap();
         assert_eq!(&datetime.to_string(), "2001-01-02T12:13:14Z");
     }
-
-    #[test]
-    fn round_trip() {
-        for year in 1970..=2100 {
-            for month in 1..=12 {
-                let max_day = if month == 2 { 28 } else { 30 };
-
-                for day in 1..=max_day {
-                    for hour in 0..=23 {
-                        let datetime1 = DateTime::new(year, month, day, hour, 0, 0).unwrap();
-                        let unix_duration = datetime1.unix_duration();
-                        let datetime2 = DateTime::from_unix_duration(unix_duration).unwrap();
-                        assert_eq!(datetime1, datetime2);
-                    }
-                }
-            }
-        }
-    }
 }

--- a/der/tests/datetime.proptest-regressions
+++ b/der/tests/datetime.proptest-regressions
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 00dbea7e90761c16aa20e2fbf7ffad420da0c84d4ed4e6df123de03c9b4567e5 # shrinks to year = 1970, month = 1, day = 1, hour = 0, min = 60, sec = 0
+cc 3b0bd01ef4cad6bea0a287f9cdcd56bad186125ec388d204f6afcd193ca12c39 # shrinks to year = 1970, month = 1, day = 1, hour = 0, min = 0, sec = 60

--- a/der/tests/datetime.rs
+++ b/der/tests/datetime.rs
@@ -1,0 +1,65 @@
+//! Tests for the [`DateTime`] type.
+
+use der::{asn1::UtcTime, DateTime, Decodable, Encodable};
+use proptest::prelude::*;
+use std::convert::TryFrom;
+
+proptest! {
+    #[test]
+    fn roundtrip_datetime(
+        year in 1970u16..=9999,
+        month in 1u16..=12,
+        day in 1u16..=31,
+        hour in 0u16..=23,
+        min in 0u16..=59,
+        sec in 0u16..=59,
+    ) {
+        let datetime1 = make_datetime(year, month, day, hour, min, sec);
+        let datetime2 = DateTime::from_unix_duration(datetime1.unix_duration()).unwrap();
+        prop_assert_eq!(datetime1, datetime2);
+    }
+
+    #[test]
+    fn roundtrip_utctime(
+        year in 1970u16..=2049,
+        month in 1u16..=12,
+        day in 1u16..=31,
+        hour in 0u16..=23,
+        min in 0u16..=59,
+        sec in 0u16..=59,
+    ) {
+        let datetime = make_datetime(year, month, day, hour, min, sec);
+        let utc_time1 = UtcTime::try_from(datetime).unwrap();
+
+        let mut buf = [0u8; 128];
+        let mut encoder = der::Encoder::new(&mut buf);
+        utc_time1.encode(&mut encoder).unwrap();
+        let der_bytes = encoder.finish().unwrap();
+
+        let utc_time2 = UtcTime::from_der(der_bytes).unwrap();
+        prop_assert_eq!(utc_time1, utc_time2);
+    }
+}
+
+fn make_datetime(year: u16, month: u16, day: u16, hour: u16, min: u16, sec: u16) -> DateTime {
+    let max_day = if month == 2 {
+        let is_leap_year = year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
+
+        if is_leap_year {
+            29
+        } else {
+            28
+        }
+    } else {
+        30
+    };
+
+    let day = if day > max_day { max_day } else { day };
+
+    DateTime::new(year, month, day, hour, min, sec).unwrap_or_else(|e| {
+        panic!(
+            "invalid DateTime: {:02}-{:02}-{:02}T{:02}:{:02}:{:02}: {}",
+            year, month, day, hour, min, sec, e
+        );
+    })
+}


### PR DESCRIPTION
Using `proptest` provides both a greater breadth of tested inputs as well as better performance, since the old tests were effectively brute force testing a set of valid inputs, whereas proptest generates randomized test cases instead.