### PR TITLE
der: fix unused lifetimes

### DIFF
--- a/der/src/asn1/integer/bigint.rs
+++ b/der/src/asn1/integer/bigint.rs
@@ -126,7 +126,7 @@ where
 
 #[cfg(feature = "bigint")]
 #[cfg_attr(docsrs, doc(cfg(feature = "bigint")))]
-impl<'a, const LIMBS: usize> EncodeValue for UInt<LIMBS>
+impl<const LIMBS: usize> EncodeValue for UInt<LIMBS>
 where
     UInt<LIMBS>: ArrayEncoding,
 {
@@ -144,7 +144,7 @@ where
 
 #[cfg(feature = "bigint")]
 #[cfg_attr(docsrs, doc(cfg(feature = "bigint")))]
-impl<'a, const LIMBS: usize> FixedTag for UInt<LIMBS>
+impl<const LIMBS: usize> FixedTag for UInt<LIMBS>
 where
     UInt<LIMBS>: ArrayEncoding,
 {

--- a/der/src/asn1/sequence_of.rs
+++ b/der/src/asn1/sequence_of.rs
@@ -129,7 +129,7 @@ where
     }
 }
 
-impl<'a, T, const N: usize> EncodeValue for [T; N]
+impl<T, const N: usize> EncodeValue for [T; N]
 where
     T: Encodable,
 {
@@ -184,7 +184,7 @@ where
 
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-impl<'a, T> EncodeValue for Vec<T>
+impl<T> EncodeValue for Vec<T>
 where
     T: Encodable,
 {

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -317,7 +317,12 @@
     html_root_url = "https://docs.rs/der/0.5.0-pre.1"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
-#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+#![warn(
+    missing_docs,
+    rust_2018_idioms,
+    unused_lifetimes,
+    unused_qualifications
+)]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;


### PR DESCRIPTION
Turns on the `unused_lifetimes` lint and fixes the occurrances.