### PR TITLE
Add `tls_codec(with = "module")` attribute to customize how struct fields are handled by derive macro

### DIFF
--- a/tls_codec/derive/src/lib.rs
+++ b/tls_codec/derive/src/lib.rs
@@ -1,4 +1,4 @@
-//! Derive macros for traits in `tls_codec`
+//! # Derive macros for traits in `tls_codec`
 //!
 //! The following attribute is available:
 //!
@@ -50,8 +50,12 @@ use syn::{
     Member, Meta, NestedMeta, Type,
 };
 
+/// Attribute name to identify attributes to be processed by derive-macros in this crate.
 const ATTR_IDENT: &str = "tls_codec";
 
+/// Prefix to add to `tls_codec` functions
+///
+/// This is either `<Type as Trait>` or a custom module containing the functions.
 #[derive(Clone)]
 enum Prefix {
     Type(Type),
@@ -59,6 +63,7 @@ enum Prefix {
 }
 
 impl Prefix {
+    /// Returns the path prefix to use for functions from the given trait.
     fn for_trait(&self, trait_name: &str) -> TokenStream2 {
         let trait_name = Ident::new(trait_name, Span::call_site());
         match self {
@@ -103,6 +108,7 @@ enum TlsStruct {
     Enum(Enum),
 }
 
+/// Attributes supported by derive-macros in this crate
 #[derive(Clone)]
 enum TlsAttr {
     With(ExprPath),
@@ -151,6 +157,8 @@ impl TlsAttr {
     }
 }
 
+/// Gets the [`Prefix`] for a field, i.e. the type itself or a module containing the `tls_codec`
+/// functions.
 fn function_prefix(field: &Field) -> Result<Prefix> {
     let prefix = field
         .attrs

--- a/tls_codec/derive/src/lib.rs
+++ b/tls_codec/derive/src/lib.rs
@@ -1,3 +1,42 @@
+//! Derive macros for traits in `tls_codec`
+//!
+//! The following attribute is available:
+//!
+//! ```text
+//! #[tls_codec(with = "module")]
+//! ```
+//! This attribute may be applied to a struct field. It indicates that deriving any of the
+//! `tls_codec` traits for the containing struct uses the following functions defined in the
+//! module `module`:
+//! - `tls_deserialize` when deriving `Deserialize`
+//! - `tls_serialize` when deriving `Serialize`
+//! - `tls_serialized_len` when deriving `Size`
+//!
+//! Their expected signatures match the corresponding methods in the traits.
+//!
+//! ```
+//! use tls_codec_derive::{TlsSerialize, TlsSize};
+//!
+//! #[derive(TlsSerialize, TlsSize)]
+//! struct Bytes {
+//!     #[tls_codec(with = "bytes")]
+//!     values: Vec<u8>,
+//! }
+//!
+//! mod bytes {
+//!     use std::io::Write;
+//!     use tls_codec::{Serialize, Size, TlsByteSliceU32};
+//!
+//!     pub fn tls_serialized_len(v: &[u8]) -> usize {
+//!         TlsByteSliceU32(v).tls_serialized_len()
+//!     }
+//!
+//!     pub fn tls_serialize<W: Write>(v: &[u8], writer: &mut W) -> Result<usize, tls_codec::Error> {
+//!         TlsByteSliceU32(v).tls_serialize(writer)
+//!     }
+//! }
+//! ```
+
 extern crate proc_macro;
 extern crate proc_macro2;
 

--- a/tls_codec/derive/src/lib.rs
+++ b/tls_codec/derive/src/lib.rs
@@ -335,7 +335,7 @@ fn impl_serialize(parsed_ast: TlsStruct) -> TokenStream2 {
                             written += #prefixes::tls_serialize(&self.#members, writer)?;
                         )*
                         if cfg!(debug_assertions) {
-                            let expected_written = self.tls_serialized_len();
+                            let expected_written = tls_codec::Size::tls_serialized_len(&self);
                             debug_assert_eq!(written, expected_written, "Expected to serialize {} bytes but only {} were generated.", expected_written, written);
                             if written != expected_written {
                                 Err(tls_codec::Error::EncodingError(format!("Expected to serialize {} bytes but only {} were generated.", expected_written, written)))

--- a/tls_codec/derive/src/lib.rs
+++ b/tls_codec/derive/src/lib.rs
@@ -3,21 +3,39 @@ extern crate proc_macro2;
 
 use proc_macro::TokenStream;
 use proc_macro2::{Span, TokenStream as TokenStream2};
-use quote::{quote, ToTokens};
+use quote::quote;
 use syn::{
     self, parenthesized,
     parse::{ParseStream, Parser, Result},
-    parse_macro_input, Data, DeriveInput, Fields, FieldsNamed, FieldsUnnamed, Generics, Ident,
-    Index,
+    parse_macro_input, Attribute, Data, DeriveInput, ExprPath, Field, Generics, Ident, Index, Lit,
+    Member, Meta, NestedMeta, Type,
 };
+
+const ATTR_IDENT: &str = "tls_codec";
+
+#[derive(Clone)]
+enum Prefix {
+    Type(Type),
+    Custom(ExprPath),
+}
+
+impl Prefix {
+    fn for_trait(&self, trait_name: &str) -> TokenStream2 {
+        let trait_name = Ident::new(trait_name, Span::call_site());
+        match self {
+            Prefix::Type(ty) => quote! { <#ty as tls_codec::#trait_name> },
+            Prefix::Custom(p) => quote! { #p },
+        }
+    }
+}
 
 #[derive(Clone)]
 struct Struct {
     call_site: Span,
     ident: Ident,
     generics: Generics,
-    field_idents: Vec<Option<Ident>>,
-    field_paths: Vec<TokenStream2>,
+    members: Vec<Member>,
+    member_prefixes: Vec<Prefix>,
 }
 
 #[derive(Clone)]
@@ -43,100 +61,116 @@ struct Enum {
 #[derive(Clone)]
 enum TlsStruct {
     Struct(Struct),
-    TupleStruct(TupleStruct),
     Enum(Enum),
+}
+
+#[derive(Clone)]
+enum TlsAttr {
+    With(ExprPath),
+}
+
+impl TlsAttr {
+    /// Parses attributes of the form:
+    /// ```text
+    /// #[tls_codec(with = "module")]
+    /// ```
+    fn parse(attr: &Attribute) -> Result<Vec<TlsAttr>> {
+        if attr.path.get_ident().map_or(true, |id| id != ATTR_IDENT) {
+            return Ok(Vec::new());
+        }
+        let meta = match attr.parse_meta()? {
+            Meta::List(list) => Ok(list),
+            _ => Err(syn::Error::new_spanned(attr, "Invalid attribute syntax")),
+        }?;
+        meta.nested
+            .iter()
+            .map(|item| match item {
+                NestedMeta::Meta(Meta::NameValue(kv)) => kv
+                    .path
+                    .get_ident()
+                    .map(|ident| {
+                        if ident == "with" {
+                            match &kv.lit {
+                                Lit::Str(s) => s.parse::<ExprPath>().map(TlsAttr::With),
+                                _ => {
+                                    Err(syn::Error::new_spanned(&kv.lit, "Expected string literal"))
+                                }
+                            }
+                        } else {
+                            Err(syn::Error::new_spanned(
+                                ident,
+                                format!("Unexpected identifier {}", ident),
+                            ))
+                        }
+                    })
+                    .unwrap_or_else(|| {
+                        Err(syn::Error::new_spanned(&kv.path, "Expected identifier"))
+                    }),
+                _ => Err(syn::Error::new_spanned(item, "Invalid attribute syntax")),
+            })
+            .collect()
+    }
+}
+
+fn function_prefix(field: &Field) -> Result<Prefix> {
+    let prefix = field
+        .attrs
+        .iter()
+        .flat_map(|attr| {
+            let (known_attrs, error) = match TlsAttr::parse(attr) {
+                Ok(attrs) => (attrs, None),
+                Err(e) => (Vec::new(), Some(Err(e))),
+            };
+            known_attrs
+                .into_iter()
+                .map(|TlsAttr::With(p)| Ok(p))
+                .chain(error)
+        })
+        .try_fold(None, |path, p| {
+            let p = p?;
+            match path {
+                None => Ok(Some(p)),
+                Some(_) => Err(syn::Error::new_spanned(
+                    p,
+                    "Attribute `with` specified more than once",
+                )),
+            }
+        })?
+        .map(Prefix::Custom)
+        .unwrap_or_else(|| Prefix::Type(field.ty.clone()));
+    Ok(prefix)
 }
 
 fn parse_ast(ast: DeriveInput) -> Result<TlsStruct> {
     let call_site = Span::call_site();
-    let ident = &ast.ident;
-    let generics = &ast.generics;
+    let ident = ast.ident.clone();
+    let generics = ast.generics.clone();
     match ast.data {
-        Data::Struct(st) => match st.fields {
-            Fields::Named(FieldsNamed { named, .. }) => {
-                let field_idents: Vec<Option<Ident>> =
-                    named.iter().map(|f| f.ident.clone()).collect();
-                let paths = named.iter().map(|f| match f.ty.clone() {
-                    syn::Type::Path(mut p) => {
-                        let path = &mut p.path;
-                        // Convert generic arguments in the path to const arguments.
-                        path.segments.iter_mut().for_each(|mut p| {
-                            if let syn::PathArguments::AngleBracketed(ab) = &mut p.arguments {
-                                let mut ab = ab.clone();
-                                ab.colon2_token = Some(syn::token::Colon2::default());
-                                p.arguments = syn::PathArguments::AngleBracketed(ab);
-                            }
-                        });
-                        syn::Type::Path(p).to_token_stream()
-                    }
-                    syn::Type::Array(a) => {
-                        quote! { <#a> }
-                    }
-                    #[allow(unused_variables)]
-                    syn::Type::Reference(syn::TypeReference {
-                        and_token,
-                        lifetime,
-                        mutability,
-                        elem,
-                    }) => {
-                        // println!(
-                        //     "(Struct::Named) contains a type reference for field \"{}\"\nThis struct can not be deserialized",
-                        //     f.ident.clone().unwrap()
-                        // );
-                        quote! {}
-                    }
-                    _ => panic!(
-                        "(Struct::Named) Invalid field type for field \"{}\"",
-                        f.ident.clone().unwrap()
-                    ),
-                });
-                let field_paths: Vec<TokenStream2> = paths.collect();
-                Ok(TlsStruct::Struct(Struct {
-                    call_site,
-                    ident: ident.clone(),
-                    generics: generics.clone(),
-                    field_idents,
-                    field_paths,
-                }))
-            }
-            #[allow(unused_variables)]
-            Fields::Unnamed(FieldsUnnamed {
-                paren_token,
-                unnamed,
-            }) => {
-                let iterator = unnamed.iter().enumerate();
-                let field_indices: Vec<Index> =
-                    iterator.map(|(i, _)| syn::Index::from(i)).collect();
-                let paths = unnamed.iter().map(|f| match f.ty.clone() {
-                    syn::Type::Path(mut p) => {
-                        let path = &mut p.path;
-                        // Convert generic arguments in the path to const arguments.
-                        path.segments.iter_mut().for_each(|mut p| {
-                            if let syn::PathArguments::AngleBracketed(ab) = &mut p.arguments {
-                                let mut ab = ab.clone();
-                                ab.colon2_token = Some(syn::token::Colon2::default());
-                                p.arguments = syn::PathArguments::AngleBracketed(ab);
-                            }
-                        });
-                        syn::Type::Path(p).to_token_stream()
-                    }
-                    syn::Type::Array(a) => {
-                        quote! { <#a> }
-                    }
-                    _ => panic!("(Struct::Unnamed) Invalid field type for {:?}", f.ident),
-                });
-
-                let field_paths: Vec<TokenStream2> = paths.collect();
-                Ok(TlsStruct::TupleStruct(TupleStruct {
-                    call_site,
-                    ident: ident.clone(),
-                    generics: generics.clone(),
-                    field_indices,
-                    field_paths,
-                }))
-            }
-            _ => unimplemented!(),
-        },
+        Data::Struct(st) => {
+            let members = st
+                .fields
+                .iter()
+                .enumerate()
+                .map(|(i, field)| {
+                    field
+                        .ident
+                        .clone()
+                        .map_or_else(|| Member::Unnamed(syn::Index::from(i)), Member::Named)
+                })
+                .collect();
+            let member_prefixes = st
+                .fields
+                .iter()
+                .map(function_prefix)
+                .collect::<std::result::Result<Vec<_>, _>>()?;
+            Ok(TlsStruct::Struct(Struct {
+                call_site,
+                ident,
+                generics,
+                members,
+                member_prefixes,
+            }))
+        }
         // Enums.
         // Note that they require a repr attribute.
         Data::Enum(syn::DataEnum { variants, .. }) => {
@@ -187,8 +221,8 @@ fn parse_ast(ast: DeriveInput) -> Result<TlsStruct> {
 
             Ok(TlsStruct::Enum(Enum {
                 call_site,
-                ident: ident.clone(),
-                generics: generics.clone(),
+                ident,
+                generics,
                 repr,
                 parsed_variants,
                 discriminants,
@@ -199,21 +233,21 @@ fn parse_ast(ast: DeriveInput) -> Result<TlsStruct> {
     }
 }
 
-#[proc_macro_derive(TlsSize)]
+#[proc_macro_derive(TlsSize, attributes(tls_codec))]
 pub fn size_macro_derive(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
     let parsed_ast = parse_ast(ast).unwrap();
     impl_tls_size(parsed_ast).into()
 }
 
-#[proc_macro_derive(TlsSerialize)]
+#[proc_macro_derive(TlsSerialize, attributes(tls_codec))]
 pub fn serialize_macro_derive(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
     let parsed_ast = parse_ast(ast).unwrap();
     impl_serialize(parsed_ast).into()
 }
 
-#[proc_macro_derive(TlsDeserialize)]
+#[proc_macro_derive(TlsDeserialize, attributes(tls_codec))]
 pub fn deserialize_macro_derive(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
     let parsed_ast = parse_ast(ast).unwrap();
@@ -227,14 +261,18 @@ fn impl_tls_size(parsed_ast: TlsStruct) -> TokenStream2 {
             call_site,
             ident,
             generics,
-            field_idents,
-            field_paths,
+            members,
+            member_prefixes,
         }) => {
+            let prefixes = member_prefixes
+                .iter()
+                .map(|p| p.for_trait("Size"))
+                .collect::<Vec<_>>();
             quote! {
                 impl #generics tls_codec::Size for #ident #generics {
                     #[inline]
                     fn tls_serialized_len(&self) -> usize {
-                        #(self.#field_idents.tls_serialized_len() + )*
+                        #(#prefixes::tls_serialized_len(&self.#members) + )*
                         0
                     }
                 }
@@ -242,33 +280,7 @@ fn impl_tls_size(parsed_ast: TlsStruct) -> TokenStream2 {
                 impl #generics tls_codec::Size for &#ident #generics {
                     #[inline]
                     fn tls_serialized_len(&self) -> usize {
-                        #(self.#field_idents.tls_serialized_len() + )*
-                        0
-                    }
-                }
-            }
-        }
-        TlsStruct::TupleStruct(TupleStruct {
-            call_site,
-            ident,
-            generics,
-            field_indices,
-            field_paths,
-        }) => {
-            quote! {
-                impl #generics tls_codec::Size for #ident #generics {
-                    #[inline]
-                    fn tls_serialized_len(&self) -> usize {
-                        #(self.#field_indices.tls_serialized_len() + )*
-                        0
-                    }
-                }
-
-                impl #generics tls_codec::Size for &#ident #generics {
-                    #[inline]
-                    fn tls_serialized_len(&self) -> usize {
-                        #(self.#field_indices.tls_serialized_len() + )*
-                        0
+                        tls_codec::Size::tls_serialized_len(*self)
                     }
                 }
             }
@@ -308,15 +320,19 @@ fn impl_serialize(parsed_ast: TlsStruct) -> TokenStream2 {
             call_site,
             ident,
             generics,
-            field_idents,
-            field_paths,
+            members,
+            member_prefixes,
         }) => {
+            let prefixes = member_prefixes
+                .iter()
+                .map(|p| p.for_trait("Serialize"))
+                .collect::<Vec<_>>();
             quote! {
                 impl #generics tls_codec::Serialize for #ident #generics {
                     fn tls_serialize<W: std::io::Write>(&self, writer: &mut W) -> core::result::Result<usize, tls_codec::Error> {
                         let mut written = 0usize;
                         #(
-                            written += self.#field_idents.tls_serialize(writer)?;
+                            written += #prefixes::tls_serialize(&self.#members, writer)?;
                         )*
                         if cfg!(debug_assertions) {
                             let expected_written = self.tls_serialized_len();
@@ -334,64 +350,7 @@ fn impl_serialize(parsed_ast: TlsStruct) -> TokenStream2 {
 
                 impl #generics tls_codec::Serialize for &#ident #generics {
                     fn tls_serialize<W: std::io::Write>(&self, writer: &mut W) -> core::result::Result<usize, tls_codec::Error> {
-                        let mut written = 0usize;
-                        #(written += self.#field_idents.tls_serialize(writer)?;)*
-                        if cfg!(debug_assertions) {
-                            let expected_written = self.tls_serialized_len();
-                            debug_assert_eq!(written, expected_written, "Expected to serialize {} bytes but only {} were generated.", expected_written, written);
-                            if written != expected_written {
-                                Err(tls_codec::Error::EncodingError(format!("Expected to serialize {} bytes but only {} were generated.", expected_written, written)))
-                            } else {
-                                Ok(written)
-                            }
-                        } else {
-                            Ok(written)
-                        }
-                    }
-                }
-            }
-        }
-        TlsStruct::TupleStruct(TupleStruct {
-            call_site,
-            ident,
-            generics,
-            field_indices,
-            field_paths,
-        }) => {
-            quote! {
-                impl #generics tls_codec::Serialize for #ident #generics {
-                    fn tls_serialize<W: std::io::Write>(&self, writer: &mut W) -> core::result::Result<usize, tls_codec::Error> {
-                        let mut written = 0usize;
-                        #(written += self.#field_indices.tls_serialize(writer)?;)*
-                        if cfg!(debug_assertions) {
-                            let expected_written = self.tls_serialized_len();
-                            debug_assert_eq!(written, expected_written, "Expected to serialize {} bytes but only {} were generated.", expected_written, written);
-                            if written != expected_written {
-                                Err(tls_codec::Error::EncodingError(format!("Expected to serialize {} bytes but only {} were generated.", expected_written, written)))
-                            } else {
-                                Ok(written)
-                            }
-                        } else {
-                            Ok(written)
-                        }
-                    }
-                }
-
-                impl #generics tls_codec::Serialize for &#ident #generics {
-                    fn tls_serialize<W: std::io::Write>(&self, writer: &mut W) -> core::result::Result<usize, tls_codec::Error> {
-                        let mut written = 0usize;
-                        #(written += self.#field_indices.tls_serialize(writer)?;)*
-                        if cfg!(debug_assertions) {
-                            let expected_written = self.tls_serialized_len();
-                            debug_assert_eq!(written, expected_written, "Expected to serialize {} bytes but only {} were generated.", expected_written, written);
-                            if written != expected_written {
-                                Err(tls_codec::Error::EncodingError(format!("Expected to serialize {} bytes but only {} were generated.", expected_written, written)))
-                            } else {
-                                Ok(written)
-                            }
-                        } else {
-                            Ok(written)
-                        }
+                        tls_codec::Serialize::tls_serialize(*self, writer)
                     }
                 }
             }
@@ -435,32 +394,19 @@ fn impl_deserialize(parsed_ast: TlsStruct) -> TokenStream2 {
             call_site,
             ident,
             generics,
-            field_idents,
-            field_paths,
+            members,
+            member_prefixes,
         }) => {
+            let prefixes = member_prefixes
+                .iter()
+                .map(|p| p.for_trait("Deserialize"))
+                .collect::<Vec<_>>();
             quote! {
                 impl tls_codec::Deserialize for #ident {
                     fn tls_deserialize<R: std::io::Read>(bytes: &mut R) -> core::result::Result<Self, tls_codec::Error> {
                         Ok(Self {
-                            #(#field_idents: #field_paths::tls_deserialize(bytes)?,)*
+                            #(#members: #prefixes::tls_deserialize(bytes)?,)*
                         })
-                    }
-                }
-            }
-        }
-        TlsStruct::TupleStruct(TupleStruct {
-            call_site,
-            ident,
-            generics,
-            field_indices,
-            field_paths,
-        }) => {
-            quote! {
-                impl tls_codec::Deserialize for #ident {
-                    fn tls_deserialize<R: std::io::Read>(bytes: &mut R) -> core::result::Result<Self, tls_codec::Error> {
-                        Ok(Self(
-                            #(#field_paths::tls_deserialize(bytes)?,)*
-                        ))
                     }
                 }
             }

--- a/tls_codec/derive/tests/decode.rs
+++ b/tls_codec/derive/tests/decode.rs
@@ -1,4 +1,4 @@
-use tls_codec::{Deserialize, Serialize, Size, TlsSliceU16, TlsVecU16, TlsVecU32, TlsVecU8};
+use tls_codec::{Deserialize, Serialize, TlsSliceU16, TlsVecU16, TlsVecU32, TlsVecU8};
 use tls_codec_derive::{TlsDeserialize, TlsSerialize, TlsSize};
 
 #[derive(TlsDeserialize, Debug, PartialEq, Clone, Copy, TlsSize, TlsSerialize)]

--- a/tls_codec/derive/tests/decode.rs
+++ b/tls_codec/derive/tests/decode.rs
@@ -220,3 +220,38 @@ fn kat_mls_key_package() {
         serialized_key_package.as_slice()
     );
 }
+
+#[derive(Debug, PartialEq, TlsDeserialize, TlsSerialize, TlsSize)]
+struct Custom {
+    #[tls_codec(with = "custom")]
+    values: Vec<u8>,
+    a: u8,
+}
+
+mod custom {
+    use std::io::{Read, Write};
+    use tls_codec::{Deserialize, Serialize, Size, TlsByteSliceU32, TlsByteVecU32};
+
+    pub fn tls_serialized_len(v: &[u8]) -> usize {
+        TlsByteSliceU32(v).tls_serialized_len()
+    }
+
+    pub fn tls_serialize<W: Write>(v: &[u8], writer: &mut W) -> Result<usize, tls_codec::Error> {
+        TlsByteSliceU32(v).tls_serialize(writer)
+    }
+
+    pub fn tls_deserialize<R: Read>(bytes: &mut R) -> Result<Vec<u8>, tls_codec::Error> {
+        Ok(TlsByteVecU32::tls_deserialize(bytes)?.into_vec())
+    }
+}
+
+#[test]
+fn custom() {
+    let x = Custom {
+        values: vec![0, 1, 2],
+        a: 3,
+    };
+    let serialized = x.tls_serialize_detached().unwrap();
+    let deserialized = Custom::tls_deserialize(&mut &*serialized).unwrap();
+    assert_eq!(x, deserialized);
+}

--- a/tls_codec/derive/tests/encode.rs
+++ b/tls_codec/derive/tests/encode.rs
@@ -1,4 +1,4 @@
-use tls_codec::{SecretTlsVecU16, Serialize, Size, TlsSliceU16, TlsVecU16, TlsVecU32};
+use tls_codec::{SecretTlsVecU16, Serialize, TlsSliceU16, TlsVecU16, TlsVecU32};
 use tls_codec_derive::{TlsSerialize, TlsSize};
 
 #[derive(TlsSerialize, TlsSize, Debug)]


### PR DESCRIPTION
This attribute allows to designate a module where to find functions to serialize, deserialize or get the serialized size of a field. This is similar to [serde's attribute](https://serde.rs/field-attrs.html#with).

The main motivation is to avoid having to resort to a manual implementation of the `tls_codec` traits for a struct as soon as the type of a field does not implement them, which is more error-prone and less maintainable.

This PR also makes structs and tuple structs share more code, and fixes a derive macro that relied on a trait being in scope.

Thank you!

cc @tomleavy