### PR TITLE
pkcs7 v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs7"
-version = "0.0.0"
+version = "0.3.0"
 dependencies = [
  "der",
  "hex-literal",

--- a/pkcs7/CHANGELOG.md
+++ b/pkcs7/CHANGELOG.md
@@ -3,3 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.3.0 (2021-11-15)
+- Initial release: older versions are a pre-RustCrypto crate.
+
+## 0.2.0 (2016-08-16)
+
+## 0.1.0 (2016-08-15)

--- a/pkcs7/Cargo.toml
+++ b/pkcs7/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs7"
-version = "0.0.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.3.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #7:
 PKCS #7: Cryptographic Message Syntax Version 1.5 (RFC 5652)

--- a/pkcs7/src/lib.rs
+++ b/pkcs7/src/lib.rs
@@ -4,7 +4,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/pkcs7/0.0.0"
+    html_root_url = "https://docs.rs/pkcs7/0.3.0"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
Initial release of the RustCrypto `pkcs7` crate