### PR TITLE
pkcs8: use `der::Document` to impl `*PrivateKeyDocument`

### DIFF
--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -34,6 +34,7 @@ alloc = ["der/alloc", "spki/alloc", "zeroize"]
 des-insecure = ["encryption", "pkcs5/des-insecure"]
 encryption = ["alloc", "pkcs5/alloc", "pkcs5/pbes2", "rand_core"]
 pem = ["alloc", "der/pem", "spki/pem"]
+rand = ["rand_core/std"]
 sha1 = ["encryption", "pkcs5/sha1"]
 std = ["alloc", "der/std", "spki/std"]
 

--- a/pkcs8/src/document/encrypted_private_key.rs
+++ b/pkcs8/src/document/encrypted_private_key.rs
@@ -3,24 +3,14 @@
 use crate::{EncryptedPrivateKeyInfo, Error, Result};
 use alloc::{borrow::ToOwned, vec::Vec};
 use core::fmt;
-use der::Encodable;
+use der::{Decodable, Document, Encodable};
 use zeroize::{Zeroize, Zeroizing};
 
 #[cfg(feature = "encryption")]
 use crate::PrivateKeyDocument;
 
 #[cfg(feature = "pem")]
-use {
-    crate::{encrypted_private_key_info::PEM_TYPE_LABEL, pem, LineEnding},
-    alloc::string::String,
-    core::str::FromStr,
-};
-
-#[cfg(feature = "std")]
-use {
-    super::private_key::write_secret_file,
-    std::{fs, path::Path},
-};
+use {crate::pem, core::str::FromStr};
 
 /// Encrypted PKCS#8 private key document.
 ///
@@ -29,9 +19,13 @@ use {
 /// "well-formed", i.e. it will parse successfully according to this crate's
 /// parsing rules.
 #[derive(Clone, Eq, PartialEq)]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-#[cfg_attr(docsrs, doc(cfg(feature = "pkcs5")))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "alloc", feature = "pkcs5"))))]
 pub struct EncryptedPrivateKeyDocument(Zeroizing<Vec<u8>>);
+
+impl<'a> Document<'a> for EncryptedPrivateKeyDocument {
+    type Message = EncryptedPrivateKeyInfo<'a>;
+    const SENSITIVE: bool = true;
+}
 
 impl EncryptedPrivateKeyDocument {
     /// Attempt to decrypt this encrypted private key using the provided
@@ -46,73 +40,6 @@ impl EncryptedPrivateKeyDocument {
     pub fn encrypted_private_key_info(&self) -> EncryptedPrivateKeyInfo<'_> {
         EncryptedPrivateKeyInfo::try_from(self.0.as_ref())
             .expect("malformed EncryptedPrivateKeyDocument")
-    }
-
-    /// Parse [`EncryptedPrivateKeyDocument`] from ASN.1 DER-encoded PKCS#8.
-    pub fn from_der(bytes: &[u8]) -> Result<Self> {
-        bytes.try_into()
-    }
-
-    /// Parse [`EncryptedPrivateKeyDocument`] from PEM-encoded PKCS#8.
-    ///
-    /// PEM-encoded encrypted private keys can be identified by the leading
-    /// delimiter:
-    ///
-    /// ```text
-    /// -----BEGIN ENCRYPTED PRIVATE KEY-----
-    /// ```
-    #[cfg(feature = "pem")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    pub fn from_pem(s: &str) -> Result<Self> {
-        let (label, der_bytes) = pem::decode_vec(s.as_bytes())?;
-
-        if label != PEM_TYPE_LABEL {
-            return Err(pem::Error::Label.into());
-        }
-
-        Self::from_der(&*der_bytes)
-    }
-
-    /// Serialize [`EncryptedPrivateKeyDocument`] as self-zeroizing PEM-encoded
-    /// PKCS#8 string with the given [`LineEnding`].
-    #[cfg(feature = "pem")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    pub fn to_pem(&self, line_ending: LineEnding) -> Result<Zeroizing<String>> {
-        pem::encode_string(PEM_TYPE_LABEL, line_ending, &self.0)
-            .map(Zeroizing::new)
-            .map_err(Error::Pem)
-    }
-
-    /// Load [`EncryptedPrivateKeyDocument`] from an ASN.1 DER-encoded file on
-    /// the local filesystem (binary format).
-    #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    pub fn read_der_file(path: impl AsRef<Path>) -> Result<Self> {
-        fs::read(path)?.try_into()
-    }
-
-    /// Load [`EncryptedPrivateKeyDocument`] from a PEM-encoded file on the
-    /// local filesystem.
-    #[cfg(all(feature = "pem", feature = "std"))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    pub fn read_pem_file(path: impl AsRef<Path>) -> Result<Self> {
-        Self::from_pem(&Zeroizing::new(fs::read_to_string(path)?))
-    }
-
-    /// Write ASN.1 DER-encoded PKCS#8 encrypted private key to the given path.
-    #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    pub fn write_der_file(&self, path: impl AsRef<Path>) -> Result<()> {
-        write_secret_file(path, self.as_ref())
-    }
-
-    /// Write PEM-encoded PKCS#8 encrypted private key to the given path.
-    #[cfg(all(feature = "pem", feature = "std"))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    pub fn write_pem_file(&self, path: impl AsRef<Path>, line_ending: LineEnding) -> Result<()> {
-        write_secret_file(path, self.to_pem(line_ending)?.as_bytes())
     }
 }
 
