### PR TITLE
der: add test for `SetOf` regression

### DIFF
--- a/der/src/asn1/set_of.rs
+++ b/der/src/asn1/set_of.rs
@@ -51,6 +51,11 @@ where
         self.inner.add(element)
     }
 
+    /// Get the nth element from this [`SetOf`].
+    pub fn get(&self, index: usize) -> Option<&T> {
+        self.inner.get(index)
+    }
+
     /// Iterate over the elements of this [`SetOf`].
     pub fn iter(&self) -> SetOfIter<'_, T> {
         SetOfIter {

--- a/der/tests/set_of.rs
+++ b/der/tests/set_of.rs
@@ -1,0 +1,31 @@
+//! `SetOf` tests.
+
+#![cfg(all(feature = "derive", feature = "oid"))]
+
+use der::{
+    asn1::{Any, ObjectIdentifier, SetOf},
+    Decodable, Sequence,
+};
+use hex_literal::hex;
+
+/// Attribute type/value pairs as defined in [RFC 5280 Section 4.1.2.4].
+///
+/// [RFC 5280 Section 4.1.2.4]: https://tools.ietf.org/html/rfc5280#section-4.1.2.4
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Sequence)]
+pub struct AttributeTypeAndValue<'a> {
+    /// OID describing the type of the attribute
+    pub oid: ObjectIdentifier,
+
+    /// Value of the attribute
+    pub value: Any<'a>,
+}
+
+/// Test to ensure ordering is handled correctly.
+#[test]
+fn ordering_regression() {
+    let der_bytes = hex!("3139301906035504030C12546573742055736572393031353734333830301C060A0992268993F22C640101130E3437303031303030303134373333");
+    let setof = SetOf::<AttributeTypeAndValue<'_>, 3>::from_der(&der_bytes).unwrap();
+
+    let attr1 = setof.get(0).unwrap();
+    assert_eq!(ObjectIdentifier::new("2.5.4.3"), attr1.oid);
+}


### PR DESCRIPTION
These were failing to parse correctly until inadvertently fixed by #178.

The problem is not fully addressed, but it's good to at least capture it in a regression test to prevent future breakages.

Note that this test also seems to be uncovering another bug in `const-oid` which will get separately addressed in a followup.