### PR TITLE
der: use `DerOrd` for `SetOf*` types

### DIFF
--- a/der/src/arrayvec.rs
+++ b/der/src/arrayvec.rs
@@ -46,14 +46,24 @@ impl<T, const N: usize> ArrayVec<T, N> {
         }
     }
 
-    /// Get the last item from this [`ArrayVec`].
-    pub fn last(&self) -> Option<&T> {
-        self.length.checked_sub(1).and_then(|n| self.get(n))
-    }
-
     /// Iterate over the elements in this [`ArrayVec`].
     pub fn iter(&self) -> Iter<'_, T> {
         Iter::new(&self.elements)
+    }
+
+    /// Is this [`ArrayVec`] empty?
+    pub fn is_empty(&self) -> bool {
+        self.length == 0
+    }
+
+    /// Get the number of elements in this [`ArrayVec`].
+    pub fn len(&self) -> usize {
+        self.length
+    }
+
+    /// Get the last item from this [`ArrayVec`].
+    pub fn last(&self) -> Option<&T> {
+        self.length.checked_sub(1).and_then(|n| self.get(n))
     }
 
     /// Try to convert this [`ArrayVec`] into a `[T; N]`.

--- a/der/src/asn1.rs
+++ b/der/src/asn1.rs
@@ -39,6 +39,10 @@ pub use self::{
     utf8_string::Utf8String,
 };
 
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+pub use self::set_of::SetOfVec;
+
 #[cfg(feature = "oid")]
 #[cfg_attr(docsrs, doc(cfg(feature = "oid")))]
 pub use const_oid::ObjectIdentifier;

--- a/der/src/asn1/sequence_of.rs
+++ b/der/src/asn1/sequence_of.rs
@@ -44,6 +44,16 @@ impl<T, const N: usize> SequenceOf<T, N> {
             inner: self.inner.iter(),
         }
     }
+
+    /// Is this [`SequenceOf`] empty?
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Number of elements in this [`SequenceOf`].
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
 }
 
 impl<T, const N: usize> Default for SequenceOf<T, N> {

--- a/der/src/error.rs
+++ b/der/src/error.rs
@@ -201,8 +201,8 @@ pub enum ErrorKind {
         oid: ObjectIdentifier,
     },
 
-    /// Ordering error.
-    Ordering,
+    /// `SET` ordering error: items not in canonical order.
+    SetOrdering,
 
     /// Integer overflow occurred (library bug!).
     Overflow,
@@ -309,7 +309,7 @@ impl fmt::Display for ErrorKind {
             ErrorKind::OidUnknown { oid } => {
                 write!(f, "unknown/unsupported OID: {}", oid)
             }
-            ErrorKind::Ordering => write!(f, "ordering error"),
+            ErrorKind::SetOrdering => write!(f, "ordering error"),
             ErrorKind::Overflow => write!(f, "integer overflow"),
             ErrorKind::Overlength => write!(f, "ASN.1 DER message is too long"),
             #[cfg(feature = "pem")]

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -13,7 +13,6 @@
 //! - [`u8`], [`u16`], [`u32`], [`u64`], [`u128`]: ASN.1 `INTEGER`.
 //! - [`str`], [`String`][`alloc::string::String`]: ASN.1 `UTF8String`.
 //!   `String` requires `alloc` feature. See also [`Utf8String`].
-//! - [`BTreeSet`][`alloc::collections::BTreeSet`]: ASN.1 `SET OF`.
 //!   Requires `alloc` feature. See also [`SetOf`].
 //! - [`Option`]: ASN.1 `OPTIONAL`.
 //! - [`SystemTime`][`std::time::SystemTime`]: ASN.1 `GeneralizedTime`. Requires `std` feature.
@@ -30,7 +29,7 @@
 //! - [`OctetString`]: ASN.1 `OCTET STRING`
 //! - [`PrintableString`]: ASN.1 `PrintableString` (ASCII subset)
 //! - [`SequenceOf`]: ASN.1 `SEQUENCE OF`
-//! - [`SetOf`]: ASN.1 `SET OF`
+//! - [`SetOf`], [`SetOfVec`]: ASN.1 `SET OF`
 //! - [`UIntBytes`]: ASN.1 unsigned `INTEGER` with raw access to encoded bytes
 //! - [`UtcTime`]: ASN.1 `UTCTime`
 //! - [`Utf8String`]: ASN.1 `UTF8String`
@@ -308,6 +307,7 @@
 //! [`PrintableString`]: asn1::PrintableString
 //! [`SequenceOf`]: asn1::SequenceOf
 //! [`SetOf`]: asn1::SetOf
+//! [`SetOfVec`]: asn1::SetOfVec
 //! [`UIntBytes`]: asn1::UIntBytes
 //! [`UtcTime`]: asn1::UtcTime
 //! [`Utf8String`]: asn1::Utf8String

--- a/der/tests/set_of.rs
+++ b/der/tests/set_of.rs
@@ -2,9 +2,10 @@
 
 #![cfg(all(feature = "derive", feature = "oid"))]
 
+use core::cmp::Ordering;
 use der::{
     asn1::{Any, ObjectIdentifier, SetOf},
-    Decodable, Sequence,
+    Decodable, Result, Sequence, ValueOrd,
 };
 use hex_literal::hex;
 
@@ -18,6 +19,15 @@ pub struct AttributeTypeAndValue<'a> {
 
     /// Value of the attribute
     pub value: Any<'a>,
+}
+
+impl ValueOrd for AttributeTypeAndValue<'_> {
+    fn value_cmp(&self, other: &Self) -> Result<Ordering> {
+        match self.oid.value_cmp(&other.oid)? {
+            Ordering::Equal => self.value.value_cmp(&other.value),
+            other => Ok(other),
+        }
+    }
 }
 
 /// Test to ensure ordering is handled correctly.


### PR DESCRIPTION
Changes `SetOf` to use the `DerOrd` trait instead of `Ord`.

Removes support for using `BTreeSet` as a `SET OF`, since we need to respect `DerOrd` instead of `Ord`.

Replaces it with a heap-backed `SetOfVec` type that works like `SetOf` but backed by a `Vec` and therefore with support for an arbitrary number of elements.