### PR TITLE
pem-rfc7468 v0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "base64ct",
 ]

--- a/pem-rfc7468/CHANGELOG.md
+++ b/pem-rfc7468/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.1 (2021-11-17)
+### Changed
+- Relax `base64ct` version requirement to `^1` ([#239])
+
+[#239]: https://github.com/RustCrypto/formats/pull/239
+
 ## 0.3.0 (2021-11-14)
 ### Added
 - `Decoder` struct ([#177])

--- a/pem-rfc7468/Cargo.toml
+++ b/pem-rfc7468/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pem-rfc7468"
-version = "0.3.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.3.1" # Also update html_root_url in lib.rs when bumping this
 description = """
 PEM Encoding (RFC 7468) for PKIX, PKCS, and CMS Structures, implementing a
 strict subset of the original Privacy-Enhanced Mail encoding intended

--- a/pem-rfc7468/src/lib.rs
+++ b/pem-rfc7468/src/lib.rs
@@ -45,7 +45,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/pem-rfc7468/0.3.0"
+    html_root_url = "https://docs.rs/pem-rfc7468/0.3.1"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Changed
- Relax `base64ct` version requirement to `^1` ([#239])

[#239]: https://github.com/RustCrypto/formats/pull/239