### PR TITLE
pkcs8: re-export `spki` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,7 +243,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d174cafe51590ef0e0a6e540b9ffc8b35a1ff47fb3adda3ab272bcc9f5bfc86c"
 dependencies = [
  "generic-array",
- "rand_core",
  "subtle",
 ]
 

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -97,7 +97,7 @@ pub use crate::{
     version::Version,
 };
 pub use der::{self, asn1::ObjectIdentifier};
-pub use spki::{AlgorithmIdentifier, DecodePublicKey, SubjectPublicKeyInfo};
+pub use spki::{self, AlgorithmIdentifier, DecodePublicKey, SubjectPublicKeyInfo};
 
 #[cfg(feature = "alloc")]
 pub use {


### PR DESCRIPTION
This makes it possible to access things like `spki::Error` without having to re-export all of them