@@ -134,7 +61,7 @@ impl TryFrom<&EncryptedPrivateKeyInfo<'_>> for EncryptedPrivateKeyDocument {
     type Error = Error;
 
     fn try_from(key: &EncryptedPrivateKeyInfo<'_>) -> Result<EncryptedPrivateKeyDocument> {
-        key.to_vec()?.try_into()
+        Ok(key.to_vec()?.try_into()?)
     }
 }
 
@@ -149,11 +76,11 @@ impl TryFrom<&[u8]> for EncryptedPrivateKeyDocument {
 }
 
 impl TryFrom<Vec<u8>> for EncryptedPrivateKeyDocument {
-    type Error = Error;
+    type Error = der::Error;
 
-    fn try_from(mut bytes: Vec<u8>) -> Result<Self> {
+    fn try_from(mut bytes: Vec<u8>) -> der::Result<Self> {
         // Ensure document is well-formed
-        if let Err(err) = EncryptedPrivateKeyInfo::try_from(bytes.as_slice()) {
+        if let Err(err) = EncryptedPrivateKeyInfo::from_der(bytes.as_slice()) {
             bytes.zeroize();
             return Err(err);
         }
@@ -176,6 +103,12 @@ impl FromStr for EncryptedPrivateKeyDocument {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self> {
-        Self::from_pem(s)
+        Ok(Self::from_pem(s)?)
     }
+}
+
+#[cfg(feature = "pem")]
+#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
+impl pem::PemLabel for EncryptedPrivateKeyDocument {
+    const TYPE_LABEL: &'static str = "ENCRYPTED PRIVATE KEY";
 }

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -151,5 +151,8 @@ pub use der::pem::{self, LineEnding};
 #[cfg(feature = "pkcs5")]
 pub use {crate::encrypted_private_key_info::EncryptedPrivateKeyInfo, pkcs5};
 
+#[cfg(feature = "rand_core")]
+pub use rand_core;
+
 #[cfg(all(feature = "alloc", feature = "pkcs5"))]
 pub use crate::document::encrypted_private_key::EncryptedPrivateKeyDocument;

--- a/pkcs8/src/private_key_info.rs
+++ b/pkcs8/src/private_key_info.rs
@@ -17,21 +17,13 @@ use {
 };
 
 #[cfg(feature = "pem")]
-use {
-    crate::{pem, LineEnding},
-    alloc::string::String,
-    zeroize::Zeroizing,
-};
+use {crate::LineEnding, alloc::string::String, der::Document, zeroize::Zeroizing};
 
 #[cfg(feature = "subtle")]
 use subtle::{Choice, ConstantTimeEq};
 
 /// Context-specific tag number for the public key.
 const PUBLIC_KEY_TAG: TagNumber = TagNumber::new(1);
-
-/// Type label for PEM-encoded private keys.
-#[cfg(feature = "pem")]
-pub(crate) const PEM_TYPE_LABEL: &str = "PRIVATE KEY";
 
 /// PKCS#8 `PrivateKeyInfo`.
 ///
@@ -156,9 +148,9 @@ impl<'a> PrivateKeyInfo<'a> {
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     pub fn to_pem(&self, line_ending: LineEnding) -> Result<Zeroizing<String>> {
-        pem::encode_string(PEM_TYPE_LABEL, line_ending, self.to_der()?.as_ref())
-            .map(Zeroizing::new)
-            .map_err(Error::Pem)
+        Ok(PrivateKeyDocument::try_from(self)?
+            .to_pem(line_ending)
+            .map(Zeroizing::new)?)
     }
 }
 

--- a/pkcs8/tests/encrypted_private_key.rs
+++ b/pkcs8/tests/encrypted_private_key.rs
@@ -11,6 +11,9 @@ use pkcs8::PrivateKeyDocument;
 #[cfg(feature = "pem")]
 use pkcs8::EncryptedPrivateKeyDocument;
 
+#[cfg(feature = "std")]
+use der::Document;
+
 /// Ed25519 PKCS#8 private key plaintext encoded as ASN.1 DER
 #[cfg(feature = "encryption")]
 const ED25519_DER_PLAINTEXT_EXAMPLE: &[u8] = include_bytes!("examples/ed25519-priv-pkcs8v1.der");

--- a/pkcs8/tests/private_key.rs
+++ b/pkcs8/tests/private_key.rs
@@ -3,6 +3,9 @@
 use hex_literal::hex;
 use pkcs8::{PrivateKeyInfo, Version};
 
+#[cfg(feature = "pem")]
+use der::Document;
+
 #[cfg(any(feature = "pem", feature = "std"))]
 use pkcs8::PrivateKeyDocument;
 
@@ -128,7 +131,7 @@ fn decode_ec_p256_pem() {
 
     // Ensure `PrivateKeyDocument` parses successfully
     let pk_info = PrivateKeyInfo::try_from(EC_P256_DER_EXAMPLE).unwrap();
-    assert_eq!(pkcs8_doc.private_key_info().algorithm, pk_info.algorithm);
+    assert_eq!(pkcs8_doc.decode().algorithm, pk_info.algorithm);
 }
 
 #[test]
@@ -139,7 +142,7 @@ fn decode_ed25519_pem() {
 
     // Ensure `PrivateKeyDocument` parses successfully
     let pk_info = PrivateKeyInfo::try_from(ED25519_DER_V1_EXAMPLE).unwrap();
-    assert_eq!(pkcs8_doc.private_key_info().algorithm, pk_info.algorithm);
+    assert_eq!(pkcs8_doc.decode().algorithm, pk_info.algorithm);
 }
 
 #[test]
@@ -150,7 +153,7 @@ fn decode_rsa_2048_pem() {
 
     // Ensure `PrivateKeyDocument` parses successfully
     let pk_info = PrivateKeyInfo::try_from(RSA_2048_DER_EXAMPLE).unwrap();
-    assert_eq!(pkcs8_doc.private_key_info().algorithm, pk_info.algorithm);
+    assert_eq!(pkcs8_doc.decode().algorithm, pk_info.algorithm);
 }
 
 #[test]
@@ -161,7 +164,7 @@ fn decode_x25519_pem() {
 
     // Ensure `PrivateKeyDocument` parses successfully
     let pk_info = PrivateKeyInfo::try_from(X25519_DER_EXAMPLE).unwrap();
-    assert_eq!(pkcs8_doc.private_key_info().algorithm, pk_info.algorithm);
+    assert_eq!(pkcs8_doc.decode().algorithm, pk_info.algorithm);
 }
 
 #[test]
@@ -183,7 +186,7 @@ fn encode_ed25519_der_v1() {
 #[cfg(all(feature = "alloc", feature = "subtle"))]
 fn encode_ed25519_der_v2() {
     let pk = PrivateKeyInfo::try_from(ED25519_DER_V2_EXAMPLE).unwrap();
-    assert_eq!(pk.to_der().unwrap().private_key_info(), pk);
+    assert_eq!(pk.to_der().unwrap().decode(), pk);
 }
 
 #[test]


### PR DESCRIPTION
Uses the new `Document` trait to impl `PrivateKeyDocument` and `EncryptedPrivateKeyDocument` including the newly added support for hardened file permissions gated on the associated `const SENSITIVE: bool = true`.