### PR TITLE
der v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.5.0-pre.1"
+version = "0.5.0"
 dependencies = [
  "const-oid",
  "crypto-bigint",

--- a/der/CHANGELOG.md
+++ b/der/CHANGELOG.md
@@ -4,6 +4,88 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2021-11-15)
+### Added
+- Support for `IMPLICIT` mode `CONTEXT-SPECIFIC` fields ([#61])
+- `DecodeValue`/`EncodeValue` traits ([#63])
+- Expose `DateTime` through public API ([#75])
+- `SEQUENCE OF` support for `[T; N]` ([#90])
+- `SequenceOf` type ([#95])
+- `SEQUENCE OF` support for `Vec` ([#96])
+- `Document` trait ([#117])
+- Basic integration with `time` crate ([#129])
+- `Tag::NumericString` ([#132])
+- Support for unused bits to `BitString` ([#141])
+- `Decoder::{peek_tag, peek_header}` ([#142])
+- Type hint in `encoder `sequence` method ([#147])
+- `Tag::Enumerated` ([#153])
+- `ErrorKind::TagNumberInvalid` ([#156])
+- `Tag::VisibleString` and `Tag::BmpString` ([#160])
+- Inherent constants for all valid `TagNumber`s ([#165])
+- `DerOrd` and `ValueOrd` traits ([#190])
+- `ContextSpecificRef` type ([#199])
+
+### Changed
+- Make `ContextSpecific` generic around an inner type ([#60])
+- Removed `SetOf` trait; rename `SetOfArray` => `SetOf` ([#97])
+- Rename `Message` trait to `Sequence` ([#99])
+- Make `GeneralizedTime`/`UtcTime` into `DateTime` newtypes ([#102])
+- Rust 2021 edition upgrade; MSRV 1.56 ([#136])
+- Replace `ErrorKind::Truncated` with `ErrorKind::Incomplete` ([#143])
+- Rename `ErrorKind::UnknownTagMode` => `ErrorKind::TagModeUnknown` ([#155])
+- Rename `ErrorKind::UnexpectedTag` => `ErrorKind::TagUnexpected` ([#155])
+- Rename `ErrorKind::UnknownTag` => `ErrorKind::TagUnknown` ([#155])
+- Consolidate `ErrorKind::{Incomplete, Underlength}` ([#157])
+- Rename `Tagged` => `FixedTag`; add new `Tagged` trait ([#189])
+- Use `DerOrd` for `SetOf*` types ([#200])
+- Switch `impl From<BitString> for &[u8]` to `TryFrom` ([#203])
+- Bump `crypto-bigint` dependency to v0.3 ([#215])
+- Bump `const-oid` dependency to v0.7 ([#216])
+- Bump `pem-rfc7468` dependency to v0.3 ([#217])
+- Bump `der_derive` dependency to v0.5 ([#221])
+
+### Removed
+- `Sequence` struct ([#98])
+- `Tagged` bound on `ContextSpecific::decode_implicit` ([#161])
+- `ErrorKind::DuplicateField` ([#162])
+
+[#60]: https://github.com/RustCrypto/formats/pull/60
+[#61]: https://github.com/RustCrypto/formats/pull/61
+[#63]: https://github.com/RustCrypto/formats/pull/63
+[#75]: https://github.com/RustCrypto/formats/pull/75
+[#90]: https://github.com/RustCrypto/formats/pull/90
+[#95]: https://github.com/RustCrypto/formats/pull/95
+[#96]: https://github.com/RustCrypto/formats/pull/96
+[#97]: https://github.com/RustCrypto/formats/pull/97
+[#98]: https://github.com/RustCrypto/formats/pull/98
+[#99]: https://github.com/RustCrypto/formats/pull/99
+[#102]: https://github.com/RustCrypto/formats/pull/102
+[#117]: https://github.com/RustCrypto/formats/pull/117
+[#129]: https://github.com/RustCrypto/formats/pull/129
+[#132]: https://github.com/RustCrypto/formats/pull/132
+[#136]: https://github.com/RustCrypto/formats/pull/136
+[#141]: https://github.com/RustCrypto/formats/pull/141
+[#142]: https://github.com/RustCrypto/formats/pull/142
+[#143]: https://github.com/RustCrypto/formats/pull/143
+[#147]: https://github.com/RustCrypto/formats/pull/147
+[#153]: https://github.com/RustCrypto/formats/pull/153
+[#155]: https://github.com/RustCrypto/formats/pull/155
+[#156]: https://github.com/RustCrypto/formats/pull/156
+[#157]: https://github.com/RustCrypto/formats/pull/157
+[#160]: https://github.com/RustCrypto/formats/pull/160
+[#161]: https://github.com/RustCrypto/formats/pull/161
+[#162]: https://github.com/RustCrypto/formats/pull/162
+[#165]: https://github.com/RustCrypto/formats/pull/165
+[#189]: https://github.com/RustCrypto/formats/pull/189
+[#190]: https://github.com/RustCrypto/formats/pull/190
+[#199]: https://github.com/RustCrypto/formats/pull/199
+[#200]: https://github.com/RustCrypto/formats/pull/200
+[#203]: https://github.com/RustCrypto/formats/pull/203
+[#215]: https://github.com/RustCrypto/formats/pull/215
+[#216]: https://github.com/RustCrypto/formats/pull/216
+[#217]: https://github.com/RustCrypto/formats/pull/217
+[#221]: https://github.com/RustCrypto/formats/pull/221
+
 ## 0.4.4 (2021-10-06)
 ### Removed
 - Accidentally checked-in `target/` directory ([#66])

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der"
-version = "0.5.0-pre.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.5.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust embedded-friendly implementation of the Distinguished Encoding Rules
 (DER) for Abstract Syntax Notation One (ASN.1) as described in ITU X.690 with

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -316,7 +316,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/der/0.5.0-pre.1"
+    html_root_url = "https://docs.rs/der/0.5.0"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(

--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-der = { version = "=0.5.0-pre.1", features = ["bigint", "oid"], path = "../der" }
+der = { version = "0.5", features = ["bigint", "oid"], path = "../der" }
 
 # optional dependencies
 zeroize = { version = "1", optional = true, default-features = false, features = ["alloc"] }

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-der = { version = "=0.5.0-pre.1", features = ["oid"], path = "../der" }
+der = { version = "0.5", features = ["oid"], path = "../der" }
 spki = { version = "=0.5.0-pre", path = "../spki" }
 
 # optional dependencies

--- a/pkcs7/Cargo.toml
+++ b/pkcs7/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-der = { version = "=0.5.0-pre.1", features = ["oid"], path = "../der" }
+der = { version = "0.5", features = ["oid"], path = "../der" }
 spki = { version = "=0.5.0-pre", path = "../spki" }
 
 [dev-dependencies]

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-der = { version = "=0.5.0-pre.1", features = ["oid"], path = "../der" }
+der = { version = "0.5", features = ["oid"], path = "../der" }
 spki = { version = "=0.5.0-pre", path = "../spki" }
 
 # optional dependencies

--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-der = { version = "=0.5.0-pre.1", features = ["oid"], path = "../der" }
+der = { version = "0.5", features = ["oid"], path = "../der" }
 generic-array = { version = "0.14", default-features = false }
 
 # optional dependencies

--- a/spki/Cargo.toml
+++ b/spki/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-der = { version = "=0.5.0-pre.1", features = ["oid"], path = "../der" }
+der = { version = "0.5", features = ["oid"], path = "../der" }
 
 # Optional dependencies
 sha2 = { version = "0.9.8", optional = true, default-features = false }

--- a/x509/Cargo.toml
+++ b/x509/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-der = { version = "=0.5.0-pre.1", features = ["derive", "alloc"], path = "../der" }
+der = { version = "0.5", features = ["derive", "alloc"], path = "../der" }
 spki = { version = "=0.5.0-pre", path = "../spki" }
 
 [dev-dependencies]


### PR DESCRIPTION
### Added
- Support for `IMPLICIT` mode `CONTEXT-SPECIFIC` fields ([#61])
- `DecodeValue`/`EncodeValue` traits ([#63])
- Expose `DateTime` through public API ([#75])
- `SEQUENCE OF` support for `[T; N]` ([#90])
- `SequenceOf` type ([#95])
- `SEQUENCE OF` support for `Vec` ([#96])
- `Document` trait ([#117])
- Basic integration with `time` crate ([#129])
- `Tag::NumericString` ([#132])
- Support for unused bits to `BitString` ([#141])
- `Decoder::{peek_tag, peek_header}` ([#142])
- Type hint in `encoder `sequence` method ([#147])
- `Tag::Enumerated` ([#153])
- `ErrorKind::TagNumberInvalid` ([#156])
- `Tag::VisibleString` and `Tag::BmpString` ([#160])
- Inherent constants for all valid `TagNumber`s ([#165])
- `DerOrd` and `ValueOrd` traits ([#190])
- `ContextSpecificRef` type ([#199])

### Changed
- Make `ContextSpecific` generic around an inner type ([#60])
- Removed `SetOf` trait; rename `SetOfArray` => `SetOf` ([#97])
- Rename `Message` trait to `Sequence` ([#99])
- Make `GeneralizedTime`/`UtcTime` into `DateTime` newtypes ([#102])
- Rust 2021 edition upgrade; MSRV 1.56 ([#136])
- Replace `ErrorKind::Truncated` with `ErrorKind::Incomplete` ([#143])
- Rename `ErrorKind::UnknownTagMode` => `ErrorKind::TagModeUnknown` ([#155])
- Rename `ErrorKind::UnexpectedTag` => `ErrorKind::TagUnexpected` ([#155])
- Rename `ErrorKind::UnknownTag` => `ErrorKind::TagUnknown` ([#155])
- Consolidate `ErrorKind::{Incomplete, Underlength}` ([#157])
- Rename `Tagged` => `FixedTag`; add new `Tagged` trait ([#189])
- Use `DerOrd` for `SetOf*` types ([#200])
- Switch `impl From<BitString> for &[u8]` to `TryFrom` ([#203])
- Bump `crypto-bigint` dependency to v0.3 ([#215])
- Bump `const-oid` dependency to v0.7 ([#216])
- Bump `pem-rfc7468` dependency to v0.3 ([#217])
- Bump `der_derive` dependency to v0.5 ([#221])

### Removed
- `Sequence` struct ([#98])
- `Tagged` bound on `ContextSpecific::decode_implicit` ([#161])
- `ErrorKind::DuplicateField` ([#162])

[#60]: https://github.com/RustCrypto/formats/pull/60
[#61]: https://github.com/RustCrypto/formats/pull/61
[#63]: https://github.com/RustCrypto/formats/pull/63
[#75]: https://github.com/RustCrypto/formats/pull/75
[#90]: https://github.com/RustCrypto/formats/pull/90
[#95]: https://github.com/RustCrypto/formats/pull/95
[#96]: https://github.com/RustCrypto/formats/pull/96
[#97]: https://github.com/RustCrypto/formats/pull/97
[#98]: https://github.com/RustCrypto/formats/pull/98
[#99]: https://github.com/RustCrypto/formats/pull/99
[#102]: https://github.com/RustCrypto/formats/pull/102
[#117]: https://github.com/RustCrypto/formats/pull/117
[#129]: https://github.com/RustCrypto/formats/pull/129
[#132]: https://github.com/RustCrypto/formats/pull/132
[#136]: https://github.com/RustCrypto/formats/pull/136
[#141]: https://github.com/RustCrypto/formats/pull/141
[#142]: https://github.com/RustCrypto/formats/pull/142
[#143]: https://github.com/RustCrypto/formats/pull/143
[#147]: https://github.com/RustCrypto/formats/pull/147
[#153]: https://github.com/RustCrypto/formats/pull/153
[#155]: https://github.com/RustCrypto/formats/pull/155
[#156]: https://github.com/RustCrypto/formats/pull/156
[#157]: https://github.com/RustCrypto/formats/pull/157
[#160]: https://github.com/RustCrypto/formats/pull/160
[#161]: https://github.com/RustCrypto/formats/pull/161
[#162]: https://github.com/RustCrypto/formats/pull/162
[#165]: https://github.com/RustCrypto/formats/pull/165
[#189]: https://github.com/RustCrypto/formats/pull/189
[#190]: https://github.com/RustCrypto/formats/pull/190
[#199]: https://github.com/RustCrypto/formats/pull/199
[#200]: https://github.com/RustCrypto/formats/pull/200
[#203]: https://github.com/RustCrypto/formats/pull/203
[#215]: https://github.com/RustCrypto/formats/pull/215
[#216]: https://github.com/RustCrypto/formats/pull/216
[#217]: https://github.com/RustCrypto/formats/pull/217
[#221]: https://github.com/RustCrypto/formats/pull/221