### PR TITLE
Add type hint in `der` encoder `sequence` method

### DIFF
--- a/der/src/encoder.rs
+++ b/der/src/encoder.rs
@@ -156,8 +156,7 @@ impl<'a> Encoder<'a> {
         let mut nested_encoder = Encoder::new(self.reserve(length)?);
         f(&mut nested_encoder)?;
 
-        let len: usize = length.try_into()?;
-        if nested_encoder.finish()?.len() == len {
+        if nested_encoder.finish()?.len() == usize::try_from(length) {
             Ok(())
         } else {
             self.error(ErrorKind::Length { tag: Tag::Sequence })

--- a/der/src/encoder.rs
+++ b/der/src/encoder.rs
@@ -156,7 +156,8 @@ impl<'a> Encoder<'a> {
         let mut nested_encoder = Encoder::new(self.reserve(length)?);
         f(&mut nested_encoder)?;
 
-        if nested_encoder.finish()?.len() == length.try_into()? {
+        let len: usize = length.try_into()?;
+        if nested_encoder.finish()?.len() == len {
             Ok(())
         } else {
             self.error(ErrorKind::Length { tag: Tag::Sequence })

--- a/der/src/encoder.rs
+++ b/der/src/encoder.rs
@@ -156,7 +156,7 @@ impl<'a> Encoder<'a> {
         let mut nested_encoder = Encoder::new(self.reserve(length)?);
         f(&mut nested_encoder)?;
 
-        if nested_encoder.finish()?.len() == usize::try_from(length) {
+        if nested_encoder.finish()?.len() == usize::try_from(length)? {
             Ok(())
         } else {
             self.error(ErrorKind::Length { tag: Tag::Sequence })


### PR DESCRIPTION
This commit adds a type hint for a `Length` that is being TryInto'd a
usize. I'm not sure what causes this failure, but this seems to be a
bandaid fix.

Closes https://github.com/RustCrypto/formats/issues/146