### PR TITLE
sec1: use `der::Document` to impl `EcPrivateKeyDocument`

### DIFF
--- a/pkcs1/src/private_key/document.rs
+++ b/pkcs1/src/private_key/document.rs
@@ -17,7 +17,7 @@ use {
 };
 
 #[cfg(feature = "std")]
-use std::{fs, path::Path, str};
+use std::{path::Path, str};
 
 /// PKCS#1 `RSA PRIVATE KEY` document.
 ///
@@ -51,14 +51,14 @@ impl DecodeRsaPrivateKey for RsaPrivateKeyDocument {
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn read_pkcs1_der_file(path: impl AsRef<Path>) -> Result<Self> {
-        Ok(fs::read(path)?.try_into()?)
+        Ok(Self::read_der_file(path)?)
     }
 
     #[cfg(all(feature = "pem", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn read_pkcs1_pem_file(path: impl AsRef<Path>) -> Result<Self> {
-        Self::from_pkcs1_pem(&Zeroizing::new(fs::read_to_string(path)?))
+        Ok(Self::read_pem_file(path)?)
     }
 }
 
@@ -93,6 +93,14 @@ impl AsRef<[u8]> for RsaPrivateKeyDocument {
     }
 }
 
+impl TryFrom<&[u8]> for RsaPrivateKeyDocument {
+    type Error = Error;
+
+    fn try_from(bytes: &[u8]) -> Result<Self> {
+        RsaPrivateKeyDocument::from_pkcs1_der(bytes)
+    }
+}
+
 impl TryFrom<RsaPrivateKey<'_>> for RsaPrivateKeyDocument {
     type Error = Error;
 
@@ -106,14 +114,6 @@ impl TryFrom<&RsaPrivateKey<'_>> for RsaPrivateKeyDocument {
 
     fn try_from(private_key: &RsaPrivateKey<'_>) -> Result<RsaPrivateKeyDocument> {
         Ok(private_key.to_vec()?.try_into()?)
-    }
-}
-
-impl TryFrom<&[u8]> for RsaPrivateKeyDocument {
-    type Error = Error;
-
-    fn try_from(bytes: &[u8]) -> Result<Self> {
-        RsaPrivateKeyDocument::from_pkcs1_der(bytes)
     }
 }
 

--- a/sec1/src/private_key.rs
+++ b/sec1/src/private_key.rs
@@ -15,10 +15,6 @@ use der::{
     Decodable, Decoder, Encodable, Sequence, TagMode, TagNumber,
 };
 
-/// Type label for PEM-encoded private keys.
-#[cfg(feature = "pem")]
-pub(crate) const PEM_TYPE_LABEL: &str = "EC PRIVATE KEY";
-
 /// `ECPrivateKey` version.
 ///
 /// From [RFC5913 Section 3]:

--- a/sec1/src/private_key/document.rs
+++ b/sec1/src/private_key/document.rs
@@ -1,23 +1,20 @@
 //! SEC1 EC private key document.
 
 use crate::{DecodeEcPrivateKey, EcPrivateKey, EncodeEcPrivateKey, Error, Result};
-use alloc::{borrow::ToOwned, vec::Vec};
+use alloc::vec::Vec;
 use core::{convert::TryFrom, fmt};
-use der::{Decodable, Encodable};
+use der::{Decodable, Document, Encodable};
 use zeroize::{Zeroize, Zeroizing};
 
 #[cfg(feature = "pem")]
 use {
-    crate::{pem, private_key::PEM_TYPE_LABEL, LineEnding},
+    crate::{pem, LineEnding},
     alloc::string::String,
     core::str::FromStr,
 };
 
 #[cfg(feature = "std")]
-use {
-    core::convert::TryInto,
-    std::{fs, path::Path, str},
-};
+use std::{path::Path, str};
 
 /// SEC1 `EC PRIVATE KEY` document.
 ///
