### PR TITLE
der: rename `Tagged` => `FixedTag`; add new `Tagged` trait

### DIFF
--- a/der/derive/src/enumerated.rs
+++ b/der/derive/src/enumerated.rs
@@ -118,7 +118,7 @@ impl DeriveEnumerated {
                 }
             }
 
-            gen impl ::der::Tagged for @Self {
+            gen impl ::der::FixedTag for @Self {
                 const TAG: ::der::Tag = ::der::Tag::Enumerated;
             }
 

--- a/der/src/asn1/bit_string.rs
+++ b/der/src/asn1/bit_string.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `BIT STRING` support.
 
 use crate::{
-    asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, ErrorKind, Length,
-    Result, Tag, Tagged,
+    asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, ErrorKind, FixedTag,
+    Length, Result, Tag,
 };
 use core::iter::FusedIterator;
 
@@ -171,7 +171,7 @@ impl<'a> From<BitString<'a>> for &'a [u8] {
     }
 }
 
-impl<'a> Tagged for BitString<'a> {
+impl<'a> FixedTag for BitString<'a> {
     const TAG: Tag = Tag::BitString;
 }
 

--- a/der/src/asn1/boolean.rs
+++ b/der/src/asn1/boolean.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `BOOLEAN` support.
 
 use crate::{
-    asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, ErrorKind, Length,
-    Result, Tag, Tagged,
+    asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, ErrorKind, FixedTag,
+    Length, Result, Tag,
 };
 
 /// Byte used to encode `true` in ASN.1 DER. From X.690 Section 11.1:
@@ -38,7 +38,7 @@ impl EncodeValue for bool {
     }
 }
 
