### PR TITLE
const-oid v0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "hex-literal",
 ]

--- a/const-oid/CHANGELOG.md
+++ b/const-oid/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.8.0 (2021-11-14)
+## 0.7.1 (2021-11-30)
+### Changed
+- Increase `MAX_SIZE` to 39 ([#258])
+
+[#258]: https://github.com/RustCrypto/formats/pull/258
+
+## 0.7.0 (2021-11-14) [YANKED]
 ### Changed
 - Rust 2021 edition upgrade; MSRV 1.56 ([#136])
 - Rename `MAX_LENGTH` to `MAX_SIZE`; bump to `31` ([#174])

--- a/const-oid/Cargo.toml
+++ b/const-oid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "const-oid"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """

--- a/const-oid/src/lib.rs
+++ b/const-oid/src/lib.rs
@@ -4,7 +4,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/const-oid/0.7.0"
+    html_root_url = "https://docs.rs/const-oid/0.7.1"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms)]


### PR DESCRIPTION
### Changed
- Increase `MAX_SIZE` to 39 ([#258])

[#258]: https://github.com/RustCrypto/formats/pull/258