### PR TITLE
pkcs7: doc fixups

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Cryptography-related format encoders/decoders: PKCS, PKIX.
 | `pem‑rfc7468` | [![crates.io](https://img.shields.io/crates/v/pem-rfc7468.svg)](https://crates.io/crates/pem-rfc7468) | [![Documentation](https://docs.rs/pem-rfc7468/badge.svg)](https://docs.rs/pem-rfc7468) | Strict PEM encoding for PKIX/PKCS/CMS objects |
 | `pkcs1` | [![crates.io](https://img.shields.io/crates/v/pkcs1.svg)](https://crates.io/crates/pkcs1) | [![Documentation](https://docs.rs/pkcs1/badge.svg)](https://docs.rs/pkcs1) | Implementation of PKCS#1: RSA Cryptography Specifications Version 2.2 ([RFC 8017]) |
 | `pkcs5` | [![crates.io](https://img.shields.io/crates/v/pkcs5.svg)](https://crates.io/crates/pkcs5) | [![Documentation](https://docs.rs/pkcs5/badge.svg)](https://docs.rs/pkcs5) | Implementation of PKCS#5: Password-Based Cryptography Specification Version 2.1 ([RFC 8018]) |
+| `pkcs7` | [![crates.io](https://img.shields.io/crates/v/pkcs7.svg)](https://crates.io/crates/pkcs7) | [![Documentation](https://docs.rs/pkcs7/badge.svg)](https://docs.rs/pkcs7) | Implementation of PKCS#7: Cryptographic Message Syntax v1.5 ([RFC 5652] and [RFC 8933]) |
 | `pkcs8` | [![crates.io](https://img.shields.io/crates/v/pkcs8.svg)](https://crates.io/crates/pkcs8) | [![Documentation](https://docs.rs/pkcs8/badge.svg)](https://docs.rs/pkcs8) | Implementation of PKCS#8(v2): Private-Key Information Syntax Specification ([RFC 5208]) and asymmetric key packages ([RFC 5958]) |
 | `sec1` | [![crates.io](https://img.shields.io/crates/v/sec1.svg)](https://crates.io/crates/sec1) | [![Documentation](https://docs.rs/sec1/badge.svg)](https://docs.rs/sec1) | [SEC1: Elliptic Curve Cryptography] encoding formats |
 | `spki` | [![crates.io](https://img.shields.io/crates/v/spki.svg)](https://crates.io/crates/spki) | [![Documentation](https://docs.rs/spki/badge.svg)](https://docs.rs/spki) | X.509 Subject Public Key Info ([RFC 5280 Section 4.1]) describing public keys as well as their associated AlgorithmIdentifiers (i.e. OIDs) |
@@ -46,7 +47,9 @@ dual licensed as above, without any additional terms or conditions.
 [RFC 5208]: https://datatracker.ietf.org/doc/html/rfc5208
 [RFC 5280 Section 4.1]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1
 [RFC 5280]: https://datatracker.ietf.org/doc/html/rfc5280
+[RFC 5652]: https://datatracker.ietf.org/doc/html/rfc5652
 [RFC 5958]: https://datatracker.ietf.org/doc/html/rfc5958
 [RFC 8017]: https://datatracker.ietf.org/doc/html/rfc8017
 [RFC 8018]: https://datatracker.ietf.org/doc/html/rfc8018
+[RFC 8933]: https://datatracker.ietf.org/doc/html/rfc8933
 [SEC1: Elliptic Curve Cryptography]: https://www.secg.org/sec1-v2.pdf

--- a/pkcs7/Cargo.toml
+++ b/pkcs7/Cargo.toml
@@ -3,7 +3,7 @@ name = "pkcs7"
 version = "0.0.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #7:
-PKCS #7: Cryptographic Message Syntax Version 1.5 (RFC 2315)
+PKCS #7: Cryptographic Message Syntax Version 1.5 (RFC 5652)
 """
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"

--- a/pkcs7/README.md
+++ b/pkcs7/README.md
@@ -1,4 +1,4 @@
-# RustCrypto: PKCS#7 (Cryptographic Message)
+# [RustCrypto]: PKCS#7 (Cryptographic Messages)
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
@@ -8,7 +8,7 @@
 [![Project Chat][chat-image]][chat-link]
 
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #7:
-Cryptographic Message Syntax v1.5 ([RFC 2315]).
+Cryptographic Message Syntax v1.5 ([RFC 5652] and [RFC 8933]).
 
 [Documentation][docs-link]
 
@@ -42,4 +42,6 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (links)
 
-[RFC 2315]: https://tools.ietf.org/html/rfc2315
+[RustCrypto]: https://github.com/rustcrypto
+[RFC 5652]: https://datatracker.ietf.org/doc/html/rfc5652
+[RFC 8933]: https://datatracker.ietf.org/doc/html/rfc8933

--- a/pkcs7/src/content_info.rs
+++ b/pkcs7/src/content_info.rs
@@ -7,7 +7,7 @@ use der::{
 
 const CONTENT_TAG: TagNumber = TagNumber::new(0);
 
-/// Content exchanged between entities [RFC 2315 § 7](https://datatracker.ietf.org/doc/html/rfc2315#section-7)
+/// Content exchanged between entities [RFC 5652 § 3](https://datatracker.ietf.org/doc/html/rfc5652#section-3)
 ///
 /// ```text
 /// ContentInfo ::= SEQUENCE {
@@ -16,10 +16,10 @@ const CONTENT_TAG: TagNumber = TagNumber::new(0);
 ///     [0] EXPLICIT ANY DEFINED BY contentType OPTIONAL }
 /// ```
 pub enum ContentInfo<'a> {
-    /// Content type `data` [RFC 2315 § 8](https://datatracker.ietf.org/doc/html/rfc2315#section-8)
+    /// Content type `data`
     Data(Option<DataContent<'a>>),
 
-    /// Content type `encrypted-data` [RFC 2315 § 13](https://datatracker.ietf.org/doc/html/rfc2315#section-13)
+    /// Content type `encrypted-data`
     EncryptedData(Option<EncryptedDataContent<'a>>),
 
     /// Catch-all case for content types that are not explicitly supported

--- a/pkcs7/src/data_content.rs
+++ b/pkcs7/src/data_content.rs
@@ -1,4 +1,4 @@
-//! `data` content type [RFC 2315 § 8](https://datatracker.ietf.org/doc/html/rfc2315#section-8)
+//! `data` content type [RFC 5652 § 4](https://datatracker.ietf.org/doc/html/rfc5652#section-4)
 
 use core::convert::{From, TryFrom};
 use der::{asn1::OctetString, DecodeValue, Decoder, EncodeValue, Encoder, Length, Tag, Tagged};

--- a/pkcs7/src/encrypted_data_content.rs
+++ b/pkcs7/src/encrypted_data_content.rs
@@ -1,4 +1,4 @@
-//! `encrypted-data` content type [RFC 2315 § 13](https://datatracker.ietf.org/doc/html/rfc2315#section-13)
+//! `encrypted-data` content type [RFC 5652 § 8](https://datatracker.ietf.org/doc/html/rfc5652#section-8)
 
 use crate::enveloped_data_content::EncryptedContentInfo;
 use der::{
@@ -11,8 +11,8 @@ use der::{
 /// Version ::= Integer
 /// ```
 ///
-/// The only supported version is 0.
-/// See [RFC 2315 § 13](https://datatracker.ietf.org/doc/html/rfc2315#section-13).
+/// The only version supported by this library is `0`.
+/// See [RFC 5652 § 8](https://datatracker.ietf.org/doc/html/rfc5652#section-8).
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Version {
     /// syntax version 0 for [EncryptedDataContent].
@@ -55,7 +55,7 @@ impl EncodeValue for Version {
     }
 }
 
-/// Encrypted-data content type [RFC 2315 § 13](https://datatracker.ietf.org/doc/html/rfc2315#section-13)
+/// Encrypted-data content type [RFC 5652 § 8](https://datatracker.ietf.org/doc/html/rfc5652#section-8)
 ///
 /// ```text
 /// EncryptedData ::= SEQUENCE {

--- a/pkcs7/src/enveloped_data_content.rs
+++ b/pkcs7/src/enveloped_data_content.rs
@@ -1,4 +1,4 @@
-//! `enveloped-data` content type [RFC 2315 § 10](https://datatracker.ietf.org/doc/html/rfc2315#section-10)
+//! `enveloped-data` content type [RFC 5652 § 6](https://datatracker.ietf.org/doc/html/rfc5652#section-6)
 
 use crate::ContentType;
 
@@ -12,7 +12,7 @@ type ContentEncryptionAlgorithmIdentifier<'a> = AlgorithmIdentifier<'a>;
 
 const ENCRYPTED_CONTENT_TAG: TagNumber = TagNumber::new(0);
 
-/// Encrypted content information [RFC 2315 § 10.1](https://datatracker.ietf.org/doc/html/rfc2315#section-10.1)
+/// Encrypted content information [RFC 5652 § 6](https://datatracker.ietf.org/doc/html/rfc5652#section-6)
 ///
 /// ```text
 /// EncryptedContentInfo ::= SEQUENCE {
@@ -33,8 +33,6 @@ const ENCRYPTED_CONTENT_TAG: TagNumber = TagNumber::new(0);
 ///   - [`content_encryption_algorithm`](EncryptedContentInfo::content_encryption_algorithm)
 ///     identifies the content-encryption algorithm (and any associated parameters) under
 ///     which the content is encrypted.
-///     The content-encryption process is described in
-///     [RFC 2315 § 10.3](https://datatracker.ietf.org/doc/html/rfc2315#section-10.3).
 ///     This algorithm is the same for all recipients.
 ///   - [`encrypted_content`](EncryptedContentInfo::encrypted_content) is the result of
 ///     encrypting the content. The field is optional, and if the field is not present,

--- a/pkcs8/README.md
+++ b/pkcs8/README.md
@@ -1,4 +1,4 @@
-# RustCrypto: PKCS#8 (Private Keys)
+# [RustCrypto]: PKCS#8 (Private Keys)
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
@@ -89,5 +89,6 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (links)
 
+[RustCrypto]: https://github.com/rustcrypto
 [RFC 5208]: https://tools.ietf.org/html/rfc5208
 [scrypt]: https://en.wikipedia.org/wiki/Scrypt


### PR DESCRIPTION
- Replace outdated references to RFC 2315 with references to RFC 5652 and RFC 8933
- Add `pkcs7` crate to the toplevel table