### PR TITLE
der v0.4.5

### DIFF
--- a/der/CHANGELOG.md
+++ b/der/CHANGELOG.md
@@ -92,6 +92,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#217]: https://github.com/RustCrypto/formats/pull/217
 [#221]: https://github.com/RustCrypto/formats/pull/221
 
+## 0.4.5 (2021-12-01)
+### Fixed
+- Backport [#147] type hint fix for WASM platforms to 0.4.x
+
 ## 0.4.4 (2021-10-06)
 ### Removed
 - Accidentally checked-in `target/` directory ([#66])


### PR DESCRIPTION
Adds a CHANGELOG.md entry for the v0.4.5 release of the `der` crate, which backports a fix for #146 from the v0.5.x series to the v0.4.x series.

As this is a backport, there aren't associated code changes.