### PR TITLE
der_derive: refactor `Derive*` constructors

### DIFF
--- a/der/derive/src/enumerated.rs
+++ b/der/derive/src/enumerated.rs
@@ -6,7 +6,7 @@ use crate::ATTR_NAME;
 use proc_macro2::TokenStream;
 use proc_macro_error::abort;
 use quote::{quote, ToTokens};
-use syn::{Attribute, DataEnum, Expr, ExprLit, Ident, Lit, LitInt};
+use syn::{DeriveInput, Expr, ExprLit, Ident, Lit, LitInt};
 
 /// Valid options for the `#[repr]` attribute on `Enumerated` types.
 const REPR_TYPES: &[&str] = &["u8", "u16", "u32"];
@@ -24,11 +24,20 @@ pub(crate) struct DeriveEnumerated {
 }
 
 impl DeriveEnumerated {
-    /// Derive `Decodable` on an enum.
-    pub fn derive(ident: Ident, data: DataEnum, attrs: &[Attribute]) -> TokenStream {
+    /// Parse [`DeriveInput`].
+    pub fn new(input: DeriveInput) -> Self {
+        let data = match input.data {
+            syn::Data::Enum(data) => data,
+            _ => abort!(
+                input.ident,
+                "can't derive `Enumerated` on this type: only `enum` types are allowed",
+            ),
+        };
+
         // Reject `asn1` attributes, parse the `repr` attribute
         let mut repr: Option<Ident> = None;
-        for attr in attrs {
+
+        for attr in &input.attrs {
             if attr.path.is_ident(ATTR_NAME) {
                 abort!(
                     attr.path,
@@ -86,22 +95,21 @@ impl DeriveEnumerated {
 
         let repr = repr.unwrap_or_else(|| {
             abort!(
-                &ident,
+                &input.ident,
                 "no `#[repr]` attribute on enum: must be one of {:?}",
                 REPR_TYPES
             )
         });
 
         Self {
-            ident,
+            ident: input.ident,
             repr,
             variants,
         }
-        .to_tokens()
     }
 
     /// Lower the derived output into a [`TokenStream`].
-    fn to_tokens(&self) -> TokenStream {
+    pub fn to_tokens(&self) -> TokenStream {
         let mut try_from_body = TokenStream::new();
         for (ident, discriminant) in &self.variants {
             { quote!(#discriminant => Ok(Self::#ident),) }.to_tokens(&mut try_from_body);

--- a/der/derive/src/lib.rs
+++ b/der/derive/src/lib.rs
@@ -108,8 +108,8 @@ use crate::{
     types::Asn1Type,
 };
 use proc_macro::TokenStream;
-use proc_macro_error::{abort, proc_macro_error};
-use syn::{parse_macro_input, DeriveInput, Generics, Lifetime};
+use proc_macro_error::proc_macro_error;
+use syn::{parse_macro_input, DeriveInput};
 
 /// Derive the [`Choice`][1] trait on an enum.
 ///
@@ -152,21 +152,7 @@ use syn::{parse_macro_input, DeriveInput, Generics, Lifetime};
 #[proc_macro_error]
 pub fn derive_choice(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
-    let lifetime = parse_lifetime(&input.generics);
-
-    let data_label = match input.data {
-        syn::Data::Enum(data) => {
-            return DeriveChoice::derive(input.ident, data, &input.attrs, lifetime).into()
-        }
-        syn::Data::Struct(_) => "struct",
-        syn::Data::Union(_) => "union",
-    };
-
-    abort!(
-        input.ident,
-        "can't derive `Choice` on `{}`: only `enum` types are allowed",
-        data_label
-    )
+    DeriveChoice::new(input).to_tokens().into()
 }
 
 /// Derive decoders and encoders for ASN.1 [`Enumerated`] types.
@@ -201,28 +187,7 @@ pub fn derive_choice(input: TokenStream) -> TokenStream {
 #[proc_macro_error]
 pub fn derive_enumerated(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
-
-    if let Some(lifetime) = parse_lifetime(&input.generics) {
-        abort!(
-            lifetime,
-            "lifetimes not allowed on `Enumerated` types: {}",
-            lifetime
-        );
-    }
-
-    let data_label = match input.data {
-        syn::Data::Enum(data) => {
-            return DeriveEnumerated::derive(input.ident, data, &input.attrs).into()
-        }
-        syn::Data::Struct(_) => "struct",
-        syn::Data::Union(_) => "union",
-    };
-
-    abort!(
-        input.ident,
-        "can't derive `Enumerated` on `{}`: only `enum` types are allowed",
-        data_label
-    )
+    DeriveEnumerated::new(input).to_tokens().into()
 }
 
 /// Derive the [`Sequence`][1] trait on a struct.
@@ -262,26 +227,5 @@ pub fn derive_enumerated(input: TokenStream) -> TokenStream {
 #[proc_macro_error]
 pub fn derive_sequence(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
-    let lifetime = parse_lifetime(&input.generics);
-
-    let data_label = match input.data {
-        syn::Data::Enum(_) => "enum",
-        syn::Data::Struct(data) => {
-            return DeriveSequence::derive(input.ident, data, &input.attrs, lifetime).into()
-        }
-        syn::Data::Union(_) => "union",
-    };
-
-    abort!(
-        input.ident,
-        "can't derive `Sequence` on `{}`: only `struct` types are allowed",
-        data_label
-    )
-}
-
-/// Parse the first lifetime of the "self" type of the custom derive
-///
-/// Returns `None` if there is no first lifetime.
-fn parse_lifetime(generics: &Generics) -> Option<Lifetime> {
-    generics.lifetimes().next().map(|lt| lt.lifetime.clone())
+    DeriveSequence::new(input).to_tokens().into()
 }


### PR DESCRIPTION
Refactors the constructors for:

- `DeriveChoice`
- `DeriveEnumerated`
- `DeriveSequence`

The constructors now handle all of the `DeriveInput` parsing, and return `Self`, which allows for a 2-step process with an IR, which should enable unit testing.