### PR TITLE
der_derive: implement `tag_mode = "implicit"` attribute

### DIFF
--- a/der/derive/src/lib.rs
+++ b/der/derive/src/lib.rs
@@ -100,15 +100,12 @@ use crate::{
     attributes::{FieldAttrs, TypeAttrs},
     choice::DeriveChoice,
     sequence::DeriveSequence,
-    tag::TagMode,
+    tag::{TagMode, TagNumber},
     types::Asn1Type,
 };
 use proc_macro2::TokenStream;
 use syn::{Generics, Lifetime};
 use synstructure::{decl_derive, Structure};
-
-/// Tag number.
-pub(crate) type TagNumber = u8;
 
 decl_derive!(
     [Choice, attributes(asn1)] =>

--- a/der/derive/src/sequence.rs
+++ b/der/derive/src/sequence.rs
@@ -55,7 +55,7 @@ impl DeriveSequence {
     fn derive_field_decoder(&mut self, name: &Ident, field_attrs: &FieldAttrs) {
         let field_binding = if field_attrs.asn1_type.is_some() {
             let field_decoder = field_attrs.decoder(&self.type_attrs);
-            quote! { let #name = #field_decoder?.try_into()?; }
+            quote! { let #name = #field_decoder.try_into()?; }
         } else {
             // TODO(tarcieri): IMPLICIT support
             if self.type_attrs.tag_mode == TagMode::Implicit {

--- a/der/derive/src/tag.rs
+++ b/der/derive/src/tag.rs
@@ -1,9 +1,14 @@
 //! Tag-related functionality.
 
+use proc_macro2::TokenStream;
+use quote::quote;
 use std::{
     fmt::{self, Display},
     str::FromStr,
 };
+
+/// Tag number.
+pub type TagNumber = u8;
 
 /// Tagging modes: `EXPLICIT` versus `IMPLICIT`.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -17,6 +22,17 @@ pub(crate) enum TagMode {
     ///
     /// Tag replaces the existing tag of the inner type.
     Implicit,
+}
+
+impl TagMode {
+    /// Get a [`TokenStream`] identifying the `der` crate's corresponding
+    /// enum variant for this tag mode.
+    pub fn tokens(self) -> TokenStream {
+        match self {
+            TagMode::Explicit => quote!(::der::TagMode::Explicit),
+            TagMode::Implicit => quote!(::der::TagMode::Implicit),
+        }
+    }
 }
 
 impl FromStr for TagMode {

--- a/der/derive/src/types.rs
+++ b/der/derive/src/types.rs
@@ -47,13 +47,13 @@ impl Asn1Type {
     /// Get a `der::Decoder` object for a particular ASN.1 type
     pub fn decoder(self) -> TokenStream {
         match self {
-            Asn1Type::BitString => quote!(decoder.bit_string()),
-            Asn1Type::Ia5String => quote!(decoder.ia5_string()),
-            Asn1Type::GeneralizedTime => quote!(decoder.generalized_time()),
-            Asn1Type::OctetString => quote!(decoder.octet_string()),
-            Asn1Type::PrintableString => quote!(decoder.printable_string()),
-            Asn1Type::UtcTime => quote!(decoder.utc_time()),
-            Asn1Type::Utf8String => quote!(decoder.utf8_string()),
+            Asn1Type::BitString => quote!(decoder.bit_string()?),
+            Asn1Type::Ia5String => quote!(decoder.ia5_string()?),
+            Asn1Type::GeneralizedTime => quote!(decoder.generalized_time()?),
+            Asn1Type::OctetString => quote!(decoder.octet_string()?),
+            Asn1Type::PrintableString => quote!(decoder.printable_string()?),
+            Asn1Type::UtcTime => quote!(decoder.utc_time()?),
+            Asn1Type::Utf8String => quote!(decoder.utf8_string()?),
         }
     }
 

--- a/der/src/asn1/utf8_string.rs
+++ b/der/src/asn1/utf8_string.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `UTF8String` support.
 
 use crate::{
-    asn1::Any, ByteSlice, DecodeValue, Decoder, Encodable, EncodeValue, Encoder, Error, Length,
-    Result, StrSlice, Tag, Tagged,
+    asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, Length, Result,
+    StrSlice, Tag, Tagged,
 };
 use core::{fmt, str};
 
@@ -135,18 +135,26 @@ impl<'a> TryFrom<Any<'a>> for &'a str {
     }
 }
 
-impl Encodable for str {
-    fn encoded_len(&self) -> Result<Length> {
-        Utf8String::new(self)?.encoded_len()
+impl EncodeValue for str {
+    fn value_len(&self) -> Result<Length> {
+        Utf8String::new(self)?.value_len()
     }
 
-    fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        Utf8String::new(self)?.encode(encoder)
+    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
+        Utf8String::new(self)?.encode_value(encoder)
     }
 }
 
 impl Tagged for str {
     const TAG: Tag = Tag::Utf8String;
+}
+
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+impl<'a> From<Utf8String<'a>> for String {
+    fn from(s: Utf8String<'a>) -> String {
+        s.as_str().to_owned()
+    }
 }
 
 #[cfg(feature = "alloc")]
@@ -161,13 +169,13 @@ impl<'a> TryFrom<Any<'a>> for String {
 
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-impl Encodable for String {
-    fn encoded_len(&self) -> Result<Length> {
-        Utf8String::new(self)?.encoded_len()
+impl EncodeValue for String {
+    fn value_len(&self) -> Result<Length> {
+        Utf8String::new(self)?.value_len()
     }
 
-    fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        Utf8String::new(self)?.encode(encoder)
+    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
+        Utf8String::new(self)?.encode_value(encoder)
     }
 }
 

--- a/der/tests/derive.rs
+++ b/der/tests/derive.rs
@@ -12,13 +12,13 @@
 #![cfg(feature = "derive")]
 
 use der::{
-    asn1::{GeneralizedTime, UtcTime},
+    asn1::{BitString, GeneralizedTime, UtcTime},
     Choice, Decodable, Encodable, Encoder,
 };
 use hex_literal::hex;
 use std::time::Duration;
 
-/// Custom derive test case for the `Choice` mcaro.
+/// Custom derive test case for the `Choice` macro.
 ///
 /// Based on `Time` as defined in RFC 5280:
 /// <https://tools.ietf.org/html/rfc5280#page-117>
@@ -50,7 +50,7 @@ const UTC_TIMESTAMP: &[u8] = &hex!("17 0d 39 31 30 35 30 36 32 33 34 35 34 30 5a
 const GENERAL_TIMESTAMP: &[u8] = &hex!("18 0f 31 39 39 31 30 35 30 36 32 33 34 35 34 30 5a");
 
 #[test]
-fn decode_enum_variants() {
+fn decode_time_variants() {
     let utc_time = Time::from_der(UTC_TIMESTAMP).unwrap();
     assert_eq!(utc_time.to_unix_duration().as_secs(), 673573540);
 
@@ -59,7 +59,7 @@ fn decode_enum_variants() {
 }
 
 #[test]
-fn encode_enum_variants() {
+fn encode_time_variants() {
     let mut buf = [0u8; 128];
 
     let utc_time = Time::from_der(UTC_TIMESTAMP).unwrap();
@@ -71,4 +71,18 @@ fn encode_enum_variants() {
     let mut encoder = Encoder::new(&mut buf);
     general_time.encode(&mut encoder).unwrap();
     assert_eq!(GENERAL_TIMESTAMP, encoder.finish().unwrap());
+}
+
+/// `Choice` macro test case for `IMPLICIT` tagging.
+#[derive(Choice)]
+#[asn1(tag_mode = "IMPLICIT")]
+pub enum ImplicitChoice<'a> {
+    #[asn1(context_specific = "0", type = "BIT STRING")]
+    BitString(BitString<'a>),
+
+    #[asn1(context_specific = "1", type = "GeneralizedTime")]
+    Time(GeneralizedTime),
+
+    #[asn1(context_specific = "2", type = "UTF8String")]
+    Utf8String(String),
 }

--- a/pkcs7/src/content_info.rs
+++ b/pkcs7/src/content_info.rs
@@ -199,7 +199,7 @@ mod tests {
             encoder.context_specific(
                 TagNumber::new(0),
                 TagMode::Explicit,
-                OctetString::new(hello)?,
+                &OctetString::new(hello)?,
             )
         })?;
         let encoded_der = encoder.finish().expect("encoding success");


### PR DESCRIPTION
Adds backend support for implicitly tagged variants of a `Choice`.