### PR TITLE
Implement `tls_codec` traits for the unit type

### DIFF
--- a/tls_codec/src/primitives.rs
+++ b/tls_codec/src/primitives.rs
@@ -190,3 +190,23 @@ where
         self.0.tls_serialized_len() + self.1.tls_serialized_len() + self.2.tls_serialized_len()
     }
 }
+
+impl Size for () {
+    #[inline(always)]
+    fn tls_serialized_len(&self) -> usize {
+        0
+    }
+}
+
+impl Deserialize for () {
+    #[inline(always)]
+    fn tls_deserialize<R: Read>(_: &mut R) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+impl Serialize for () {
+    fn tls_serialize<W: Write>(&self, _: &mut W) -> Result<usize, Error> {
+        Ok(0)
+    }
+}


### PR DESCRIPTION
This allows to derive the `tls_codec` traits for types that contain fields of type unit (e.g. a private unit field to prevent direct construction in other modules).
Thank you.