### PR TITLE
der: add `*Ord` traits

### DIFF
--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -1,9 +1,10 @@
 //! ASN.1 `ANY` type.
 
 use crate::{
-    asn1::*, ByteSlice, Choice, Decodable, DecodeValue, Decoder, EncodeValue, Encoder, Error,
-    ErrorKind, FixedTag, Header, Length, Result, Tag, Tagged,
+    asn1::*, ByteSlice, Choice, Decodable, DecodeValue, Decoder, DerOrd, EncodeValue, Encoder,
+    Error, ErrorKind, FixedTag, Header, Length, Result, Tag, Tagged, ValueOrd,
 };
+use core::cmp::Ordering;
 
 #[cfg(feature = "oid")]
 use crate::asn1::ObjectIdentifier;
@@ -162,6 +163,12 @@ impl EncodeValue for Any<'_> {
 impl Tagged for Any<'_> {
     fn tag(&self) -> Tag {
         self.tag
+    }
+}
+
+impl ValueOrd for Any<'_> {
+    fn value_cmp(&self, other: &Self) -> Result<Ordering> {
+        self.value.der_cmp(&other.value)
     }
 }
 

--- a/der/src/asn1/boolean.rs
+++ b/der/src/asn1/boolean.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, ErrorKind, FixedTag,
-    Length, Result, Tag,
+    Length, OrdIsValueOrd, Result, Tag,
 };
 
 /// Byte used to encode `true` in ASN.1 DER. From X.690 Section 11.1:
@@ -41,6 +41,8 @@ impl EncodeValue for bool {
 impl FixedTag for bool {
     const TAG: Tag = Tag::Boolean;
 }
+
+impl OrdIsValueOrd for bool {}
 
 impl From<bool> for Any<'static> {
     fn from(value: bool) -> Any<'static> {

--- a/der/src/asn1/generalized_time.rs
+++ b/der/src/asn1/generalized_time.rs
@@ -3,7 +3,8 @@
 use crate::{
     asn1::Any,
     datetime::{self, DateTime},
-    ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, FixedTag, Length, Result, Tag,
+    ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, FixedTag, Length, OrdIsValueOrd,
+    Result, Tag,
 };
 use core::time::Duration;
 
@@ -113,6 +114,12 @@ impl EncodeValue for GeneralizedTime {
     }
 }
 
+impl FixedTag for GeneralizedTime {
+    const TAG: Tag = Tag::GeneralizedTime;
+}
+
+impl OrdIsValueOrd for GeneralizedTime {}
+
 impl From<&GeneralizedTime> for GeneralizedTime {
     fn from(value: &GeneralizedTime) -> GeneralizedTime {
         *value
@@ -151,10 +158,6 @@ impl TryFrom<Any<'_>> for GeneralizedTime {
     }
 }
 
-impl FixedTag for GeneralizedTime {
-    const TAG: Tag = Tag::GeneralizedTime;
-}
-
 impl DecodeValue<'_> for DateTime {
     fn decode_value(decoder: &mut Decoder<'_>, length: Length) -> Result<Self> {
         Ok(GeneralizedTime::decode_value(decoder, length)?.into())
@@ -174,6 +177,8 @@ impl EncodeValue for DateTime {
 impl FixedTag for DateTime {
     const TAG: Tag = Tag::GeneralizedTime;
 }
+
+impl OrdIsValueOrd for DateTime {}
 
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
@@ -247,6 +252,10 @@ impl FixedTag for SystemTime {
     const TAG: Tag = Tag::GeneralizedTime;
 }
 
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+impl OrdIsValueOrd for SystemTime {}
+
 #[cfg(feature = "time")]
 #[cfg_attr(docsrs, doc(cfg(feature = "time")))]
 impl DecodeValue<'_> for PrimitiveDateTime {
@@ -266,6 +275,16 @@ impl EncodeValue for PrimitiveDateTime {
         GeneralizedTime::try_from(self)?.encode_value(encoder)
     }
 }
+
+#[cfg(feature = "time")]
+#[cfg_attr(docsrs, doc(cfg(feature = "time")))]
+impl FixedTag for PrimitiveDateTime {
+    const TAG: Tag = Tag::GeneralizedTime;
+}
+
+#[cfg(feature = "time")]
+#[cfg_attr(docsrs, doc(cfg(feature = "time")))]
+impl OrdIsValueOrd for PrimitiveDateTime {}
 
 #[cfg(feature = "time")]
 #[cfg_attr(docsrs, doc(cfg(feature = "time")))]
@@ -295,12 +314,6 @@ impl TryFrom<GeneralizedTime> for PrimitiveDateTime {
     fn try_from(time: GeneralizedTime) -> Result<PrimitiveDateTime> {
         time.to_date_time().try_into()
     }
-}
-
-#[cfg(feature = "time")]
-#[cfg_attr(docsrs, doc(cfg(feature = "time")))]
-impl FixedTag for PrimitiveDateTime {
-    const TAG: Tag = Tag::GeneralizedTime;
 }
 
 #[cfg(test)]

--- a/der/src/asn1/ia5_string.rs
+++ b/der/src/asn1/ia5_string.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, FixedTag, Length,
-    Result, StrSlice, Tag,
+    OrdIsValueOrd, Result, StrSlice, Tag,
 };
 use core::{fmt, str};
 
