### PR TITLE
pkcs1: make `RsaPrivateKey::version` implicit

### DIFF
--- a/pkcs1/tests/private_key.rs
+++ b/pkcs1/tests/private_key.rs
@@ -29,7 +29,7 @@ const RSA_4096_PEM_EXAMPLE: &str = include_str!("examples/rsa4096-priv.pem");
 #[test]
 fn decode_rsa2048_der() {
     let key = RsaPrivateKey::try_from(RSA_2048_DER_EXAMPLE).unwrap();
-    assert_eq!(key.version, Version::TwoPrime);
+    assert_eq!(key.version(), Version::TwoPrime);
 
     // Extracted using:
     // $ openssl asn1parse -in tests/examples/rsa2048-priv.pem
@@ -47,7 +47,7 @@ fn decode_rsa2048_der() {
 #[test]
 fn decode_rsa4096_der() {
     let key = RsaPrivateKey::try_from(RSA_4096_DER_EXAMPLE).unwrap();
-    assert_eq!(key.version, Version::TwoPrime);
+    assert_eq!(key.version(), Version::TwoPrime);
 
     // Extracted using:
     // $ openssl asn1parse -in tests/examples/rsa4096-priv.pem
@@ -73,7 +73,7 @@ fn decode_rsa2048_multi_prime_der() {
 #[test]
 fn decode_rsa2048_multi_prime_der() {
     let key = RsaPrivateKey::try_from(RSA_2048_MULTI_PRIME_DER_EXAMPLE).unwrap();
-    assert_eq!(key.version, Version::Multi);
+    assert_eq!(key.version(), Version::Multi);
 
     // Extracted using:
     // $ openssl asn1parse -in tests/examples/rsa2048-priv-3prime.pem


### PR DESCRIPTION
Uses an approach similar to the one from the `pkcs8` crate, where the `version` field is computed based on the presence or absence of the `other_prime_infos` field in the private key.

This avoids scenarios where the user has set it incorrectly.