### PR TITLE
tls_codec: Implement traits for `&T`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "tls_codec"
-version = "0.2.0-pre.1"
+version = "0.2.0-pre.2"
 dependencies = [
  "criterion",
  "serde",
@@ -1012,7 +1012,7 @@ dependencies = [
 
 [[package]]
 name = "tls_codec_derive"
-version = "0.2.0-pre.1"
+version = "0.2.0-pre.2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/tls_codec/Cargo.toml
+++ b/tls_codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tls_codec"
-version = "0.2.0-pre.1"
+version = "0.2.0-pre.2"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/tls_codec/"
@@ -15,7 +15,7 @@ zeroize = { version = "1", features = ["zeroize_derive"] }
 
 # optional dependencies
 serde = { version = "1.0", features = ["derive"], optional = true }
-tls_codec_derive = { version = "=0.2.0-pre.1", path = "derive", optional = true }
+tls_codec_derive = { version = "=0.2.0-pre.2", path = "derive", optional = true }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/tls_codec/derive/Cargo.toml
+++ b/tls_codec/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tls_codec_derive"
-version = "0.2.0-pre.1"
+version = "0.2.0-pre.2"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/tls_codec_derive/"

--- a/tls_codec/derive/tests/encode.rs
+++ b/tls_codec/derive/tests/encode.rs
@@ -142,3 +142,23 @@ fn custom() {
     let serialized = x.tls_serialize_detached().unwrap();
     assert_eq!(vec![0, 0, 0, 3, 0, 1, 2, 3], serialized);
 }
+
+#[derive(TlsSerialize, TlsSize)]
+struct OptionalMemberRef<'a> {
+    optional_member: Option<&'a u32>,
+    ref_optional_member: &'a Option<&'a u32>,
+    ref_vector: &'a TlsVecU16<u16>,
+}
+
+#[test]
+fn optional_member() {
+    let m = 6;
+    let v = vec![1, 2, 3];
+    let x = OptionalMemberRef {
+        optional_member: Some(&m),
+        ref_optional_member: &None,
+        ref_vector: &v.into(),
+    };
+    let serialized = x.tls_serialize_detached().unwrap();
+    assert_eq!(vec![1, 0, 0, 0, 6, 0, 0, 6, 0, 1, 0, 2, 0, 3], serialized);
+}

--- a/tls_codec/src/arrays.rs
+++ b/tls_codec/src/arrays.rs
@@ -4,6 +4,7 @@ use super::{Deserialize, Error, Serialize, Size};
 use std::io::{Read, Write};
 
 impl<const LEN: usize> Serialize for [u8; LEN] {
+    #[inline]
     fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
         let written = writer.write(self)?;
         if written == LEN {
@@ -18,6 +19,7 @@ impl<const LEN: usize> Serialize for [u8; LEN] {
 }
 
 impl<const LEN: usize> Deserialize for [u8; LEN] {
+    #[inline]
     fn tls_deserialize<R: Read>(bytes: &mut R) -> Result<Self, Error> {
         let mut out = [0u8; LEN];
         bytes.read_exact(&mut out)?;

--- a/tls_codec/src/primitives.rs
+++ b/tls_codec/src/primitives.rs
@@ -14,6 +14,13 @@ impl<T: Size> Size for Option<T> {
     }
 }
 
+impl<T: Size> Size for &Option<T> {
+    #[inline]
+    fn tls_serialized_len(&self) -> usize {
+        (*self).tls_serialized_len()
+    }
+}
+
 impl<T: Serialize> Serialize for Option<T> {
     fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
         match self {
@@ -27,6 +34,12 @@ impl<T: Serialize> Serialize for Option<T> {
                 Ok(1)
             }
         }
+    }
+}
+
+impl<T: Serialize> Serialize for &Option<T> {
+    fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
+        (*self).tls_serialize(writer)
     }
 }
 

--- a/tls_codec/tests/decode.rs
+++ b/tls_codec/tests/decode.rs
@@ -1,6 +1,6 @@
 use tls_codec::{
     Deserialize, Serialize, Size, TlsByteSliceU16, TlsByteVecU16, TlsByteVecU8, TlsSliceU16,
-    TlsVecU16, TlsVecU8,
+    TlsVecU16, TlsVecU32, TlsVecU8,
 };
 
 #[test]
@@ -75,4 +75,31 @@ fn deserialize_tls_byte_vec() {
     );
     assert_eq!(long_vector.len(), deserialized_long_vec.len());
     assert_eq!(long_vector.as_slice(), deserialized_long_vec.as_slice());
+}
+
+#[test]
+fn deserialize_tuples() {
+    let t = (
+        TlsVecU16::from(vec![1u8, 2, 3]),
+        TlsVecU32::from(vec![1u16, 2, 3]),
+    );
+    let t1 = TlsVecU16::from(vec![1u8, 2, 3]);
+    let t2 = TlsVecU32::from(vec![1u16, 2, 3]);
+    let t_borrowed = (&t1, &t2);
+
+    let mut bytes = Vec::new();
+    let serialized_len = t
+        .tls_serialize(&mut bytes)
+        .expect("Error serializing tuple");
+    assert_eq!(serialized_len, 2 + 3 + 4 + 6);
+
+    let mut bytes2 = Vec::new();
+    let serialized_len = t_borrowed
+        .tls_serialize(&mut bytes2)
+        .expect("Error serializing borrow tuple");
+    assert_eq!(serialized_len, 2 + 3 + 4 + 6);
+
+    let deserialized = <(TlsVecU16<u8>, TlsVecU32<u16>)>::tls_deserialize(&mut bytes.as_slice())
+        .expect("Error deserializing tuple.");
+    assert_eq!(deserialized, t);
 }


### PR DESCRIPTION
- Implement traits for `&T`.
- set version to 0.2.0 pre.2

The changes in #250 require implementing traits for the borrowed type explicitly.