### PR TITLE
tai64: remove `quickcheck` tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,15 +15,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,16 +329,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
-name = "env_logger"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -636,17 +617,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
-name = "quickcheck"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
-dependencies = [
- "env_logger",
- "log",
- "rand",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -744,8 +714,6 @@ version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
- "aho-corasick",
- "memchr",
  "regex-syntax",
 ]
 
@@ -960,7 +928,6 @@ dependencies = [
 name = "tai64"
 version = "3.1.0"
 dependencies = [
- "quickcheck",
  "serde",
  "zeroize",
 ]

--- a/tai64/Cargo.toml
+++ b/tai64/Cargo.toml
@@ -19,8 +19,5 @@ zeroize = { version = "1.1", optional = true, default-features = false }
 default = ["std"]
 std = []
 
-[dev-dependencies]
-quickcheck = "1"
-
 [package.metadata.docs.rs]
 all-features = true

--- a/tai64/src/lib.rs
+++ b/tai64/src/lib.rs
@@ -328,7 +328,6 @@ impl std::error::Error for Error {}
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use super::*;
-    use quickcheck::{quickcheck, Arbitrary, Gen};
 
     #[test]
     fn before_epoch() {
@@ -349,41 +348,5 @@ mod tests {
         let t1 = tai64n.to_system_time();
 
         assert_eq!(t, t1);
-    }
-
-    impl Arbitrary for Tai64N {
-        fn arbitrary(g: &mut Gen) -> Self {
-            let s = u64::arbitrary(g);
-            let n = u32::arbitrary(g) % NANOS_PER_SECOND;
-            Tai64N(Tai64(s), n)
-        }
-    }
-
-    quickcheck! {
-        fn duration_add_sub(x: Tai64N, y: Tai64N) -> bool {
-            match x.duration_since(&y) {
-                Ok(d) => {
-                    assert_eq!(x, y + d);
-                    assert_eq!(y, x - d);
-                }
-                Err(d) => {
-                    assert_eq!(y, x + d);
-                    assert_eq!(x, y - d);
-                }
-            }
-            true
-        }
-
-        fn to_from_system_time(before_epoch: bool, d: Duration) -> bool {
-            let st = if before_epoch {
-                UNIX_EPOCH + d
-            } else {
-                UNIX_EPOCH - d
-            };
-
-            let st1 = Tai64N::from_system_time(&st).to_system_time();
-
-            st == st1
-        }
     }
 }


### PR DESCRIPTION
I attempted to translate these to `proptest`, but they don't really seem to be doing a whole lot for us.