### PR TITLE
sec1: rustdoc fixups

### DIFF
--- a/sec1/src/lib.rs
+++ b/sec1/src/lib.rs
@@ -44,11 +44,13 @@ pub use der::pem::{self, LineEnding};
 #[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
 pub use pkcs8;
 
+#[cfg(feature = "pkcs8")]
+use pkcs8::ObjectIdentifier;
+
 /// Algorithm [`ObjectIdentifier`] for elliptic curve public key cryptography
 /// (`id-ecPublicKey`).
 ///
 /// <http://oid-info.com/get/1.2.840.10045.2.1>
 #[cfg(feature = "pkcs8")]
 #[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
-pub const ALGORITHM_OID: pkcs8::ObjectIdentifier =
-    pkcs8::ObjectIdentifier::new("1.2.840.10045.2.1");
+pub const ALGORITHM_OID: ObjectIdentifier = ObjectIdentifier::new("1.2.840.10045.2.1");

--- a/sec1/src/traits.rs
+++ b/sec1/src/traits.rs
@@ -115,7 +115,7 @@ impl<T: pkcs8::DecodePrivateKey> DecodeEcPrivateKey for T {
 }
 
 #[cfg(all(feature = "alloc", feature = "pkcs8"))]
-#[cfg_attr(docsrs, doc(all(feature = "alloc", feature = "pkcs8")))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "alloc", feature = "pkcs8"))))]
 impl<T: pkcs8::EncodePrivateKey> EncodeEcPrivateKey for T {
     fn to_sec1_der(&self) -> Result<EcPrivateKeyDocument> {
         let doc = self.to_pkcs8_der()?;


### PR DESCRIPTION
Fix broken links and malformed `doc(cfg(...))` attributes