### PR TITLE
der_derive: add integration tests for `Sequence` macro

### DIFF
--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -242,16 +242,15 @@
 //! }
 //!
 //! // Example parameters value: OID for the NIST P-256 elliptic curve.
-//! let parameters = "1.2.840.10045.3.1.7".parse::<ObjectIdentifier>().unwrap();
-//! let der_encoded_parameters = parameters.to_vec().unwrap();
+//! let parameters_oid = "1.2.840.10045.3.1.7".parse::<ObjectIdentifier>().unwrap();
 //!
 //! let algorithm_identifier = AlgorithmIdentifier {
 //!     // OID for `id-ecPublicKey`, if you're curious
 //!     algorithm: "1.2.840.10045.2.1".parse().unwrap(),
 //!
-//!     // `Any<'a>` impls `TryFrom<&'a [u8]>`, which parses the provided
+//!     // `Any<'a>` impls `From<&'a ObjectIdentifier>`, which parses the provided
 //!     // slice as an ASN.1 DER-encoded message.
-//!     parameters: Some(der_encoded_parameters.as_slice().try_into().unwrap())
+//!     parameters: Some(Any::from(&parameters_oid))
 //! };
 //!
 //! // Encode

--- a/der/tests/derive.rs
+++ b/der/tests/derive.rs
@@ -11,129 +11,203 @@
 
 #![cfg(feature = "derive")]
 