@@ -79,7 +79,7 @@ impl<'a> DecodeValue<'a> for Ia5String<'a> {
     }
 }
 
-impl<'a> EncodeValue for Ia5String<'a> {
+impl EncodeValue for Ia5String<'_> {
     fn value_len(&self) -> Result<Length> {
         self.inner.value_len()
     }
@@ -88,6 +88,12 @@ impl<'a> EncodeValue for Ia5String<'a> {
         self.inner.encode_value(encoder)
     }
 }
+
+impl<'a> FixedTag for Ia5String<'a> {
+    const TAG: Tag = Tag::Ia5String;
+}
+
+impl OrdIsValueOrd for Ia5String<'_> {}
 
 impl<'a> From<&Ia5String<'a>> for Ia5String<'a> {
     fn from(value: &Ia5String<'a>) -> Ia5String<'a> {
@@ -113,10 +119,6 @@ impl<'a> From<Ia5String<'a>> for &'a [u8] {
     fn from(printable_string: Ia5String<'a>) -> &'a [u8] {
         printable_string.as_bytes()
     }
-}
-
-impl<'a> FixedTag for Ia5String<'a> {
-    const TAG: Tag = Tag::Ia5String;
 }
 
 impl<'a> fmt::Display for Ia5String<'a> {

--- a/der/src/asn1/null.rs
+++ b/der/src/asn1/null.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     asn1::Any, ByteSlice, DecodeValue, Decoder, Encodable, EncodeValue, Encoder, Error, ErrorKind,
-    FixedTag, Length, Result, Tag,
+    FixedTag, Length, OrdIsValueOrd, Result, Tag,
 };
 
 /// ASN.1 `NULL` type.
@@ -29,6 +29,12 @@ impl EncodeValue for Null {
     }
 }
 
+impl FixedTag for Null {
+    const TAG: Tag = Tag::Null;
+}
+
+impl OrdIsValueOrd for Null {}
+
 impl<'a> From<Null> for Any<'a> {
     fn from(_: Null) -> Any<'a> {
         Any::from_tag_and_value(Tag::Null, ByteSlice::default())
@@ -41,10 +47,6 @@ impl TryFrom<Any<'_>> for Null {
     fn try_from(any: Any<'_>) -> Result<Null> {
         any.decode_into()
     }
-}
-
-impl FixedTag for Null {
-    const TAG: Tag = Tag::Null;
 }
 
 impl TryFrom<Any<'_>> for () {

--- a/der/src/asn1/octet_string.rs
+++ b/der/src/asn1/octet_string.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, ErrorKind, FixedTag,
-    Length, Result, Tag,
+    Length, OrdIsValueOrd, Result, Tag,
 };
 
 /// ASN.1 `OCTET STRING` type.
@@ -50,7 +50,7 @@ impl<'a> DecodeValue<'a> for OctetString<'a> {
     }
 }
 
