### PR TITLE
pem-rfc7468 v0.2.4

### DIFF
--- a/pem-rfc7468/CHANGELOG.md
+++ b/pem-rfc7468/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.4 (2021-11-07)
+### Changed
+- Restrict `base64ct` dependency to `<1.2` to prevent MSRV breakages
+
 ## 0.2.3 (2021-10-17)
 ### Added
 - `PemLabel` trait ([#117])


### PR DESCRIPTION
This commit adds a changelog entry about `pem-rfc7468` v0.2.4, which was released to address RustCrypto/RSA#116.

The release is identical to v0.2.3, but with `base64ct` restricted to `<1.2` in order to prevent MSRV-related breakages.

Since `master` is already on `pem-rfc7468` v0.3.0-pre which is also a 2021 edition crate, those changes are not actually included in this commit, but rather just the changelog entry.