### PR TITLE
sec1: add `pkcs8` feature

### DIFF
--- a/.github/workflows/sec1.yml
+++ b/.github/workflows/sec1.yml
@@ -42,9 +42,10 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pem
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pkcs8
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features subtle
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features zeroize
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,pem,subtle,zeroize
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,pem,pkcs8,subtle,zeroize
 
   test:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -832,6 +832,7 @@ dependencies = [
  "der",
  "generic-array",
  "hex-literal",
+ "pkcs8",
  "subtle",
  "zeroize",
 ]

--- a/pkcs1/src/lib.rs
+++ b/pkcs1/src/lib.rs
@@ -22,7 +22,7 @@ mod version;
 
 #[cfg(feature = "pkcs8")]
 #[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
-mod pkcs8;
+pub mod pkcs8;
 
 pub use der::{self, asn1::UIntBytes};
 

--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -20,14 +20,15 @@ der = { version = "0.5", features = ["oid"], path = "../der" }
 generic-array = { version = "0.14", default-features = false }
 
 # optional dependencies
+pkcs8 = { version = "=0.8.0-pre", optional = true, default-features = false, path = "../pkcs8" }
 subtle = { version = "2", optional = true, default-features = false }
-zeroize = { version = "1", optional = true, default-features = false, features = ["alloc"] }
+zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.3"
 
 [features]
-alloc = ["der/alloc", "zeroize"]
+alloc = ["der/alloc", "pkcs8/alloc", "zeroize/alloc"]
 pem = ["alloc", "der/pem"]
 std = ["der/std"]
 

