### PR TITLE
Remove explicit `TryFrom`/`TryInto` imports

### DIFF
--- a/const-oid/src/arcs.rs
+++ b/const-oid/src/arcs.rs
@@ -1,7 +1,7 @@
 //! Arcs are integer values which exist within an OID's hierarchy.
 
 use crate::{Error, ObjectIdentifier, Result};
-use core::{convert::TryFrom, mem};
+use core::mem;
 
 /// Type used to represent an "arc" (i.e. integer identifier value).
 pub type Arc = u32;

--- a/const-oid/src/lib.rs
+++ b/const-oid/src/lib.rs
@@ -78,7 +78,7 @@ pub use crate::{
 };
 
 use crate::arcs::{RootArcs, ARC_MAX_BYTES, ARC_MAX_LAST_OCTET};
-use core::{convert::TryFrom, fmt, str::FromStr};
+use core::{fmt, str::FromStr};
 
 /// Object identifier (OID).
 ///

--- a/der/derive/src/choice.rs
+++ b/der/derive/src/choice.rs
@@ -174,9 +174,6 @@ impl DeriveChoice {
 
             gen impl ::der::Decodable<#lifetime> for @Self {
                 fn decode(decoder: &mut ::der::Decoder<#lifetime>) -> ::der::Result<Self> {
-                    #[allow(unused_imports)]
-                    use core::convert::{TryFrom, TryInto};
-
                     let octet = decoder.peek().ok_or_else(|| {
                         decoder.error(::der::ErrorKind::Truncated)
                     })?;
@@ -196,9 +193,6 @@ impl DeriveChoice {
 
             gen impl ::der::Encodable for @Self {
                 fn encode(&self, encoder: &mut ::der::Encoder<'_>) -> ::der::Result<()> {
-                    #[allow(unused_imports)]
-                    use core::convert::TryFrom;
-
                     match self {
                         #encode_body
                     }

--- a/der/derive/src/sequence.rs
+++ b/der/derive/src/sequence.rs
@@ -102,9 +102,6 @@ impl DeriveSequence {
         s.gen_impl(quote! {
             gen impl ::der::Decodable<#lifetime> for @Self {
                 fn decode(decoder: &mut ::der::Decoder<#lifetime>) -> ::der::Result<Self> {
-                    #[allow(unused_imports)]
-                    use core::convert::TryInto;
-
                     decoder.sequence(|decoder| {
                         #decode_fields
                         Ok(Self { #decode_result })
@@ -117,9 +114,6 @@ impl DeriveSequence {
                 where
                     F: FnOnce(&[&dyn der::Encodable]) -> ::der::Result<T>,
                 {
-                    #[allow(unused_imports)]
-                    use core::convert::TryFrom;
-
                     f(&[#encode_fields])
                 }
             }

--- a/der/src/arrayvec.rs
+++ b/der/src/arrayvec.rs
@@ -3,7 +3,6 @@
 // See: https://github.com/rust-lang/rfcs/pull/2990
 
 use crate::{ErrorKind, Result};
-use core::convert::TryInto;
 
 /// Array-backed append-only vector type.
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]

--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -4,7 +4,6 @@ use crate::{
     asn1::*, ByteSlice, Choice, Decodable, DecodeValue, Decoder, Encodable, EncodeValue, Encoder,
     Error, ErrorKind, Header, Length, Result, Tag, Tagged,
 };
-use core::convert::{TryFrom, TryInto};
 
 #[cfg(feature = "oid")]
 use crate::asn1::ObjectIdentifier;

--- a/der/src/asn1/bit_string.rs
+++ b/der/src/asn1/bit_string.rs
@@ -4,7 +4,6 @@ use crate::{
     asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, ErrorKind, Length,
     Result, Tag, Tagged,
 };
-use core::convert::TryFrom;
 
 /// ASN.1 `BIT STRING` type.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -100,7 +99,6 @@ impl<'a> Tagged for BitString<'a> {
 mod tests {
     use super::{BitString, Result, Tag};
     use crate::asn1::Any;
-    use core::convert::TryInto;
 
     /// Parse a `BitString` from an ASN.1 `Any` value to test decoding behaviors.
     fn parse_bitstring_from_any(bytes: &[u8]) -> Result<BitString<'_>> {

--- a/der/src/asn1/boolean.rs
+++ b/der/src/asn1/boolean.rs
@@ -4,7 +4,6 @@ use crate::{
     asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, ErrorKind, Length,
     Result, Tag, Tagged,
 };
-use core::convert::{TryFrom, TryInto};
 
 /// Byte used to encode `true` in ASN.1 DER. From X.690 Section 11.1:
 ///

--- a/der/src/asn1/context_specific.rs
+++ b/der/src/asn1/context_specific.rs
@@ -4,7 +4,6 @@ use crate::{
     asn1::Any, Choice, Decodable, DecodeValue, Decoder, Encodable, EncodeValue, Encoder, Error,
     Header, Length, Result, Tag, TagMode, TagNumber, Tagged,
 };
-use core::convert::{TryFrom, TryInto};
 
 /// Context-specific field.
 ///

--- a/der/src/asn1/generalized_time.rs
+++ b/der/src/asn1/generalized_time.rs
@@ -5,13 +5,13 @@ use crate::{
     datetime::{self, DateTime},
     ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, Length, Result, Tag, Tagged,
 };
-use core::{convert::TryFrom, time::Duration};
+use core::time::Duration;
 
 #[cfg(feature = "std")]
 use std::time::SystemTime;
 
 #[cfg(feature = "time")]
-use {core::convert::TryInto, time::PrimitiveDateTime};
+use time::PrimitiveDateTime;
 
 /// ASN.1 `GeneralizedTime` type.
 ///

--- a/der/src/asn1/ia5_string.rs
+++ b/der/src/asn1/ia5_string.rs
@@ -4,7 +4,7 @@ use crate::{
     asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, Length, Result,
     StrSlice, Tag, Tagged,
 };
-use core::{convert::TryFrom, fmt, str};
+use core::{fmt, str};
 
 /// ASN.1 `IA5String` type.
 ///

--- a/der/src/asn1/integer.rs
+++ b/der/src/asn1/integer.rs
@@ -8,7 +8,6 @@ use crate::{
     asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, Length, Result, Tag,
     Tagged,
 };
-use core::convert::TryFrom;
 
 macro_rules! impl_int_encoding {
     ($($int:ty => $uint:ty),+) => {

--- a/der/src/asn1/integer/bigint.rs
+++ b/der/src/asn1/integer/bigint.rs
@@ -5,13 +5,9 @@ use crate::{
     asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, ErrorKind, Length,
     Result, Tag, Tagged,
 };
-use core::convert::TryFrom;
 
 #[cfg(feature = "bigint")]
-use {
-    core::convert::TryInto,
-    crypto_bigint::{generic_array::GenericArray, ArrayEncoding, UInt},
-};
+use crypto_bigint::{generic_array::GenericArray, ArrayEncoding, UInt};
 
 /// "Big" unsigned ASN.1 `INTEGER` type.
 ///
@@ -57,10 +53,10 @@ impl<'a> DecodeValue<'a> for UIntBytes<'a> {
         let bytes = ByteSlice::decode_value(decoder, length)?.as_bytes();
         let result = Self::new(uint::decode_to_slice(bytes)?)?;
 
-        // Ensure we compute the same encoded length as the original any value
-        // if any.encoded_len()? != result.encoded_len()? {
-        //     return Err(Self::TAG.non_canonical_error());
-        // }
+        // Ensure we compute the same encoded length as the original any value.
+        if result.value_len()? != length {
+            return Err(Self::TAG.non_canonical_error());
+        }
 
         Ok(result)
     }
@@ -162,7 +158,6 @@ mod tests {
         asn1::{integer::tests::*, Any},
         Decodable, Encodable, Encoder, ErrorKind, Tag,
     };
-    use core::convert::TryFrom;
 
     #[test]
     fn decode_uint_bytes() {

--- a/der/src/asn1/integer/int.rs
+++ b/der/src/asn1/integer/int.rs
@@ -2,7 +2,6 @@
 
 use super::is_highest_bit_set;
 use crate::{Encoder, ErrorKind, Length, Result};
-use core::convert::TryFrom;
 
 /// Decode an unsigned integer of the specified size.
 ///

--- a/der/src/asn1/integer/uint.rs
+++ b/der/src/asn1/integer/uint.rs
@@ -1,7 +1,6 @@
 //! Unsigned integer decoders/encoders.
 
 use crate::{Encoder, Length, Result, Tag};
-use core::convert::TryFrom;
 
 /// Decode an unsigned integer into a big endian byte slice with all leading
 /// zeroes removed.

--- a/der/src/asn1/null.rs
+++ b/der/src/asn1/null.rs
@@ -4,7 +4,6 @@ use crate::{
     asn1::Any, ByteSlice, DecodeValue, Decoder, Encodable, EncodeValue, Encoder, Error, ErrorKind,
     Length, Result, Tag, Tagged,
 };
-use core::convert::TryFrom;
 
 /// ASN.1 `NULL` type.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]

--- a/der/src/asn1/octet_string.rs
+++ b/der/src/asn1/octet_string.rs
@@ -4,7 +4,6 @@ use crate::{
     asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, ErrorKind, Length,
     Result, Tag, Tagged,
 };
-use core::convert::TryFrom;
 
 /// ASN.1 `OCTET STRING` type.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]

--- a/der/src/asn1/oid.rs
+++ b/der/src/asn1/oid.rs
@@ -5,7 +5,6 @@ use crate::{
     Tagged,
 };
 use const_oid::ObjectIdentifier;
-use core::convert::{TryFrom, TryInto};
 
 impl DecodeValue<'_> for ObjectIdentifier {
     fn decode_value(decoder: &mut Decoder<'_>, length: Length) -> Result<Self> {
@@ -56,7 +55,6 @@ impl<'a> Tagged for ObjectIdentifier {
 mod tests {
     use super::ObjectIdentifier;
     use crate::{Decodable, Encodable, Length};
-    use core::convert::TryInto;
 
     const EXAMPLE_OID: ObjectIdentifier = ObjectIdentifier::new("1.2.840.113549");
     const EXAMPLE_OID_BYTES: &[u8; 8] = &[0x06, 0x06, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d];

--- a/der/src/asn1/optional.rs
+++ b/der/src/asn1/optional.rs
@@ -1,7 +1,6 @@
 //! ASN.1 `OPTIONAL` as mapped to Rust's `Option` type
 
 use crate::{Choice, Decodable, Decoder, Encodable, Encoder, Length, Result, Tag};
-use core::convert::TryFrom;
 
 impl<'a, T> Decodable<'a> for Option<T>
 where

--- a/der/src/asn1/printable_string.rs
+++ b/der/src/asn1/printable_string.rs
@@ -4,7 +4,7 @@ use crate::{
     asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, Length, Result,
     StrSlice, Tag, Tagged,
 };
-use core::{convert::TryFrom, fmt, str};
+use core::{fmt, str};
 
 /// ASN.1 `PrintableString` type.
 ///

--- a/der/src/asn1/set_of.rs
+++ b/der/src/asn1/set_of.rs
@@ -9,7 +9,6 @@ use crate::{
 use {
     crate::{asn1::Any, Error},
     alloc::collections::BTreeSet,
-    core::convert::TryFrom,
 };
 
 /// ASN.1 `SET OF` backed by an array.

--- a/der/src/asn1/utc_time.rs
+++ b/der/src/asn1/utc_time.rs
@@ -5,10 +5,7 @@ use crate::{
     datetime::{self, DateTime},
     ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, Length, Result, Tag, Tagged,
 };
-use core::{
-    convert::{TryFrom, TryInto},
-    time::Duration,
-};
+use core::time::Duration;
 
 #[cfg(feature = "std")]
 use std::time::SystemTime;

--- a/der/src/asn1/utf8_string.rs
+++ b/der/src/asn1/utf8_string.rs
@@ -4,7 +4,7 @@ use crate::{
     asn1::Any, ByteSlice, DecodeValue, Decoder, Encodable, EncodeValue, Encoder, Error, Length,
     Result, StrSlice, Tag, Tagged,
 };
-use core::{convert::TryFrom, fmt, str};
+use core::{fmt, str};
 
 #[cfg(feature = "alloc")]
 use alloc::{borrow::ToOwned, string::String};

--- a/der/src/byte_slice.rs
+++ b/der/src/byte_slice.rs
@@ -5,7 +5,6 @@ use crate::{
     str_slice::StrSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, ErrorKind, Length,
     Result,
 };
-use core::convert::TryFrom;
 
 /// Byte slice newtype which respects the `Length::max()` limit.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]

--- a/der/src/datetime.rs
+++ b/der/src/datetime.rs
@@ -12,10 +12,7 @@ use core::{fmt, str::FromStr, time::Duration};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 #[cfg(feature = "time")]
-use {core::convert::TryInto, time::PrimitiveDateTime};
-
-#[cfg(any(feature = "std", feature = "time"))]
-use core::convert::TryFrom;
+use time::PrimitiveDateTime;
 
 /// Minimum year allowed in [`DateTime`] values.
 const MIN_YEAR: u16 = 1970;

--- a/der/src/decoder.rs
+++ b/der/src/decoder.rs
@@ -4,7 +4,6 @@ use crate::{
     asn1::*, Choice, Decodable, DecodeValue, Error, ErrorKind, Length, Result, Tag, TagMode,
     TagNumber, Tagged,
 };
-use core::convert::{TryFrom, TryInto};
 
 /// DER decoder.
 #[derive(Debug)]

--- a/der/src/document.rs
+++ b/der/src/document.rs
@@ -2,7 +2,6 @@
 
 use crate::{Decodable, Encodable, Error, Result};
 use alloc::{boxed::Box, vec::Vec};
-use core::convert::{TryFrom, TryInto};
 
 #[cfg(feature = "pem")]
 use {crate::pem, alloc::string::String};

--- a/der/src/encodable.rs
+++ b/der/src/encodable.rs
@@ -3,14 +3,7 @@
 use crate::{EncodeValue, Encoder, Header, Length, Result, Tagged};
 
 #[cfg(feature = "alloc")]
-use {
-    crate::ErrorKind,
-    alloc::vec::Vec,
-    core::{
-        convert::{TryFrom, TryInto},
-        iter,
-    },
-};
+use {crate::ErrorKind, alloc::vec::Vec, core::iter};
 
 /// Encoding trait.
 pub trait Encodable {

--- a/der/src/encoder.rs
+++ b/der/src/encoder.rs
@@ -4,7 +4,6 @@ use crate::{
     asn1::*, Encodable, EncodeValue, Error, ErrorKind, Header, Length, Result, Tag, TagMode,
     TagNumber, Tagged,
 };
-use core::convert::{TryFrom, TryInto};
 
 /// DER encoder.
 #[derive(Debug)]

--- a/der/src/header.rs
+++ b/der/src/header.rs
@@ -1,7 +1,6 @@
 //! ASN.1 DER headers.
 
 use crate::{Decodable, Decoder, Encodable, Encoder, ErrorKind, Length, Result, Tag};
-use core::convert::TryInto;
 
 /// ASN.1 DER headers: tag + length component of TLV-encoded values
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/der/src/length.rs
+++ b/der/src/length.rs
@@ -2,7 +2,6 @@
 
 use crate::{Decodable, Decoder, Encodable, Encoder, Error, ErrorKind, Result};
 use core::{
-    convert::{TryFrom, TryInto},
     fmt,
     ops::{Add, Sub},
 };
@@ -255,7 +254,6 @@ impl fmt::Display for Length {
 mod tests {
     use super::Length;
     use crate::{Decodable, Encodable, ErrorKind};
-    use core::convert::TryFrom;
 
     #[test]
     fn decode() {

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -86,7 +86,6 @@
 //! // Note: the following example does not require the `std` feature at all.
 //! // It does leverage the `alloc` feature, but also provides instructions for
 //! // "heapless" usage when the `alloc` feature is disabled.
-//! use core::convert::{TryFrom, TryInto};
 //! use der::{
 //!     asn1::{Any, ObjectIdentifier},
 //!     Decodable, Decoder, Encodable, Sequence
@@ -230,7 +229,6 @@
 //! # #[cfg(all(feature = "alloc", feature = "derive", feature = "oid"))]
 //! # {
 //! use der::{asn1::{Any, ObjectIdentifier}, Encodable, Decodable, Sequence};
-//! use core::convert::TryInto;
 //!
 //! /// X.509 `AlgorithmIdentifier` (same as above)
 //! #[derive(Copy, Clone, Debug, Eq, PartialEq, Sequence)] // NOTE: added `Sequence`

--- a/der/src/str_slice.rs
+++ b/der/src/str_slice.rs
@@ -2,7 +2,7 @@
 //! library-level length limitation i.e. `Length::max()`.
 
 use crate::{ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Length, Result};
-use core::{convert::TryFrom, str};
+use core::str;
 
 /// String slice newtype which respects the [`Length::max`] limit.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]

--- a/der/src/tag.rs
+++ b/der/src/tag.rs
@@ -7,7 +7,7 @@ mod number;
 pub use self::{class::Class, mode::TagMode, number::TagNumber};
 
 use crate::{Decodable, Decoder, Encodable, Encoder, Error, ErrorKind, Length, Result};
-use core::{convert::TryFrom, fmt};
+use core::fmt;
 
 /// Indicator bit for constructed form encoding (i.e. vs primitive form)
 const CONSTRUCTED_FLAG: u8 = 0b100000;

--- a/der/src/tag/number.rs
+++ b/der/src/tag/number.rs
@@ -2,7 +2,7 @@
 
 use super::Tag;
 use crate::{Error, ErrorKind, Result};
-use core::{convert::TryFrom, fmt};
+use core::fmt;
 
 /// ASN.1 tag numbers (i.e. lower 5 bits of a [`Tag`]).
 ///

--- a/der/tests/datetime.rs
+++ b/der/tests/datetime.rs
@@ -2,7 +2,6 @@
 
 use der::{asn1::UtcTime, DateTime, Decodable, Encodable};
 use proptest::prelude::*;
-use std::convert::TryFrom;
 
 proptest! {
     #[test]

--- a/pem-rfc7468/src/decoder.rs
+++ b/pem-rfc7468/src/decoder.rs
@@ -18,7 +18,7 @@ use crate::{
     PRE_ENCAPSULATION_BOUNDARY,
 };
 use base64ct::{Base64, Encoding};
-use core::{convert::TryFrom, str};
+use core::str;
 
 /// Decode a PEM document according to RFC 7468's "Strict" grammar.
 ///

--- a/pkcs1/src/private_key.rs
+++ b/pkcs1/src/private_key.rs
@@ -6,7 +6,7 @@ pub(crate) mod document;
 pub(crate) mod other_prime_info;
 
 use crate::{Error, Result, RsaPublicKey, Version};
-use core::{convert::TryFrom, fmt};
+use core::fmt;
 use der::{asn1::UIntBytes, Decodable, Decoder, Encodable, Sequence, Tag};
 
 #[cfg(feature = "alloc")]
@@ -14,7 +14,6 @@ use {
     self::other_prime_info::OtherPrimeInfo,
     crate::{EncodeRsaPrivateKey, RsaPrivateKeyDocument},
     alloc::vec::Vec,
-    core::convert::TryInto,
 };
 
 #[cfg(feature = "pem")]

--- a/pkcs1/src/private_key/document.rs
+++ b/pkcs1/src/private_key/document.rs
@@ -2,10 +2,7 @@
 
 use crate::{DecodeRsaPrivateKey, EncodeRsaPrivateKey, Error, Result, RsaPrivateKey};
 use alloc::vec::Vec;
-use core::{
-    convert::{TryFrom, TryInto},
-    fmt,
-};
+use core::fmt;
 use der::{Decodable, Document, Encodable};
 use zeroize::{Zeroize, Zeroizing};
 

--- a/pkcs1/src/public_key.rs
+++ b/pkcs1/src/public_key.rs
@@ -4,7 +4,6 @@
 pub(crate) mod document;
 
 use crate::{Error, Result};
-use core::convert::TryFrom;
 use der::{asn1::UIntBytes, Decodable, Decoder, Encodable, Sequence};
 
 #[cfg(feature = "alloc")]

--- a/pkcs1/src/public_key/document.rs
+++ b/pkcs1/src/public_key/document.rs
@@ -2,10 +2,7 @@
 
 use crate::{error, DecodeRsaPublicKey, EncodeRsaPublicKey, Error, Result, RsaPublicKey};
 use alloc::vec::Vec;
-use core::{
-    convert::{TryFrom, TryInto},
-    fmt,
-};
+use core::fmt;
 use der::{Decodable, Document, Encodable};
 
 #[cfg(feature = "pem")]

--- a/pkcs1/src/traits.rs
+++ b/pkcs1/src/traits.rs
@@ -1,7 +1,6 @@
 //! Traits for parsing objects from PKCS#1 encoded documents
 
 use crate::{Result, RsaPrivateKey, RsaPublicKey};
-use core::convert::TryFrom;
 
 #[cfg(feature = "alloc")]
 use crate::{RsaPrivateKeyDocument, RsaPublicKeyDocument};

--- a/pkcs1/src/version.rs
+++ b/pkcs1/src/version.rs
@@ -1,7 +1,6 @@
 //! PKCS#1 version identifier.
 
 use crate::Error;
-use core::convert::TryFrom;
 use der::{Decodable, Decoder, Encodable, Encoder, Tag, Tagged};
 
 /// Version identifier for PKCS#1 documents as defined in

--- a/pkcs1/tests/private_key.rs
+++ b/pkcs1/tests/private_key.rs
@@ -1,6 +1,5 @@
 //! PKCS#1 private key tests
 
-use core::convert::TryFrom;
 use hex_literal::hex;
 use pkcs1::{RsaPrivateKey, Version};
 

--- a/pkcs1/tests/public_key.rs
+++ b/pkcs1/tests/public_key.rs
@@ -1,6 +1,5 @@
 //! PKCS#1 public key tests
 
-use core::convert::TryFrom;
 use hex_literal::hex;
 use pkcs1::RsaPublicKey;
 

--- a/pkcs5/src/lib.rs
+++ b/pkcs5/src/lib.rs
@@ -37,7 +37,6 @@ pub use crate::error::{Error, Result};
 pub use der::{self, asn1::ObjectIdentifier};
 pub use spki::AlgorithmIdentifier;
 
-use core::convert::{TryFrom, TryInto};
 use der::{Decodable, Decoder, Encodable, Encoder, Length};
 
 #[cfg(all(feature = "alloc", feature = "pbes2"))]

--- a/pkcs5/src/pbes1.rs
+++ b/pkcs5/src/pbes1.rs
@@ -3,7 +3,6 @@
 //! [RFC 8018 Section 6.1]: https://tools.ietf.org/html/rfc8018#section-6.1
 
 use crate::AlgorithmIdentifier;
-use core::convert::{TryFrom, TryInto};
 use der::{
     asn1::{ObjectIdentifier, OctetString},
     Decodable, Decoder, Encodable, Encoder, ErrorKind, Length, Tag, Tagged,

--- a/pkcs5/src/pbes2.rs
+++ b/pkcs5/src/pbes2.rs
@@ -13,7 +13,6 @@ pub use self::kdf::{
 };
 
 use crate::{AlgorithmIdentifier, Error, Result};
-use core::convert::{TryFrom, TryInto};
 use der::{
     asn1::{Any, ObjectIdentifier, OctetString},
     Decodable, Decoder, Encodable, Encoder, ErrorKind, Length, Sequence,

--- a/pkcs5/src/pbes2/encryption.rs
+++ b/pkcs5/src/pbes2/encryption.rs
@@ -1,10 +1,8 @@
-//! PBES2 encryption implementation
+//! PBES2 encryption.
 
 use super::{EncryptionScheme, Kdf, Parameters, Pbkdf2Params, Pbkdf2Prf, ScryptParams};
 use crate::{Error, Result};
-use block_modes::block_padding::Pkcs7;
-use block_modes::{BlockMode, Cbc};
-use core::convert::TryInto;
+use block_modes::{block_padding::Pkcs7, BlockMode, Cbc};
 use hmac::{
     digest::{generic_array::ArrayLength, BlockInput, FixedOutput, Reset, Update},
     Hmac,
@@ -15,6 +13,7 @@ use scrypt::scrypt;
 type Aes128Cbc = Cbc<aes::Aes128, Pkcs7>;
 type Aes192Cbc = Cbc<aes::Aes192, Pkcs7>;
 type Aes256Cbc = Cbc<aes::Aes256, Pkcs7>;
+
 #[cfg(feature = "des-insecure")]
 type DesCbc = Cbc<des::Des, Pkcs7>;
 #[cfg(feature = "3des")]

--- a/pkcs5/src/pbes2/kdf.rs
+++ b/pkcs5/src/pbes2/kdf.rs
@@ -1,7 +1,6 @@
 //! Key derivation functions.
 
 use crate::{AlgorithmIdentifier, Error, Result};
-use core::convert::{TryFrom, TryInto};
 use der::{
     asn1::{Any, ObjectIdentifier, OctetString},
     Decodable, Decoder, Encodable, Encoder, ErrorKind, Length, Sequence,

--- a/pkcs5/tests/encryption.rs
+++ b/pkcs5/tests/encryption.rs
@@ -2,7 +2,6 @@
 
 #![cfg(feature = "pbes2")]
 
-use core::convert::TryFrom;
 use hex_literal::hex;
 
 /// PBES2 + PBKDF2-SHA256 + AES-256-CBC `AlgorithmIdentifier` example.

--- a/pkcs5/tests/pbes2.rs
+++ b/pkcs5/tests/pbes2.rs
@@ -1,6 +1,5 @@
 //! Password-Based Encryption Scheme 2 tests
 
-use core::convert::TryFrom;
 use der::Encodable;
 use hex_literal::hex;
 use pkcs5::pbes2;

--- a/pkcs8/src/document/encrypted_private_key.rs
+++ b/pkcs8/src/document/encrypted_private_key.rs
@@ -2,10 +2,7 @@
 
 use crate::{EncryptedPrivateKeyInfo, Error, Result};
 use alloc::{borrow::ToOwned, vec::Vec};
-use core::{
-    convert::{TryFrom, TryInto},
-    fmt,
-};
+use core::fmt;
 use der::Encodable;
 use zeroize::{Zeroize, Zeroizing};
 

--- a/pkcs8/src/document/private_key.rs
+++ b/pkcs8/src/document/private_key.rs
@@ -2,7 +2,7 @@
 
 use crate::{DecodePrivateKey, EncodePrivateKey, Error, PrivateKeyInfo, Result};
 use alloc::{borrow::ToOwned, vec::Vec};
-use core::{convert::TryFrom, fmt};
+use core::fmt;
 use der::Encodable;
 use zeroize::{Zeroize, Zeroizing};
 
@@ -22,9 +22,6 @@ use {
 
 #[cfg(feature = "std")]
 use std::{fs, path::Path};
-
-#[cfg(any(feature = "encryption", feature = "std"))]
-use core::convert::TryInto;
 
 /// PKCS#8 private key document.
 ///

--- a/pkcs8/src/encrypted_private_key_info.rs
+++ b/pkcs8/src/encrypted_private_key_info.rs
@@ -1,15 +1,12 @@
 //! PKCS#8 `EncryptedPrivateKeyInfo`
 
 use crate::{Error, Result};
-use core::{convert::TryFrom, fmt};
+use core::fmt;
 use der::{asn1::OctetString, Decodable, Decoder, Encodable, Sequence};
 use pkcs5::EncryptionScheme;
 
 #[cfg(feature = "alloc")]
 use crate::{EncryptedPrivateKeyDocument, PrivateKeyDocument};
-
-#[cfg(feature = "encryption")]
-use core::convert::TryInto;
 
 #[cfg(feature = "pem")]
 use {

--- a/pkcs8/src/private_key_info.rs
+++ b/pkcs8/src/private_key_info.rs
@@ -1,14 +1,14 @@
 //! PKCS#8 `PrivateKeyInfo`.
 
 use crate::{AlgorithmIdentifier, Error, Result, Version};
-use core::{convert::TryFrom, fmt};
+use core::fmt;
 use der::{
     asn1::{Any, BitString, ContextSpecific, OctetString},
     Decodable, Decoder, Encodable, Sequence, TagMode, TagNumber,
 };
 
 #[cfg(feature = "alloc")]
-use {crate::PrivateKeyDocument, core::convert::TryInto};
+use crate::PrivateKeyDocument;
 
 #[cfg(feature = "encryption")]
 use {

--- a/pkcs8/src/traits.rs
+++ b/pkcs8/src/traits.rs
@@ -1,7 +1,6 @@
 //! Traits for parsing objects from PKCS#8 encoded documents
 
 use crate::{PrivateKeyInfo, Result};
-use core::convert::TryFrom;
 
 #[cfg(feature = "alloc")]
 use crate::PrivateKeyDocument;

--- a/pkcs8/src/version.rs
+++ b/pkcs8/src/version.rs
@@ -1,9 +1,7 @@
 //! PKCS#8 version identifier.
 
-use core::convert::TryFrom;
-use der::{Decodable, Decoder, Encodable, Encoder, Tag, Tagged};
-
 use crate::Error;
+use der::{Decodable, Decoder, Encodable, Encoder, Tag, Tagged};
 
 /// Version identifier for PKCS#8 documents.
 ///

--- a/pkcs8/tests/encrypted_private_key.rs
+++ b/pkcs8/tests/encrypted_private_key.rs
@@ -2,7 +2,6 @@
 
 #![cfg(feature = "pkcs5")]
 
-use core::convert::TryFrom;
 use hex_literal::hex;
 use pkcs8::{pkcs5::pbes2, EncryptedPrivateKeyInfo};
 

--- a/pkcs8/tests/private_key.rs
+++ b/pkcs8/tests/private_key.rs
@@ -1,6 +1,5 @@
 //! PKCS#8 private key tests
 
-use core::convert::TryFrom;
 use hex_literal::hex;
 use pkcs8::{PrivateKeyInfo, Version};
 

--- a/pkcs8/tests/public_key.rs
+++ b/pkcs8/tests/public_key.rs
@@ -1,6 +1,5 @@
 //! Public key (`SubjectPublicKeyInfo`) tests
 
-use core::convert::TryFrom;
 use hex_literal::hex;
 use pkcs8::SubjectPublicKeyInfo;
 

--- a/sec1/src/private_key.rs
+++ b/sec1/src/private_key.rs
@@ -9,7 +9,7 @@
 pub(crate) mod document;
 
 use crate::{EcParameters, Error};
-use core::{convert::TryFrom, fmt};
+use core::fmt;
 use der::{
     asn1::{BitString, ContextSpecific, OctetString},
     Decodable, Decoder, Encodable, Sequence, TagMode, TagNumber,

--- a/sec1/src/private_key/document.rs
+++ b/sec1/src/private_key/document.rs
@@ -2,7 +2,7 @@
 
 use crate::{DecodeEcPrivateKey, EcPrivateKey, EncodeEcPrivateKey, Error, Result};
 use alloc::vec::Vec;
-use core::{convert::TryFrom, fmt};
+use core::fmt;
 use der::{Decodable, Document, Encodable};
 use zeroize::{Zeroize, Zeroizing};
 

--- a/sec1/src/traits.rs
+++ b/sec1/src/traits.rs
@@ -1,7 +1,6 @@
 //! Traits for parsing objects from SEC1 encoded documents
 
 use crate::{EcPrivateKey, Error, Result};
-use core::convert::TryFrom;
 use der::Decodable;
 
 #[cfg(feature = "alloc")]

--- a/sec1/tests/private_key.rs
+++ b/sec1/tests/private_key.rs
@@ -1,6 +1,5 @@
 //! SEC1 private key tests
 
-use core::convert::TryFrom;
 use der::asn1::ObjectIdentifier;
 use hex_literal::hex;
 use sec1::{EcParameters, EcPrivateKey};

--- a/spki/src/algorithm.rs
+++ b/spki/src/algorithm.rs
@@ -1,6 +1,5 @@
 //! X.509 `AlgorithmIdentifier`
 
-use core::convert::{TryFrom, TryInto};
 use der::{
     asn1::{Any, ObjectIdentifier},
     Decodable, Decoder, Encodable, Error, ErrorKind, Result, Sequence,

--- a/spki/src/document.rs
+++ b/spki/src/document.rs
@@ -2,7 +2,7 @@
 
 use crate::{DecodePublicKey, EncodePublicKey, SubjectPublicKeyInfo};
 use alloc::vec::Vec;
-use core::{convert::TryFrom, fmt};
+use core::fmt;
 use der::{Document, Error, Result};
 
 #[cfg(feature = "std")]

--- a/spki/src/spki.rs
+++ b/spki/src/spki.rs
@@ -1,7 +1,6 @@
 //! X.509 `SubjectPublicKeyInfo`
 
 use crate::AlgorithmIdentifier;
-use core::convert::TryFrom;
 use der::{asn1::BitString, Decodable, Decoder, Encodable, Error, Result, Sequence};
 
 #[cfg(feature = "fingerprint")]

--- a/spki/src/traits.rs
+++ b/spki/src/traits.rs
@@ -1,7 +1,6 @@
 //! Traits for encoding/decoding SPKI public keys.
 
 use crate::SubjectPublicKeyInfo;
-use core::convert::TryFrom;
 use der::Result;
 
 #[cfg(feature = "alloc")]

--- a/spki/tests/spki.rs
+++ b/spki/tests/spki.rs
@@ -4,7 +4,7 @@
 use spki::der::Encodable;
 
 #[cfg(feature = "fingerprint")]
-use {core::convert::TryFrom, hex_literal::hex, spki::SubjectPublicKeyInfo};
+use {hex_literal::hex, spki::SubjectPublicKeyInfo};
 
 #[cfg(feature = "pem")]
 use spki::{der::Document, EncodePublicKey, PublicKeyDocument};

--- a/x509/src/validity.rs
+++ b/x509/src/validity.rs
@@ -1,7 +1,6 @@
 //! Validity [`Validity`] as defined in RFC 5280
 
 use crate::Time;
-use core::convert::TryFrom;
 use der::{Decodable, Error, Result, Sequence};
 
 /// X.509 `Validity` as defined in [RFC 5280 Section 4.1.2.5]

--- a/x509/tests/validity.rs
+++ b/x509/tests/validity.rs
@@ -1,5 +1,5 @@
 //! Validity tests
-use core::convert::TryFrom;
+
 use der::Encodable;
 use hex_literal::hex;
 use x509::Validity;


### PR DESCRIPTION
Now that we've upgraded to Rust 2021 edition, these are now available via the prelude, making explicit imports redundant.