### PR TITLE
const-oid: rename `MAX_LENGTH` to `MAX_SIZE`; bump to 31

### DIFF
--- a/const-oid/src/encoder.rs
+++ b/const-oid/src/encoder.rs
@@ -11,7 +11,7 @@ pub(crate) struct Encoder {
     state: State,
 
     /// Bytes of the OID being encoded in-progress
-    bytes: [u8; ObjectIdentifier::MAX_LENGTH],
+    bytes: [u8; ObjectIdentifier::MAX_SIZE],
 
     /// Current position within the byte buffer
     cursor: usize,
@@ -34,7 +34,7 @@ impl Encoder {
     pub(crate) const fn new() -> Self {
         Self {
             state: State::Initial,
-            bytes: [0u8; ObjectIdentifier::MAX_LENGTH],
+            bytes: [0u8; ObjectIdentifier::MAX_SIZE],
             cursor: 0,
         }
     }
@@ -59,7 +59,7 @@ impl Encoder {
                 let nbytes = base128_len(arc);
 
                 const_assert!(
-                    self.cursor + nbytes + 1 < ObjectIdentifier::MAX_LENGTH,
+                    self.cursor + nbytes + 1 < ObjectIdentifier::MAX_SIZE,
                     "OID too long (exceeded max DER bytes)"
                 );
 

--- a/const-oid/src/lib.rs
+++ b/const-oid/src/lib.rs
@@ -42,11 +42,11 @@ use core::{fmt, str::FromStr};
 /// - The first arc MUST be within the range 0-2
 /// - The second arc MUST be within the range 0-39
 /// - The BER/DER encoding of the OID MUST be shorter than
-///   [`ObjectIdentifier::MAX_LENGTH`]
+///   [`ObjectIdentifier::MAX_SIZE`]
 #[derive(Copy, Clone, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub struct ObjectIdentifier {
     /// Array containing BER/DER-serialized bytes (no header)
-    bytes: [u8; Self::MAX_LENGTH],
+    bytes: [u8; Self::MAX_SIZE],
 
     /// Length in bytes
     length: u8,
@@ -54,8 +54,8 @@ pub struct ObjectIdentifier {
 
 #[allow(clippy::len_without_is_empty)]
 impl ObjectIdentifier {
-    /// Maximum length of a BER/DER-encoded OID in bytes.
-    pub const MAX_LENGTH: usize = 23; // 24-bytes total w\ 1-byte length
+    /// Maximum size of a BER/DER-encoded OID in bytes.
+    pub const MAX_SIZE: usize = 31; // 24-bytes total w\ 1-byte length
 
     /// Parse an [`ObjectIdentifier`] from the dot-delimited string form, e.g.:
     ///
@@ -85,7 +85,7 @@ impl ObjectIdentifier {
 
     /// Parse an OID from a slice of [`Arc`] values (i.e. integers).
     pub fn from_arcs(arcs: &[Arc]) -> Result<Self> {
-        let mut bytes = [0u8; Self::MAX_LENGTH];
+        let mut bytes = [0u8; Self::MAX_SIZE];
 
         bytes[0] = match *arcs {
             [first, second, _, ..] => RootArcs::new(first, second)?.into(),
@@ -108,7 +108,7 @@ impl ObjectIdentifier {
     pub fn from_bytes(ber_bytes: &[u8]) -> Result<Self> {
         let len = ber_bytes.len();
 
-        if !(2..=Self::MAX_LENGTH).contains(&len) {
+        if !(2..=Self::MAX_SIZE).contains(&len) {
             return Err(Error);
         }
 
@@ -143,7 +143,7 @@ impl ObjectIdentifier {
             }
         }
 
-        let mut bytes = [0u8; Self::MAX_LENGTH];
+        let mut bytes = [0u8; Self::MAX_SIZE];
         bytes[..len].copy_from_slice(ber_bytes);
 
         Ok(Self {
@@ -188,7 +188,7 @@ impl FromStr for ObjectIdentifier {
         let first_arc = split.next().and_then(|s| s.parse().ok()).ok_or(Error)?;
         let second_arc = split.next().and_then(|s| s.parse().ok()).ok_or(Error)?;
 
-        let mut bytes = [0u8; Self::MAX_LENGTH];
+        let mut bytes = [0u8; Self::MAX_SIZE];
         bytes[0] = RootArcs::new(first_arc, second_arc)?.into();
 
         let mut offset = 1;

--- a/der/src/asn1/oid.rs
+++ b/der/src/asn1/oid.rs
@@ -77,6 +77,6 @@ mod tests {
     #[test]
     fn length() {
         // Ensure an infallible `From` conversion to `Any` will never panic
-        assert!(ObjectIdentifier::MAX_LENGTH <= Length::MAX.try_into().unwrap());
+        assert!(ObjectIdentifier::MAX_SIZE <= Length::MAX.try_into().unwrap());
     }
 }


### PR DESCRIPTION
Renames the `MAX_LENGTH` field to `MAX_SIZE` for consistency with other usages of "size" within the RustCrypto project.

Bumps it to 31 as we've encountered some real-world PKIX OIDs which are excessively large.