@@ -28,50 +25,33 @@ use {
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub struct EcPrivateKeyDocument(Zeroizing<Vec<u8>>);
 
-impl EcPrivateKeyDocument {
-    /// Parse the [`EcPrivateKey`] contained in this [`EcPrivateKeyDocument`]
-    pub fn private_key(&self) -> EcPrivateKey<'_> {
-        EcPrivateKey::from_der(self.0.as_ref()).expect("malformed EcPrivateKeyDocument")
-    }
-
-    /// Borrow the inner DER encoded bytes.
-    pub fn as_der(&self) -> &[u8] {
-        self.0.as_ref()
-    }
+impl<'a> Document<'a> for EcPrivateKeyDocument {
+    type Message = EcPrivateKey<'a>;
+    const SENSITIVE: bool = true;
 }
 
 impl DecodeEcPrivateKey for EcPrivateKeyDocument {
     fn from_sec1_der(bytes: &[u8]) -> Result<Self> {
-        // Ensure document is well-formed
-        EcPrivateKey::from_der(bytes)?;
-        Ok(Self(Zeroizing::new(bytes.to_owned())))
+        Ok(Self::from_der(bytes)?)
     }
 
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     fn from_sec1_pem(s: &str) -> Result<Self> {
-        let (label, der_bytes) = pem::decode_vec(s.as_bytes())?;
-
-        if label != PEM_TYPE_LABEL {
-            return Err(pem::Error::Label.into());
-        }
-
-        // Ensure document is well-formed
-        EcPrivateKey::from_der(der_bytes.as_slice())?;
-        Ok(Self(Zeroizing::new(der_bytes)))
+        Ok(Self::from_pem(s)?)
     }
 
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn read_sec1_der_file(path: impl AsRef<Path>) -> Result<Self> {
-        fs::read(path)?.try_into()
+        Ok(Self::read_der_file(path)?)
     }
 
     #[cfg(all(feature = "pem", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn read_sec1_pem_file(path: impl AsRef<Path>) -> Result<Self> {
-        Self::from_sec1_pem(&Zeroizing::new(fs::read_to_string(path)?))
+        Ok(Self::read_pem_file(path)?)
     }
 }
 
@@ -83,28 +63,26 @@ impl EncodeEcPrivateKey for EcPrivateKeyDocument {
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     fn to_sec1_pem(&self, line_ending: LineEnding) -> Result<Zeroizing<String>> {
-        let pem_doc = pem::encode_string(PEM_TYPE_LABEL, line_ending, self.as_der())?;
-        Ok(Zeroizing::new(pem_doc))
+        Ok(Zeroizing::new(self.to_pem(line_ending)?))
     }
 
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn write_sec1_der_file(&self, path: impl AsRef<Path>) -> Result<()> {
-        write_secret_file(path, self.as_der())
+        Ok(self.write_der_file(path)?)
     }
 
     #[cfg(all(feature = "pem", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn write_sec1_pem_file(&self, path: impl AsRef<Path>, line_ending: LineEnding) -> Result<()> {
-        let pem_doc = self.to_sec1_pem(line_ending)?;
-        write_secret_file(path, pem_doc.as_bytes())
+        Ok(self.write_pem_file(path, line_ending)?)
     }
 }
 
 impl AsRef<[u8]> for EcPrivateKeyDocument {
     fn as_ref(&self) -> &[u8] {
-        self.as_der()
+        self.0.as_ref()
     }
 }
 
