### PR TITLE
sec1 v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "der",
  "generic-array",

--- a/sec1/CHANGELOG.md
+++ b/sec1/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.0 (2021-11-17)
+## 0.2.1 (2021-11-18)
+### Added
+- `serde` feature ([#248])
+- Hexadecimal serialization/deserialization support for `EncodedPoint` ([#248])
+
+[#248]: https://github.com/RustCrypto/formats/pull/248
+
+## 0.2.0 (2021-11-17) [YANKED]
 ### Added
 - `pkcs8` feature ([#229])
 

--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sec1"
-version = "0.2.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.1" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of SEC1: Elliptic Curve Cryptography encoding formats
 including ASN.1 DER-serialized private keys as well as the

--- a/sec1/src/lib.rs
+++ b/sec1/src/lib.rs
@@ -14,7 +14,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/sec1/0.2.0"
+    html_root_url = "https://docs.rs/sec1/0.2.1"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Added
- `serde` feature ([#248])
- Hexadecimal serialization/deserialization support for `EncodedPoint` ([#248])

[#248]: https://github.com/RustCrypto/formats/pull/248