-impl Tagged for bool {
+impl FixedTag for bool {
     const TAG: Tag = Tag::Boolean;
 }
 

--- a/der/src/asn1/choice.rs
+++ b/der/src/asn1/choice.rs
@@ -1,15 +1,15 @@
 //! ASN.1 `CHOICE` support.
 
-use crate::{Decodable, Tag, Tagged};
+use crate::{Decodable, FixedTag, Tag, Tagged};
 
 /// ASN.1 `CHOICE` denotes a union of one or more possible alternatives.
 ///
 /// The types MUST have distinct tags.
 ///
 /// This crate models choice as a trait, with a blanket impl for all types
-/// which impl `Decodable + Encodable + Tagged` (i.e. they are modeled as
-/// a `CHOICE` with only one possible variant)
-pub trait Choice<'a>: Decodable<'a> {
+/// which impl `Decodable + FixedTag` (i.e. they are modeled as a `CHOICE`
+/// with only one possible variant)
+pub trait Choice<'a>: Decodable<'a> + Tagged {
     /// Is the provided [`Tag`] decodable as a variant of this `CHOICE`?
     fn can_decode(tag: Tag) -> bool;
 }
@@ -18,7 +18,7 @@ pub trait Choice<'a>: Decodable<'a> {
 /// with a single alternative.
 impl<'a, T> Choice<'a> for T
 where
-    T: Decodable<'a> + Tagged,
+    T: Decodable<'a> + FixedTag,
 {
     fn can_decode(tag: Tag) -> bool {
         T::TAG == tag

--- a/der/src/asn1/generalized_time.rs
+++ b/der/src/asn1/generalized_time.rs
@@ -3,7 +3,7 @@
 use crate::{
     asn1::Any,
     datetime::{self, DateTime},
-    ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, Length, Result, Tag, Tagged,
+    ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, FixedTag, Length, Result, Tag,
 };
 use core::time::Duration;
 
@@ -151,7 +151,7 @@ impl TryFrom<Any<'_>> for GeneralizedTime {
     }
 }
 
-impl Tagged for GeneralizedTime {
+impl FixedTag for GeneralizedTime {
     const TAG: Tag = Tag::GeneralizedTime;
 }
 
@@ -171,7 +171,7 @@ impl EncodeValue for DateTime {
     }
 }
 
-impl Tagged for DateTime {
+impl FixedTag for DateTime {
     const TAG: Tag = Tag::GeneralizedTime;
 }
 
@@ -243,7 +243,7 @@ impl<'a> TryFrom<Any<'a>> for SystemTime {
 
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl Tagged for SystemTime {
+impl FixedTag for SystemTime {
     const TAG: Tag = Tag::GeneralizedTime;
 }
 
@@ -299,7 +299,7 @@ impl TryFrom<GeneralizedTime> for PrimitiveDateTime {
 
 #[cfg(feature = "time")]
 #[cfg_attr(docsrs, doc(cfg(feature = "time")))]
-impl Tagged for PrimitiveDateTime {
+impl FixedTag for PrimitiveDateTime {
     const TAG: Tag = Tag::GeneralizedTime;
 }
 

--- a/der/src/asn1/ia5_string.rs
+++ b/der/src/asn1/ia5_string.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `IA5String` support.
 
 use crate::{
-    asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, Length, Result,
-    StrSlice, Tag, Tagged,
+    asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, FixedTag, Length,
+    Result, StrSlice, Tag,
 };
 use core::{fmt, str};
 
@@ -115,7 +115,7 @@ impl<'a> From<Ia5String<'a>> for &'a [u8] {
     }
 }
 
-impl<'a> Tagged for Ia5String<'a> {
+impl<'a> FixedTag for Ia5String<'a> {
     const TAG: Tag = Tag::Ia5String;
 }
 

--- a/der/src/asn1/integer.rs
+++ b/der/src/asn1/integer.rs
@@ -5,8 +5,8 @@ mod int;
 mod uint;
 
 use crate::{
-    asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, Length, Result, Tag,
-    Tagged,
+    asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, FixedTag, Length,
+    Result, Tag,
 };
 
 macro_rules! impl_int_encoding {
@@ -49,7 +49,7 @@ macro_rules! impl_int_encoding {
                 }
             }
 
-            impl Tagged for $int {
+            impl FixedTag for $int {
                 const TAG: Tag = Tag::Integer;
             }
 
@@ -91,7 +91,7 @@ macro_rules! impl_uint_encoding {
                 }
             }
 
-            impl Tagged for $uint {
+            impl FixedTag for $uint {
                 const TAG: Tag = Tag::Integer;
             }
 

--- a/der/src/asn1/integer/bigint.rs
+++ b/der/src/asn1/integer/bigint.rs
@@ -2,8 +2,8 @@
 
 use super::uint;
 use crate::{
-    asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, ErrorKind, Length,
-    Result, Tag, Tagged,
+    asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, ErrorKind, FixedTag,
+    Length, Result, Tag,
 };
 
 #[cfg(feature = "bigint")]
@@ -91,7 +91,7 @@ impl<'a> TryFrom<Any<'a>> for UIntBytes<'a> {
     }
 }
 
-impl<'a> Tagged for UIntBytes<'a> {
+impl<'a> FixedTag for UIntBytes<'a> {
     const TAG: Tag = Tag::Integer;
 }
 
@@ -144,7 +144,7 @@ where
 
 #[cfg(feature = "bigint")]
 #[cfg_attr(docsrs, doc(cfg(feature = "bigint")))]
-impl<'a, const LIMBS: usize> Tagged for UInt<LIMBS>
+impl<'a, const LIMBS: usize> FixedTag for UInt<LIMBS>
 where
     UInt<LIMBS>: ArrayEncoding,
 {

--- a/der/src/asn1/null.rs
+++ b/der/src/asn1/null.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     asn1::Any, ByteSlice, DecodeValue, Decoder, Encodable, EncodeValue, Encoder, Error, ErrorKind,
-    Length, Result, Tag, Tagged,
+    FixedTag, Length, Result, Tag,
 };
 
 /// ASN.1 `NULL` type.
@@ -43,7 +43,7 @@ impl TryFrom<Any<'_>> for Null {
     }
 }
 
-impl Tagged for Null {
+impl FixedTag for Null {
     const TAG: Tag = Tag::Null;
 }
 
@@ -78,7 +78,7 @@ impl Encodable for () {
     }
 }
 
-impl Tagged for () {
+impl FixedTag for () {
     const TAG: Tag = Tag::Null;
 }
 

--- a/der/src/asn1/octet_string.rs
+++ b/der/src/asn1/octet_string.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `OCTET STRING` support.
 
 use crate::{
-    asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, ErrorKind, Length,
-    Result, Tag, Tagged,
+    asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, ErrorKind, FixedTag,
+    Length, Result, Tag,
 };
 
 /// ASN.1 `OCTET STRING` type.
@@ -86,6 +86,6 @@ impl<'a> From<OctetString<'a>> for &'a [u8] {
     }
 }
 
-impl<'a> Tagged for OctetString<'a> {
+impl<'a> FixedTag for OctetString<'a> {
     const TAG: Tag = Tag::OctetString;
 }

--- a/der/src/asn1/oid.rs
+++ b/der/src/asn1/oid.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `OBJECT IDENTIFIER`
 
 use crate::{
-    asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, Length, Result, Tag,
-    Tagged,
+    asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, FixedTag, Length,
+    Result, Tag, Tagged,
 };
 use const_oid::ObjectIdentifier;
 
@@ -47,7 +47,7 @@ impl TryFrom<Any<'_>> for ObjectIdentifier {
     }
 }
 
-impl<'a> Tagged for ObjectIdentifier {
+impl<'a> FixedTag for ObjectIdentifier {
     const TAG: Tag = Tag::ObjectIdentifier;
 }
 

--- a/der/src/asn1/printable_string.rs
+++ b/der/src/asn1/printable_string.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `PrintableString` support.
 
 use crate::{
-    asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, Length, Result,
-    StrSlice, Tag, Tagged,
+    asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, FixedTag, Length,
+    Result, StrSlice, Tag,
 };
 use core::{fmt, str};
 
@@ -148,7 +148,7 @@ impl<'a> From<PrintableString<'a>> for &'a [u8] {
     }
 }
 
