### PR TITLE
der: finish deriving context-specific `Choice`; add tests

### DIFF
--- a/der/derive/src/choice.rs
+++ b/der/derive/src/choice.rs
@@ -58,7 +58,12 @@ impl DeriveChoice {
                     variant.ident
                 )
             });
-            let tag = asn1_type.tag();
+            let tag = field_attrs.tag(&state.type_attrs).unwrap_or_else(|| {
+                panic!(
+                    "no #[asn1(type=...)] specified for enum variant: {}",
+                    variant.ident
+                )
+            });
 
             Alternative::register(&mut state.alternatives, asn1_type, variant);
             state.derive_variant_choice(&tag);
@@ -114,8 +119,7 @@ impl DeriveChoice {
         variant
             .each(|bi| {
                 let binding = &bi.binding;
-                let encoder_obj = field_attrs.encoder(&quote!(#binding), &self.type_attrs);
-                quote!(#encoder_obj?.encode(encoder))
+                field_attrs.encoder(&quote!(#binding), &self.type_attrs)
             })
             .to_tokens(&mut self.encode_body);
     }

--- a/der/derive/src/tag.rs
+++ b/der/derive/src/tag.rs
@@ -7,9 +7,6 @@ use std::{
     str::FromStr,
 };
 
-/// Tag number.
-pub type TagNumber = u8;
-
 /// Tagging modes: `EXPLICIT` versus `IMPLICIT`.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub(crate) enum TagMode {
@@ -59,6 +56,73 @@ impl Display for TagMode {
             TagMode::Explicit => f.write_str("EXPLICIT"),
             TagMode::Implicit => f.write_str("IMPLICIT"),
         }
+    }
+}
+
+/// ASN.1 tag numbers (i.e. lower 5 bits of a [`Tag`]).
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub(crate) struct TagNumber(u8);
+
+impl TagNumber {
+    /// Maximum tag number supported (inclusive).
+    pub const MAX: u8 = 30;
+
+    /// Get tokens describing this tag.
+    pub fn to_tokens(self) -> TokenStream {
+        match self.0 {
+            0 => quote!(::der::TagNumber::N0),
+            1 => quote!(::der::TagNumber::N1),
+            2 => quote!(::der::TagNumber::N2),
+            3 => quote!(::der::TagNumber::N3),
+            4 => quote!(::der::TagNumber::N4),
+            5 => quote!(::der::TagNumber::N5),
+            6 => quote!(::der::TagNumber::N6),
+            7 => quote!(::der::TagNumber::N7),
+            8 => quote!(::der::TagNumber::N8),
+            9 => quote!(::der::TagNumber::N9),
+            10 => quote!(::der::TagNumber::N10),
+            11 => quote!(::der::TagNumber::N11),
+            12 => quote!(::der::TagNumber::N12),
+            13 => quote!(::der::TagNumber::N13),
+            14 => quote!(::der::TagNumber::N14),
+            15 => quote!(::der::TagNumber::N15),
+            16 => quote!(::der::TagNumber::N16),
+            17 => quote!(::der::TagNumber::N17),
+            18 => quote!(::der::TagNumber::N18),
+            19 => quote!(::der::TagNumber::N19),
+            20 => quote!(::der::TagNumber::N20),
+            21 => quote!(::der::TagNumber::N21),
+            22 => quote!(::der::TagNumber::N22),
+            23 => quote!(::der::TagNumber::N23),
+            24 => quote!(::der::TagNumber::N24),
+            25 => quote!(::der::TagNumber::N25),
+            26 => quote!(::der::TagNumber::N26),
+            27 => quote!(::der::TagNumber::N27),
+            28 => quote!(::der::TagNumber::N28),
+            29 => quote!(::der::TagNumber::N29),
+            30 => quote!(::der::TagNumber::N30),
+            _ => unreachable!("tag number out of range: {}", self),
+        }
+    }
+}
+
+impl FromStr for TagNumber {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, ParseError> {
+        let n = s.parse::<u8>().map_err(|_| ParseError)?;
+
+        if n <= Self::MAX {
+            Ok(Self(n))
+        } else {
+            Err(ParseError)
+        }
+    }
+}
+
+impl Display for TagNumber {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 


### PR DESCRIPTION
The custom derive support for `IMPLICIT`-ly tagged context-specific fields was previously incomplete and didn't work correctly.

This commit finishes basic end-to-end support for both decoding and encoding and adds an initial integration test.