### PR TITLE
base64ct v1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "base64ct"
-version = "1.2.0-pre"
+version = "1.2.0"
 
 [[package]]
 name = "bit-set"

--- a/base64ct/CHANGELOG.md
+++ b/base64ct/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.2.0 (2021-11-03)
+### Changed
+- Rust 2021 edition upgrade; MSRV 1.56 ([#136])
+
+### Fixed
+- Benchmarks ([#135])
+
+[#135]: https://github.com/RustCrypto/formats/pull/135
+[#136]: https://github.com/RustCrypto/formats/pull/136
+
 ## 1.1.1 (2021-10-14)
 ### Changed
 - Update `Util::Lookup` paper references ([#32])

--- a/base64ct/Cargo.toml
+++ b/base64ct/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base64ct"
-version = "1.2.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "1.2.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Base64 (RFC 4648) which avoids any usages of
 data-dependent branches/LUTs and thereby provides portable "best effort"

--- a/base64ct/src/lib.rs
+++ b/base64ct/src/lib.rs
@@ -60,7 +60,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/base64ct/1.2.0-pre"
+    html_root_url = "https://docs.rs/base64ct/1.2.0"
 )]
 #![warn(missing_docs, rust_2018_idioms)]
 

--- a/pem-rfc7468/Cargo.toml
+++ b/pem-rfc7468/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-base64ct = { version = "=1.2.0-pre", path = "../base64ct" }
+base64ct = { version = "1.2", path = "../base64ct" }
 
 [features]
 alloc = []

--- a/spki/Cargo.toml
+++ b/spki/Cargo.toml
@@ -19,7 +19,7 @@ der = { version = "=0.5.0-pre.1", features = ["oid"], path = "../der" }
 
 # Optional dependencies
 sha2 = { version = "0.9.8", optional = true, default-features = false }
-base64ct = { version = "=1.2.0-pre", path = "../base64ct", optional = true, default-features = false }
+base64ct = { version = "1.2", path = "../base64ct", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.3"


### PR DESCRIPTION
### Changed
- Rust 2021 edition upgrade; MSRV 1.56 ([#136])

### Fixed
- Benchmarks ([#135])

[#135]: https://github.com/RustCrypto/formats/pull/135
[#136]: https://github.com/RustCrypto/formats/pull/136