### PR TITLE
Remove I/O related errors from key format crates

### DIFF
--- a/pkcs1/src/error.rs
+++ b/pkcs1/src/error.rs
@@ -2,13 +2,6 @@
 
 use core::fmt;
 
-#[cfg(feature = "pem")]
-use crate::pem;
-
-/// Message to display when an `expect`-ed DER encoding error occurs
-#[cfg(feature = "alloc")]
-pub(crate) const DER_ENCODING_MSG: &str = "DER encoding error";
-
 /// Result type
 pub type Result<T> = core::result::Result<T, Error>;
 
@@ -27,25 +20,6 @@ pub enum Error {
     /// a number expected to be a prime was not a prime.
     Crypto,
 
-    /// File not found error.
-    #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    FileNotFound,
-
-    /// I/O errors.
-    #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    Io,
-
-    /// PEM encoding errors.
-    #[cfg(feature = "pem")]
-    Pem(pem::Error),
-
-    /// Permission denied reading file.
-    #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    PermissionDenied,
-
     /// Version errors
     Version,
 }
@@ -55,15 +29,7 @@ impl fmt::Display for Error {
         match self {
             Error::Asn1(err) => write!(f, "PKCS#1 ASN.1 error: {}", err),
             Error::Crypto => f.write_str("PKCS#1 cryptographic error"),
-            #[cfg(feature = "std")]
-            Error::FileNotFound => f.write_str("file not found"),
-            #[cfg(feature = "std")]
-            Error::Io => f.write_str("I/O error"),
-            #[cfg(feature = "pem")]
-            Error::Pem(err) => write!(f, "PKCS#1 {}", err),
             Error::Version => f.write_str("PKCS#1 version error"),
-            #[cfg(feature = "std")]
-            Error::PermissionDenied => f.write_str("permission denied"),
         }
     }
 }
@@ -74,23 +40,5 @@ impl From<der::Error> for Error {
     }
 }
 
-#[cfg(feature = "pem")]
-impl From<pem::Error> for Error {
-    fn from(err: pem::Error) -> Error {
-        Error::Pem(err)
-    }
-}
-
 #[cfg(feature = "std")]
 impl std::error::Error for Error {}
-
-#[cfg(feature = "std")]
-impl From<std::io::Error> for Error {
-    fn from(err: std::io::Error) -> Error {
-        match err.kind() {
-            std::io::ErrorKind::NotFound => Error::FileNotFound,
-            std::io::ErrorKind::PermissionDenied => Error::PermissionDenied,
-            _ => Error::Io,
-        }
-    }
-}

--- a/pkcs1/src/private_key.rs
+++ b/pkcs1/src/private_key.rs
@@ -94,7 +94,7 @@ impl<'a> RsaPrivateKey<'a> {
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     pub fn to_pem(&self, line_ending: LineEnding) -> Result<Zeroizing<String>> {
-        RsaPrivateKeyDocument::try_from(self)?.to_pkcs1_pem(line_ending)
+        self.to_der()?.to_pkcs1_pem(line_ending)
     }
 }
 

--- a/pkcs1/src/public_key.rs
+++ b/pkcs1/src/public_key.rs
@@ -10,14 +10,7 @@ use der::{asn1::UIntBytes, Decodable, Decoder, Encodable, Sequence};
 use crate::RsaPublicKeyDocument;
 
 #[cfg(feature = "pem")]
-use {
-    crate::{pem, LineEnding},
-    alloc::string::String,
-};
-
-/// Type label for PEM-encoded public keys.
-#[cfg(feature = "pem")]
-pub(crate) const PEM_TYPE_LABEL: &str = "RSA PUBLIC KEY";
+use {crate::LineEnding, alloc::string::String, der::Document};
 
 /// PKCS#1 RSA Public Keys as defined in [RFC 8017 Appendix 1.1].
 ///
@@ -44,8 +37,8 @@ impl<'a> RsaPublicKey<'a> {
     /// Encode this [`RsaPublicKey`] as ASN.1 DER.
     #[cfg(feature = "alloc")]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-    pub fn to_der(self) -> RsaPublicKeyDocument {
-        self.into()
+    pub fn to_der(self) -> Result<RsaPublicKeyDocument> {
+        self.try_into()
     }
 
     /// Encode this [`RsaPublicKey`] as PEM-encoded ASN.1 DER with the given
@@ -53,11 +46,7 @@ impl<'a> RsaPublicKey<'a> {
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     pub fn to_pem(self, line_ending: LineEnding) -> Result<String> {
-        Ok(pem::encode_string(
-            PEM_TYPE_LABEL,
-            line_ending,
-            self.to_der().as_ref(),
-        )?)
+        Ok(self.to_der()?.to_pem(line_ending)?)
     }
 }
 

--- a/pkcs1/src/public_key/document.rs
+++ b/pkcs1/src/public_key/document.rs
@@ -1,6 +1,6 @@
 //! PKCS#1 RSA public key document.
 
-use crate::{error, DecodeRsaPublicKey, EncodeRsaPublicKey, Error, Result, RsaPublicKey};
+use crate::{DecodeRsaPublicKey, EncodeRsaPublicKey, Error, Result, RsaPublicKey};
 use alloc::vec::Vec;
 use core::fmt;
 use der::{Decodable, Document, Encodable};
@@ -96,19 +96,19 @@ impl TryFrom<&[u8]> for RsaPublicKeyDocument {
     }
 }
 
