### PR TITLE
const-oid v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.7.0-pre"
+version = "0.7.0"
 dependencies = [
  "hex-literal",
 ]

--- a/const-oid/CHANGELOG.md
+++ b/const-oid/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.0 (2021-11-14)
+### Changed
+- Rust 2021 edition upgrade; MSRV 1.56 ([#136])
+- Rename `MAX_LENGTH` to `MAX_SIZE`; bump to `31` ([#174])
+- Make `length` the first field of `ObjectIdentifier` ([#178])
+
+### Fixed
+- `debug_assert!` false positive on large arc ([#180])
+
+[#136]: https://github.com/RustCrypto/formats/pull/136
+[#174]: https://github.com/RustCrypto/formats/pull/174
+[#178]: https://github.com/RustCrypto/formats/pull/178
+[#180]: https://github.com/RustCrypto/formats/pull/180
+
 ## 0.6.2 (2021-10-14)
 ### Fixed
 - Off-by-one error parsing large BER arcs ([#84])

--- a/const-oid/Cargo.toml
+++ b/const-oid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "const-oid"
-version = "0.7.0-pre"
+version = "0.7.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """

--- a/const-oid/src/lib.rs
+++ b/const-oid/src/lib.rs
@@ -4,7 +4,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/const-oid/0.7.0-pre"
+    html_root_url = "https://docs.rs/const-oid/0.7.0"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms)]

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-const-oid = { version = "=0.7.0-pre", optional = true, path = "../const-oid" }
+const-oid = { version = "0.7", optional = true, path = "../const-oid" }
 crypto-bigint = { version = "0.3", optional = true, default-features = false, features = ["generic-array"] }
 der_derive = { version = "=0.5.0-pre.1", optional = true, path = "derive" }
 pem-rfc7468 = { version = "=0.3.0-pre", optional = true, path = "../pem-rfc7468" }


### PR DESCRIPTION
### Changed
- Rust 2021 edition upgrade; MSRV 1.56 ([#136])
- Rename `MAX_LENGTH` to `MAX_SIZE`; bump to `31` ([#174])
- Make `length` the first field of `ObjectIdentifier` ([#178])

### Fixed
- `debug_assert!` false positive on large arc ([#180])

[#136]: https://github.com/RustCrypto/formats/pull/136
[#174]: https://github.com/RustCrypto/formats/pull/174
[#178]: https://github.com/RustCrypto/formats/pull/178
[#180]: https://github.com/RustCrypto/formats/pull/180