### PR TITLE
base64ct: fix benchmarks

### DIFF
--- a/.github/workflows/base64ct.yml
+++ b/.github/workflows/base64ct.yml
@@ -55,3 +55,14 @@ jobs:
       - run: cargo test --release
       - run: cargo test --release --features alloc
       - run: cargo test --release --all-features
+
+  bench:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly-2021-10-19 # Pinned to avoid nightly breakages. Bump if needed.
+          override: true
+      - run: cargo build --benches

--- a/base64ct/benches/mod.rs
+++ b/base64ct/benches/mod.rs
@@ -1,5 +1,9 @@
+//! `base64ct` benchmarks
+
 #![feature(test)]
 extern crate test;
+
+use base64ct::{Base64Unpadded, Encoding};
 use test::Bencher;
 
 const B64_LEN: usize = 100_002;
@@ -28,7 +32,7 @@ fn decode_bench(b: &mut Bencher) {
     let b64_data = get_b64_data();
     let mut buf = get_raw_data();
     b.iter(|| {
-        let out = base64ct::decode(&b64_data, &mut buf).unwrap();
+        let out = Base64Unpadded::decode(&b64_data, &mut buf).unwrap();
         test::black_box(out);
     });
     b.bytes = RAW_LEN as u64;
@@ -40,7 +44,7 @@ fn decode_in_place_bench(b: &mut Bencher) {
     b.iter(|| {
         // since it works on the same buffer over and over,
         // almost always `out` will be an error
-        let out = base64ct::decode_in_place(&mut b64_data);
+        let out = Base64Unpadded::decode_in_place(&mut b64_data);
         let _ = test::black_box(out);
     });
     b.bytes = RAW_LEN as u64;
@@ -51,7 +55,7 @@ fn encode_bench(b: &mut Bencher) {
     let mut buf = get_b64_data().into_bytes();
     let raw_data = get_raw_data();
     b.iter(|| {
-        let out = base64ct::encode(&raw_data, &mut buf).unwrap();
+        let out = Base64Unpadded::encode(&raw_data, &mut buf).unwrap();
         test::black_box(out);
     });
     b.bytes = RAW_LEN as u64;


### PR DESCRIPTION
Fixes benchmarks so they compile/run.

Adds a `bench` CI job to ensure the benchmarks still compile against a pinned nightly release.