### PR TITLE
der_derive: fix `#[asn1(type = "...")]` attribute

### DIFF
--- a/der/derive/src/lib.rs
+++ b/der/derive/src/lib.rs
@@ -90,6 +90,7 @@
 //! [`der::asn1::Utf8String`]: https://docs.rs/der/latest/der/asn1/struct.Utf8String.html
 
 #![crate_type = "proc-macro"]
+#![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(rust_2018_idioms, trivial_casts, unused_qualifications)]
 
 mod asn1_type;

--- a/der/src/asn1.rs
+++ b/der/src/asn1.rs
@@ -31,6 +31,7 @@ pub use self::{
     integer::bigint::UIntBytes,
     null::Null,
     octet_string::OctetString,
+    optional::OptionalRef,
     printable_string::PrintableString,
     sequence::Sequence,
     sequence_of::{SequenceOf, SequenceOfIter},

--- a/der/src/asn1/optional.rs
+++ b/der/src/asn1/optional.rs
@@ -55,3 +55,27 @@ where
         }
     }
 }
+
+/// A reference to an ASN.1 `OPTIONAL` type, used for encoding only.
+pub struct OptionalRef<'a, T>(pub Option<&'a T>);
+
+impl<'a, T> Encodable for OptionalRef<'a, T>
+where
+    T: Encodable,
+{
+    fn encoded_len(&self) -> Result<Length> {
+        if let Some(encodable) = self.0 {
+            encodable.encoded_len()
+        } else {
+            Ok(0u8.into())
+        }
+    }
+
+    fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
+        if let Some(encodable) = self.0 {
+            encodable.encode(encoder)
+        } else {
+            Ok(())
+        }
+    }
+}

--- a/der/tests/derive.rs
+++ b/der/tests/derive.rs
@@ -201,7 +201,7 @@ mod enumerated {
 /// Custom derive test cases for the `Sequence` macro.
 mod sequence {
     use der::{
-        asn1::{Any, BitString, ObjectIdentifier},
+        asn1::{Any, ObjectIdentifier},
         Decodable, Encodable, Sequence,
     };
     use hex_literal::hex;
@@ -217,8 +217,24 @@ mod sequence {
     #[derive(Copy, Clone, Debug, Eq, PartialEq, Sequence)]
     pub struct SubjectPublicKeyInfo<'a> {
         pub algorithm: AlgorithmIdentifier<'a>,
+        #[asn1(type = "BIT STRING")]
+        pub subject_public_key: &'a [u8],
+    }
 
-        pub subject_public_key: BitString<'a>,
+    /// X.509 extension
+    // TODO(tarcieri): tests for code derived with the `default` attribute
+    #[derive(Clone, Debug, Eq, PartialEq, Sequence)]
+    pub struct Extension<'a> {
+        extn_id: ObjectIdentifier,
+        #[asn1(default = "critical_default")]
+        critical: bool,
+        #[asn1(type = "OCTET STRING")]
+        extn_value: &'a [u8],
+    }
+
+    /// Default value of the `critical` bit
+    fn critical_default() -> bool {
+        false
     }
 
     const ID_EC_PUBLIC_KEY_OID: ObjectIdentifier = ObjectIdentifier::new("1.2.840.10045.2.1");


### PR DESCRIPTION
PR #202 removed support for the `#[asn1(type = "...")]` attribute when deriving `Sequence`.

This PR restores it, and also slightly changes the way the `default` attribute is handled, with added tests.