### PR TITLE
pkcs5 v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs5"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "aes",
  "block-modes",

--- a/pkcs5/CHANGELOG.md
+++ b/pkcs5/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2021-11-15)
+### Changed
+- Introduce `Error` enum with new error cases ([#26])
+- Introduce specialized `Result` type for crate ([#26])
+- Rust 2021 edition upgrade; MSRV 1.56 ([#136])
+- Bump `der` dependency to v0.5 ([#222])
+- Bump `spki` dependency to v0.5 ([#223])
+
+### Removed
+- Legacy DES encryption support ([#25])
+
+[#25]: https://github.com/RustCrypto/formats/pull/25
+[#26]: https://github.com/RustCrypto/formats/pull/26
+[#136]: https://github.com/RustCrypto/formats/pull/136
+[#222]: https://github.com/RustCrypto/formats/pull/222
+[#223]: https://github.com/RustCrypto/formats/pull/223
+
 ## 0.3.2 (2021-09-14)
 ### Added
 - `3des` and `des-insecure` features

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs5"
-version = "0.4.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.4.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #5:
 Password-Based Cryptography Specification Version 2.1 (RFC 8018)

--- a/pkcs5/src/lib.rs
+++ b/pkcs5/src/lib.rs
@@ -14,7 +14,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/pkcs5/0.4.0-pre"
+    html_root_url = "https://docs.rs/pkcs5/0.4.0"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -21,7 +21,7 @@ spki = { version = "0.5", path = "../spki" }
 
 # optional dependencies
 rand_core = { version = "0.6", optional = true, default-features = false }
-pkcs5 = { version = "=0.4.0-pre", optional = true, path = "../pkcs5" }
+pkcs5 = { version = "0.4", optional = true, path = "../pkcs5" }
 subtle = { version = "2", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false, features = ["alloc"] }
 


### PR DESCRIPTION
### Changed
- Introduce `Error` enum with new error cases ([#26])
- Introduce specialized `Result` type for crate ([#26])
- Rust 2021 edition upgrade; MSRV 1.56 ([#136])
- Bump `der` dependency to v0.5 ([#222])
- Bump `spki` dependency to v0.5 ([#223])

### Removed
- Legacy DES encryption support ([#25])

[#25]: https://github.com/RustCrypto/formats/pull/25
[#26]: https://github.com/RustCrypto/formats/pull/26
[#136]: https://github.com/RustCrypto/formats/pull/136
[#222]: https://github.com/RustCrypto/formats/pull/222
[#223]: https://github.com/RustCrypto/formats/pull/223