### PR TITLE
der_derive: replace `panic!` with `proc-macro-error`

### DIFF
--- a/der/derive/src/attributes.rs
+++ b/der/derive/src/attributes.rs
@@ -2,6 +2,7 @@
 
 use crate::{Asn1Type, TagMode, TagNumber};
 use proc_macro2::TokenStream;
+use proc_macro_error::{abort, abort_call_site};
 use quote::quote;
 use std::{fmt::Debug, str::FromStr};
 use syn::{Attribute, Lit, Meta, MetaList, MetaNameValue, NestedMeta, Path};
@@ -34,15 +35,14 @@ impl TypeAttrs {
             // `tag_mode = "..."` attribute
             if let Some(mode) = attr.parse_value("tag_mode") {
                 if tag_mode.is_some() {
-                    panic!("duplicate ASN.1 `tag_mode` attribute: {}", attr.value);
+                    abort!(attr.value, "duplicate ASN.1 `tag_mode` attribute");
                 }
 
                 tag_mode = Some(mode);
             } else {
-                panic!(
-                    "unknown field-level `asn1` attribute: {:?} \
-                    (valid options are `tag_mode`)",
-                    attr.name
+                abort!(
+                    attr.name,
+                    "invalid `asn1` attribute (valid options are `tag_mode`)",
                 );
             }
         }
@@ -76,25 +76,22 @@ impl FieldAttrs {
             // `context_specific = "..."` attribute
             if let Some(tag_number) = attr.parse_value("context_specific") {
                 if context_specific.is_some() {
-                    panic!(
-                        "duplicate ASN.1 `context_specific` attribute: {}",
-                        tag_number
-                    );
+                    abort!(attr.name, "duplicate ASN.1 `context_specific` attribute");
                 }
 
                 context_specific = Some(tag_number);
             // `type = "..."` attribute
             } else if let Some(ty) = attr.parse_value("type") {
                 if asn1_type.is_some() {
-                    panic!("duplicate ASN.1 `type` attribute: {}", attr.value);
+                    abort!(attr.value, "duplicate ASN.1 `type` attribute: {}");
                 }
 
                 asn1_type = Some(ty);
             } else {
-                panic!(
-                    "unknown field-level `asn1` attribute: {:?} \
+                abort!(
+                    attr.name,
+                    "unknown field-level `asn1` attribute \
                     (valid options are `context_specific`, `type`)",
-                    attr.name
                 );
             }
         }
@@ -123,7 +120,7 @@ impl FieldAttrs {
                         }
                     })
                 }
-                None => panic!("implicit tagging requires an associated `tag_number`"),
+                None => abort_call_site!("implicit tagging requires an associated `tag_number`"),
             },
         }
     }
@@ -195,7 +192,7 @@ impl AttrNameValue {
 
             let nested = match attr.parse_meta().expect(PARSE_ERR_MSG) {
                 Meta::List(MetaList { nested, .. }) => nested,
-                other => panic!("malformed `asn1` attribute: {:?}", other),
+                other => abort!(other, "malformed `asn1` attribute"),
             };
 
             for meta in &nested {
@@ -208,7 +205,7 @@ impl AttrNameValue {
                         name: path.clone(),
                         value: lit_str.value(),
                     }),
-                    _ => panic!("malformed `asn1` attribute: {:?}", nested),
+                    _ => abort!(nested, "malformed `asn1` attribute"),
                 }
             }
         }
@@ -224,7 +221,7 @@ impl AttrNameValue {
             Some(
                 self.value
                     .parse()
-                    .unwrap_or_else(|_| panic!("error parsing `{}` attribute", name)),
+                    .unwrap_or_else(|_| abort!(self.name, "error parsing `{}` attribute")),
             )
         } else {
             None

--- a/der/derive/src/choice.rs
+++ b/der/derive/src/choice.rs
@@ -4,6 +4,7 @@
 
 use crate::{FieldAttrs, TypeAttrs};
 use proc_macro2::TokenStream;
+use proc_macro_error::abort;
 use quote::{quote, ToTokens};
 use syn::{Attribute, DataEnum, Fields, Ident, Lifetime, Variant};
 
@@ -56,9 +57,9 @@ impl DeriveChoice {
         for variant in &data.variants {
             let field_attrs = FieldAttrs::parse(&variant.attrs);
             let tag = field_attrs.tag(&state.type_attrs).unwrap_or_else(|| {
-                panic!(
-                    "no #[asn1(type=...)] specified for enum variant: {}",
-                    variant.ident
+                abort!(
+                    &variant.ident,
+                    "no #[asn1(type=...)] specified for enum variant",
                 )
             });
 
@@ -72,9 +73,9 @@ impl DeriveChoice {
                     state.derive_variant_encoded_len(variant);
                     state.derive_variant_tagged(variant, &tag);
                 }
-                _ => panic!(
-                    "enum variant `{}` must be a 1-element tuple struct",
-                    &variant.ident
+                _ => abort!(
+                    &variant.ident,
+                    "enum variant must be a 1-element tuple struct"
                 ),
             }
         }

--- a/der/derive/src/sequence.rs
+++ b/der/derive/src/sequence.rs
@@ -3,6 +3,7 @@
 
 use crate::{FieldAttrs, TagMode, TypeAttrs};
 use proc_macro2::TokenStream;
+use proc_macro_error::abort;
 use quote::{quote, ToTokens};
 use syn::{Attribute, DataStruct, Field, Ident, Lifetime};
 
@@ -71,9 +72,9 @@ impl DeriveSequence {
         } else {
             // TODO(tarcieri): IMPLICIT support
             if self.type_attrs.tag_mode == TagMode::Implicit {
-                panic!(
-                    "IMPLICIT tagging not presently supported in this context: {}",
-                    name
+                abort!(
+                    name,
+                    "IMPLICIT tagging not presently supported for `Sequence`"
                 );
             }
 


### PR DESCRIPTION
Replaces all remaining occurrences of `panic!` with the `proc-macro-error` crate's `abort!` macro, which provides better diagnostics.