### PR TITLE
base64ct: add stateful `Decoder` type

### DIFF
--- a/base64ct/src/decoder.rs
+++ b/base64ct/src/decoder.rs
@@ -1,0 +1,250 @@
+//! Stateful Base64 decoder.
+
+use crate::{
+    encoding::decode_padding,
+    variant::Variant,
+    Encoding,
+    Error::{self, InvalidLength},
+};
+use core::marker::PhantomData;
+
+#[cfg(docsrs)]
+use crate::{Base64, Base64Unpadded};
+
+/// Stateful Base64 decoder with support for buffered, incremental decoding.
+///
+/// The `E` type parameter can be any type which impls [`Encoding`] such as
+/// [`Base64`] or [`Base64Unpadded`].
+///
+/// Internally it uses a sealed `Variant` trait which is an implementation
+/// detail of this crate, and leverages a [blanket impl] of [`Encoding`].
+///
+/// [blanket impl]: ./trait.Encoding.html#impl-Encoding
+pub struct Decoder<'i, E: Variant> {
+    /// Remaining data in the input buffer.
+    remaining: &'i [u8],
+
+    /// Block buffer used for non-block-aligned data.
+    buffer: Option<BlockBuffer>,
+
+    /// Phantom parameter for the Base64 encoding in use.
+    encoding: PhantomData<E>,
+}
+
+impl<'i, E: Variant> Decoder<'i, E> {
+    /// Create a new decoder for a byte slice containing contiguous
+    /// (non-newline-delimited) Base64-encoded data.
+    pub fn new(input: &'i [u8]) -> Result<Self, Error> {
+        let remaining = if E::PADDED {
+            let (unpadded_len, err) = decode_padding(input)?;
+            if err != 0 {
+                return Err(Error::InvalidEncoding);
+            }
+
+            &input[..unpadded_len]
+        } else {
+            input
+        };
+
+        Ok(Self {
+            remaining,
+            buffer: None,
+            encoding: PhantomData,
+        })
+    }
+
+    /// Write as many bytes of decoded data as possible into the provided
+    /// buffer.
+    ///
+    /// If there is not sufficient input data to completely fill the buffer,
+    /// it returns a partial result.
+    ///
+    /// # Returns
+    /// - `Ok(Some(bytes))` if there was data available
+    /// - `Ok(None)` if there is no remaining data
+    /// - `Err(err)` if there was a Base64 decoding error
+    pub fn decode_partial<'o>(&mut self, out: &'o mut [u8]) -> Result<Option<&'o [u8]>, Error> {
+        if self.is_finished() {
+            return Ok(None);
+        }
+
+        let mut out_offset = 0;
+
+        let take_buffer = self
+            .buffer
+            .as_mut()
+            .map(|buf| {
+                let bytes = buf.take(out.len());
+                out[..bytes.len()].copy_from_slice(bytes);
+                out_offset += bytes.len();
+                buf.is_empty()
+            })
+            .unwrap_or_default();
+
+        if take_buffer {
+            self.buffer = None;
+        }
+
+        let out_len = out.len().checked_sub(out_offset).ok_or(InvalidLength)?;
+        let out_aligned = out_len.checked_sub(out_len % 3).ok_or(InvalidLength)?;
+
+        let mut in_len = out_aligned
+            .checked_mul(4)
+            .and_then(|n| n.checked_div(3))
+            .ok_or(InvalidLength)?;
+
+        if in_len > self.remaining.len() {
+            in_len = self
+                .remaining
+                .len()
+                .checked_sub(self.remaining.len() % 4)
+                .ok_or(InvalidLength)?;
+        }
+
+        if in_len < 4 {
+            in_len = 0;
+        }
+
+        let (aligned, rest) = self.remaining.split_at(in_len);
+
+        if in_len != 0 {
+            let decoded_len =
+                E::Unpadded::decode(aligned, &mut out[out_offset..][..out_aligned])?.len();
+
+            out_offset = out_offset.checked_add(decoded_len).ok_or(InvalidLength)?;
+            self.remaining = rest;
+        }
+
+        if out_offset < out.len() && !self.remaining.is_empty() {
+            if self.remaining.len() < 4 {
+                return Err(InvalidLength);
+            }
+
+            let (block, rest) = self.remaining.split_at(4);
+            let mut buf =
+                BlockBuffer::new::<E::Unpadded>(block.try_into().map_err(|_| InvalidLength)?)?;
+            self.remaining = rest;
+
+            let bytes = buf.take(out.len().checked_sub(out_offset).ok_or(InvalidLength)?);
+            out[out_offset..][..bytes.len()].copy_from_slice(bytes);
+            out_offset = out_offset.checked_add(bytes.len()).ok_or(InvalidLength)?;
+
+            debug_assert!(!buf.is_empty());
+            debug_assert!(self.buffer.is_none());
+            self.buffer = Some(buf);
+        }
+
+        Ok(Some(&out[..out_offset]))
+    }
+
+    /// Write an exact amount of data to a buffer.
+    ///
+    /// # Returns
+    /// - `Ok(bytes)` if the expected amount of data was read
+    /// - `Err(Error::Length)` if the exact amount of data couldn't be read
+    pub fn decode_exact<'o>(&mut self, out: &'o mut [u8]) -> Result<&'o [u8], Error> {
+        let expected_len = out.len();
+
+        if let Some(slice) = self.decode_partial(out)? {
+            if slice.len() == expected_len {
+                return Ok(slice);
+            }
+        }
+
+        Err(InvalidLength)
+    }
+
+    /// Has all of the input data been decoded?
+    pub fn is_finished(&self) -> bool {
+        self.remaining.is_empty()
+            && self
+                .buffer
+                .as_ref()
+                .map(|buf| buf.is_empty())
+                .unwrap_or(true)
+    }
+}
+
+/// Base64 decode buffer for a 1-block input.
+///
+/// This handles a partially decoded block of data, i.e. data which has been
+/// decoded but not read.
+struct BlockBuffer {
+    /// 3 decoded bytes from a 4-byte Base64-encoded input.
+    decoded: [u8; 3],
+
+    /// Length of the buffer.
+    length: usize,
+
+    /// Position within the buffer.
+    position: usize,
+}
+
+impl BlockBuffer {
+    /// Decode the provided 4-byte input as Base64.
+    pub(crate) fn new<E: Variant>(input: &[u8; 4]) -> Result<Self, Error> {
+        let mut decoded = [0u8; 3];
+        let length = E::decode(input, &mut decoded)?.len();
+
+        Ok(Self {
+            decoded,
+            length,
+            position: 0,
+        })
+    }
+
+    /// Take a specified number of bytes from the buffer.
+    ///
+    /// Returns as many bytes as possible, or an empty slice if the buffer has
+    /// already been read to completion.
+    pub(crate) fn take(&mut self, mut nbytes: usize) -> &[u8] {
+        debug_assert!(self.position <= self.length);
+        let start_pos = self.position;
+        let remaining_len = self.length - start_pos;
+
+        if nbytes > remaining_len {
+            nbytes = remaining_len;
+        }
+
+        self.position += nbytes;
+        &self.decoded[start_pos..][..nbytes]
+    }
+
+    /// Have all of the bytes in this buffer been consumed?
+    pub fn is_empty(&self) -> bool {
+        self.position == self.length
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Base64Unpadded, Decoder};
+
+    /// Unpadded Base64-encoded example
+    // TODO(tarcieri): padded Base64 tests
+    const UNPADDED_BASE64: &str =
+        "AAAAC3NzaC1lZDI1NTE5AAAAILM+rvN+ot98qgEN796jTiQfZfG1KaT0PtFDJ/XFSqti";
+    const UNPADDED_BIN: &[u8] = &[
+        0, 0, 0, 11, 115, 115, 104, 45, 101, 100, 50, 53, 53, 49, 57, 0, 0, 0, 32, 179, 62, 174,
+        243, 126, 162, 223, 124, 170, 1, 13, 239, 222, 163, 78, 36, 31, 101, 241, 181, 41, 164,
+        244, 62, 209, 67, 39, 245, 197, 74, 171, 98,
+    ];
+
+    #[test]
+    fn decode_unpadded() {
+        for chunk_size in 1..UNPADDED_BIN.len() {
+            let mut decoder = Decoder::<Base64Unpadded>::new(UNPADDED_BASE64.as_bytes()).unwrap();
+            let mut buffer = [0u8; 64];
+
+            for chunk in UNPADDED_BIN.chunks(chunk_size) {
+                assert!(!decoder.is_finished());
+                match decoder.decode_partial(&mut buffer[..chunk_size]) {
+                    Ok(Some(decoded)) => assert_eq!(chunk, decoded),
+                    other => panic!("decode failed: {:?}", other),
+                }
+            }
+
+            assert!(decoder.is_finished());
+        }
+    }
+}

