### PR TITLE
der: add support for unused bits to `BitString`

### DIFF
--- a/der/derive/src/types.rs
+++ b/der/derive/src/types.rs
@@ -56,7 +56,7 @@ impl Asn1Type {
     /// Get a `der::Encoder` object for a particular ASN.1 type
     pub fn encoder(&self, binding: TokenStream) -> TokenStream {
         match self {
-            Asn1Type::BitString => quote!(::der::asn1::BitString::new(#binding)),
+            Asn1Type::BitString => quote!(::der::asn1::BitString::try_from(#binding)),
             Asn1Type::GeneralizedTime => quote!(::der::asn1::GeneralizedTime::try_from(#binding)),
             Asn1Type::OctetString => quote!(::der::asn1::OctetString::new(#binding)),
             Asn1Type::PrintableString => quote!(::der::asn1::PrintableString::new(#binding)),

--- a/der/src/asn1.rs
+++ b/der/src/asn1.rs
@@ -1,4 +1,5 @@
-//! ASN.1 built-in types.
+//! Module containing all of the various ASN.1 built-in types supported by
+//! this library.
 
 mod any;
 mod bit_string;
@@ -22,7 +23,7 @@ mod utf8_string;
 
 pub use self::{
     any::Any,
-    bit_string::BitString,
+    bit_string::{BitString, BitStringIter},
     choice::Choice,
     context_specific::ContextSpecific,
     generalized_time::GeneralizedTime,

--- a/der/src/asn1/bit_string.rs
+++ b/der/src/asn1/bit_string.rs
@@ -4,32 +4,76 @@ use crate::{
     asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, ErrorKind, Length,
     Result, Tag, Tagged,
 };
+use core::iter::FusedIterator;
 
 /// ASN.1 `BIT STRING` type.
+///
+/// This type contains a sequence of any number of bits, modeled internally as
+/// a sequence of bytes with a known number of "unused bits".
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct BitString<'a> {
-    /// Inner value
-    pub(crate) inner: ByteSlice<'a>,
+    /// Number of unused bits in the final octet.
+    unused_bits: u8,
 
-    /// Length after encoding (with leading `0` byte)
-    pub(crate) encoded_len: Length,
+    /// Length of this `BIT STRING` in bits.
+    bit_length: usize,
+
+    /// Bitstring represented as a slice of bytes.
+    inner: ByteSlice<'a>,
 }
 
 impl<'a> BitString<'a> {
+    /// Maximum number of unused bits allowed.
+    pub const MAX_UNUSED_BITS: u8 = 7;
+
     /// Create a new ASN.1 `BIT STRING` from a byte slice.
-    pub fn new(bytes: &'a [u8]) -> Result<Self> {
-        let inner = ByteSlice::new(bytes).map_err(|_| ErrorKind::Length { tag: Self::TAG })?;
-        let encoded_len = (inner.len() + 1u8).map_err(|_| ErrorKind::Length { tag: Self::TAG })?;
-        Ok(Self { inner, encoded_len })
+    ///
+    /// Accepts an optional number of "unused bits" (0-7) which are omitted
+    /// from the final octet. This number is 0 if the value is octet-aligned.
+    pub fn new(unused_bits: u8, bytes: &'a [u8]) -> Result<Self> {
+        if (unused_bits > Self::MAX_UNUSED_BITS) || (unused_bits != 0 && bytes.is_empty()) {
+            return Err(Self::TAG.value_error());
+        }
+
+        let inner = ByteSlice::new(bytes).map_err(|_| Self::TAG.length_error())?;
+
+        let bit_length = usize::try_from(inner.len())?
+            .checked_mul(8)
+            .and_then(|n| n.checked_sub(usize::from(unused_bits)))
+            .ok_or(ErrorKind::Overflow)?;
+
+        Ok(Self {
+            unused_bits,
+            bit_length,
+            inner,
+        })
     }
 
-    /// Borrow the inner byte slice.
-    pub fn as_bytes(&self) -> &'a [u8] {
-        self.inner.as_bytes()
+    /// Create a new ASN.1 `BIT STRING` from the given bytes.
+    ///
+    /// The "unused bits" are set to 0.
+    pub fn from_bytes(bytes: &'a [u8]) -> Result<Self> {
+        Self::new(0, bytes)
     }
 
-    /// Get the length of the inner byte slice (sans leading `0` byte).
-    pub fn len(&self) -> Length {
+    /// Get the number of unused bits in this byte slice.
+    pub fn unused_bits(&self) -> u8 {
+        self.unused_bits
+    }
+
+    /// Is the number of unused bits a value other than 0?
+    pub fn has_unused_bits(&self) -> bool {
+        self.unused_bits != 0
+    }
+
+    /// Get the length of this `BIT STRING` in bits.
+    pub fn bit_len(&self) -> usize {
+        self.bit_length
+    }
+
+    /// Get the number of bytes/octets needed to represent this `BIT STRING`
+    /// when serialized in an octet-aligned manner.
+    pub fn byte_len(&self) -> Length {
         self.inner.len()
     }
 
@@ -37,49 +81,62 @@ impl<'a> BitString<'a> {
     pub fn is_empty(&self) -> bool {
         self.inner.is_empty()
     }
-}
 
-impl AsRef<[u8]> for BitString<'_> {
-    fn as_ref(&self) -> &[u8] {
-        self.as_bytes()
+    /// Borrow the inner byte slice.
+    ///
+    /// Returns `None` if the number of unused bits is *not* equal to zero,
+    /// i.e. if the `BIT STRING` is not octet aligned.
+    ///
+    /// Use [`BitString::raw_bytes`] to obtain access to the raw value
+    /// regardless of the presence of unused bits.
+    pub fn as_bytes(&self) -> Option<&'a [u8]> {
+        if self.has_unused_bits() {
+            None
+        } else {
+            Some(self.raw_bytes())
+        }
+    }
+
+    /// Borrow the raw bytes of this `BIT STRING`.
+    ///
+    /// Note that the byte string may contain extra unused bits in the final
+    /// octet. If the number of unused bits is expected to be 0, the
+    /// [`BitString::as_bytes`] function can be used instead.
+    pub fn raw_bytes(&self) -> &'a [u8] {
+        self.inner.as_bytes()
+    }
+
+    /// Iterator over the bits of this `BIT STRING`.
+    pub fn bits(self) -> BitStringIter<'a> {
+        BitStringIter {
+            bit_string: self,
+            position: 0,
+        }
     }
 }
 
 impl<'a> DecodeValue<'a> for BitString<'a> {
     fn decode_value(decoder: &mut Decoder<'a>, encoded_len: Length) -> Result<Self> {
-        // The prefix octet indicates the the number of bits which are
-        // contained in the final byte of the BIT STRING.
-        //
-        // In DER this value is always `0`.
-        if decoder.byte()? != 0 {
-            return Err(Tag::BitString.non_canonical_error());
-        }
-
+        let unused_bits = decoder.byte()?;
         let inner = ByteSlice::decode_value(decoder, (encoded_len - Length::ONE)?)?;
-        Ok(Self { inner, encoded_len })
+        Self::new(unused_bits, inner.as_bytes())
     }
 }
 
 impl<'a> EncodeValue for BitString<'a> {
     fn value_len(&self) -> Result<Length> {
-        Ok(self.encoded_len)
+        self.byte_len() + Length::ONE
     }
 
     fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        encoder.byte(0)?;
-        encoder.bytes(self.as_bytes())
+        encoder.byte(self.unused_bits)?;
+        encoder.bytes(self.raw_bytes())
     }
 }
 
 impl<'a> From<&BitString<'a>> for BitString<'a> {
     fn from(value: &BitString<'a>) -> BitString<'a> {
         *value
-    }
-}
-
-impl<'a> From<BitString<'a>> for &'a [u8] {
-    fn from(bit_string: BitString<'a>) -> &'a [u8] {
-        bit_string.as_bytes()
     }
 }
 
@@ -91,29 +148,112 @@ impl<'a> TryFrom<Any<'a>> for BitString<'a> {
     }
 }
 
+impl<'a> TryFrom<&'a [u8]> for BitString<'a> {
+    type Error = Error;
+
+    fn try_from(bytes: &'a [u8]) -> Result<BitString<'a>> {
+        BitString::from_bytes(bytes)
+    }
+}
+
+/// Hack for simplifying the custom derive use case.
+impl<'a> TryFrom<&&'a [u8]> for BitString<'a> {
+    type Error = Error;
+
+    fn try_from(bytes: &&'a [u8]) -> Result<BitString<'a>> {
+        BitString::from_bytes(*bytes)
+    }
+}
+
+impl<'a> From<BitString<'a>> for &'a [u8] {
+    fn from(bit_string: BitString<'a>) -> &'a [u8] {
+        bit_string.raw_bytes()
+    }
+}
+
 impl<'a> Tagged for BitString<'a> {
     const TAG: Tag = Tag::BitString;
 }
+
+/// Iterator over the bits of a [`BitString`].
+pub struct BitStringIter<'a> {
+    /// [`BitString`] being iterated over.
+    bit_string: BitString<'a>,
+
+    /// Current bit position within the iterator.
+    position: usize,
+}
+
+impl<'a> Iterator for BitStringIter<'a> {
+    type Item = bool;
+
+    fn next(&mut self) -> Option<bool> {
+        if self.position >= self.bit_string.bit_len() {
+            return None;
+        }
+
+        let byte = self.bit_string.raw_bytes().get(self.position / 8)?;
+        let bit = 1u8 << (7 - (self.position % 8));
+        self.position = self.position.checked_add(1)?;
+        Some(byte & bit != 0)
+    }
+}
+
+impl<'a> ExactSizeIterator for BitStringIter<'a> {
+    fn len(&self) -> usize {
+        self.bit_string.bit_len()
+    }
+}
+
+impl<'a> FusedIterator for BitStringIter<'a> {}
 
 #[cfg(test)]
 mod tests {
     use super::{BitString, Result, Tag};
     use crate::asn1::Any;
+    use hex_literal::hex;
 
     /// Parse a `BitString` from an ASN.1 `Any` value to test decoding behaviors.
-    fn parse_bitstring_from_any(bytes: &[u8]) -> Result<BitString<'_>> {
+    fn parse_bitstring(bytes: &[u8]) -> Result<BitString<'_>> {
         Any::new(Tag::BitString, bytes)?.try_into()
     }
 
     #[test]
     fn decode_empty_bitstring() {
-        let bs = parse_bitstring_from_any(&[0]).unwrap();
-        assert_eq!(bs.as_ref(), &[]);
+        let bs = parse_bitstring(&hex!("00")).unwrap();
+        assert_eq!(bs.as_bytes().unwrap(), &[]);
     }
 
     #[test]
     fn decode_non_empty_bitstring() {
-        let bs = parse_bitstring_from_any(&[0, 1, 2, 3]).unwrap();
-        assert_eq!(bs.as_ref(), &[1, 2, 3]);
+        let bs = parse_bitstring(&hex!("00010203")).unwrap();
+        assert_eq!(bs.as_bytes().unwrap(), &[0x01, 0x02, 0x03]);
+    }
+
+    #[test]
+    fn decode_bitstring_with_unused_bits() {
+        let bs = parse_bitstring(&hex!("066e5dc0")).unwrap();
+        assert_eq!(bs.unused_bits(), 6);
+        assert_eq!(bs.raw_bytes(), &hex!("6e5dc0"));
+
+        // Expected: 011011100101110111
+        let mut bits = bs.bits();
+        assert_eq!(bits.len(), 18);
+
+        for bit in [0, 1, 1, 0, 1, 1, 1, 0, 0, 1, 0, 1, 1, 1, 0, 1, 1, 1] {
+            assert_eq!(bits.next().unwrap() as u8, bit)
+        }
+
+        // Ensure `None` is returned on successive calls
+        assert_eq!(bits.next(), None);
+        assert_eq!(bits.next(), None);
+    }
+
+    #[test]
+    fn reject_unused_bits_in_empty_string() {
+        assert_eq!(
+            parse_bitstring(&[0x03]).err().unwrap().kind(),
+            Tag::BitString.value_error().kind()
+        )
     }
 }

--- a/der/src/asn1/context_specific.rs
+++ b/der/src/asn1/context_specific.rs
@@ -213,7 +213,10 @@ mod tests {
     fn round_trip() {
         let field = ContextSpecific::<BitString<'_>>::from_der(EXAMPLE_BYTES).unwrap();
         assert_eq!(field.tag_number.value(), 1);
-        assert_eq!(field.value, BitString::new(&EXAMPLE_BYTES[5..]).unwrap());
+        assert_eq!(
+            field.value,
+            BitString::from_bytes(&EXAMPLE_BYTES[5..]).unwrap()
+        );
 
         let mut buf = [0u8; 128];
         let encoded = field.encode_to_slice(&mut buf).unwrap();
@@ -270,7 +273,7 @@ mod tests {
         assert_eq!(field.tag_number, tag_number);
         assert_eq!(field.tag_mode, TagMode::Implicit);
         assert_eq!(
-            field.value.as_bytes(),
+            field.value.as_bytes().unwrap(),
             &context_specific_implicit_bytes[3..]
         );
     }

--- a/der/src/encoder.rs
+++ b/der/src/encoder.rs
@@ -272,7 +272,7 @@ mod tests {
             &hex!("81210019BF44096984CDFE8541BAC167DC3B96C85086AA30B6B6CB0C5C38AD703166E1");
 
         let tag_number = TagNumber::new(1);
-        let bit_string = BitString::new(&EXPECTED_BYTES[3..]).unwrap();
+        let bit_string = BitString::from_bytes(&EXPECTED_BYTES[3..]).unwrap();
 
         let mut buf = [0u8; EXPECTED_BYTES.len()];
         let mut encoder = Encoder::new(&mut buf);

--- a/der/src/length.rs
+++ b/der/src/length.rs
@@ -165,6 +165,12 @@ impl TryFrom<u32> for Length {
     }
 }
 
+impl From<Length> for u32 {
+    fn from(length: Length) -> u32 {
+        length.0
+    }
+}
+
 impl TryFrom<usize> for Length {
     type Error = Error;
 


### PR DESCRIPTION
Adds support for ASN.1 `BIT STRING` values which include a number of "unused bits", i.e. bits of the final octet which are not a part of the `BIT STRING`.

This is needed for e.g. X.509 Key Usage.