### PR TITLE
tai64 v4.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "tai64"
-version = "3.1.0"
+version = "4.0.0"
 dependencies = [
  "serde",
  "zeroize",

--- a/tai64/CHANGELOG.md
+++ b/tai64/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 4.0.0 (2021-11-04)
+### Changed
+- Upgrade to Rust 2021 edition; MSRV 1.56+
+- Moved to `RustCrypto/utils` repository ([#182])
+- Rename `TAI64` => `Tai64`; `TAI64N` => `Tai64N` ([#183])
+- Make constants inherent ([#184])
+  - `TAI64_LEN` => `Tai64::BYTE_SIZE`
+  - `TAI64N_LEN` => `Tai64N::BYTE_SIZE`
+  - `UNIX_EPOCH_TAI64` => `Tai64::UNIX_EPOCH`
+  - `UNIX_EPOCH_TAI64N` => `Tai64N::UNIX_EPOCH`
+
+### Removed
+- `chrono` support
+
+[#182]: https://github.com/RustCrypto/formats/pull/182
+[#183]: https://github.com/RustCrypto/formats/pull/183
+[#184]: https://github.com/RustCrypto/formats/pull/184
+
 ## 3.1.0 (2019-10-25)
 - Add `TryFrom` impls for slices
 - Add (optional) `serde` support

--- a/tai64/Cargo.toml
+++ b/tai64/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tai64"
 description = "TAI64 and TAI64N (i.e. Temps Atomique International) timestamp support for Rust"
-version = "3.1.0" # Also update html_root_url in lib.rs when bumping this
+version = "4.0.0" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/formats/tree/master/tai64"

--- a/tai64/src/lib.rs
+++ b/tai64/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 #![doc = include_str!("../README.md")]
-#![doc(html_root_url = "https://docs.rs/tai64/3.1.0")]
+#![doc(html_root_url = "https://docs.rs/tai64/4.0.0")]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 


### PR DESCRIPTION
### Changed
- Upgrade to Rust 2021 edition; MSRV 1.56+
- Moved to `RustCrypto/utils` repository ([#182])
- Rename `TAI64` => `Tai64`; `TAI64N` => `Tai64N` ([#183])
- Make constants inherent ([#184])
  - `TAI64_LEN` => `Tai64::BYTE_SIZE`
  - `TAI64N_LEN` => `Tai64N::BYTE_SIZE`
  - `UNIX_EPOCH_TAI64` => `Tai64::UNIX_EPOCH`
  - `UNIX_EPOCH_TAI64N` => `Tai64N::UNIX_EPOCH`

### Removed
- `chrono` support

[#182]: https://github.com/RustCrypto/formats/pull/182
[#183]: https://github.com/RustCrypto/formats/pull/183
[#184]: https://github.com/RustCrypto/formats/pull/184