### PR TITLE
der: make fields of `DateTime` match `time` crate types

### DIFF
--- a/der/src/asn1/generalized_time.rs
+++ b/der/src/asn1/generalized_time.rs
@@ -76,8 +76,8 @@ impl DecodeValue<'_> for GeneralizedTime {
         match *ByteSlice::decode_value(decoder, length)?.as_bytes() {
             // RFC 5280 requires mandatory seconds and Z-normalized time zone
             [y1, y2, y3, y4, mon1, mon2, day1, day2, hour1, hour2, min1, min2, sec1, sec2, b'Z'] => {
-                let year = datetime::decode_decimal(Self::TAG, y1, y2)? * 100
-                    + datetime::decode_decimal(Self::TAG, y3, y4)?;
+                let year = datetime::decode_decimal(Self::TAG, y1, y2)? as u16 * 100
+                    + datetime::decode_decimal(Self::TAG, y3, y4)? as u16;
                 let month = datetime::decode_decimal(Self::TAG, mon1, mon2)?;
                 let day = datetime::decode_decimal(Self::TAG, day1, day2)?;
                 let hour = datetime::decode_decimal(Self::TAG, hour1, hour2)?;
@@ -99,8 +99,8 @@ impl EncodeValue for GeneralizedTime {
     }
 
     fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        let year_hi = self.0.year() / 100;
-        let year_lo = self.0.year() % 100;
+        let year_hi = (self.0.year() / 100) as u8;
+        let year_lo = (self.0.year() % 100) as u8;
 
         datetime::encode_decimal(encoder, Self::TAG, year_hi)?;
         datetime::encode_decimal(encoder, Self::TAG, year_lo)?;

--- a/der/src/asn1/utc_time.rs
+++ b/der/src/asn1/utc_time.rs
@@ -90,7 +90,11 @@ impl DecodeValue<'_> for UtcTime {
                 let second = datetime::decode_decimal(Self::TAG, sec1, sec2)?;
 
                 // RFC 5280 rules for interpreting the year
-                let year = if year >= 50 { year + 1900 } else { year + 2000 };
+                let year = if year >= 50 {
+                    year as u16 + 1900
+                } else {
+                    year as u16 + 2000
+                };
 
                 DateTime::new(year, month, day, hour, minute, second)
                     .map_err(|_| Self::TAG.value_error())
@@ -111,7 +115,7 @@ impl EncodeValue for UtcTime {
             y @ 1950..=1999 => y - 1900,
             y @ 2000..=2049 => y - 2000,
             _ => return Err(Self::TAG.value_error()),
-        };
+        } as u8;
 
         datetime::encode_decimal(encoder, Self::TAG, year)?;
         datetime::encode_decimal(encoder, Self::TAG, self.0.month())?;

--- a/der/tests/datetime.rs
+++ b/der/tests/datetime.rs
@@ -7,11 +7,11 @@ proptest! {
     #[test]
     fn roundtrip_datetime(
         year in 1970u16..=9999,
-        month in 1u16..=12,
-        day in 1u16..=31,
-        hour in 0u16..=23,
-        min in 0u16..=59,
-        sec in 0u16..=59,
+        month in 1u8..=12,
+        day in 1u8..=31,
+        hour in 0u8..=23,
+        min in 0u8..=59,
+        sec in 0u8..=59,
     ) {
         let datetime1 = make_datetime(year, month, day, hour, min, sec);
         let datetime2 = DateTime::from_unix_duration(datetime1.unix_duration()).unwrap();
@@ -21,11 +21,11 @@ proptest! {
     #[test]
     fn roundtrip_utctime(
         year in 1970u16..=2049,
-        month in 1u16..=12,
-        day in 1u16..=31,
-        hour in 0u16..=23,
-        min in 0u16..=59,
-        sec in 0u16..=59,
+        month in 1u8..=12,
+        day in 1u8..=31,
+        hour in 0u8..=23,
+        min in 0u8..=59,
+        sec in 0u8..=59,
     ) {
         let datetime = make_datetime(year, month, day, hour, min, sec);
         let utc_time1 = UtcTime::try_from(datetime).unwrap();
@@ -40,7 +40,7 @@ proptest! {
     }
 }
 
-fn make_datetime(year: u16, month: u16, day: u16, hour: u16, min: u16, sec: u16) -> DateTime {
+fn make_datetime(year: u16, month: u8, day: u8, hour: u8, min: u8, sec: u8) -> DateTime {
     let max_day = if month == 2 {
         let is_leap_year = year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
 


### PR DESCRIPTION
The `time` crate uses `u8` for all fields of a `PrimitiveDateTime` except for the year (and technically `Month`, which is an `enum` that can be converted `Into` a `u8`).

This commit changes the `der` crate's  primitive `DateTime` type to match this set of types, which simplifies conversions.