-impl<'a> Tagged for PrintableString<'a> {
+impl<'a> FixedTag for PrintableString<'a> {
     const TAG: Tag = Tag::PrintableString;
 }
 

--- a/der/src/asn1/sequence.rs
+++ b/der/src/asn1/sequence.rs
@@ -1,7 +1,7 @@
 //! The [`Sequence`] trait simplifies writing decoders/encoders which map ASN.1
 //! `SEQUENCE`s to Rust structs.
 
-use crate::{Decodable, Encodable, EncodeValue, Encoder, Length, Result, Tag, Tagged};
+use crate::{Decodable, Encodable, EncodeValue, Encoder, FixedTag, Length, Result, Tag};
 
 /// ASN.1 `SEQUENCE` trait.
 ///
@@ -42,7 +42,7 @@ where
     }
 }
 
-impl<'a, M> Tagged for M
+impl<'a, M> FixedTag for M
 where
     M: Sequence<'a>,
 {

--- a/der/src/asn1/sequence_of.rs
+++ b/der/src/asn1/sequence_of.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     arrayvec, ArrayVec, Decodable, DecodeValue, Decoder, Encodable, EncodeValue, Encoder,
-    ErrorKind, Length, Result, Tag, Tagged,
+    ErrorKind, FixedTag, Length, Result, Tag,
 };
 
 #[cfg(feature = "alloc")]
@@ -89,7 +89,7 @@ where
     }
 }
 
-impl<'a, T, const N: usize> Tagged for SequenceOf<T, N> {
+impl<'a, T, const N: usize> FixedTag for SequenceOf<T, N> {
     const TAG: Tag = Tag::Sequence;
 }
 
