### PR TITLE
pem-rfc7468: add `Decoder` struct

### DIFF
--- a/pem-rfc7468/src/lib.rs
+++ b/pem-rfc7468/src/lib.rs
@@ -62,7 +62,7 @@ mod error;
 mod grammar;
 
 pub use crate::{
-    decoder::{decode, decode_label},
+    decoder::{decode, decode_label, Decoder},
     encoder::{encode, encoded_len, LineEnding},
     error::{Error, Result},
 };


### PR DESCRIPTION
This adds a `Decoder` struct which supports one configurable setting: the Base64 line-wrapping width.

From RFC7468 Section 2:

> Parsers MAY handle other line sizes.

Closes #176