### PR TITLE
sec1 v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.2.0-pre"
+version = "0.2.0"
 dependencies = [
  "der",
  "generic-array",

--- a/pkcs1/CHANGELOG.md
+++ b/pkcs1/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use `der::Document` to impl `RsaPrivateKeyDocument` ([#131])
 - Rust 2021 edition upgrade; MSRV 1.56 ([#136])
 - Make `RsaPrivateKey::version` implicit ([#188])
-- Bump `der` dependency to v0.5 ([#222])
+- Bump `der` crate dependency to v0.5 ([#222])
 - Activate `pkcs8/pem` when `pem` feature is enabled ([#232])
 
 ### Removed

--- a/sec1/CHANGELOG.md
+++ b/sec1/CHANGELOG.md
@@ -4,5 +4,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2021-11-17)
+### Added
+- `pkcs8` feature ([#229])
+
+### Changed
+- Rename `From/ToEcPrivateKey` => `DecodeEcPrivateKey`/`EncodeEcPrivateKey` ([#122])
+- Use `der::Document` to impl `EcPrivateKeyDocument` ([#133])
+- Rust 2021 edition upgrade; MSRV 1.56 ([#136])
+- Bump `der` crate dependency to v0.5 ([#222])
+
+### Removed
+- I/O related errors ([#158])
+
+[#122]: https://github.com/RustCrypto/formats/pull/122
+[#133]: https://github.com/RustCrypto/formats/pull/133
+[#136]: https://github.com/RustCrypto/formats/pull/136
+[#158]: https://github.com/RustCrypto/formats/pull/158
+[#222]: https://github.com/RustCrypto/formats/pull/222
+[#229]: https://github.com/RustCrypto/formats/pull/229
+
 ## 0.1.0 (2021-09-22)
 - Initial release

--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sec1"
-version = "0.2.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of SEC1: Elliptic Curve Cryptography encoding formats
 including ASN.1 DER-serialized private keys as well as the

--- a/sec1/src/lib.rs
+++ b/sec1/src/lib.rs
@@ -4,7 +4,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/sec1/0.2.0-pre"
+    html_root_url = "https://docs.rs/sec1/0.2.0"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Added
- `pkcs8` feature ([#229])

### Changed
- Rename `From/ToEcPrivateKey` => `DecodeEcPrivateKey`/`EncodeEcPrivateKey` ([#122])
- Use `der::Document` to impl `EcPrivateKeyDocument` ([#133])
- Rust 2021 edition upgrade; MSRV 1.56 ([#136])
- Bump `der` crate dependency to v0.5 ([#222])

### Removed
- I/O related errors ([#158])

[#122]: https://github.com/RustCrypto/formats/pull/122
[#133]: https://github.com/RustCrypto/formats/pull/133
[#136]: https://github.com/RustCrypto/formats/pull/136
[#158]: https://github.com/RustCrypto/formats/pull/158
[#222]: https://github.com/RustCrypto/formats/pull/222
[#229]: https://github.com/RustCrypto/formats/pull/229