### PR TITLE
sec1: `serde` feature

### DIFF
--- a/.github/workflows/sec1.yml
+++ b/.github/workflows/sec1.yml
@@ -43,9 +43,10 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pem
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pkcs8
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features serde
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features subtle
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features zeroize
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,pem,pkcs8,subtle,zeroize
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,pem,pkcs8,serde,subtle,zeroize
 
   test:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,6 +833,7 @@ dependencies = [
  "generic-array",
  "hex-literal",
  "pkcs8",
+ "serde",
  "subtle",
  "zeroize",
 ]

--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -21,6 +21,7 @@ generic-array = { version = "0.14", default-features = false }
 
 # optional dependencies
 pkcs8 = { version = "0.8", optional = true, default-features = false, path = "../pkcs8" }
+serde = { version = "1", optional = true, default-features = false }
 subtle = { version = "2", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 

--- a/sec1/src/lib.rs
+++ b/sec1/src/lib.rs
@@ -1,6 +1,16 @@
+#![doc = include_str!("../README.md")]
+
+//! ## `serde` support
+//!
+//! When the `serde` feature of this crate is enabled, the [`EncodedPoint`]
+//! type receives impls of [`serde::Serialize`] and [`serde::Deserialize`].
+//!
+//! Additionally, when both the `alloc` and `serde` features are enabled, the
+//! serializers/deserializers will autodetect if a "human friendly" textual
+//! encoding is being used, and if so encode the points as hexadecimal.
+
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",


### PR DESCRIPTION
Adds an optional `serde` feature with support for decoding/encoding `EncodedPoint`s using the `Serialize`/`Deserialize` traits.

This additionally adds support for hex encoding/decoding points which is always available.