@@ -137,10 +137,7 @@ where
     }
 }
 
-impl<'a, T, const N: usize> Tagged for [T; N]
-where
-    T: Decodable<'a>,
-{
+impl<'a, T, const N: usize> FixedTag for [T; N] {
     const TAG: Tag = Tag::Sequence;
 }
 
@@ -188,9 +185,6 @@ where
 
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-impl<'a, T> Tagged for Vec<T>
-where
-    T: Decodable<'a>,
-{
+impl<'a, T> FixedTag for Vec<T> {
     const TAG: Tag = Tag::Sequence;
 }

--- a/der/src/asn1/set_of.rs
+++ b/der/src/asn1/set_of.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     arrayvec, ArrayVec, Decodable, DecodeValue, Decoder, Encodable, EncodeValue, Encoder,
-    ErrorKind, Length, Result, Tag, Tagged,
+    ErrorKind, FixedTag, Length, Result, Tag,
 };
 
 #[cfg(feature = "alloc")]
@@ -111,7 +111,7 @@ where
     }
 }
 
-impl<'a, T, const N: usize> Tagged for SetOf<T, N>
+impl<'a, T, const N: usize> FixedTag for SetOf<T, N>
 where
     T: Clone + Decodable<'a> + Ord,
 {
@@ -205,7 +205,7 @@ where
 
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-impl<'a, T> Tagged for BTreeSet<T>
+impl<'a, T> FixedTag for BTreeSet<T>
 where
     T: Clone + Decodable<'a> + Ord,
 {

--- a/der/src/asn1/utc_time.rs
+++ b/der/src/asn1/utc_time.rs
@@ -3,7 +3,7 @@
 use crate::{
     asn1::Any,
     datetime::{self, DateTime},
-    ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, Length, Result, Tag, Tagged,
+    ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, FixedTag, Length, Result, Tag,
 };
 use core::time::Duration;
 
@@ -177,7 +177,7 @@ impl TryFrom<Any<'_>> for UtcTime {
     }
 }
 
-impl Tagged for UtcTime {
+impl FixedTag for UtcTime {
     const TAG: Tag = Tag::UtcTime;
 }
 

--- a/der/src/asn1/utf8_string.rs
+++ b/der/src/asn1/utf8_string.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `UTF8String` support.
 
 use crate::{
-    asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, Length, Result,
-    StrSlice, Tag, Tagged,
+    asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, FixedTag, Length,
+    Result, StrSlice, Tag,
 };
 use core::{fmt, str};
 
@@ -111,7 +111,7 @@ impl<'a> From<Utf8String<'a>> for &'a [u8] {
     }
 }
 
-impl<'a> Tagged for Utf8String<'a> {
+impl<'a> FixedTag for Utf8String<'a> {
     const TAG: Tag = Tag::Utf8String;
 }
 
@@ -145,7 +145,7 @@ impl EncodeValue for str {
     }
 }
 
