### PR TITLE
der: switch `impl From<BitString> for &[u8]` to `TryFrom`

### DIFF
--- a/der/src/asn1/bit_string.rs
+++ b/der/src/asn1/bit_string.rs
@@ -174,9 +174,13 @@ impl<'a> TryFrom<&&'a [u8]> for BitString<'a> {
     }
 }
 
-impl<'a> From<BitString<'a>> for &'a [u8] {
-    fn from(bit_string: BitString<'a>) -> &'a [u8] {
-        bit_string.raw_bytes()
+impl<'a> TryFrom<BitString<'a>> for &'a [u8] {
+    type Error = Error;
+
+    fn try_from(bit_string: BitString<'a>) -> Result<&'a [u8]> {
+        bit_string
+            .as_bytes()
+            .ok_or_else(|| Tag::BitString.value_error())
     }
 }
 


### PR DESCRIPTION
Previously this conversion was infallible because only octet-aligned `BIT STRING`s were accepted.

Now that we support "unused bits", this conversion should only succeed if the number of unused bits is equal to zero.