### PR TITLE
der: add `Decoder::{peek_tag, peek_header}`

### DIFF
--- a/der/derive/src/choice.rs
+++ b/der/derive/src/choice.rs
@@ -174,13 +174,7 @@ impl DeriveChoice {
 
             gen impl ::der::Decodable<#lifetime> for @Self {
                 fn decode(decoder: &mut ::der::Decoder<#lifetime>) -> ::der::Result<Self> {
-                    let octet = decoder.peek().ok_or_else(|| {
-                        decoder.error(::der::ErrorKind::Truncated)
-                    })?;
-
-                    let tag = ::der::Tag::try_from(octet).map_err(|e| decoder.error(e.kind()))?;
-
-                    match tag {
+                    match decoder.peek_tag()? {
                         #decode_body
                         actual => Err(der::ErrorKind::UnexpectedTag {
                             expected: None,

--- a/der/src/asn1/context_specific.rs
+++ b/der/src/asn1/context_specific.rs
@@ -95,7 +95,7 @@ impl<T> ContextSpecific<T> {
     where
         F: FnOnce(&mut Decoder<'a>) -> Result<Self>,
     {
-        while let Some(octet) = decoder.peek() {
+        while let Some(octet) = decoder.peek_byte() {
             let tag = Tag::try_from(octet)?;
 
             if !tag.is_context_specific() || tag.number() > tag_number {

--- a/der/src/asn1/optional.rs
+++ b/der/src/asn1/optional.rs
@@ -7,7 +7,7 @@ where
     T: Choice<'a>, // NOTE: all `Decodable + Tagged` types receive a blanket `Choice` impl
 {
     fn decode(decoder: &mut Decoder<'a>) -> Result<Option<T>> {
-        if let Some(byte) = decoder.peek() {
+        if let Some(byte) = decoder.peek_byte() {
             if T::can_decode(Tag::try_from(byte)?) {
                 return T::decode(decoder).map(Some);
             }

--- a/der/src/decoder.rs
+++ b/der/src/decoder.rs
@@ -1,12 +1,12 @@
 //! DER decoder.
 
 use crate::{
-    asn1::*, Choice, Decodable, DecodeValue, Error, ErrorKind, Length, Result, Tag, TagMode,
-    TagNumber, Tagged,
+    asn1::*, Choice, Decodable, DecodeValue, Error, ErrorKind, Header, Length, Result, Tag,
+    TagMode, TagNumber, Tagged,
 };
 
 /// DER decoder.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Decoder<'a> {
     /// Byte slice being decoded.
     ///
@@ -62,10 +62,26 @@ impl<'a> Decoder<'a> {
     }
 
     /// Peek at the next byte in the decoder without modifying the cursor.
-    pub fn peek(&self) -> Option<u8> {
+    pub fn peek_byte(&self) -> Option<u8> {
         self.remaining()
             .ok()
             .and_then(|bytes| bytes.get(0).cloned())
+    }
+
+    /// Peek at the next byte in the decoder and attempt to decode it as a
+    /// [`Tag`] value.
+    ///
+    /// Does not modify the decoder's state.
+    pub fn peek_tag(&self) -> Result<Tag> {
+        self.peek_byte().ok_or(ErrorKind::Truncated)?.try_into()
+    }
+
+    /// Peek forward in the decoder, attempting to decode a [`Header`] from
+    /// the data at the current position in the decoder.
+    ///
+    /// Does not modify the decoder's state.
+    pub fn peek_header(&self) -> Result<Header> {
+        Header::decode(&mut self.clone())
     }
 
     /// Finish decoding, returning the given value if there is no
@@ -289,7 +305,11 @@ impl<'a> From<&'a [u8]> for Decoder<'a> {
 #[cfg(test)]
 mod tests {
     use super::Decoder;
-    use crate::{Decodable, ErrorKind, Length};
+    use crate::{Decodable, ErrorKind, Length, Tag};
+    use hex_literal::hex;
+
+    // INTEGER: 42
+    const EXAMPLE_MSG: &[u8] = &hex!("02012A00");
 
     #[test]
     fn truncated_message() {
@@ -301,7 +321,7 @@ mod tests {
 
     #[test]
     fn invalid_field_length() {
-        let mut decoder = Decoder::new(&[0x02, 0x01]);
+        let mut decoder = Decoder::new(&EXAMPLE_MSG[..2]);
         let err = i8::decode(&mut decoder).err().unwrap();
         assert_eq!(ErrorKind::Truncated, err.kind());
         assert_eq!(Some(Length::from(2u8)), err.position());
@@ -309,7 +329,7 @@ mod tests {
 
     #[test]
     fn trailing_data() {
-        let mut decoder = Decoder::new(&[0x02, 0x01, 0x2A, 0x00]);
+        let mut decoder = Decoder::new(EXAMPLE_MSG);
         let x = decoder.decode().unwrap();
         assert_eq!(42i8, x);
 
@@ -322,5 +342,24 @@ mod tests {
             err.kind()
         );
         assert_eq!(Some(Length::from(3u8)), err.position());
+    }
+
+    #[test]
+    fn peek_tag() {
+        let decoder = Decoder::new(EXAMPLE_MSG);
+        assert_eq!(decoder.position(), Length::ZERO);
+        assert_eq!(decoder.peek_tag().unwrap(), Tag::Integer);
+        assert_eq!(decoder.position(), Length::ZERO); // Position unchanged
+    }
+
+    #[test]
+    fn peek_header() {
+        let decoder = Decoder::new(EXAMPLE_MSG);
+        assert_eq!(decoder.position(), Length::ZERO);
+
+        let header = decoder.peek_header().unwrap();
+        assert_eq!(header.tag, Tag::Integer);
+        assert_eq!(header.length, Length::ONE);
+        assert_eq!(decoder.position(), Length::ZERO); // Position unchanged
     }
 }


### PR DESCRIPTION
Also renames the previous `Decoder::peek` method to `peek_byte`.