### PR TITLE
spki: error improvements

### DIFF
--- a/pkcs8/src/error.rs
+++ b/pkcs8/src/error.rs
@@ -28,6 +28,9 @@ pub enum Error {
     /// [`AlgorithmIdentifier::parameters`][`crate::AlgorithmIdentifier::parameters`]
     /// is malformed or otherwise encoded in an unexpected manner.
     ParametersMalformed,
+
+    /// Public key errors propagated from the [`spki::Error`] type.
+    PublicKey(spki::Error),
 }
 
 impl fmt::Display for Error {
@@ -37,6 +40,7 @@ impl fmt::Display for Error {
             Error::Crypto => f.write_str("PKCS#8 cryptographic error"),
             Error::KeyMalformed => f.write_str("PKCS#8 cryptographic key data malformed"),
             Error::ParametersMalformed => f.write_str("PKCS#8 algorithm parameters malformed"),
+            Error::PublicKey(err) => write!(f, "public key error: {}", err),
         }
     }
 }
@@ -53,5 +57,11 @@ impl From<der::Error> for Error {
 impl From<der::ErrorKind> for Error {
     fn from(err: der::ErrorKind) -> Error {
         Error::Asn1(err.into())
+    }
+}
+
+impl From<spki::Error> for Error {
+    fn from(err: spki::Error) -> Error {
+        Error::PublicKey(err)
     }
 }

--- a/spki/src/algorithm.rs
+++ b/spki/src/algorithm.rs
@@ -31,7 +31,7 @@ impl<'a> AlgorithmIdentifier<'a> {
         if self.oid == expected_oid {
             Ok(expected_oid)
         } else {
-            Err(Error::UnknownOid { oid: expected_oid })
+            Err(Error::OidUnknown { oid: expected_oid })
         }
     }
 
@@ -45,7 +45,7 @@ impl<'a> AlgorithmIdentifier<'a> {
         if actual_oid == expected_oid {
             Ok(actual_oid)
         } else {
-            Err(Error::UnknownOid { oid: expected_oid })
+            Err(Error::OidUnknown { oid: expected_oid })
         }
     }
 

--- a/spki/src/error.rs
+++ b/spki/src/error.rs
@@ -17,7 +17,7 @@ pub enum Error {
     Asn1(der::Error),
 
     /// Unknown algorithm OID.
-    UnknownOid {
+    OidUnknown {
         /// Unrecognized OID value found in e.g. a SPKI `AlgorithmIdentifier`.
         oid: ObjectIdentifier,
     },
@@ -30,7 +30,7 @@ impl fmt::Display for Error {
                 f.write_str("AlgorithmIdentifier parameters missing")
             }
             Error::Asn1(err) => write!(f, "ASN.1 error: {}", err),
-            Error::UnknownOid { oid } => {
+            Error::OidUnknown { oid } => {
                 write!(f, "unknown/unsupported algorithm OID: {}", oid)
             }
         }
@@ -39,7 +39,11 @@ impl fmt::Display for Error {
 
 impl From<der::Error> for Error {
     fn from(err: der::Error) -> Error {
-        Error::Asn1(err)
+        if let der::ErrorKind::OidUnknown { oid } = err.kind() {
+            Error::OidUnknown { oid }
+        } else {
+            Error::Asn1(err)
+        }
     }
 }
 


### PR DESCRIPTION
- Renames `spki::Error::UnknownOid` => `OidUnknown` for consistency with `der::ErrorKind::OidUnknown`
- Adds `pkcs8::Error::PublicKey` as a wrapper for `spki::Error`