### PR TITLE
der: consolidate `ErrorKind::{Incomplete, Underlength}`

### DIFF
--- a/der/src/arrayvec.rs
+++ b/der/src/arrayvec.rs
@@ -61,9 +61,9 @@ impl<T, const N: usize> ArrayVec<T, N> {
     /// Returns `None` if the [`ArrayVec`] does not contain `N` elements.
     pub fn try_into_array(self) -> Result<[T; N]> {
         if self.length != N {
-            return Err(ErrorKind::Underlength {
-                expected: N.try_into()?,
-                actual: self.length.try_into()?,
+            return Err(ErrorKind::Incomplete {
+                expected_len: N.try_into()?,
+                actual_len: self.length.try_into()?,
             }
             .into());
         }

--- a/der/src/encodable.rs
+++ b/der/src/encodable.rs
@@ -35,9 +35,9 @@ pub trait Encodable {
         let actual_len = encoder.finish()?.len();
 
         if expected_len != actual_len {
-            return Err(ErrorKind::Underlength {
-                expected: expected_len.try_into()?,
-                actual: actual_len.try_into()?,
+            return Err(ErrorKind::Incomplete {
+                expected_len: expected_len.try_into()?,
+                actual_len: actual_len.try_into()?,
             }
             .into());
         }

--- a/der/src/error.rs
+++ b/der/src/error.rs
@@ -263,17 +263,6 @@ pub enum ErrorKind {
         remaining: Length,
     },
 
-    /// Encoded message is shorter than the expected length.
-    ///
-    /// (i.e. an `Encodable` impl on a particular type has a buggy `encoded_len`)
-    Underlength {
-        /// Expected length
-        expected: Length,
-
-        /// Actual length
-        actual: Length,
-    },
-
     /// UTF-8 errors.
     Utf8(Utf8Error),
 
@@ -355,11 +344,6 @@ impl fmt::Display for ErrorKind {
                     decoded, remaining
                 )
             }
-            ErrorKind::Underlength { expected, actual } => write!(
-                f,
-                "DER message too short: expected {}, got {}",
-                expected, actual
-            ),
             ErrorKind::Utf8(e) => write!(f, "{}", e),
             ErrorKind::Value { tag } => write!(f, "malformed ASN.1 DER value for {}", tag),
         }

--- a/der/src/length.rs
+++ b/der/src/length.rs
@@ -123,9 +123,9 @@ impl Sub for Length {
         self.0
             .checked_sub(other.0)
             .ok_or_else(|| {
-                ErrorKind::Underlength {
-                    expected: other,
-                    actual: self,
+                ErrorKind::Incomplete {
+                    expected_len: other,
+                    actual_len: self,
                 }
                 .into()
             })


### PR DESCRIPTION
The latter was used for encoding errors and the former for decoding errors, but really the error types have the same "shape" and there's no need for separate variants for encoding/decoding, since there's no way they could get confused.