### PR TITLE
pkcs8 v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.8.0-pre"
+version = "0.8.0"
 dependencies = [
  "der",
  "hex-literal",

--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.56"
 der = { version = "0.5", features = ["bigint", "oid"], path = "../der" }
 
 # optional dependencies
-pkcs8 = { version = "=0.8.0-pre", optional = true, default-features = false, path = "../pkcs8" }
+pkcs8 = { version = "0.8", optional = true, default-features = false, path = "../pkcs8" }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/pkcs8/CHANGELOG.md
+++ b/pkcs8/CHANGELOG.md
@@ -4,6 +4,45 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.0 (2021-11-16)
+### Added
+- Re-export `spki` crate ([#210])
+
+### Changed
+- Replace usages of `expect` with fallible methods ([#108])
+- Impl `From*Key`/`To*Key` traits on `Document` types ([#110])
+- Rename `From/ToPrivateKey` => `DecodePrivateKey`/`EncodePrivateKey` ([#121])
+- Rust 2021 edition upgrade; MSRV 1.56 ([#136])
+- Use `der::Document` to impl `*PrivateKeyDocument` ([#140])
+- Rename `Error::Crypto` => `Error::EncryptedPrivateKey` ([#213], [#214])
+- Bump `der` dependency to v0.5 ([#222])
+- Bump `spki` dependency to v0.5 ([#223])
+- Bump `pkcs5` dependency to v0.4 ([#224])
+- Replace `from_pkcs8_private_key_info` with `TryFrom` ([#230])
+
+### Removed
+- `*_with_le` PEM encoding methods ([#109])
+- PKCS#1 support; moved to `pkcs1` crate ([#124])
+- I/O related errors from key format crates ([#158])
+- `der::pem` export ([#211])
+
+[#108]: https://github.com/RustCrypto/formats/pull/108
+[#109]: https://github.com/RustCrypto/formats/pull/109
+[#110]: https://github.com/RustCrypto/formats/pull/110
+[#121]: https://github.com/RustCrypto/formats/pull/121
+[#124]: https://github.com/RustCrypto/formats/pull/124
+[#136]: https://github.com/RustCrypto/formats/pull/136
+[#140]: https://github.com/RustCrypto/formats/pull/140
+[#158]: https://github.com/RustCrypto/formats/pull/158
+[#210]: https://github.com/RustCrypto/formats/pull/210
+[#211]: https://github.com/RustCrypto/formats/pull/211
+[#213]: https://github.com/RustCrypto/formats/pull/213
+[#214]: https://github.com/RustCrypto/formats/pull/214
+[#222]: https://github.com/RustCrypto/formats/pull/222
+[#223]: https://github.com/RustCrypto/formats/pull/223
+[#224]: https://github.com/RustCrypto/formats/pull/224
+[#230]: https://github.com/RustCrypto/formats/pull/230
+
 ## 0.7.6 (2021-09-14)
 ### Added
 - `3des` and `des-insecure` features

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs8"
-version = "0.8.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.8.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #8:
 Private-Key Information Syntax Specification (RFC 5208), with additional

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -69,7 +69,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/pkcs8/0.8.0-pre"
+    html_root_url = "https://docs.rs/pkcs8/0.8.0"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]

--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -20,7 +20,7 @@ der = { version = "0.5", features = ["oid"], path = "../der" }
 generic-array = { version = "0.14", default-features = false }
 
 # optional dependencies
-pkcs8 = { version = "=0.8.0-pre", optional = true, default-features = false, path = "../pkcs8" }
+pkcs8 = { version = "0.8", optional = true, default-features = false, path = "../pkcs8" }
 subtle = { version = "2", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 


### PR DESCRIPTION
### Added
- Re-export `spki` crate ([#210])

### Changed
- Replace usages of `expect` with fallible methods ([#108])
- Impl `From*Key`/`To*Key` traits on `Document` types ([#110])
- Rename `From/ToPrivateKey` => `DecodePrivateKey`/`EncodePrivateKey` ([#121])
- Rust 2021 edition upgrade; MSRV 1.56 ([#136])
- Use `der::Document` to impl `*PrivateKeyDocument` ([#140])
- Rename `Error::Crypto` => `Error::EncryptedPrivateKey` ([#213], [#214])
- Bump `der` dependency to v0.5 ([#222])
- Bump `spki` dependency to v0.5 ([#223])
- Bump `pkcs5` dependency to v0.4 ([#224])
- Replace `from_pkcs8_private_key_info` with `TryFrom` ([#230])

### Removed
- `*_with_le` PEM encoding methods ([#109])
- PKCS#1 support; moved to `pkcs1` crate ([#124])
- I/O related errors from key format crates ([#158])
- `der::pem` export ([#211])

[#108]: https://github.com/RustCrypto/formats/pull/108
[#109]: https://github.com/RustCrypto/formats/pull/109
[#110]: https://github.com/RustCrypto/formats/pull/110
[#121]: https://github.com/RustCrypto/formats/pull/121
[#124]: https://github.com/RustCrypto/formats/pull/124
[#136]: https://github.com/RustCrypto/formats/pull/136
[#140]: https://github.com/RustCrypto/formats/pull/140
[#158]: https://github.com/RustCrypto/formats/pull/158
[#210]: https://github.com/RustCrypto/formats/pull/210
[#211]: https://github.com/RustCrypto/formats/pull/211
[#213]: https://github.com/RustCrypto/formats/pull/213
[#214]: https://github.com/RustCrypto/formats/pull/214
[#222]: https://github.com/RustCrypto/formats/pull/222
[#223]: https://github.com/RustCrypto/formats/pull/223
[#224]: https://github.com/RustCrypto/formats/pull/224
[#230]: https://github.com/RustCrypto/formats/pull/230