### PR TITLE
der: replace `ErrorKind::Truncated` with `ErrorKind::Incomplete`

### DIFF
--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -54,7 +54,7 @@ impl<'a> Any<'a> {
         T: DecodeValue<'a> + Tagged,
     {
         self.tag.assert_eq(T::TAG)?;
-        let mut decoder = Decoder::new(self.value());
+        let mut decoder = Decoder::new(self.value())?;
         let result = T::decode_value(&mut decoder, self.value.len())?;
         decoder.finish(result)
     }
@@ -123,7 +123,7 @@ impl<'a> Any<'a> {
         F: FnOnce(&mut Decoder<'a>) -> Result<T>,
     {
         self.tag.assert_eq(Tag::Sequence)?;
-        let mut seq_decoder = Decoder::new(self.value.as_bytes());
+        let mut seq_decoder = Decoder::new(self.value.as_bytes())?;
         let result = f(&mut seq_decoder)?;
         seq_decoder.finish(result)
     }

--- a/der/src/asn1/context_specific.rs
+++ b/der/src/asn1/context_specific.rs
@@ -228,21 +228,21 @@ mod tests {
         let tag_number = TagNumber::new(0);
 
         // Empty message
-        let mut decoder = Decoder::new(&[]);
+        let mut decoder = Decoder::new(&[]).unwrap();
         assert_eq!(
             ContextSpecific::<u8>::decode_explicit(&mut decoder, tag_number).unwrap(),
             None
         );
 
         // Message containing a non-context-specific type
-        let mut decoder = Decoder::new(&hex!("020100"));
+        let mut decoder = Decoder::new(&hex!("020100")).unwrap();
         assert_eq!(
             ContextSpecific::<u8>::decode_explicit(&mut decoder, tag_number).unwrap(),
             None
         );
 
         // Message containing an EXPLICIT context-specific field
-        let mut decoder = Decoder::new(&hex!("A003020100"));
+        let mut decoder = Decoder::new(&hex!("A003020100")).unwrap();
         let field = ContextSpecific::<u8>::decode_explicit(&mut decoder, tag_number)
             .unwrap()
             .unwrap();
@@ -265,7 +265,7 @@ mod tests {
 
         let tag_number = TagNumber::new(1);
 
-        let mut decoder = Decoder::new(&context_specific_implicit_bytes);
+        let mut decoder = Decoder::new(&context_specific_implicit_bytes).unwrap();
         let field = ContextSpecific::<BitString<'_>>::decode_implicit(&mut decoder, tag_number)
             .unwrap()
             .unwrap();
@@ -281,7 +281,7 @@ mod tests {
     #[test]
     fn context_specific_skipping_unknown_field() {
         let tag = TagNumber::new(1);
-        let mut decoder = Decoder::new(&hex!("A003020100A103020101"));
+        let mut decoder = Decoder::new(&hex!("A003020100A103020101")).unwrap();
         let field = ContextSpecific::<u8>::decode_explicit(&mut decoder, tag)
             .unwrap()
             .unwrap();
@@ -291,7 +291,7 @@ mod tests {
     #[test]
     fn context_specific_returns_none_on_greater_tag_number() {
         let tag = TagNumber::new(0);
-        let mut decoder = Decoder::new(&hex!("A103020101"));
+        let mut decoder = Decoder::new(&hex!("A103020101")).unwrap();
         assert_eq!(
             ContextSpecific::<u8>::decode_explicit(&mut decoder, tag).unwrap(),
             None

--- a/der/src/byte_slice.rs
+++ b/der/src/byte_slice.rs
@@ -2,8 +2,7 @@
 //! library-level length limitation i.e. `Length::max()`.
 
 use crate::{
-    str_slice::StrSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, ErrorKind, Length,
-    Result,
+    str_slice::StrSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, Length, Result,
 };
 
 /// Byte slice newtype which respects the `Length::max()` limit.
@@ -50,10 +49,7 @@ impl AsRef<[u8]> for ByteSlice<'_> {
 
 impl<'a> DecodeValue<'a> for ByteSlice<'a> {
     fn decode_value(decoder: &mut Decoder<'a>, length: Length) -> Result<Self> {
-        decoder
-            .bytes(length)
-            .map_err(|_| decoder.error(ErrorKind::Truncated))
-            .and_then(Self::new)
+        decoder.bytes(length).and_then(Self::new)
     }
 }
 

--- a/der/src/decodable.rs
+++ b/der/src/decodable.rs
@@ -18,7 +18,7 @@ pub trait Decodable<'a>: Sized {
 
     /// Parse `Self` from the provided DER-encoded byte slice.
     fn from_der(bytes: &'a [u8]) -> Result<Self> {
-        let mut decoder = Decoder::new(bytes);
+        let mut decoder = Decoder::new(bytes)?;
         let result = Self::decode(&mut decoder)?;
         decoder.finish(result)
     }

--- a/der/src/encoder.rs
+++ b/der/src/encoder.rs
@@ -63,7 +63,9 @@ impl<'a> Encoder<'a> {
         let range = ..usize::try_from(self.position)?;
 
         match self.bytes {
-            Some(bytes) => bytes.get(range).ok_or_else(|| ErrorKind::Truncated.at(pos)),
+            Some(bytes) => bytes
+                .get(range)
+                .ok_or_else(|| ErrorKind::Overlength.at(pos)),
             None => Err(ErrorKind::Failed.at(pos)),
         }
     }
@@ -213,7 +215,7 @@ impl<'a> Encoder<'a> {
                 *b = byte;
                 Ok(())
             }
-            None => self.error(ErrorKind::Truncated),
+            None => self.error(ErrorKind::Overlength),
         }
     }
 
@@ -238,7 +240,7 @@ impl<'a> Encoder<'a> {
 
         buffer_len
             .checked_sub(self.position.try_into()?)
-            .ok_or_else(|| ErrorKind::Truncated.at(self.position))
+            .ok_or_else(|| ErrorKind::Overlength.at(self.position))
             .and_then(TryInto::try_into)
     }
 }

--- a/spki/src/document.rs
+++ b/spki/src/document.rs
@@ -1,9 +1,9 @@
 //! SPKI public key document.
 
-use crate::{DecodePublicKey, EncodePublicKey, SubjectPublicKeyInfo};
+use crate::{DecodePublicKey, EncodePublicKey, Error, Result, SubjectPublicKeyInfo};
 use alloc::vec::Vec;
 use core::fmt;
-use der::{Document, Error, Result};
+use der::{Decodable, Document};
 
 #[cfg(feature = "std")]
 use std::path::Path;
@@ -31,29 +31,29 @@ impl<'a> Document<'a> for PublicKeyDocument {
 
 impl DecodePublicKey for PublicKeyDocument {
     fn from_spki(spki: SubjectPublicKeyInfo<'_>) -> Result<Self> {
-        Self::from_msg(&spki)
+        Ok(Self::from_msg(&spki)?)
     }
 
     fn from_public_key_der(bytes: &[u8]) -> Result<Self> {
-        Self::from_der(bytes)
+        Ok(Self::from_der(bytes)?)
     }
 
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     fn from_public_key_pem(s: &str) -> Result<Self> {
-        Self::from_pem(s)
+        Ok(Self::from_pem(s)?)
     }
 
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn read_public_key_der_file(path: impl AsRef<Path>) -> Result<Self> {
-        Self::read_der_file(path)
+        Ok(Self::read_der_file(path)?)
     }
 
     #[cfg(all(feature = "pem", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(all(feature = "pem", feature = "std"))))]
     fn read_public_key_pem_file(path: impl AsRef<Path>) -> Result<Self> {
-        Self::read_pem_file(path)
+        Ok(Self::read_pem_file(path)?)
     }
 }
 
@@ -65,13 +65,13 @@ impl EncodePublicKey for PublicKeyDocument {
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     fn to_public_key_pem(&self, line_ending: LineEnding) -> Result<String> {
-        self.to_pem(line_ending)
+        Ok(self.to_pem(line_ending)?)
     }
 
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn write_public_key_der_file(&self, path: impl AsRef<Path>) -> Result<()> {
-        self.write_der_file(path)
+        Ok(self.write_der_file(path)?)
     }
 
     #[cfg(all(feature = "pem", feature = "std"))]
@@ -81,7 +81,7 @@ impl EncodePublicKey for PublicKeyDocument {
         path: impl AsRef<Path>,
         line_ending: LineEnding,
     ) -> Result<()> {
-        self.write_pem_file(path, line_ending)
+        Ok(self.write_pem_file(path, line_ending)?)
     }
 }
 
@@ -95,7 +95,7 @@ impl TryFrom<&[u8]> for PublicKeyDocument {
     type Error = Error;
 
     fn try_from(bytes: &[u8]) -> Result<Self> {
-        Self::from_der(bytes)
+        Ok(Self::from_der(bytes)?)
     }
 }
 
@@ -116,11 +116,11 @@ impl TryFrom<&SubjectPublicKeyInfo<'_>> for PublicKeyDocument {
 }
 
 impl TryFrom<Vec<u8>> for PublicKeyDocument {
-    type Error = Error;
+    type Error = der::Error;
 
-    fn try_from(bytes: Vec<u8>) -> Result<Self> {
+    fn try_from(bytes: Vec<u8>) -> der::Result<Self> {
         // Ensure document is well-formed
-        SubjectPublicKeyInfo::try_from(bytes.as_slice())?;
+        SubjectPublicKeyInfo::from_der(bytes.as_slice())?;
         Ok(Self(bytes))
     }
 }

--- a/spki/src/error.rs
+++ b/spki/src/error.rs
@@ -1,0 +1,47 @@
+//! Error types
+
+use core::fmt;
+use der::asn1::ObjectIdentifier;
+
+/// Result type with `spki` crate's [`Error`] type.
+pub type Result<T> = core::result::Result<T, Error>;
+
+/// Error type
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum Error {
+    /// Algorithm parameters are missing.
+    AlgorithmParametersMissing,
+
+    /// ASN.1 DER-related errors.
+    Asn1(der::Error),
+
+    /// Unknown algorithm OID.
+    UnknownOid {
+        /// Unrecognized OID value found in e.g. a SPKI `AlgorithmIdentifier`.
+        oid: ObjectIdentifier,
+    },
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::AlgorithmParametersMissing => {
+                f.write_str("AlgorithmIdentifier parameters missing")
+            }
+            Error::Asn1(err) => write!(f, "ASN.1 error: {}", err),
+            Error::UnknownOid { oid } => {
+                write!(f, "unknown/unsupported algorithm OID: {}", oid)
+            }
+        }
+    }
+}
+
+impl From<der::Error> for Error {
+    fn from(err: der::Error) -> Error {
+        Error::Asn1(err)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}

--- a/spki/src/lib.rs
+++ b/spki/src/lib.rs
@@ -43,6 +43,7 @@ extern crate alloc;
 extern crate std;
 
 mod algorithm;
+mod error;
 mod spki;
 mod traits;
 
@@ -50,7 +51,10 @@ mod traits;
 mod document;
 
 pub use crate::{
-    algorithm::AlgorithmIdentifier, spki::SubjectPublicKeyInfo, traits::DecodePublicKey,
+    algorithm::AlgorithmIdentifier,
+    error::{Error, Result},
+    spki::SubjectPublicKeyInfo,
+    traits::DecodePublicKey,
 };
 pub use der::{self, asn1::ObjectIdentifier};
 

--- a/spki/src/spki.rs
+++ b/spki/src/spki.rs
@@ -1,7 +1,7 @@
 //! X.509 `SubjectPublicKeyInfo`
 
-use crate::AlgorithmIdentifier;
-use der::{asn1::BitString, Decodable, Decoder, Encodable, Error, Result, Sequence};
+use crate::{AlgorithmIdentifier, Error, Result};
+use der::{asn1::BitString, Decodable, Decoder, Encodable, Sequence};
 
 #[cfg(feature = "fingerprint")]
 use sha2::{digest, Digest, Sha256};
@@ -52,7 +52,7 @@ impl<'a> SubjectPublicKeyInfo<'a> {
 }
 
 impl<'a> Decodable<'a> for SubjectPublicKeyInfo<'a> {
-    fn decode(decoder: &mut Decoder<'a>) -> Result<Self> {
+    fn decode(decoder: &mut Decoder<'a>) -> der::Result<Self> {
         decoder.sequence(|decoder| {
             let algorithm = decoder.decode()?;
             let subject_public_key = decoder
@@ -69,9 +69,9 @@ impl<'a> Decodable<'a> for SubjectPublicKeyInfo<'a> {
 }
 
 impl<'a> Sequence<'a> for SubjectPublicKeyInfo<'a> {
-    fn fields<F, T>(&self, f: F) -> Result<T>
+    fn fields<F, T>(&self, f: F) -> der::Result<T>
     where
-        F: FnOnce(&[&dyn Encodable]) -> Result<T>,
+        F: FnOnce(&[&dyn Encodable]) -> der::Result<T>,
     {
         f(&[
             &self.algorithm,
@@ -84,6 +84,6 @@ impl<'a> TryFrom<&'a [u8]> for SubjectPublicKeyInfo<'a> {
     type Error = Error;
 
     fn try_from(bytes: &'a [u8]) -> Result<Self> {
-        Self::from_der(bytes)
+        Ok(Self::from_der(bytes)?)
     }
 }

--- a/spki/src/traits.rs
+++ b/spki/src/traits.rs
@@ -1,7 +1,6 @@
 //! Traits for encoding/decoding SPKI public keys.
 
-use crate::SubjectPublicKeyInfo;
-use der::Result;
+use crate::{Result, SubjectPublicKeyInfo};
 
 #[cfg(feature = "alloc")]
 use {crate::PublicKeyDocument, der::Document};


### PR DESCRIPTION
Renames and replaces the previous `ErrorKind::Truncated` which carried no additional information with an `ErrorKind::Incomplete` which carries the expected and actual lengths.

This is useful for incremental processing where a reader might attempt to perform an I/O operation to further fill a buffer in the event that the document is incomplete.

This commit includes a number of incidental changes to handle cases where `ErrorKind::Truncated` was inappropriately used before. One of the biggest is adding an error type to the `spki` crate in order to better signal the error conditions (e.g. `AlgorithmParametersMissing`) which were previously unhelpfully propagated as `der::ErrorKind::Truncated`.