-impl<'a> EncodeValue for OctetString<'a> {
+impl EncodeValue for OctetString<'_> {
     fn value_len(&self) -> Result<Length> {
         self.inner.value_len()
     }
@@ -59,6 +59,12 @@ impl<'a> EncodeValue for OctetString<'a> {
         self.inner.encode_value(encoder)
     }
 }
+
+impl FixedTag for OctetString<'_> {
+    const TAG: Tag = Tag::OctetString;
+}
+
+impl OrdIsValueOrd for OctetString<'_> {}
 
 impl<'a> From<&OctetString<'a>> for OctetString<'a> {
     fn from(value: &OctetString<'a>) -> OctetString<'a> {
@@ -84,8 +90,4 @@ impl<'a> From<OctetString<'a>> for &'a [u8] {
     fn from(octet_string: OctetString<'a>) -> &'a [u8] {
         octet_string.as_bytes()
     }
-}
-
-impl<'a> FixedTag for OctetString<'a> {
-    const TAG: Tag = Tag::OctetString;
 }

--- a/der/src/asn1/oid.rs
+++ b/der/src/asn1/oid.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, FixedTag, Length,
-    Result, Tag, Tagged,
+    OrdIsValueOrd, Result, Tag, Tagged,
 };
 use const_oid::ObjectIdentifier;
 
@@ -22,6 +22,12 @@ impl EncodeValue for ObjectIdentifier {
         encoder.bytes(self.as_bytes())
     }
 }
+
+impl FixedTag for ObjectIdentifier {
+    const TAG: Tag = Tag::ObjectIdentifier;
+}
+
+impl OrdIsValueOrd for ObjectIdentifier {}
 
 impl<'a> From<&'a ObjectIdentifier> for Any<'a> {
     fn from(oid: &'a ObjectIdentifier) -> Any<'a> {
@@ -45,10 +51,6 @@ impl TryFrom<Any<'_>> for ObjectIdentifier {
         any.tag().assert_eq(Tag::ObjectIdentifier)?;
         Ok(ObjectIdentifier::from_bytes(any.value())?)
     }
-}
-
-impl<'a> FixedTag for ObjectIdentifier {
-    const TAG: Tag = Tag::ObjectIdentifier;
 }
 
 #[cfg(test)]

--- a/der/src/asn1/optional.rs
+++ b/der/src/asn1/optional.rs
@@ -1,6 +1,7 @@
 //! ASN.1 `OPTIONAL` as mapped to Rust's `Option` type
 
-use crate::{Choice, Decodable, Decoder, Encodable, Encoder, Length, Result, Tag};
+use crate::{Choice, Decodable, Decoder, DerOrd, Encodable, Encoder, Length, Result, Tag};
+use core::cmp::Ordering;
 
 impl<'a, T> Decodable<'a> for Option<T>
 where
@@ -34,6 +35,23 @@ where
             encodable.encode(encoder)
         } else {
             Ok(())
+        }
+    }
+}
+
+impl<T> DerOrd for Option<T>
+where
+    T: DerOrd,
+{
+    fn der_cmp(&self, other: &Self) -> Result<Ordering> {
+        if let Some(a) = self {
+            if let Some(b) = other {
+                a.der_cmp(b)
+            } else {
+                Ok(Ordering::Greater)
+            }
+        } else {
+            Ok(Ordering::Less)
         }
     }
 }

--- a/der/src/asn1/printable_string.rs
+++ b/der/src/asn1/printable_string.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, FixedTag, Length,
-    Result, StrSlice, Tag,
+    OrdIsValueOrd, Result, StrSlice, Tag,
 };
 use core::{fmt, str};
 
@@ -122,6 +122,12 @@ impl<'a> EncodeValue for PrintableString<'a> {
     }
 }
 
