### PR TITLE
pem-rfc7468 v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.3.0-pre"
+version = "0.3.0"
 dependencies = [
  "base64ct",
 ]

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.56"
 const-oid = { version = "0.7", optional = true, path = "../const-oid" }
 crypto-bigint = { version = "0.3", optional = true, default-features = false, features = ["generic-array"] }
 der_derive = { version = "=0.5.0-pre.1", optional = true, path = "derive" }
-pem-rfc7468 = { version = "=0.3.0-pre", optional = true, path = "../pem-rfc7468" }
+pem-rfc7468 = { version = "0.3", optional = true, path = "../pem-rfc7468" }
 time = { version = "0.3", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/pem-rfc7468/CHANGELOG.md
+++ b/pem-rfc7468/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2021-11-14)
+### Added
+- `Decoder` struct ([#177])
+
+### Changed
+- Rust 2021 edition upgrade; MSRV 1.56 ([#136])
+- Bump `base64ct` dependency to v1.2 ([#175])
+
+[#136]: https://github.com/RustCrypto/formats/pull/136
+[#175]: https://github.com/RustCrypto/formats/pull/175
+[#177]: https://github.com/RustCrypto/formats/pull/177
+
 ## 0.2.4 (2021-11-07)
 ### Changed
 - Restrict `base64ct` dependency to `<1.2` to prevent MSRV breakages

--- a/pem-rfc7468/Cargo.toml
+++ b/pem-rfc7468/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pem-rfc7468"
-version = "0.3.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.3.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 PEM Encoding (RFC 7468) for PKIX, PKCS, and CMS Structures, implementing a
 strict subset of the original Privacy-Enhanced Mail encoding intended

--- a/pem-rfc7468/src/lib.rs
+++ b/pem-rfc7468/src/lib.rs
@@ -45,7 +45,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/pem-rfc7468/0.3.0-pre"
+    html_root_url = "https://docs.rs/pem-rfc7468/0.3.0"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Added
- `Decoder` struct ([#177])

### Changed
- Rust 2021 edition upgrade; MSRV 1.56 ([#136])
- Bump `base64ct` dependency to v1.2 ([#175])

[#136]: https://github.com/RustCrypto/formats/pull/136
[#175]: https://github.com/RustCrypto/formats/pull/175
[#177]: https://github.com/RustCrypto/formats/pull/177