### PR TITLE
der_derive: use `proc-macro-error` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,6 +296,7 @@ dependencies = [
 name = "der_derive"
 version = "0.5.0-pre.1"
 dependencies = [
+ "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn",
@@ -573,6 +574,30 @@ name = "ppv-lite86"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"

--- a/der/derive/Cargo.toml
+++ b/der/derive/Cargo.toml
@@ -17,5 +17,6 @@ proc-macro = true
 
 [dependencies]
 proc-macro2 = "1"
+proc-macro-error = "1"
 quote = "1"
 syn = { version = "1", features = ["extra-traits"] }

--- a/der/derive/src/lib.rs
+++ b/der/derive/src/lib.rs
@@ -108,6 +108,7 @@ use crate::{
     types::Asn1Type,
 };
 use proc_macro::TokenStream;
+use proc_macro_error::{abort, proc_macro_error};
 use syn::{parse_macro_input, DeriveInput, Generics, Lifetime};
 
 /// Derive the [`Choice`][1] trait on an enum.
@@ -148,6 +149,7 @@ use syn::{parse_macro_input, DeriveInput, Generics, Lifetime};
 /// [3]: https://docs.rs/der/latest/der/trait.Encodable.html
 /// [4]: https://docs.rs/der_derive/
 #[proc_macro_derive(Choice, attributes(asn1))]
+#[proc_macro_error]
 pub fn derive_choice(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let lifetime = parse_lifetime(&input.generics);
@@ -160,7 +162,8 @@ pub fn derive_choice(input: TokenStream) -> TokenStream {
         syn::Data::Union(_) => "union",
     };
 
-    panic!(
+    abort!(
+        input.ident,
         "can't derive `Choice` on `{}`: only `enum` types are allowed",
         data_label
     )
@@ -195,11 +198,16 @@ pub fn derive_choice(input: TokenStream) -> TokenStream {
 /// Note that the derive macro will write a `TryFrom<...>` impl for the
 /// provided `#[repr]`, which is used by the decoder.
 #[proc_macro_derive(Enumerated)]
+#[proc_macro_error]
 pub fn derive_enumerated(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
     if let Some(lifetime) = parse_lifetime(&input.generics) {
-        panic!("lifetimes not allowed on `Enumerated` types: {}", lifetime);
+        abort!(
+            lifetime,
+            "lifetimes not allowed on `Enumerated` types: {}",
+            lifetime
+        );
     }
 
     let data_label = match input.data {
@@ -210,7 +218,8 @@ pub fn derive_enumerated(input: TokenStream) -> TokenStream {
         syn::Data::Union(_) => "union",
     };
 
-    panic!(
+    abort!(
+        input.ident,
         "can't derive `Enumerated` on `{}`: only `enum` types are allowed",
         data_label
     )
@@ -250,6 +259,7 @@ pub fn derive_enumerated(input: TokenStream) -> TokenStream {
 /// [1]: https://docs.rs/der/latest/der/trait.Sequence.html
 /// [2]: https://docs.rs/der_derive/
 #[proc_macro_derive(Sequence, attributes(asn1))]
+#[proc_macro_error]
 pub fn derive_sequence(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let lifetime = parse_lifetime(&input.generics);
@@ -262,7 +272,8 @@ pub fn derive_sequence(input: TokenStream) -> TokenStream {
         syn::Data::Union(_) => "union",
     };
 
-    panic!(
+    abort!(
+        input.ident,
         "can't derive `Sequence` on `{}`: only `struct` types are allowed",
         data_label
     )


### PR DESCRIPTION
Provides better formatted errors for the proc macro