### PR TITLE
der_derive: CONTEXT-SPECIFIC support for SEQUENCE

### DIFF
--- a/der/derive/src/choice.rs
+++ b/der/derive/src/choice.rs
@@ -147,6 +147,10 @@ impl ChoiceVariant {
         let ident = input.ident.clone();
         let attrs = FieldAttrs::parse(&input.attrs, type_attrs);
 
+        if attrs.extensible {
+            abort!(&ident, "`extensible` is not allowed on CHOICE");
+        }
+
         // Validate that variant is a 1-element tuple struct
         match &input.fields {
             // TODO(tarcieri): handle 0 bindings for ASN.1 NULL

--- a/der/derive/src/lib.rs
+++ b/der/derive/src/lib.rs
@@ -57,6 +57,21 @@
 //!
 //! The value must be quoted and contain a number, e.g. `#[asn1(context_specific = "42"]`.
 //!
+//! ### `#[asn1(default = "...")` attribute: `DEFAULT` support
+//!
+//! This behaves like `serde_derive`'s `default` attribute, allowing you to
+//! specify the path to a function which returns a default value.
+//!
+//! ### `#[asn1(extensible = "true")` attribute: support for `...` extensibility operator
+//!
+//! This attribute can be applied to the fields of `struct` types, and will
+//! skip over unrecognized lower-numbered `CONTEXT-SPECIFIC` fields when
+//! looking for a particular field of a struct.
+//!
+//! ### `#[asn1(optional = "true")` attribute: support for `OPTIONAL` fields
+//!
+//! This attribute explicitly annotates a field as `OPTIONAL`.
+//!
 //! ### `#[asn1(type = "...")]` attribute: ASN.1 type declaration
 //!
 //! This attribute can be used to specify the ASN.1 type for a particular

--- a/der/tests/derive.rs
+++ b/der/tests/derive.rs
@@ -201,7 +201,7 @@ mod enumerated {
 /// Custom derive test cases for the `Sequence` macro.
 mod sequence {
     use der::{
-        asn1::{Any, ObjectIdentifier},
+        asn1::{Any, ObjectIdentifier, SetOf},
         Decodable, Encodable, Sequence, ValueOrd,
     };
     use hex_literal::hex;
@@ -219,6 +219,24 @@ mod sequence {
         pub algorithm: AlgorithmIdentifier<'a>,
         #[asn1(type = "BIT STRING")]
         pub subject_public_key: &'a [u8],
+    }
+
+    /// PKCS#8v2 `OneAsymmetricKey`
+    #[derive(Sequence)]
+    pub struct OneAsymmetricKey<'a> {
+        pub version: u8,
+        pub private_key_algorithm: AlgorithmIdentifier<'a>,
+        #[asn1(type = "OCTET STRING")]
+        pub private_key: &'a [u8],
+        #[asn1(context_specific = "0", extensible = "true", optional = "true")]
+        pub attributes: Option<SetOf<Any<'a>, 1>>,
+        #[asn1(
+            context_specific = "1",
+            extensible = "true",
+            optional = "true",
+            type = "BIT STRING"
+        )]
+        pub public_key: Option<&'a [u8]>,
     }
 
     /// X.509 extension


### PR DESCRIPTION
Adds support for deriving `CONTEXT-SPECIFIC` fields when using the `Sequence` proc macro.

It's a bit incomplete with corner cases involving combinations of attributes probably not handled correctly, but it's a start.