### PR TITLE
pem-rfc7468+spki: relax `base64ct` requirements to `^1`

### DIFF
--- a/pem-rfc7468/Cargo.toml
+++ b/pem-rfc7468/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-base64ct = { version = "1.2", path = "../base64ct" }
+base64ct = { version = "1", path = "../base64ct" }
 
 [features]
 alloc = []

--- a/spki/Cargo.toml
+++ b/spki/Cargo.toml
@@ -19,7 +19,7 @@ der = { version = "0.5", features = ["oid"], path = "../der" }
 
 # Optional dependencies
 sha2 = { version = "0.9.8", optional = true, default-features = false }
-base64ct = { version = "1.2", path = "../base64ct", optional = true, default-features = false }
+base64ct = { version = "1", path = "../base64ct", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.3"


### PR DESCRIPTION
Neither of these crates are depending on functionality added after the original v1.0 release.

However, they were pinned to `1.2` instead of `1` following the latest round of prereleases, effectively by mistake when the version in their respective Cargo.toml files was changed from a prerelease to the final release.

This makes these crates (and anything depending on them) mutually incompatible with at least the `password-hash` crate, which has `base64ct` pinned to prevent MSRV breakages:

https://github.com/RustCrypto/traits/runs/4239715372?check_suite_focus=true

```
error: failed to select a version for `base64ct`.
    ... required by package `spki v0.5.1`
    ... which satisfies dependency `spki = "^0.5"` of package `pkcs8 v0.8.0`
    ... which satisfies dependency `pkcs8 = "^0.8"` of package `sec1 v0.2.0`
    ... which satisfies dependency `sec1 = "^0.2"` of package `elliptic-curve v0.11.0-pre (/home/runner/work/traits/traits/elliptic-curve)`
    ... which satisfies path dependency `elliptic-curve` of package `crypto v0.4.0-pre (/home/runner/work/traits/traits/crypto)`
versions that meet the requirements `^1.2` are: 1.2.0

all possible versions conflict with previously selected packages.

  previously selected package `base64ct v1.0.1`
    ... which satisfies dependency `base64ct = ">=1, <1.1.0"` of package `password-hash v0.3.2 (/home/runner/work/traits/traits/password-hash)`
    ... which satisfies path dependency `password-hash` of package `crypto v0.4.0-pre (/home/runner/work/traits/traits/crypto)`

failed to select a version for `base64ct` which could resolve this conflict
```

Relaxing the version requirements fixes this incompatibility.