### PR TITLE
der: rename `ErrorKind::Tag*`

### DIFF
--- a/der/derive/src/choice.rs
+++ b/der/derive/src/choice.rs
@@ -170,7 +170,7 @@ impl DeriveChoice {
                 fn decode(decoder: &mut ::der::Decoder<#lifetime>) -> ::der::Result<Self> {
                     match decoder.peek_tag()? {
                         #decode_body
-                        actual => Err(der::ErrorKind::UnexpectedTag {
+                        actual => Err(der::ErrorKind::TagUnexpected {
                             expected: None,
                             actual
                         }

--- a/der/src/tag.rs
+++ b/der/src/tag.rs
@@ -112,7 +112,7 @@ pub enum Tag {
 impl Tag {
     /// Assert that this [`Tag`] matches the provided expected tag.
     ///
-    /// On mismatch, returns an [`Error`] with [`ErrorKind::UnexpectedTag`].
+    /// On mismatch, returns an [`Error`] with [`ErrorKind::TagUnexpected`].
     pub fn assert_eq(self, expected: Tag) -> Result<Tag> {
         if self == expected {
             Ok(self)
@@ -208,7 +208,7 @@ impl Tag {
     /// Create an [`Error`] because the current tag was unexpected, with an
     /// optional expected tag.
     pub fn unexpected_error(self, expected: Option<Self>) -> Error {
-        ErrorKind::UnexpectedTag {
+        ErrorKind::TagUnexpected {
             expected,
             actual: self,
         }
@@ -257,7 +257,7 @@ impl TryFrom<u8> for Tag {
                 constructed,
                 number,
             }),
-            _ => Err(ErrorKind::UnknownTag { byte }.into()),
+            _ => Err(ErrorKind::TagUnknown { byte }.into()),
         }
     }
 }

--- a/der/src/tag/mode.rs
+++ b/der/src/tag/mode.rs
@@ -30,7 +30,7 @@ impl FromStr for TagMode {
         match s {
             "EXPLICIT" | "explicit" => Ok(TagMode::Explicit),
             "IMPLICIT" | "implicit" => Ok(TagMode::Implicit),
-            _ => Err(ErrorKind::UnknownTagMode.into()),
+            _ => Err(ErrorKind::TagModeUnknown.into()),
         }
     }
 }

--- a/der/src/tag/number.rs
+++ b/der/src/tag/number.rs
@@ -75,7 +75,7 @@ impl TryFrom<u8> for TagNumber {
     fn try_from(byte: u8) -> Result<Self> {
         match byte {
             0..=Self::MAX => Ok(Self(byte)),
-            _ => Err(ErrorKind::UnknownTag { byte }.into()),
+            _ => Err(ErrorKind::TagUnknown { byte }.into()),
         }
     }
 }


### PR DESCRIPTION
Renames the following to emphasize the `Tag` on the beginning of the variant name instead of the end:

- `ErrorKind::UnknownTagMode` => `ErrorKind::TagModeUnknown`
- `ErrorKind::UnexpectedTag` => `ErrorKind::TagUnexpected`
- `ErrorKind::UnknownTag` => `ErrorKind::TagUnknown`