-use der::{
-    asn1::{BitString, GeneralizedTime, UtcTime},
-    Choice, Decodable, Encodable, Encoder,
-};
-use hex_literal::hex;
-use std::time::Duration;
+/// Custom derive test cases for the `Choice` macro.
+mod choice {
+    /// `Choice` with `EXPLICIT` tagging.
+    mod explicit {
+        use der::{
+            asn1::{GeneralizedTime, UtcTime},
+            Choice, Decodable, Encodable, Encoder,
+        };
+        use hex_literal::hex;
+        use std::time::Duration;
 
-/// Custom derive test case for the `Choice` macro.
-///
-/// Based on `Time` as defined in RFC 5280:
-/// <https://tools.ietf.org/html/rfc5280#page-117>
-///
-/// ```text
-/// Time ::= CHOICE {
-///      utcTime        UTCTime,
-///      generalTime    GeneralizedTime }
-/// ```
-#[derive(Choice)]
-pub enum Time {
-    #[asn1(type = "UTCTime")]
-    UtcTime(UtcTime),
+        /// Custom derive test case for the `Choice` macro.
+        ///
+        /// Based on `Time` as defined in RFC 5280:
+        /// <https://tools.ietf.org/html/rfc5280#page-117>
+        ///
+        /// ```text
+        /// Time ::= CHOICE {
+        ///      utcTime        UTCTime,
+        ///      generalTime    GeneralizedTime }
+        /// ```
+        #[derive(Choice)]
+        pub enum Time {
+            #[asn1(type = "UTCTime")]
+            UtcTime(UtcTime),
 
-    #[asn1(type = "GeneralizedTime")]
-    GeneralTime(GeneralizedTime),
-}
+            #[asn1(type = "GeneralizedTime")]
+            GeneralTime(GeneralizedTime),
+        }
 
-impl Time {
-    const UTC_TIMESTAMP_BYTES: &'static [u8] =
-        &hex!("17 0d 39 31 30 35 30 36 32 33 34 35 34 30 5a");
-    const GENERAL_TIMESTAMP_BYTES: &'static [u8] =
-        &hex!("18 0f 31 39 39 31 30 35 30 36 32 33 34 35 34 30 5a");
+        impl Time {
+            const UTC_TIMESTAMP_DER: &'static [u8] =
+                &hex!("17 0d 39 31 30 35 30 36 32 33 34 35 34 30 5a");
+            const GENERAL_TIMESTAMP_DER: &'static [u8] =
+                &hex!("18 0f 31 39 39 31 30 35 30 36 32 33 34 35 34 30 5a");
 
-    fn to_unix_duration(self) -> Duration {
-        match self {
-            Time::UtcTime(t) => t.to_unix_duration(),
-            Time::GeneralTime(t) => t.to_unix_duration(),
+            fn to_unix_duration(self) -> Duration {
+                match self {
+                    Time::UtcTime(t) => t.to_unix_duration(),
+                    Time::GeneralTime(t) => t.to_unix_duration(),
+                }
+            }
+        }
+
+        #[test]
+        fn decode() {
+            let utc_time = Time::from_der(Time::UTC_TIMESTAMP_DER).unwrap();
+            assert_eq!(utc_time.to_unix_duration().as_secs(), 673573540);
+
+            let general_time = Time::from_der(Time::GENERAL_TIMESTAMP_DER).unwrap();
+            assert_eq!(general_time.to_unix_duration().as_secs(), 673573540);
+        }
+
+        #[test]
+        fn encode() {
+            let mut buf = [0u8; 128];
+
+            let utc_time = Time::from_der(Time::UTC_TIMESTAMP_DER).unwrap();
+            let mut encoder = Encoder::new(&mut buf);
+            utc_time.encode(&mut encoder).unwrap();
+            assert_eq!(Time::UTC_TIMESTAMP_DER, encoder.finish().unwrap());
+
+            let general_time = Time::from_der(Time::GENERAL_TIMESTAMP_DER).unwrap();
+            let mut encoder = Encoder::new(&mut buf);
+            general_time.encode(&mut encoder).unwrap();
+            assert_eq!(Time::GENERAL_TIMESTAMP_DER, encoder.finish().unwrap());
+        }
+    }
+
+    /// `Choice` with `IMPLICIT` tagging.
+    mod implicit {
+        use der::{
+            asn1::{BitString, GeneralizedTime},
+            Choice, Decodable, Encodable, Encoder,
+        };
+        use hex_literal::hex;
+
+        /// `Choice` macro test case for `IMPLICIT` tagging.
+        #[derive(Choice, Debug, Eq, PartialEq)]
+        #[asn1(tag_mode = "IMPLICIT")]
+        pub enum ImplicitChoice<'a> {
+            #[asn1(context_specific = "0", type = "BIT STRING")]
+            BitString(BitString<'a>),
+
+            #[asn1(context_specific = "1", type = "GeneralizedTime")]
+            Time(GeneralizedTime),
+
+            #[asn1(context_specific = "2", type = "UTF8String")]
+            Utf8String(String),
+        }
+
+        impl<'a> ImplicitChoice<'a> {
+            const BITSTRING_DER: &'static [u8] = &hex!("80 04 00 01 02 03");
+            const TIME_DER: &'static [u8] =
+                &hex!("81 0f 31 39 39 31 30 35 30 36 32 33 34 35 34 30 5a");
+
+            pub fn bit_string(&self) -> Option<BitString<'a>> {
+                match self {
+                    Self::BitString(bs) => Some(*bs),
+                    _ => None,
+                }
+            }
+
+            pub fn time(&self) -> Option<GeneralizedTime> {
+                match self {
+                    Self::Time(time) => Some(*time),
+                    _ => None,
+                }
+            }
+        }
+
+        #[test]
+        fn decode() {
+            let cs_bit_string = ImplicitChoice::from_der(ImplicitChoice::BITSTRING_DER).unwrap();
+            assert_eq!(
+                cs_bit_string.bit_string().unwrap().as_bytes().unwrap(),
+                &[1, 2, 3]
+            );
+
+            let cs_time = ImplicitChoice::from_der(ImplicitChoice::TIME_DER).unwrap();
+            assert_eq!(
+                cs_time.time().unwrap().to_unix_duration().as_secs(),
+                673573540
+            );
+        }
+
+        #[test]
+        fn encode() {
+            let mut buf = [0u8; 128];
+
+            let cs_bit_string = ImplicitChoice::from_der(ImplicitChoice::BITSTRING_DER).unwrap();
+            let mut encoder = Encoder::new(&mut buf);
+            cs_bit_string.encode(&mut encoder).unwrap();
+            assert_eq!(ImplicitChoice::BITSTRING_DER, encoder.finish().unwrap());
+
+            let cs_time = ImplicitChoice::from_der(ImplicitChoice::TIME_DER).unwrap();
+            let mut encoder = Encoder::new(&mut buf);
+            cs_time.encode(&mut encoder).unwrap();
+            assert_eq!(ImplicitChoice::TIME_DER, encoder.finish().unwrap());
         }
     }
 }
 
-/// `Choice` macro test case for `IMPLICIT` tagging.
-#[derive(Choice, Debug, Eq, PartialEq)]
-#[asn1(tag_mode = "IMPLICIT")]
-pub enum ImplicitChoice<'a> {
-    #[asn1(context_specific = "0", type = "BIT STRING")]
-    BitString(BitString<'a>),
+/// Custom derive test cases for the `Sequence` macro.
+mod sequence {
+    use der::{
+        asn1::{Any, ObjectIdentifier},
+        Decodable, Encodable, Sequence,
+    };
+    use hex_literal::hex;
 
-    #[asn1(context_specific = "1", type = "GeneralizedTime")]
-    Time(GeneralizedTime),
-
-    #[asn1(context_specific = "2", type = "UTF8String")]
-    Utf8String(String),
-}
-
-impl<'a> ImplicitChoice<'a> {
-    const BITSTRING_BYTES: &'static [u8] = &hex!("80 04 00 01 02 03");
-    const TIME_BYTES: &'static [u8] = &hex!("81 0f 31 39 39 31 30 35 30 36 32 33 34 35 34 30 5a");
-
-    pub fn bit_string(&self) -> Option<BitString<'a>> {
-        match self {
-            Self::BitString(bs) => Some(*bs),
-            _ => None,
-        }
+    /// X.509 `AlgorithmIdentifier`
+    #[derive(Copy, Clone, Debug, Eq, PartialEq, Sequence)]
+    pub struct AlgorithmIdentifier<'a> {
+        pub algorithm: ObjectIdentifier,
+        pub parameters: Option<Any<'a>>,
     }
 
-    pub fn time(&self) -> Option<GeneralizedTime> {
-        match self {
-            Self::Time(time) => Some(*time),
-            _ => None,
-        }
+    /// X.509 `SubjectPublicKeyInfo` (SPKI)
+    #[derive(Copy, Clone, Debug, Eq, PartialEq, Sequence)]
+    pub struct SubjectPublicKeyInfo<'a> {
+        pub algorithm: AlgorithmIdentifier<'a>,
+
+        #[asn1(type = "BIT STRING")]
+        pub subject_public_key: &'a [u8],
     }
-}
 
-#[test]
-fn decode_time_variants() {
-    let utc_time = Time::from_der(Time::UTC_TIMESTAMP_BYTES).unwrap();
-    assert_eq!(utc_time.to_unix_duration().as_secs(), 673573540);
+    const ID_EC_PUBLIC_KEY_OID: ObjectIdentifier = ObjectIdentifier::new("1.2.840.10045.2.1");
+    const PRIME256V1_OID: ObjectIdentifier = ObjectIdentifier::new("1.2.840.10045.3.1.7");
 
-    let general_time = Time::from_der(Time::GENERAL_TIMESTAMP_BYTES).unwrap();
-    assert_eq!(general_time.to_unix_duration().as_secs(), 673573540);
-}
+    const ALGORITHM_IDENTIFIER_DER: &[u8] =
+        &hex!("30 13 06 07 2a 86 48 ce 3d 02 01 06 08 2a 86 48 ce 3d 03 01 07");
 
-#[test]
-fn encode_time_variants() {
-    let mut buf = [0u8; 128];
+    #[test]
+    fn decode() {
+        let algorithm_identifier =
+            AlgorithmIdentifier::from_der(&ALGORITHM_IDENTIFIER_DER).unwrap();
 
-    let utc_time = Time::from_der(Time::UTC_TIMESTAMP_BYTES).unwrap();
-    let mut encoder = Encoder::new(&mut buf);
-    utc_time.encode(&mut encoder).unwrap();
-    assert_eq!(Time::UTC_TIMESTAMP_BYTES, encoder.finish().unwrap());
+        assert_eq!(ID_EC_PUBLIC_KEY_OID, algorithm_identifier.algorithm);
+        assert_eq!(
+            PRIME256V1_OID,
+            ObjectIdentifier::try_from(algorithm_identifier.parameters.unwrap()).unwrap()
+        );
+    }
 
-    let general_time = Time::from_der(Time::GENERAL_TIMESTAMP_BYTES).unwrap();
-    let mut encoder = Encoder::new(&mut buf);
-    general_time.encode(&mut encoder).unwrap();
-    assert_eq!(Time::GENERAL_TIMESTAMP_BYTES, encoder.finish().unwrap());
-}
+    #[test]
+    fn encode() {
+        let parameters_oid = PRIME256V1_OID;
 
-#[test]
-fn decode_implicit_choice() {
-    let cs_bit_string = ImplicitChoice::from_der(ImplicitChoice::BITSTRING_BYTES).unwrap();
-    assert_eq!(
-        cs_bit_string.bit_string().unwrap().as_bytes().unwrap(),
-        &[1, 2, 3]
-    );
+        let algorithm_identifier = AlgorithmIdentifier {
+            algorithm: ID_EC_PUBLIC_KEY_OID,
+            parameters: Some(Any::from(&parameters_oid)),
+        };
 
-    let cs_time = ImplicitChoice::from_der(ImplicitChoice::TIME_BYTES).unwrap();
-    assert_eq!(
-        cs_time.time().unwrap().to_unix_duration().as_secs(),
-        673573540
-    );
-}
-
-#[test]
-fn encode_implicit_choice() {
-    let mut buf = [0u8; 128];
-
-    let cs_bit_string = ImplicitChoice::from_der(ImplicitChoice::BITSTRING_BYTES).unwrap();
-    let mut encoder = Encoder::new(&mut buf);
-    cs_bit_string.encode(&mut encoder).unwrap();
-    assert_eq!(ImplicitChoice::BITSTRING_BYTES, encoder.finish().unwrap());
-
-    let cs_time = ImplicitChoice::from_der(ImplicitChoice::TIME_BYTES).unwrap();
-    let mut encoder = Encoder::new(&mut buf);
-    cs_time.encode(&mut encoder).unwrap();
-    assert_eq!(ImplicitChoice::TIME_BYTES, encoder.finish().unwrap());
+        assert_eq!(
+            ALGORITHM_IDENTIFIER_DER,
+            algorithm_identifier.to_vec().unwrap()
+        );
+    }
 }


### PR DESCRIPTION
Adds integration tests based on the X.509 test cases covered in the documentation.