### PR TITLE
pkcs8: don't re-export `der::pem`

### DIFF
--- a/pkcs8/src/document/encrypted_private_key.rs
+++ b/pkcs8/src/document/encrypted_private_key.rs
@@ -10,7 +10,7 @@ use zeroize::{Zeroize, Zeroizing};
 use crate::PrivateKeyDocument;
 
 #[cfg(feature = "pem")]
-use {crate::pem, core::str::FromStr};
+use {core::str::FromStr, der::pem};
 
 /// Encrypted PKCS#8 private key document.
 ///

--- a/pkcs8/src/document/private_key.rs
+++ b/pkcs8/src/document/private_key.rs
@@ -15,9 +15,9 @@ use {
 
 #[cfg(feature = "pem")]
 use {
-    crate::{pem, LineEnding},
     alloc::string::String,
     core::str::FromStr,
+    der::pem::{self, LineEnding},
 };
 
 #[cfg(feature = "std")]

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -107,7 +107,7 @@ pub use {
 
 #[cfg(feature = "pem")]
 #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-pub use der::pem::{self, LineEnding};
+pub use der::pem::LineEnding;
 
 #[cfg(feature = "pkcs5")]
 pub use {crate::encrypted_private_key_info::EncryptedPrivateKeyInfo, pkcs5};


### PR DESCRIPTION
It can be easily accessed as `pkcs8::der::pem`