-impl From<RsaPublicKey<'_>> for RsaPublicKeyDocument {
-    fn from(public_key: RsaPublicKey<'_>) -> RsaPublicKeyDocument {
-        RsaPublicKeyDocument::from(&public_key)
+impl TryFrom<RsaPublicKey<'_>> for RsaPublicKeyDocument {
+    type Error = Error;
+
+    fn try_from(public_key: RsaPublicKey<'_>) -> Result<RsaPublicKeyDocument> {
+        RsaPublicKeyDocument::try_from(&public_key)
     }
 }
 
-impl From<&RsaPublicKey<'_>> for RsaPublicKeyDocument {
-    fn from(public_key: &RsaPublicKey<'_>) -> RsaPublicKeyDocument {
-        public_key
-            .to_vec()
-            .ok()
-            .and_then(|buf| buf.try_into().ok())
-            .expect(error::DER_ENCODING_MSG)
+impl TryFrom<&RsaPublicKey<'_>> for RsaPublicKeyDocument {
+    type Error = Error;
+
+    fn try_from(public_key: &RsaPublicKey<'_>) -> Result<RsaPublicKeyDocument> {
+        Ok(public_key.to_vec()?.try_into()?)
     }
 }
 

--- a/pkcs8/src/private_key_info.rs
+++ b/pkcs8/src/private_key_info.rs
@@ -17,7 +17,11 @@ use {
 };
 
 #[cfg(feature = "pem")]
-use {crate::LineEnding, alloc::string::String, der::Document, zeroize::Zeroizing};
+use {
+    crate::{EncodePrivateKey, LineEnding},
+    alloc::string::String,
+    zeroize::Zeroizing,
+};
 
 #[cfg(feature = "subtle")]
 use subtle::{Choice, ConstantTimeEq};
@@ -133,7 +137,7 @@ impl<'a> PrivateKeyInfo<'a> {
         rng: impl CryptoRng + RngCore,
         password: impl AsRef<[u8]>,
     ) -> Result<EncryptedPrivateKeyDocument> {
-        PrivateKeyDocument::try_from(self)?.encrypt(rng, password)
+        self.to_der()?.encrypt(rng, password)
     }
 
     /// Encode this [`PrivateKeyInfo`] as ASN.1 DER.
@@ -148,9 +152,7 @@ impl<'a> PrivateKeyInfo<'a> {
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     pub fn to_pem(&self, line_ending: LineEnding) -> Result<Zeroizing<String>> {
-        Ok(PrivateKeyDocument::try_from(self)?
-            .to_pem(line_ending)
-            .map(Zeroizing::new)?)
+        self.to_der()?.to_pkcs8_pem(line_ending)
     }
 }
 

--- a/sec1/src/error.rs
+++ b/sec1/src/error.rs
@@ -2,9 +2,6 @@
 
 use core::fmt;
 
-#[cfg(feature = "pem")]
-use crate::pem;
-
 /// Result type with `sec1` crate's [`Error`] type.
 pub type Result<T> = core::result::Result<T, Error>;
 
@@ -23,25 +20,6 @@ pub enum Error {
     /// a number expected to be a prime was not a prime.
     Crypto,
 
-    /// File not found error.
-    #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    FileNotFound,
-
-    /// I/O errors.
-    #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    Io,
-
-    /// PEM encoding errors.
-    #[cfg(feature = "pem")]
-    Pem(pem::Error),
-
-    /// Permission denied reading file.
-    #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    PermissionDenied,
-
     /// Errors relating to the `Elliptic-Curve-Point-to-Octet-String` or
     /// `Octet-String-to-Elliptic-Curve-Point` encodings.
     PointEncoding,
@@ -55,24 +33,9 @@ impl fmt::Display for Error {
         match self {
             Error::Asn1(err) => write!(f, "SEC1 ASN.1 error: {}", err),
             Error::Crypto => f.write_str("SEC1 cryptographic error"),
-            #[cfg(feature = "std")]
-            Error::FileNotFound => f.write_str("file not found"),
-            #[cfg(feature = "std")]
-            Error::Io => f.write_str("I/O error"),
-            #[cfg(feature = "pem")]
-            Error::Pem(err) => write!(f, "SEC1 {}", err),
             Error::PointEncoding => f.write_str("elliptic curve point encoding error"),
             Error::Version => f.write_str("SEC1 version error"),
-            #[cfg(feature = "std")]
-            Error::PermissionDenied => f.write_str("permission denied"),
         }
-    }
-}
-
-#[cfg(feature = "pem")]
-impl From<pem::Error> for Error {
-    fn from(err: pem::Error) -> Error {
-        Error::Pem(err)
     }
 }
 
@@ -82,16 +45,5 @@ impl std::error::Error for Error {}
 impl From<der::Error> for Error {
     fn from(err: der::Error) -> Error {
         Error::Asn1(err)
-    }
-}
-
-#[cfg(feature = "std")]
-impl From<std::io::Error> for Error {
-    fn from(err: std::io::Error) -> Error {
-        match err.kind() {
-            std::io::ErrorKind::NotFound => Error::FileNotFound,
-            std::io::ErrorKind::PermissionDenied => Error::PermissionDenied,
-            _ => Error::Io,
-        }
     }
 }


### PR DESCRIPTION
Removes error variants like `FileNotFound` and `PermissionDenied` from the `pkcs1`, `pkcs8`, and `sec1` crates, now that these concerns are encapsulated by `der::Document`.