### PR TITLE
der_derive v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,7 +293,7 @@ dependencies = [
 
 [[package]]
 name = "der_derive"
-version = "0.5.0-pre.1"
+version = "0.5.0"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.56"
 [dependencies]
 const-oid = { version = "0.7", optional = true, path = "../const-oid" }
 crypto-bigint = { version = "0.3", optional = true, default-features = false, features = ["generic-array"] }
-der_derive = { version = "=0.5.0-pre.1", optional = true, path = "derive" }
+der_derive = { version = "0.5", optional = true, path = "derive" }
 pem-rfc7468 = { version = "0.3", optional = true, path = "../pem-rfc7468" }
 time = { version = "0.3", optional = true, default-features = false }
 

--- a/der/derive/CHANGELOG.md
+++ b/der/derive/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2021-11-15)
+### Added
+- `asn1(tag_mode = "...")` derive attribute ([#150])
+- `asn1(context_specific = "...")` derive attribute ([#150])
+- `Enumerated` custom derive macro ([#171])
+- `asn1(tag_mode = "...")` attribute ([#197])
+- Support for handling `DEFAULT` values of `SEQUENCE`s ([#202])
+- `ValueOrd` custom derive macro ([#206])
+- `CONTEXT-SPECIFIC` support for `Sequence` custom derive ([#220])
+
+### Changed
+- Rename `Message` trait to `Sequence` ([#99])
+- Rust 2021 edition upgrade; MSRV 1.56 ([#136])
+
+### Removed
+- Don't automatically derive `From` impls for `Choice` ([#168])
+
+[#99]: https://github.com/RustCrypto/formats/pull/99
+[#136]: https://github.com/RustCrypto/formats/pull/136
+[#150]: https://github.com/RustCrypto/formats/pull/150
+[#168]: https://github.com/RustCrypto/formats/pull/150
+[#171]: https://github.com/RustCrypto/formats/pull/171
+[#197]: https://github.com/RustCrypto/formats/pull/197
+[#202]: https://github.com/RustCrypto/formats/pull/202
+[#206]: https://github.com/RustCrypto/formats/pull/206
+[#220]: https://github.com/RustCrypto/formats/pull/220
+
 ## 0.4.1 (2021-09-14)
 ### Changed
 - Moved to `formats` repo ([#2])

--- a/der/derive/Cargo.toml
+++ b/der/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der_derive"
-version = "0.5.0-pre.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.5.0" # Also update html_root_url in lib.rs when bumping this
 description = "Custom derive support for the `der` crate's `Choice` and `Sequence` traits"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"

--- a/der/derive/src/lib.rs
+++ b/der/derive/src/lib.rs
@@ -35,7 +35,7 @@
 //! The following attributes can be added to an `enum` or `struct` when
 //! deriving either [`Choice`] or [`Sequence`] respectively:
 //!
-//! ### `#[asn1(tag_mode = "...")` attribute: `EXPLICIT` vs `IMPLICIT`
+//! ### `#[asn1(tag_mode = "...")]` attribute: `EXPLICIT` vs `IMPLICIT`
 //!
 //! This attribute can be used to declare the tagging mode used by a particular
 //! ASN.1 module.
@@ -57,18 +57,18 @@
 //!
 //! The value must be quoted and contain a number, e.g. `#[asn1(context_specific = "42"]`.
 //!
-//! ### `#[asn1(default = "...")` attribute: `DEFAULT` support
+//! ### `#[asn1(default = "...")]` attribute: `DEFAULT` support
 //!
 //! This behaves like `serde_derive`'s `default` attribute, allowing you to
 //! specify the path to a function which returns a default value.
 //!
-//! ### `#[asn1(extensible = "true")` attribute: support for `...` extensibility operator
+//! ### `#[asn1(extensible = "true")]` attribute: support for `...` extensibility operator
 //!
 //! This attribute can be applied to the fields of `struct` types, and will
 //! skip over unrecognized lower-numbered `CONTEXT-SPECIFIC` fields when
 //! looking for a particular field of a struct.
 //!
-//! ### `#[asn1(optional = "true")` attribute: support for `OPTIONAL` fields
+//! ### `#[asn1(optional = "true")]` attribute: support for `OPTIONAL` fields
 //!
 //! This attribute explicitly annotates a field as `OPTIONAL`.
 //!


### PR DESCRIPTION
### Added
- `asn1(tag_mode = "...")` derive attribute ([#150])
- `asn1(context_specific = "...")` derive attribute ([#150])
- `Enumerated` custom derive macro ([#171])
- `asn1(tag_mode = "...")` attribute ([#197])
- Support for handling `DEFAULT` values of `SEQUENCE`s ([#202])
- `ValueOrd` custom derive macro ([#206])
- `CONTEXT-SPECIFIC` support for `Sequence` custom derive ([#220])

### Changed
- Rename `Message` trait to `Sequence` ([#99])
- Rust 2021 edition upgrade; MSRV 1.56 ([#136])

### Removed
- Don't automatically derive `From` impls for `Choice` ([#168])

[#99]: https://github.com/RustCrypto/formats/pull/99
[#136]: https://github.com/RustCrypto/formats/pull/136
[#150]: https://github.com/RustCrypto/formats/pull/150
[#168]: https://github.com/RustCrypto/formats/pull/150
[#171]: https://github.com/RustCrypto/formats/pull/171
[#197]: https://github.com/RustCrypto/formats/pull/197
[#202]: https://github.com/RustCrypto/formats/pull/202
[#206]: https://github.com/RustCrypto/formats/pull/206
[#220]: https://github.com/RustCrypto/formats/pull/220