### PR TITLE
pkcs1 v0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs1"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "der",
  "hex-literal",

--- a/pkcs1/CHANGELOG.md
+++ b/pkcs1/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.1 (2021-11-29)
+### Changed
+- Use `finish_non_exhaustive` in Debug impls ([#245])
+
+[#245]: https://github.com/RustCrypto/formats/pull/245
+
 ## 0.3.0 (2021-11-17)
 ### Added
 - Support for multi-prime RSA keys ([#115])

--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs1"
-version = "0.3.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.3.1" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #1:
 RSA Cryptography Specifications Version 2.2 (RFC 8017)

--- a/pkcs1/src/lib.rs
+++ b/pkcs1/src/lib.rs
@@ -4,7 +4,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/pkcs1/0.3.0"
+    html_root_url = "https://docs.rs/pkcs1/0.3.1"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Changed
- Use `finish_non_exhaustive` in `Debug` impls ([#245])

[#245]: https://github.com/RustCrypto/formats/pull/245