### PR TITLE
spki v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -910,7 +910,7 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.5.0-pre"
+version = "0.5.0"
 dependencies = [
  "base64ct",
  "der",

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.56"
 
 [dependencies]
 der = { version = "0.5", features = ["oid"], path = "../der" }
-spki = { version = "=0.5.0-pre", path = "../spki" }
+spki = { version = "0.5", path = "../spki" }
 
 # optional dependencies
 aes = { version = "0.7", optional = true }

--- a/pkcs7/Cargo.toml
+++ b/pkcs7/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.56"
 
 [dependencies]
 der = { version = "0.5", features = ["oid"], path = "../der" }
-spki = { version = "=0.5.0-pre", path = "../spki" }
+spki = { version = "0.5", path = "../spki" }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.56"
 
 [dependencies]
 der = { version = "0.5", features = ["oid"], path = "../der" }
-spki = { version = "=0.5.0-pre", path = "../spki" }
+spki = { version = "0.5", path = "../spki" }
 
 # optional dependencies
 rand_core = { version = "0.6", optional = true, default-features = false }

--- a/spki/CHANGELOG.md
+++ b/spki/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2021-11-15)
+### Added
+- SPKI fingerprint support ([#36])
+- `PublicKeyDocument` type originally from `pkcs8` crate ([#118])
+- `Error` type ([#143])
+
+### Changed
+- Rename `From/ToPublicKey` => `DecodePublicKey`/`EncodePublicKey` ([#119])
+- Use `der::Document` to impl `PublicKeyDocument` ([#134])
+- Rust 2021 edition upgrade; MSRV 1.56 ([#136])
+- Bump `der` dependency to v0.5 ([#222])
+
+[#36]: https://github.com/RustCrypto/formats/pull/36
+[#118]: https://github.com/RustCrypto/formats/pull/118
+[#119]: https://github.com/RustCrypto/formats/pull/119
+[#134]: https://github.com/RustCrypto/formats/pull/134
+[#136]: https://github.com/RustCrypto/formats/pull/136
+[#143]: https://github.com/RustCrypto/formats/pull/143
+[#222]: https://github.com/RustCrypto/formats/pull/222
+
 ## 0.4.1 (2021-09-14)
 ### Changed
 - Moved to `formats` repo ([#2])

--- a/spki/Cargo.toml
+++ b/spki/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spki"
-version = "0.5.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.5.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 X.509 Subject Public Key Info (RFC5280) describing public keys as well as their
 associated AlgorithmIdentifiers (i.e. OIDs)

--- a/spki/src/lib.rs
+++ b/spki/src/lib.rs
@@ -23,7 +23,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/spki/0.5.0-pre"
+    html_root_url = "https://docs.rs/spki/0.5.0"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]

--- a/x509/Cargo.toml
+++ b/x509/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.56"
 
 [dependencies]
 der = { version = "0.5", features = ["derive", "alloc"], path = "../der" }
-spki = { version = "=0.5.0-pre", path = "../spki" }
+spki = { version = "0.5", path = "../spki" }
 
 [dev-dependencies]
 hex-literal = "0.3"


### PR DESCRIPTION
### Added
- SPKI fingerprint support ([#36])
- `PublicKeyDocument` type originally from `pkcs8` crate ([#118])
- `Error` type ([#143])

### Changed
- Rename `From/ToPublicKey` => `DecodePublicKey`/`EncodePublicKey` ([#119])
- Use `der::Document` to impl `PublicKeyDocument` ([#134])
- Rust 2021 edition upgrade; MSRV 1.56 ([#136])
- Bump `der` dependency to v0.5 ([#222])

[#36]: https://github.com/RustCrypto/formats/pull/36
[#118]: https://github.com/RustCrypto/formats/pull/118
[#119]: https://github.com/RustCrypto/formats/pull/119
[#134]: https://github.com/RustCrypto/formats/pull/134
[#136]: https://github.com/RustCrypto/formats/pull/136
[#143]: https://github.com/RustCrypto/formats/pull/143
[#222]: https://github.com/RustCrypto/formats/pull/222