### PR TITLE
const-oid: fix `debug_assert!` misfire on large arc

### DIFF
--- a/const-oid/src/arcs.rs
+++ b/const-oid/src/arcs.rs
@@ -62,7 +62,7 @@ impl<'a> Iterator for Arcs<'a> {
                         Some(byte) => {
                             arc_bytes += 1;
                             debug_assert!(
-                                arc_bytes < ARC_MAX_BYTES || byte & ARC_MAX_LAST_OCTET == 0,
+                                arc_bytes <= ARC_MAX_BYTES || byte & ARC_MAX_LAST_OCTET == 0,
                                 "OID arc overflowed"
                             );
                             result = result << 7 | (byte & 0b1111111) as Arc;

--- a/const-oid/tests/lib.rs
+++ b/const-oid/tests/lib.rs
@@ -8,25 +8,24 @@ use hex_literal::hex;
 use std::string::ToString;
 
 /// Example OID value with a root arc of `0` (and large arc).
-const EXAMPLE_OID_0_STRING: &str = "0.9.2342.19200300.100.1.1";
+const EXAMPLE_OID_0_STR: &str = "0.9.2342.19200300.100.1.1";
 const EXAMPLE_OID_0_BER: &[u8] = &hex!("0992268993F22C640101");
-const EXAMPLE_OID_0: ObjectIdentifier = ObjectIdentifier::new(EXAMPLE_OID_0_STRING);
+const EXAMPLE_OID_0: ObjectIdentifier = ObjectIdentifier::new(EXAMPLE_OID_0_STR);
 
 /// Example OID value with a root arc of `1`.
-const EXAMPLE_OID_1_STRING: &str = "1.2.840.10045.2.1";
+const EXAMPLE_OID_1_STR: &str = "1.2.840.10045.2.1";
 const EXAMPLE_OID_1_BER: &[u8] = &hex!("2A8648CE3D0201");
-const EXAMPLE_OID_1: ObjectIdentifier = ObjectIdentifier::new(EXAMPLE_OID_1_STRING);
+const EXAMPLE_OID_1: ObjectIdentifier = ObjectIdentifier::new(EXAMPLE_OID_1_STR);
 
 /// Example OID value with a root arc of `2`.
-const EXAMPLE_OID_2_STRING: &str = "2.16.840.1.101.3.4.1.42";
+const EXAMPLE_OID_2_STR: &str = "2.16.840.1.101.3.4.1.42";
 const EXAMPLE_OID_2_BER: &[u8] = &hex!("60864801650304012A");
-const EXAMPLE_OID_2: ObjectIdentifier = ObjectIdentifier::new(EXAMPLE_OID_2_STRING);
+const EXAMPLE_OID_2: ObjectIdentifier = ObjectIdentifier::new(EXAMPLE_OID_2_STR);
 
-#[test]
-fn display() {
-    assert_eq!(EXAMPLE_OID_1.to_string(), EXAMPLE_OID_1_STRING);
-    assert_eq!(EXAMPLE_OID_2.to_string(), EXAMPLE_OID_2_STRING);
-}
+/// Example OID value with a large arc
+const EXAMPLE_OID_LARGE_ARC_STR: &str = "0.9.2342.19200300.100.1.1";
+const EXAMPLE_OID_LARGE_ARC_BER: &[u8] = &hex!("0992268993F22C640101");
+const EXAMPLE_OID_LARGE_ARC: ObjectIdentifier = ObjectIdentifier::new("0.9.2342.19200300.100.1.1");
 
 #[test]
 fn from_bytes() {
@@ -45,6 +44,16 @@ fn from_bytes() {
     assert_eq!(oid2.arc(1).unwrap(), 16);
     assert_eq!(oid2, EXAMPLE_OID_2);
 
+    let oid3 = ObjectIdentifier::from_bytes(EXAMPLE_OID_LARGE_ARC_BER).unwrap();
+    assert_eq!(oid3.arc(0).unwrap(), 0);
+    assert_eq!(oid3.arc(1).unwrap(), 9);
+    assert_eq!(oid3.arc(2).unwrap(), 2342);
+    assert_eq!(oid3.arc(3).unwrap(), 19200300);
+    assert_eq!(oid3.arc(4).unwrap(), 100);
+    assert_eq!(oid3.arc(5).unwrap(), 1);
+    assert_eq!(oid3.arc(6).unwrap(), 1);
+    assert_eq!(oid3, EXAMPLE_OID_LARGE_ARC);
+
     // Empty
     assert!(ObjectIdentifier::from_bytes(&[]).is_err());
 
@@ -55,20 +64,32 @@ fn from_bytes() {
 
 #[test]
 fn from_str() {
-    let oid0 = EXAMPLE_OID_0_STRING.parse::<ObjectIdentifier>().unwrap();
+    let oid0 = EXAMPLE_OID_0_STR.parse::<ObjectIdentifier>().unwrap();
     assert_eq!(oid0.arc(0).unwrap(), 0);
     assert_eq!(oid0.arc(1).unwrap(), 9);
     assert_eq!(oid0, EXAMPLE_OID_0);
 
-    let oid1 = EXAMPLE_OID_1_STRING.parse::<ObjectIdentifier>().unwrap();
+    let oid1 = EXAMPLE_OID_1_STR.parse::<ObjectIdentifier>().unwrap();
     assert_eq!(oid1.arc(0).unwrap(), 1);
     assert_eq!(oid1.arc(1).unwrap(), 2);
     assert_eq!(oid1, EXAMPLE_OID_1);
 
-    let oid2 = EXAMPLE_OID_2_STRING.parse::<ObjectIdentifier>().unwrap();
+    let oid2 = EXAMPLE_OID_2_STR.parse::<ObjectIdentifier>().unwrap();
     assert_eq!(oid2.arc(0).unwrap(), 2);
     assert_eq!(oid2.arc(1).unwrap(), 16);
     assert_eq!(oid2, EXAMPLE_OID_2);
+
+    let oid3 = EXAMPLE_OID_LARGE_ARC_STR
+        .parse::<ObjectIdentifier>()
+        .unwrap();
+    assert_eq!(oid3.arc(0).unwrap(), 0);
+    assert_eq!(oid3.arc(1).unwrap(), 9);
+    assert_eq!(oid3.arc(2).unwrap(), 2342);
+    assert_eq!(oid3.arc(3).unwrap(), 19200300);
+    assert_eq!(oid3.arc(4).unwrap(), 100);
+    assert_eq!(oid3.arc(5).unwrap(), 1);
+    assert_eq!(oid3.arc(6).unwrap(), 1);
+    assert_eq!(oid3, EXAMPLE_OID_LARGE_ARC);
 
     // Too short
     assert!("1.2".parse::<ObjectIdentifier>().is_err());
@@ -81,6 +102,14 @@ fn from_str() {
 
     // Invalid second arc
     assert!("1.40.840.10045.2.1".parse::<ObjectIdentifier>().is_err());
+}
+
+#[test]
+fn display() {
+    assert_eq!(EXAMPLE_OID_0.to_string(), EXAMPLE_OID_0_STR);
+    assert_eq!(EXAMPLE_OID_1.to_string(), EXAMPLE_OID_1_STR);
+    assert_eq!(EXAMPLE_OID_2.to_string(), EXAMPLE_OID_2_STR);
+    assert_eq!(EXAMPLE_OID_LARGE_ARC.to_string(), EXAMPLE_OID_LARGE_ARC_STR);
 }
 
 #[test]


### PR DESCRIPTION
There was an off-by-one error in this assertion which was causing it to fire on a well-formed, in-range arc.