--- a/sec1/src/error.rs
+++ b/sec1/src/error.rs
@@ -20,6 +20,10 @@ pub enum Error {
     /// a number expected to be a prime was not a prime.
     Crypto,
 
+    /// PKCS#8 errors.
+    #[cfg(feature = "pkcs8")]
+    Pkcs8(pkcs8::Error),
+
     /// Errors relating to the `Elliptic-Curve-Point-to-Octet-String` or
     /// `Octet-String-to-Elliptic-Curve-Point` encodings.
     PointEncoding,
@@ -33,17 +37,33 @@ impl fmt::Display for Error {
         match self {
             Error::Asn1(err) => write!(f, "SEC1 ASN.1 error: {}", err),
             Error::Crypto => f.write_str("SEC1 cryptographic error"),
+            #[cfg(feature = "pkcs8")]
+            Error::Pkcs8(err) => write!(f, "{}", err),
             Error::PointEncoding => f.write_str("elliptic curve point encoding error"),
             Error::Version => f.write_str("SEC1 version error"),
         }
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
-
 impl From<der::Error> for Error {
     fn from(err: der::Error) -> Error {
         Error::Asn1(err)
     }
 }
+
+#[cfg(feature = "pkcs8")]
+impl From<pkcs8::Error> for Error {
+    fn from(err: pkcs8::Error) -> Error {
+        Error::Pkcs8(err)
+    }
+}
+
+#[cfg(feature = "pkcs8")]
+impl From<pkcs8::spki::Error> for Error {
+    fn from(err: pkcs8::spki::Error) -> Error {
+        Error::Pkcs8(pkcs8::Error::PublicKey(err))
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}

--- a/sec1/src/lib.rs
+++ b/sec1/src/lib.rs
@@ -21,6 +21,10 @@ mod parameters;
 mod private_key;
 mod traits;
 
+#[cfg(feature = "pkcs8")]
+#[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
+pub mod pkcs8;
+
 pub use der;
 
 pub use self::{

--- a/sec1/src/pkcs8.rs
+++ b/sec1/src/pkcs8.rs
@@ -1,0 +1,49 @@
+//! Blanket impl of SEC1 support for types with PKCS#8 support.
+
+pub use pkcs8::*;
+
+use crate::{DecodeEcPrivateKey, EcPrivateKey, Result};
+use der::Decodable;
+
+#[cfg(feature = "alloc")]
+use {
+    crate::{EcPrivateKeyDocument, EncodeEcPrivateKey},
+    der::Document,
+};
+
+/// Algorithm [`ObjectIdentifier`] for elliptic curve public key cryptography
+/// (`id-ecPublicKey`).
+///
+/// <http://oid-info.com/get/1.2.840.10045.2.1>
+pub const ALGORITHM_OID: ObjectIdentifier = ObjectIdentifier::new("1.2.840.10045.2.1");
+
+impl<T: DecodePrivateKey> DecodeEcPrivateKey for T {
+    fn from_sec1_der(private_key: &[u8]) -> Result<Self> {
+        let params_oid = EcPrivateKey::from_der(private_key)?
+            .parameters
+            .and_then(|params| params.named_curve());
+
+        let algorithm = AlgorithmIdentifier {
+            oid: ALGORITHM_OID,
+            parameters: params_oid.as_ref().map(Into::into),
+        };
+
+        Ok(Self::from_pkcs8_private_key_info(PrivateKeyInfo {
+            algorithm,
+            private_key,
+            public_key: None,
+        })?)
+    }
+}
+
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+impl<T: EncodePrivateKey> EncodeEcPrivateKey for T {
+    fn to_sec1_der(&self) -> Result<EcPrivateKeyDocument> {
+        let doc = self.to_pkcs8_der()?;
+        let pkcs8_key = PrivateKeyInfo::from_der(doc.as_der())?;
+        let mut pkcs1_key = EcPrivateKey::from_der(pkcs8_key.private_key)?;
+        pkcs1_key.parameters = Some(pkcs8_key.algorithm.parameters_oid()?.into());
+        pkcs1_key.try_into()
+    }
+}

--- a/sec1/src/traits.rs
+++ b/sec1/src/traits.rs
@@ -1,7 +1,6 @@
 //! Traits for parsing objects from SEC1 encoded documents
 
-use crate::{EcPrivateKey, Error, Result};
-use der::Decodable;
+use crate::Result;
 
 #[cfg(feature = "alloc")]
 use crate::EcPrivateKeyDocument;
@@ -16,12 +15,10 @@ use std::path::Path;
 use {der::Document, zeroize::Zeroizing};
 
 /// Parse an [`EcPrivateKey`] from a SEC1-encoded document.
-pub trait DecodeEcPrivateKey: for<'a> TryFrom<EcPrivateKey<'a>, Error = Error> + Sized {
+pub trait DecodeEcPrivateKey: Sized {
     /// Deserialize SEC1 private key from ASN.1 DER-encoded data
     /// (binary format).
-    fn from_sec1_der(bytes: &[u8]) -> Result<Self> {
-        Self::try_from(EcPrivateKey::from_der(bytes)?)
-    }
+    fn from_sec1_der(bytes: &[u8]) -> Result<Self>;
 
     /// Deserialize SEC1-encoded private key from PEM.
     ///
@@ -33,7 +30,7 @@ pub trait DecodeEcPrivateKey: for<'a> TryFrom<EcPrivateKey<'a>, Error = Error> +
     #[cfg(feature = "pem")]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     fn from_sec1_pem(s: &str) -> Result<Self> {
-        EcPrivateKeyDocument::from_sec1_pem(s).and_then(|doc| Self::try_from(doc.decode()))
+        EcPrivateKeyDocument::from_sec1_pem(s).and_then(|doc| Self::from_sec1_der(doc.as_der()))
     }
 
     /// Load SEC1 private key from an ASN.1 DER-encoded file on the local
@@ -41,7 +38,8 @@ pub trait DecodeEcPrivateKey: for<'a> TryFrom<EcPrivateKey<'a>, Error = Error> +
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn read_sec1_der_file(path: impl AsRef<Path>) -> Result<Self> {
-        EcPrivateKeyDocument::read_sec1_der_file(path).and_then(|doc| Self::try_from(doc.decode()))
+        EcPrivateKeyDocument::read_sec1_der_file(path)
+            .and_then(|doc| Self::from_sec1_der(doc.as_der()))
     }
 
     /// Load SEC1 private key from a PEM-encoded file on the local filesystem.
@@ -49,7 +47,8 @@ pub trait DecodeEcPrivateKey: for<'a> TryFrom<EcPrivateKey<'a>, Error = Error> +
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn read_sec1_pem_file(path: impl AsRef<Path>) -> Result<Self> {
-        EcPrivateKeyDocument::read_sec1_pem_file(path).and_then(|doc| Self::try_from(doc.decode()))
+        EcPrivateKeyDocument::read_sec1_pem_file(path)
+            .and_then(|doc| Self::from_sec1_der(doc.as_der()))
     }
 }
 


### PR DESCRIPTION
Adds an optional `pkcs8` crate integration which provides a blanket impl of the `sec1` decoding/encoding traits for any type that impls the corresponding `pkcs8` traits.