### PR TITLE
pkcs1+sec1: activate `pkcs8/pem` when `pem` feature is enabled

### DIFF
--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -26,7 +26,7 @@ hex-literal = "0.3"
 
 [features]
 alloc = ["der/alloc", "pkcs8/alloc", "zeroize/alloc"]
-pem = ["alloc", "der/pem"]
+pem = ["alloc", "der/pem", "pkcs8/pem"]
 std = ["der/std"]
 
 [package.metadata.docs.rs]

--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -29,7 +29,7 @@ hex-literal = "0.3"
 
 [features]
 alloc = ["der/alloc", "pkcs8/alloc", "zeroize/alloc"]
-pem = ["alloc", "der/pem"]
+pem = ["alloc", "der/pem", "pkcs8/pem"]
 std = ["der/std"]
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Ideally weak feature activation could be used here, but unfortunately it is not yet stable.

This otherwise makes it possible to use the PEM functionality of `pkcs8` directly via blanket impls in `pkcs1` and `sec1`.