-impl Tagged for str {
+impl FixedTag for str {
     const TAG: Tag = Tag::Utf8String;
 }
 
@@ -181,7 +181,7 @@ impl EncodeValue for String {
 
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-impl Tagged for String {
+impl FixedTag for String {
     const TAG: Tag = Tag::Utf8String;
 }
 

--- a/der/src/decodable.rs
+++ b/der/src/decodable.rs
@@ -1,6 +1,6 @@
 //! Trait definition for [`Decodable`].
 
-use crate::{DecodeValue, Decoder, Header, Result, Tagged};
+use crate::{DecodeValue, Decoder, FixedTag, Header, Result};
 
 /// Decoding trait.
 ///
@@ -26,7 +26,7 @@ pub trait Decodable<'a>: Sized {
 
 impl<'a, T> Decodable<'a> for T
 where
-    T: DecodeValue<'a> + Tagged,
+    T: DecodeValue<'a> + FixedTag,
 {
     fn decode(decoder: &mut Decoder<'a>) -> Result<T> {
         let header = Header::decode(decoder)?;

--- a/der/src/decoder.rs
+++ b/der/src/decoder.rs
@@ -1,8 +1,8 @@
 //! DER decoder.
 
 use crate::{
-    asn1::*, ByteSlice, Choice, Decodable, DecodeValue, Error, ErrorKind, Header, Length, Result,
-    Tag, TagMode, TagNumber, Tagged,
+    asn1::*, ByteSlice, Choice, Decodable, DecodeValue, Error, ErrorKind, FixedTag, Header, Length,
+    Result, Tag, TagMode, TagNumber,
 };
 
 /// DER decoder.
@@ -169,7 +169,7 @@ impl<'a> Decoder<'a> {
         tag_mode: TagMode,
     ) -> Result<Option<T>>
     where
-        T: DecodeValue<'a> + Tagged,
+        T: DecodeValue<'a> + FixedTag,
     {
         Ok(match tag_mode {
             TagMode::Explicit => ContextSpecific::<T>::decode_explicit(self, tag_number)?,

--- a/der/src/encodable.rs
+++ b/der/src/encodable.rs
@@ -1,6 +1,6 @@
 //! Trait definition for [`Encodable`].
 
-use crate::{EncodeValue, Encoder, Header, Length, Result, Tagged};
+use crate::{EncodeValue, Encoder, Length, Result, Tagged};
 
 #[cfg(feature = "alloc")]
 use {crate::ErrorKind, alloc::vec::Vec, core::iter};
@@ -66,7 +66,7 @@ where
 
     /// Encode this value as ASN.1 DER using the provided [`Encoder`].
     fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        Header::new(T::TAG, self.value_len()?)?.encode(encoder)?;
+        self.header()?.encode(encoder)?;
         self.encode_value(encoder)
     }
 }

--- a/der/src/encoder.rs
+++ b/der/src/encoder.rs
@@ -90,7 +90,7 @@ impl<'a> Encoder<'a> {
     {
         let constructed = match tag_mode {
             TagMode::Explicit => true,
-            TagMode::Implicit => T::TAG.is_constructed(),
+            TagMode::Implicit => value.tag().is_constructed(),
         };
 
         let tag = Tag::ContextSpecific {

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -353,7 +353,7 @@ pub use crate::{
     error::{Error, ErrorKind, Result},
     header::Header,
     length::Length,
-    tag::{Class, Tag, TagMode, TagNumber, Tagged},
+    tag::{Class, FixedTag, Tag, TagMode, TagNumber, Tagged},
     value::{DecodeValue, EncodeValue},
 };
 

--- a/der/src/tag.rs
+++ b/der/src/tag.rs
@@ -12,10 +12,23 @@ use core::fmt;
 /// Indicator bit for constructed form encoding (i.e. vs primitive form)
 const CONSTRUCTED_FLAG: u8 = 0b100000;
 
-/// Types with an associated ASN.1 [`Tag`].
-pub trait Tagged {
+/// Types which have a constant ASN.1 [`Tag`].
+pub trait FixedTag {
     /// ASN.1 tag
     const TAG: Tag;
+}
+
+/// Types which have an ASN.1 [`Tag`].
+pub trait Tagged {
+    /// Get the ASN.1 tag that this type is encoded with.
+    fn tag(&self) -> Tag;
+}
+
+/// Types which are [`FixedTag`] always have a known [`Tag`] type.
+impl<T: FixedTag> Tagged for T {
+    fn tag(&self) -> Tag {
+        T::TAG
+    }
 }
 
 /// ASN.1 tags.

--- a/der/src/value.rs
+++ b/der/src/value.rs
@@ -1,6 +1,6 @@
 //! Value traits
 
-use crate::{Decoder, Encoder, Length, Result};
+use crate::{Decoder, Encoder, Header, Length, Result, Tagged};
 
 #[cfg(doc)]
 use crate::Tag;
@@ -15,6 +15,14 @@ pub trait DecodeValue<'a>: Sized {
 /// Encode the value part of a Tag-Length-Value encoded field, sans the [`Tag`]
 /// and [`Length`].
 pub trait EncodeValue {
+    /// Get the [`Header`] used to encode this value.
+    fn header(&self) -> Result<Header>
+    where
+        Self: Tagged,
+    {
+        Header::new(self.tag(), self.value_len()?)
+    }
+
     /// Compute the length of this value (sans [`Tag`]+[`Length`] header) when
     /// encoded as ASN.1 DER.
     fn value_len(&self) -> Result<Length>;

--- a/pkcs1/src/private_key.rs
+++ b/pkcs1/src/private_key.rs
@@ -212,7 +212,7 @@ impl<'a> Decodable<'a> for OtherPrimeInfos<'a> {
 }
 
 #[cfg(not(feature = "alloc"))]
-impl<'a> der::Tagged for OtherPrimeInfos<'a> {
+impl<'a> der::FixedTag for OtherPrimeInfos<'a> {
     const TAG: Tag = Tag::Sequence;
 }
 

--- a/pkcs1/src/version.rs
+++ b/pkcs1/src/version.rs
@@ -1,7 +1,7 @@
 //! PKCS#1 version identifier.
 
 use crate::Error;
-use der::{Decodable, Decoder, Encodable, Encoder, Tag, Tagged};
+use der::{Decodable, Decoder, Encodable, Encoder, FixedTag, Tag};
 
 /// Version identifier for PKCS#1 documents as defined in
 /// [RFC 8017 Appendix 1.2].
@@ -67,6 +67,6 @@ impl Encodable for Version {
     }
 }
 
-impl Tagged for Version {
+impl FixedTag for Version {
     const TAG: Tag = Tag::Integer;
 }

--- a/pkcs5/src/pbes1.rs
+++ b/pkcs5/src/pbes1.rs
@@ -5,7 +5,7 @@
 use crate::AlgorithmIdentifier;
 use der::{
     asn1::{ObjectIdentifier, OctetString},
-    Decodable, Decoder, Encodable, Encoder, ErrorKind, Length, Tag, Tagged,
+    Decodable, Decoder, Encodable, Encoder, ErrorKind, FixedTag, Length, Tag,
 };
 
 /// `pbeWithMD2AndDES-CBC` Object Identifier (OID).
@@ -105,7 +105,7 @@ impl Encodable for Parameters {
     }
 }
 
-impl Tagged for Parameters {
+impl FixedTag for Parameters {
     const TAG: Tag = Tag::Sequence;
 }
 

--- a/pkcs5/src/pbes2/kdf.rs
+++ b/pkcs5/src/pbes2/kdf.rs
@@ -3,7 +3,7 @@
 use crate::{AlgorithmIdentifier, Error, Result};
 use der::{
     asn1::{Any, ObjectIdentifier, OctetString},
-    Decodable, Decoder, Encodable, Encoder, ErrorKind, Length, Sequence, Tag,
+    Decodable, Decoder, Encodable, Encoder, ErrorKind, Length, Sequence, Tag, Tagged,
 };
 
 /// Password-Based Key Derivation Function (PBKDF2) OID.

--- a/pkcs7/src/content_type.rs
+++ b/pkcs7/src/content_type.rs
@@ -1,5 +1,5 @@
 use der::asn1::ObjectIdentifier;
-use der::{DecodeValue, Decoder, EncodeValue, Encoder, ErrorKind, Length, Tag, Tagged};
+use der::{DecodeValue, Decoder, EncodeValue, Encoder, ErrorKind, FixedTag, Length, Tag};
 
 /// Indicates the type of content.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -62,6 +62,6 @@ impl EncodeValue for ContentType {
     }
 }
 
-impl Tagged for ContentType {
+impl FixedTag for ContentType {
     const TAG: Tag = Tag::ObjectIdentifier;
 }

--- a/pkcs7/src/data_content.rs
+++ b/pkcs7/src/data_content.rs
@@ -1,7 +1,7 @@
 //! `data` content type [RFC 5652 § 4](https://datatracker.ietf.org/doc/html/rfc5652#section-4)
 
 use core::convert::{From, TryFrom};
-use der::{asn1::OctetString, DecodeValue, Decoder, EncodeValue, Encoder, Length, Tag, Tagged};
+use der::{asn1::OctetString, DecodeValue, Decoder, EncodeValue, Encoder, FixedTag, Length, Tag};
 
 /// The content that is just an octet string.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -46,6 +46,6 @@ impl<'a> EncodeValue for DataContent<'a> {
     }
 }
 
-impl<'a> Tagged for DataContent<'a> {
+impl<'a> FixedTag for DataContent<'a> {
     const TAG: Tag = Tag::OctetString;
 }

--- a/pkcs7/src/encrypted_data_content.rs
+++ b/pkcs7/src/encrypted_data_content.rs
@@ -2,7 +2,8 @@
 
 use crate::enveloped_data_content::EncryptedContentInfo;
 use der::{
-    Decodable, DecodeValue, Decoder, Encodable, EncodeValue, Encoder, Length, Sequence, Tag, Tagged,
+    Decodable, DecodeValue, Decoder, Encodable, EncodeValue, Encoder, FixedTag, Length, Sequence,
+    Tag,
 };
 
 /// Syntax version of the `encrypted-data` content type.
@@ -19,7 +20,7 @@ pub enum Version {
     V0 = 0,
 }
 
-impl Tagged for Version {
+impl FixedTag for Version {
     const TAG: Tag = Tag::Integer;
 }
 

--- a/pkcs8/src/version.rs
+++ b/pkcs8/src/version.rs
@@ -1,7 +1,7 @@
 //! PKCS#8 version identifier.
 
 use crate::Error;
-use der::{Decodable, Decoder, Encodable, Encoder, Tag, Tagged};
+use der::{Decodable, Decoder, Encodable, Encoder, FixedTag, Tag};
 
 /// Version identifier for PKCS#8 documents.
 ///
@@ -58,6 +58,6 @@ impl TryFrom<u8> for Version {
     }
 }
 
-impl Tagged for Version {
+impl FixedTag for Version {
     const TAG: Tag = Tag::Integer;
 }

--- a/sec1/src/parameters.rs
+++ b/sec1/src/parameters.rs
@@ -1,6 +1,6 @@
 use der::{
     asn1::{Any, ObjectIdentifier},
-    DecodeValue, Decoder, EncodeValue, Encoder, Length, Tag, Tagged,
+    DecodeValue, Decoder, EncodeValue, Encoder, FixedTag, Length, Tag,
 };
 
 /// Elliptic curve parameters as described in
@@ -70,6 +70,6 @@ impl From<ObjectIdentifier> for EcParameters {
     }
 }
 
-impl Tagged for EcParameters {
+impl FixedTag for EcParameters {
     const TAG: Tag = Tag::ObjectIdentifier;
 }


### PR DESCRIPTION
This commit does the following:

- Renames the old `Tagged` trait to `FixedTag`, to reflect that the tag for that type is constant regardless of its value.
- Introduces a new `Tagged` trait with a `fn tag(&self) -> Tag` method.
  This allows types like `Any` and `ContextSpecific` to be able to participate in protocols that need to know a given type's tag.
- Bounds `Choice` on `Tagged`.

`Tagged` has a blanket impl for all `FixedTag` types.

This change is pretty necessary for determining DER ordering for `SET OF`, as it allows for constructing the `Header` of any type which is `EncodeValue + Tagged`, which is needed to compare `Header`s.

The `Header` is also useful for generalizing `Encodable`, and indeed this commit removes the handwritten impl of `Encodable` for both `Any` and `ContextSpecific` since the blanket impls now write them automatically.