### PR TITLE
der_derive: don't automatically derive `From` impls for `Choice`

### DIFF
--- a/x509/src/time.rs
+++ b/x509/src/time.rs
@@ -51,3 +51,41 @@ impl Time {
         }
     }
 }
+
+impl From<UtcTime> for Time {
+    fn from(time: UtcTime) -> Time {
+        Time::UtcTime(time)
+    }
+}
+
+impl From<GeneralizedTime> for Time {
+    fn from(time: GeneralizedTime) -> Time {
+        Time::GeneralTime(time)
+    }
+}
+
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+impl From<Time> for SystemTime {
+    fn from(time: Time) -> SystemTime {
+        time.to_system_time()
+    }
+}
+
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+impl From<&Time> for SystemTime {
+    fn from(time: &Time) -> SystemTime {
+        time.to_system_time()
+    }
+}
+
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+impl TryFrom<SystemTime> for Time {
+    type Error = der::Error;
+
+    fn try_from(time: SystemTime) -> der::Result<Time> {
+        Ok(GeneralizedTime::try_from(time)?.into())
+    }
+}


### PR DESCRIPTION
Previously the custom derive for `Choice` would also write `From` impls for each of the variants, which would convert the inner type into a particular variant of the enum. This used to be an integral part of the `Decode` impl, but is no longer.

This is problematic because it means no two variants can have the same inner type. This commit gets rid of these derives since they're no longer needed for decoding and have this limitation.