+impl FixedTag for PrintableString<'_> {
+    const TAG: Tag = Tag::PrintableString;
+}
+
+impl OrdIsValueOrd for PrintableString<'_> {}
+
 impl<'a> From<&PrintableString<'a>> for PrintableString<'a> {
     fn from(value: &PrintableString<'a>) -> PrintableString<'a> {
         *value
@@ -146,10 +152,6 @@ impl<'a> From<PrintableString<'a>> for &'a [u8] {
     fn from(printable_string: PrintableString<'a>) -> &'a [u8] {
         printable_string.as_bytes()
     }
-}
-
-impl<'a> FixedTag for PrintableString<'a> {
-    const TAG: Tag = Tag::PrintableString;
 }
 
 impl<'a> fmt::Display for PrintableString<'a> {

--- a/der/src/asn1/utc_time.rs
+++ b/der/src/asn1/utc_time.rs
@@ -3,7 +3,8 @@
 use crate::{
     asn1::Any,
     datetime::{self, DateTime},
-    ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, FixedTag, Length, Result, Tag,
+    ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, FixedTag, Length, OrdIsValueOrd,
+    Result, Tag,
 };
 use core::time::Duration;
 
@@ -127,6 +128,12 @@ impl EncodeValue for UtcTime {
     }
 }
 
+impl FixedTag for UtcTime {
+    const TAG: Tag = Tag::UtcTime;
+}
+
+impl OrdIsValueOrd for UtcTime {}
+
 impl From<&UtcTime> for UtcTime {
     fn from(value: &UtcTime) -> UtcTime {
         *value
@@ -175,10 +182,6 @@ impl TryFrom<Any<'_>> for UtcTime {
     fn try_from(any: Any<'_>) -> Result<UtcTime> {
         any.decode_into()
     }
-}
-
-impl FixedTag for UtcTime {
-    const TAG: Tag = Tag::UtcTime;
 }
 
 #[cfg(test)]

--- a/der/src/asn1/utf8_string.rs
+++ b/der/src/asn1/utf8_string.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, FixedTag, Length,
-    Result, StrSlice, Tag,
+    OrdIsValueOrd, Result, StrSlice, Tag,
 };
 use core::{fmt, str};
 
@@ -75,7 +75,7 @@ impl<'a> DecodeValue<'a> for Utf8String<'a> {
     }
 }
 
-impl<'a> EncodeValue for Utf8String<'a> {
+impl EncodeValue for Utf8String<'_> {
     fn value_len(&self) -> Result<Length> {
         self.inner.value_len()
     }
@@ -84,6 +84,12 @@ impl<'a> EncodeValue for Utf8String<'a> {
         self.inner.encode_value(encoder)
     }
 }