--- a/base64ct/src/lib.rs
+++ b/base64ct/src/lib.rs
@@ -70,11 +70,13 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
+mod decoder;
 mod encoding;
 mod errors;
 mod variant;
 
 pub use crate::{
+    decoder::Decoder,
     encoding::Encoding,
     errors::{Error, InvalidEncodingError, InvalidLengthError},
     variant::{

--- a/base64ct/src/variant.rs
+++ b/base64ct/src/variant.rs
@@ -9,6 +9,11 @@ pub mod url;
 
 /// Core encoder/decoder functions for a particular Base64 variant
 pub trait Variant {
+    /// Unpadded equivalent of this variant.
+    ///
+    /// For variants that are unpadded to begin with, this should be `Self`.
+    type Unpadded: Variant;
+
     /// Is this encoding padded?
     const PADDED: bool;
 

--- a/base64ct/src/variant/bcrypt.rs
+++ b/base64ct/src/variant/bcrypt.rs
@@ -11,6 +11,7 @@ use super::{Decode, Encode, Variant};
 pub struct Base64Bcrypt;
 
 impl Variant for Base64Bcrypt {
+    type Unpadded = Self;
     const PADDED: bool = false;
     const BASE: u8 = b'.';
 

--- a/base64ct/src/variant/crypt.rs
+++ b/base64ct/src/variant/crypt.rs
@@ -11,6 +11,7 @@ use super::{Decode, Encode, Variant};
 pub struct Base64Crypt;
 
 impl Variant for Base64Crypt {
+    type Unpadded = Self;
     const PADDED: bool = false;
     const BASE: u8 = b'.';
 

--- a/base64ct/src/variant/standard.rs
+++ b/base64ct/src/variant/standard.rs
@@ -11,6 +11,7 @@ use super::{Decode, Encode, Variant};
 pub struct Base64;
 
 impl Variant for Base64 {
+    type Unpadded = Base64Unpadded;
     const PADDED: bool = true;
     const BASE: u8 = b'A';
     const DECODER: &'static [Decode] = DECODER;
@@ -26,6 +27,7 @@ impl Variant for Base64 {
 pub struct Base64Unpadded;
 
 impl Variant for Base64Unpadded {
+    type Unpadded = Self;
     const PADDED: bool = false;
     const BASE: u8 = b'A';
     const DECODER: &'static [Decode] = DECODER;

--- a/base64ct/src/variant/url.rs
+++ b/base64ct/src/variant/url.rs
@@ -11,6 +11,7 @@ use super::{Decode, Encode, Variant};
 pub struct Base64Url;
 
 impl Variant for Base64Url {
+    type Unpadded = Base64UrlUnpadded;
     const PADDED: bool = true;
     const BASE: u8 = b'A';
     const DECODER: &'static [Decode] = DECODER;
@@ -26,6 +27,7 @@ impl Variant for Base64Url {
 pub struct Base64UrlUnpadded;
 
 impl Variant for Base64UrlUnpadded {
+    type Unpadded = Self;
     const PADDED: bool = false;
     const BASE: u8 = b'A';
     const DECODER: &'static [Decode] = DECODER;


### PR DESCRIPTION
Adds a buffered `Decoder` which is able to incrementally decode an output stream from an unpadded input.

Presently constrained to contiguous Base64 inputs which do not contain newlines, although an important next step is to encapsulate line-wrapped inputs.

Support for padded inputs is untested and broken, but will be fixed in a followup commit.