@@ -133,13 +111,13 @@ impl TryFrom<&EcPrivateKey<'_>> for EcPrivateKeyDocument {
 }
 
 impl TryFrom<Vec<u8>> for EcPrivateKeyDocument {
-    type Error = Error;
+    type Error = der::Error;
 
-    fn try_from(mut bytes: Vec<u8>) -> Result<Self> {
+    fn try_from(mut bytes: Vec<u8>) -> der::Result<Self> {
         // Ensure document is well-formed
         if let Err(err) = EcPrivateKey::from_der(bytes.as_slice()) {
             bytes.zeroize();
-            return Err(err.into());
+            return Err(err);
         }
 
         Ok(Self(Zeroizing::new(bytes)))
@@ -149,7 +127,7 @@ impl TryFrom<Vec<u8>> for EcPrivateKeyDocument {
 impl fmt::Debug for EcPrivateKeyDocument {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_tuple("EcPrivateKeyDocument")
-            .field(&self.private_key())
+            .field(&self.decode())
             .finish()
     }
 }
@@ -164,31 +142,8 @@ impl FromStr for EcPrivateKeyDocument {
     }
 }
 
-/// Write a file containing secret data to the filesystem, restricting the
-/// file permissions so it's only readable by the owner
-#[cfg(all(unix, feature = "std"))]
-pub(super) fn write_secret_file(path: impl AsRef<Path>, data: &[u8]) -> Result<()> {
-    use std::{io::Write, os::unix::fs::OpenOptionsExt};
-
-    /// File permissions for secret data
-    #[cfg(unix)]
-    const SECRET_FILE_PERMS: u32 = 0o600;
-
-    fs::OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(true)
-        .mode(SECRET_FILE_PERMS)
-        .open(path)
-        .and_then(|mut file| file.write_all(data))?;
-
-    Ok(())
-}
-
-/// Write a file containing secret data to the filesystem
-// TODO(tarcieri): permissions hardening on Windows
-#[cfg(all(not(unix), feature = "std"))]
-pub(super) fn write_secret_file(path: impl AsRef<Path>, data: &[u8]) -> Result<()> {
-    fs::write(path, data)?;
-    Ok(())
+#[cfg(feature = "pem")]
+#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
+impl pem::PemLabel for EcPrivateKeyDocument {
+    const TYPE_LABEL: &'static str = "EC PRIVATE KEY";
 }

--- a/sec1/src/traits.rs
+++ b/sec1/src/traits.rs
@@ -14,7 +14,7 @@ use {crate::LineEnding, alloc::string::String};
 use std::path::Path;
 
 #[cfg(any(feature = "pem", feature = "std"))]
-use zeroize::Zeroizing;
+use {der::Document, zeroize::Zeroizing};
 
 /// Parse an [`EcPrivateKey`] from a SEC1-encoded document.
 pub trait DecodeEcPrivateKey: for<'a> TryFrom<EcPrivateKey<'a>, Error = Error> + Sized {
@@ -34,7 +34,7 @@ pub trait DecodeEcPrivateKey: for<'a> TryFrom<EcPrivateKey<'a>, Error = Error> +
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     fn from_sec1_pem(s: &str) -> Result<Self> {
-        EcPrivateKeyDocument::from_sec1_pem(s).and_then(|doc| Self::try_from(doc.private_key()))
+        EcPrivateKeyDocument::from_sec1_pem(s).and_then(|doc| Self::try_from(doc.decode()))
     }
 
     /// Load SEC1 private key from an ASN.1 DER-encoded file on the local
@@ -42,8 +42,7 @@ pub trait DecodeEcPrivateKey: for<'a> TryFrom<EcPrivateKey<'a>, Error = Error> +
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn read_sec1_der_file(path: impl AsRef<Path>) -> Result<Self> {
-        EcPrivateKeyDocument::read_sec1_der_file(path)
-            .and_then(|doc| Self::try_from(doc.private_key()))
+        EcPrivateKeyDocument::read_sec1_der_file(path).and_then(|doc| Self::try_from(doc.decode()))
     }
 
     /// Load SEC1 private key from a PEM-encoded file on the local filesystem.
@@ -51,8 +50,7 @@ pub trait DecodeEcPrivateKey: for<'a> TryFrom<EcPrivateKey<'a>, Error = Error> +
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn read_sec1_pem_file(path: impl AsRef<Path>) -> Result<Self> {
-        EcPrivateKeyDocument::read_sec1_pem_file(path)
-            .and_then(|doc| Self::try_from(doc.private_key()))
+        EcPrivateKeyDocument::read_sec1_pem_file(path).and_then(|doc| Self::try_from(doc.decode()))
     }
 }
 

--- a/sec1/tests/private_key.rs
+++ b/sec1/tests/private_key.rs
@@ -6,7 +6,7 @@ use hex_literal::hex;
 use sec1::{EcParameters, EcPrivateKey};
 
 #[cfg(feature = "pem")]
-use sec1::EcPrivateKeyDocument;
+use sec1::{der::Document, EcPrivateKeyDocument};
 
 /// NIST P-256 SEC1 private key encoded as ASN.1 DER.
 ///
@@ -45,5 +45,5 @@ fn decode_p256_pem() {
 
     // Ensure `EcPrivateKeyDocument` parses successfully
     let pk = EcPrivateKey::try_from(P256_DER_EXAMPLE).unwrap();
-    assert_eq!(sec1_doc.private_key().private_key, pk.private_key);
+    assert_eq!(sec1_doc.decode().private_key, pk.private_key);
 }


### PR DESCRIPTION
Uses the new `Document` trait to impl `EcPrivateKeyDocument`, including the newly added support for hardened file permissions gated on the associated `const SENSITIVE: bool = true`.