+
+impl FixedTag for Utf8String<'_> {
+    const TAG: Tag = Tag::Utf8String;
+}
+
+impl OrdIsValueOrd for Utf8String<'_> {}
 
 impl<'a> From<&Utf8String<'a>> for Utf8String<'a> {
     fn from(value: &Utf8String<'a>) -> Utf8String<'a> {
@@ -109,10 +115,6 @@ impl<'a> From<Utf8String<'a>> for &'a [u8] {
     fn from(utf8_string: Utf8String<'a>) -> &'a [u8] {
         utf8_string.as_bytes()
     }
-}
-
-impl<'a> FixedTag for Utf8String<'a> {
-    const TAG: Tag = Tag::Utf8String;
 }
 
 impl<'a> fmt::Display for Utf8String<'a> {
@@ -149,6 +151,8 @@ impl FixedTag for str {
     const TAG: Tag = Tag::Utf8String;
 }
 
+impl OrdIsValueOrd for str {}
+
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<'a> From<Utf8String<'a>> for String {
@@ -184,6 +188,10 @@ impl EncodeValue for String {
 impl FixedTag for String {
     const TAG: Tag = Tag::Utf8String;
 }
+
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+impl OrdIsValueOrd for String {}
 
 #[cfg(test)]
 mod tests {

--- a/der/src/header.rs
+++ b/der/src/header.rs
@@ -1,6 +1,7 @@
 //! ASN.1 DER headers.
 
-use crate::{Decodable, Decoder, Encodable, Encoder, ErrorKind, Length, Result, Tag};
+use crate::{Decodable, Decoder, DerOrd, Encodable, Encoder, ErrorKind, Length, Result, Tag};
+use core::cmp::Ordering;
 
 /// ASN.1 DER headers: tag + length component of TLV-encoded values
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -46,5 +47,14 @@ impl Encodable for Header {
     fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
         self.tag.encode(encoder)?;
         self.length.encode(encoder)
+    }
+}
+
+impl DerOrd for Header {
+    fn der_cmp(&self, other: &Self) -> Result<Ordering> {
+        match self.tag.der_cmp(&other.tag)? {
+            Ordering::Equal => self.length.der_cmp(&other.length),
+            ordering => Ok(ordering),
+        }
     }
 }

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -336,6 +336,7 @@ mod encoder;
 mod error;
 mod header;
 mod length;
+mod ord;
 mod str_slice;
 mod tag;
 mod value;
@@ -353,6 +354,7 @@ pub use crate::{
     error::{Error, ErrorKind, Result},
     header::Header,
     length::Length,
+    ord::{DerOrd, OrdIsValueOrd, ValueOrd},
     tag::{Class, FixedTag, Tag, TagMode, TagNumber, Tagged},
     value::{DecodeValue, EncodeValue},
 };

--- a/der/src/ord.rs
+++ b/der/src/ord.rs
@@ -1,0 +1,53 @@
+//! Ordering trait.
+
+use crate::{EncodeValue, Result, Tagged};
+use core::cmp::Ordering;
+
+/// DER ordering trait.
+///
+/// Compares the ordering of two values based on their ASN.1 DER
+/// serializations.
+///
+/// This is used by the DER encoding for `SET OF` in order to establish an
+/// ordering for the elements of sets.
+pub trait DerOrd {
+    /// Return an [`Ordering`] between `self` and `other` when serialized as
+    /// ASN.1 DER.
+    fn der_cmp(&self, other: &Self) -> Result<Ordering>;
+}
+
+/// DER value ordering trait.
+///
+/// Compares the ordering of the value portion of TLV-encoded DER productions.
+pub trait ValueOrd {
+    /// Return an [`Ordering`] between value portion of TLV-encoded `self` and
+    /// `other` when serialized as ASN.1 DER.
+    fn value_cmp(&self, other: &Self) -> Result<Ordering>;
+}
+
+impl<T> DerOrd for T
+where
+    T: EncodeValue + ValueOrd + Tagged,
+{
+    fn der_cmp(&self, other: &Self) -> Result<Ordering> {
+        match self.header()?.der_cmp(&other.header()?)? {
+            Ordering::Equal => self.value_cmp(other),
+            ordering => Ok(ordering),
+        }
+    }
+}
+
+/// Marker trait for types whose `Ord` impl can be used as `ValueOrd`.
+///
+/// This means the `Ord` impl will sort values in the same order as their DER
+/// encodings.
+pub trait OrdIsValueOrd: Ord {}
+
+impl<T> ValueOrd for T
+where
+    T: OrdIsValueOrd,
+{
+    fn value_cmp(&self, other: &Self) -> Result<Ordering> {
+        Ok(self.cmp(other))
+    }
+}

--- a/der/src/tag.rs
+++ b/der/src/tag.rs
@@ -6,8 +6,8 @@ mod number;
 
 pub use self::{class::Class, mode::TagMode, number::TagNumber};
 
-use crate::{Decodable, Decoder, Encodable, Encoder, Error, ErrorKind, Length, Result};
-use core::fmt;
+use crate::{Decodable, Decoder, DerOrd, Encodable, Encoder, Error, ErrorKind, Length, Result};
+use core::{cmp::Ordering, fmt};
 
 /// Indicator bit for constructed form encoding (i.e. vs primitive form)
 const CONSTRUCTED_FLAG: u8 = 0b100000;
@@ -310,6 +310,12 @@ impl Encodable for Tag {
 
     fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
         encoder.byte(self.into())
+    }
+}
+
+impl DerOrd for Tag {
+    fn der_cmp(&self, other: &Self) -> Result<Ordering> {
+        Ok(self.octet().cmp(&other.octet()))
     }
 }
 


### PR DESCRIPTION
Adds traits for establishing a lexicographic ordering for DER serialized values, for use with `SET OF`:

- `DerOrd`: ordering of two types when serialized as ASN.1 DER
- `ValueOrd`: ordering of the value portion of a TLV-encoded DER production, with a blanket impl for `DerOrd` that computes the header
- `OrdIsValueOrd`: marker trait for types whose `Ord` impl can be used as the `ValueOrd` impl