### PR TITLE
ssh-key: initial `public` key types

### DIFF
--- a/.github/workflows/ssh-key.yml
+++ b/.github/workflows/ssh-key.yml
@@ -3,6 +3,8 @@ name: ssh-key
 on:
   pull_request:
     paths:
+      - "base64ct/**"
+      - "sec1/**"
       - "ssh-key/**"
       - "Cargo.*"
   push:
@@ -36,6 +38,9 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features sec1
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,sec1
 
   test:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,6 +934,11 @@ dependencies = [
 [[package]]
 name = "ssh-key"
 version = "0.0.0"
+dependencies = [
+ "base64ct",
+ "hex-literal",
+ "sec1",
+]
 
 [[package]]
 name = "subtle"

--- a/base64ct/src/decoder.rs
+++ b/base64ct/src/decoder.rs
@@ -144,7 +144,7 @@ impl<'i, E: Variant> Decoder<'i, E> {
     ///
     /// # Returns
     /// - `Ok(bytes)` if the expected amount of data was read
-    /// - `Err(Error::Length)` if the exact amount of data couldn't be read
+    /// - `Err(Error::InvalidLength)` if the exact amount of data couldn't be read
     pub fn decode_exact<'o>(&mut self, out: &'o mut [u8]) -> Result<&'o [u8], Error> {
         let expected_len = out.len();
 

--- a/sec1/src/point.rs
+++ b/sec1/src/point.rs
@@ -598,6 +598,14 @@ impl Tag {
     }
 }
 
+impl TryFrom<u8> for Tag {
+    type Error = Error;
+
+    fn try_from(byte: u8) -> Result<Self> {
+        Self::from_u8(byte)
+    }
+}
+
 impl From<Tag> for u8 {
     fn from(tag: Tag) -> u8 {
         tag as u8

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "ssh-key"
 version = "0.0.0" # Also update html_root_url in lib.rs when bumping this
-description = "Pure Rust implementation of SSH key file formats as described in RFC4716"
+description = """
+Pure Rust implementation of SSH key file format decoders/encoders as described
+in RFC4253 and RFC4716 as well as the OpenSSH key formats. Supports "heapless"
+`no_std` embedded targets with an optional `alloc` feature (Ed25519 and ECDSA only)
+"""
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/formats/tree/master/ssh-key"
@@ -12,6 +16,18 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
+base64ct = { version = "1", path = "../base64ct" } # TODO: bump to 1.3.0 before release
+
+# optional dependencies
+sec1 = { version = "0.2", optional = true, default-features = false, path = "../sec1" }
+
+[dev-dependencies]
+hex-literal = "0.3"
+
+[features]
+default = ["alloc", "sec1"]
+alloc = []
+std = ["alloc", "base64ct/std"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/ssh-key/README.md
+++ b/ssh-key/README.md
@@ -11,8 +11,11 @@
 
 ## About
 
-Pure Rust implementation of SSH key file formats as described in [RFC4716]
-as well as OpenSSH's [PROTOCOL.key] format specification.
+Pure Rust implementation of SSH key file format decoders/encoders as described
+in [RFC4253] and [RFC4716] as well as OpenSSH's [PROTOCOL.key] format specification.
+
+Supports "heapless" `no_std` embedded targets with an optional `alloc` feature
+(Ed25519 and ECDSA only).
 
 ## Minimum Supported Rust Version
 
@@ -52,5 +55,6 @@ dual licensed as above, without any additional terms or conditions.
 [//]: # (links)
 
 [RustCrypto]: https://github.com/rustcrypto
+[RFC4253]: https://datatracker.ietf.org/doc/html/rfc4253
 [RFC4716]: https://datatracker.ietf.org/doc/html/rfc4716
 [PROTOCOL.key]: https://github.com/openssh/openssh-portable/blob/master/PROTOCOL.key

--- a/ssh-key/src/algorithm.rs
+++ b/ssh-key/src/algorithm.rs
@@ -1,0 +1,186 @@
+//! Algorithm registry
+
+use crate::{base64, Error, Result};
+use core::{fmt, str};
+
+/// ECDSA with SHA-256 + NIST P-256
+const ECDSA_SHA2_P256: &str = "ecdsa-sha2-nistp256";
+
+/// ECDSA with SHA-256 + NIST P-256
+const ECDSA_SHA2_P384: &str = "ecdsa-sha2-nistp384";
+
+/// ECDSA with SHA-256 + NIST P-256
+const ECDSA_SHA2_P521: &str = "ecdsa-sha2-nistp521";
+
+/// Digital Signature Algorithm
+const SSH_DSA: &str = "ssh-dss";
+
+/// Ed25519
+const SSH_ED25519: &str = "ssh-ed25519";
+
+/// RSA
+const SSH_RSA: &str = "ssh-rsa";
+
+/// SSH key algorithms.
+///
+/// This type provides a registry of supported digital signature algorithms
+/// used for SSH keys.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[non_exhaustive]
+pub enum Algorithm {
+    /// Digital Signature Algorithm
+    Dsa,
+
+    /// Elliptic Curve Digital Signature Algorithm
+    Ecdsa(EcdsaCurve),
+
+    /// Ed25519
+    Ed25519,
+
+    /// RSA
+    Rsa,
+}
+
+impl Algorithm {
+    /// Maximum size of algorithms known to this crate in bytes.
+    const MAX_SIZE: usize = 20;
+
+    /// Decode algorithm from the given string identifier.
+    ///
+    /// # Supported algorithms
+    ///
+    /// - `ecdsa-sha2-nistp256`
+    /// - `ecdsa-sha2-nistp384`
+    /// - `ecdsa-sha2-nistp521`
+    /// - `ssh-dss`
+    /// - `ssh-ed25519`
+    /// - `ssh-rsa`
+    pub fn new(id: &str) -> Result<Self> {
+        match id {
+            ECDSA_SHA2_P256 => Ok(Algorithm::Ecdsa(EcdsaCurve::NistP256)),
+            ECDSA_SHA2_P384 => Ok(Algorithm::Ecdsa(EcdsaCurve::NistP384)),
+            ECDSA_SHA2_P521 => Ok(Algorithm::Ecdsa(EcdsaCurve::NistP521)),
+            SSH_DSA => Ok(Algorithm::Dsa),
+            SSH_ED25519 => Ok(Algorithm::Ed25519),
+            SSH_RSA => Ok(Algorithm::Rsa),
+            _ => Err(Error::Algorithm),
+        }
+    }
+
+    /// Get the string identifier which corresponds to this algorithm.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Algorithm::Dsa => SSH_DSA,
+            Algorithm::Ecdsa(EcdsaCurve::NistP256) => ECDSA_SHA2_P256,
+            Algorithm::Ecdsa(EcdsaCurve::NistP384) => ECDSA_SHA2_P384,
+            Algorithm::Ecdsa(EcdsaCurve::NistP521) => ECDSA_SHA2_P521,
+            Algorithm::Ed25519 => SSH_ED25519,
+            Algorithm::Rsa => SSH_RSA,
+        }
+    }
+
+    /// Is the algorithm DSA?
+    pub fn is_dsa(self) -> bool {
+        self == Algorithm::Dsa
+    }
+
+    /// Is the algorithm ECDSA?
+    pub fn is_ecdsa(self) -> bool {
+        matches!(self, Algorithm::Ecdsa(_))
+    }
+
+    /// Is the algorithm Ed25519?
+    pub fn is_ed25519(self) -> bool {
+        self == Algorithm::Ed25519
+    }
+
+    /// Is the algorithm RSA?
+    pub fn is_rsa(self) -> bool {
+        self == Algorithm::Rsa
+    }
+
+    /// Decode algorithm using the supplied Base64 decoder.
+    pub(crate) fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+        let mut buf = [0u8; Self::MAX_SIZE];
+        Self::new(decoder.decode_str(&mut buf)?)
+    }
+}
+
+impl fmt::Display for Algorithm {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl str::FromStr for Algorithm {
+    type Err = Error;
+
+    fn from_str(id: &str) -> Result<Self> {
+        Algorithm::new(id)
+    }
+}
+
+/// Elliptic curves supported for use with ECDSA.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+pub enum EcdsaCurve {
+    /// NIST P-256 (a.k.a. prime256v1, secp256r1)
+    NistP256,
+
+    /// NIST P-384 (a.k.a. secp384r1)
+    NistP384,
+
+    /// NIST P-521 (a.k.a. secp521r1)
+    NistP521,
+}
+
+impl EcdsaCurve {
+    /// Maximum size of a curve identifier known to this crate in bytes.
+    #[cfg(feature = "sec1")]
+    const MAX_SIZE: usize = 8;
+
+    /// Decode elliptic curve from the given string identifier.
+    ///
+    /// # Supported curves
+    ///
+    /// - `nistp256`
+    /// - `nistp384`
+    /// - `nistp521`
+    pub fn new(id: &str) -> Result<Self> {
+        match id {
+            "nistp256" => Ok(EcdsaCurve::NistP256),
+            "nistp384" => Ok(EcdsaCurve::NistP384),
+            "nistp521" => Ok(EcdsaCurve::NistP521),
+            _ => Err(Error::Algorithm),
+        }
+    }
+
+    /// Get the string identifier which corresponds to this ECDSA elliptic curve.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            EcdsaCurve::NistP256 => "nistp256",
+            EcdsaCurve::NistP384 => "nistp384",
+            EcdsaCurve::NistP521 => "nistp521",
+        }
+    }
+
+    /// Decode ECDSA curve type using the supplied Base64 decoder.
+    #[cfg(feature = "sec1")]
+    pub(crate) fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+        let mut buf = [0u8; Self::MAX_SIZE];
+        Self::new(decoder.decode_str(&mut buf)?)
+    }
+}
+
+impl fmt::Display for EcdsaCurve {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl str::FromStr for EcdsaCurve {
+    type Err = Error;
+
+    fn from_str(id: &str) -> Result<Self> {
+        EcdsaCurve::new(id)
+    }
+}

--- a/ssh-key/src/base64.rs
+++ b/ssh-key/src/base64.rs
@@ -1,0 +1,133 @@
+//! Base64 support.
+//!
+//! Provides helper types which use the `base64ct` crate's constant-time Base64
+//! implementation for decoding.
+
+use crate::{Error, Result};
+use core::str;
+
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
+/// Stateful Base64 decoder.
+pub(crate) struct Decoder<'i> {
+    inner: base64ct::Decoder<'i, base64ct::Base64>,
+}
+
+impl<'i> Decoder<'i> {
+    /// Create a new decoder for a byte slice containing contiguous
+    /// (non-newline-delimited) Base64-encoded data.
+    pub(crate) fn new(input: &'i [u8]) -> Result<Self> {
+        let inner = base64ct::Decoder::new(input)?;
+        Ok(Self { inner })
+    }
+
+    /// Decode as much Base64 as is needed to exactly fill `out`.
+    ///
+    /// # Returns
+    /// - `Ok(bytes)` if the expected amount of data was read
+    /// - `Err(Error::Length)` if the exact amount of data couldn't be read
+    pub(crate) fn decode_into<'o>(&mut self, out: &'o mut [u8]) -> Result<&'o [u8]> {
+        Ok(self.inner.decode_exact(out)?)
+    }
+
+    /// Decodes a `uint32` as described in [RFC4251 § 5]:
+    ///
+    /// > Represents a 32-bit unsigned integer.  Stored as four bytes in the
+    /// > order of decreasing significance (network byte order).  For
+    /// > example: the value 699921578 (0x29b7f4aa) is stored as 29 b7 f4 aa.
+    ///
+    /// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
+    pub(crate) fn decode_u32(&mut self) -> Result<u32> {
+        let mut bytes = [0u8; 4];
+        self.decode_into(&mut bytes)?;
+        Ok(u32::from_be_bytes(bytes))
+    }
+
+    /// Decode a `usize`.
+    ///
+    /// Uses [`Decoder::decode_u32`] and then converts to a `usize`, handling
+    /// potential overflow if `usize` is smaller than `u32`.
+    pub(crate) fn decode_usize(&mut self) -> Result<usize> {
+        Ok(self.decode_u32()?.try_into()?)
+    }
+
+    /// Decodes `[u8]` from `byte[n]` as described in [RFC4251 § 5]:
+    ///
+    /// > A byte represents an arbitrary 8-bit value (octet).  Fixed length
+    /// > data is sometimes represented as an array of bytes, written
+    /// > byte[n], where n is the number of bytes in the array.
+    ///
+    /// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
+    pub(crate) fn decode_byte_slice<'o>(&mut self, out: &'o mut [u8]) -> Result<&'o [u8]> {
+        let len = self.decode_usize()?;
+        let result = out.get_mut(..len).ok_or(Error::Length)?;
+        self.decode_into(result)?;
+        Ok(result)
+    }
+
+    /// Decodes `Vec<u8>` from `byte[n]` as described in [RFC4251 § 5]:
+    ///
+    /// > A byte represents an arbitrary 8-bit value (octet).  Fixed length
+    /// > data is sometimes represented as an array of bytes, written
+    /// > byte[n], where n is the number of bytes in the array.
+    ///
+    /// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
+    #[cfg(feature = "alloc")]
+    pub(crate) fn decode_byte_vec(&mut self) -> Result<Vec<u8>> {
+        let len = self.decode_usize()?;
+        let mut result = vec![0u8; len];
+        self.decode_into(&mut result)?;
+        Ok(result)
+    }
+
+    /// Decodes a `string` as described in [RFC4251 § 5]:
+    ///
+    /// > Arbitrary length binary string.  Strings are allowed to contain
+    /// > arbitrary binary data, including null characters and 8-bit
+    /// > characters.  They are stored as a uint32 containing its length
+    /// > (number of bytes that follow) and zero (= empty string) or more
+    /// > bytes that are the value of the string.  Terminating null
+    /// > characters are not used.
+    /// >
+    /// > Strings are also used to store text.  In that case, US-ASCII is
+    /// > used for internal names, and ISO-10646 UTF-8 for text that might
+    /// > be displayed to the user.  The terminating null character SHOULD
+    /// > NOT normally be stored in the string.  For example: the US-ASCII
+    /// > string "testing" is represented as 00 00 00 07 t e s t i n g.  The
+    /// > UTF-8 mapping does not alter the encoding of US-ASCII characters.
+    ///
+    /// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
+    pub(crate) fn decode_str<'o>(&mut self, buf: &'o mut [u8]) -> Result<&'o str> {
+        Ok(str::from_utf8(self.decode_byte_slice(buf)?)?)
+    }
+
+    /// Has all of the input data been decoded?
+    pub(crate) fn is_finished(&self) -> bool {
+        self.inner.is_finished()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Decoder;
+
+    /// From `id_ecdsa_p256.pub`
+    const EXAMPLE_BASE64: &str =
+        "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHwf2HMM5TRXvo2SQJjsNkiDD5KqiiNjrGVv3UUh+mMT5RHxiRtOnlqvjhQtBq0VpmpCV/PwUdhOig4vkbqAcEc=";
+    const EXAMPLE_BIN: &[u8] = &[
+        0, 0, 0, 19, 101, 99, 100, 115, 97, 45, 115, 104, 97, 50, 45, 110, 105, 115, 116, 112, 50,
+        53, 54, 0, 0, 0, 8, 110, 105, 115, 116, 112, 50, 53, 54, 0, 0, 0, 65, 4, 124, 31, 216, 115,
+        12, 229, 52, 87, 190, 141, 146, 64, 152, 236, 54, 72, 131, 15, 146, 170, 138, 35, 99, 172,
+        101, 111, 221, 69, 33, 250, 99, 19, 229, 17, 241, 137, 27, 78, 158, 90, 175, 142, 20, 45,
+        6, 173, 21, 166, 106, 66, 87, 243, 240, 81, 216, 78, 138, 14, 47, 145, 186, 128, 112, 71,
+    ];
+
+    #[test]
+    fn decode_into() {
+        let mut decoder = Decoder::new(EXAMPLE_BASE64.as_bytes()).unwrap();
+        let mut buf = [0u8; EXAMPLE_BIN.len()];
+        let decoded = decoder.decode_into(&mut buf).unwrap();
+        assert_eq!(EXAMPLE_BIN, decoded);
+    }
+}

--- a/ssh-key/src/error.rs
+++ b/ssh-key/src/error.rs
@@ -1,0 +1,80 @@
+//! Error types
+
+use core::fmt;
+
+/// Result type with `ssh-key`'s [`Error`] as the error type.
+pub type Result<T> = core::result::Result<T, Error>;
+
+/// Error type.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum Error {
+    /// Algorithm-related errors.
+    Algorithm,
+
+    /// Base64-related errors.
+    Base64(base64ct::Error),
+
+    /// Character encoding-related errors.
+    CharacterEncoding,
+
+    /// ECDSA key encoding errors.
+    #[cfg(feature = "sec1")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "sec1")))]
+    Ecdsa(sec1::Error),
+
+    /// Invalid length.
+    Length,
+
+    /// Overflow errors.
+    Overflow,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Algorithm => f.write_str("unknown or unsupported algorithm"),
+            Error::Base64(err) => write!(f, "Base64 encoding error: {}", err),
+            Error::CharacterEncoding => f.write_str("character encoding invalid"),
+            #[cfg(feature = "sec1")]
+            Error::Ecdsa(err) => write!(f, "ECDSA encoding error: {}", err),
+            Error::Length => f.write_str("length invalid"),
+            Error::Overflow => f.write_str("internal overflow error"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
+
+impl From<base64ct::Error> for Error {
+    fn from(err: base64ct::Error) -> Error {
+        Error::Base64(err)
+    }
+}
+
+impl From<base64ct::InvalidLengthError> for Error {
+    fn from(_: base64ct::InvalidLengthError) -> Error {
+        Error::Length
+    }
+}
+
+impl From<core::num::TryFromIntError> for Error {
+    fn from(_: core::num::TryFromIntError) -> Error {
+        Error::Overflow
+    }
+}
+
+impl From<core::str::Utf8Error> for Error {
+    fn from(_: core::str::Utf8Error) -> Error {
+        Error::CharacterEncoding
+    }
+}
+
+#[cfg(feature = "sec1")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sec1")))]
+impl From<sec1::Error> for Error {
+    fn from(err: sec1::Error) -> Error {
+        Error::Ecdsa(err)
+    }
+}

--- a/ssh-key/src/lib.rs
+++ b/ssh-key/src/lib.rs
@@ -1,6 +1,40 @@
+#![doc = include_str!("../README.md")]
+
+//! ## Usage
+//!
+//! ### OpenSSH Public Keys
+//!
+//! ```
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # #[cfg(feature = "std")]
+//! # {
+//! use ssh_key::PublicKey;
+//!
+//! let encoded_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILM+rvN+ot98qgEN796jTiQfZfG1KaT0PtFDJ/XFSqti foo@bar.com";
+//! let key = PublicKey::from_openssh(encoded_key)?;
+//!
+//! // Key attributes
+//! assert_eq!(key.algorithm(), ssh_key::Algorithm::Ed25519);
+//! assert_eq!(key.comment, "foo@bar.com");
+//!
+//! // Key data
+//! if let Some(ed25519_key) = key.data.ed25519() {
+//!     assert_eq!(
+//!         ed25519_key.as_ref(),
+//!         [
+//!             0xb3, 0x3e, 0xae, 0xf3, 0x7e, 0xa2, 0xdf, 0x7c, 0xaa, 0x1, 0xd, 0xef, 0xde, 0xa3,
+//!             0x4e, 0x24, 0x1f, 0x65, 0xf1, 0xb5, 0x29, 0xa4, 0xf4, 0x3e, 0xd1, 0x43, 0x27, 0xf5,
+//!             0xc5, 0x4a, 0xab, 0x62
+//!         ].as_ref()
+//!     );
+//! }
+//! # }
+//! # Ok(())
+//! # }
+//! ```
+
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
@@ -8,3 +42,31 @@
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+
+#[cfg(feature = "alloc")]
+#[macro_use]
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
+
+pub mod public;
+
+mod algorithm;
+mod base64;
+mod error;
+
+#[cfg(feature = "alloc")]
+mod mpint;
+
+pub use crate::{
+    algorithm::{Algorithm, EcdsaCurve},
+    error::{Error, Result},
+    public::PublicKey,
+};
+
+#[cfg(feature = "alloc")]
+pub use crate::mpint::MPInt;
+
+#[cfg(feature = "sec1")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sec1")))]
+pub use sec1;

--- a/ssh-key/src/mpint.rs
+++ b/ssh-key/src/mpint.rs
@@ -1,0 +1,131 @@
+//! Multiple precision integer
+
+use crate::{base64, Error, Result};
+use alloc::vec::Vec;
+use core::fmt;
+
+/// Multiple precision integer, a.k.a. "mpint".
+///
+/// This type is used for representing the big integer components of
+/// DSA and RSA keys.
+///
+/// Described in [RFC4251 § 5](https://datatracker.ietf.org/doc/html/rfc4251#section-5):
+///
+/// > Represents multiple precision integers in two's complement format,
+/// > stored as a string, 8 bits per byte, MSB first.  Negative numbers
+/// > have the value 1 as the most significant bit of the first byte of
+/// > the data partition.  If the most significant bit would be set for
+/// > a positive number, the number MUST be preceded by a zero byte.
+/// > Unnecessary leading bytes with the value 0 or 255 MUST NOT be
+/// > included.  The value zero MUST be stored as a string with zero
+/// > bytes of data.
+/// >
+/// > By convention, a number that is used in modular computations in
+/// > Z_n SHOULD be represented in the range 0 <= x < n.
+///
+/// ## Examples
+///
+/// | value (hex)     | representation (hex) |
+/// |-----------------|----------------------|
+/// | 0               | `00 00 00 00`
+/// | 9a378f9b2e332a7 | `00 00 00 08 09 a3 78 f9 b2 e3 32 a7`
+/// | 80              | `00 00 00 02 00 80`
+/// |-1234            | `00 00 00 02 ed cc`
+/// | -deadbeef       | `00 00 00 05 ff 21 52 41 11`
+// TODO(tarcieri): support for heapless platforms, constant time comparisons
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct MPInt {
+    /// Inner big endian-serialized integer value
+    inner: Vec<u8>,
+}
+
+impl MPInt {
+    /// Create a new multiple precision integer from the given
+    /// big endian-encoded byte slice.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
+        Vec::from(bytes).try_into()
+    }
+
+    /// Get the big integer data encoded as big endian bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        self.inner.as_ref()
+    }
+
+    /// Decode multiple-precision integer using the supplied Base64 decoder.
+    pub(crate) fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+        decoder.decode_byte_vec()?.try_into()
+    }
+}
+
+impl AsRef<[u8]> for MPInt {
+    fn as_ref(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}
+
+impl TryFrom<Vec<u8>> for MPInt {
+    type Error = Error;
+
+    fn try_from(bytes: Vec<u8>) -> Result<Self> {
+        // TODO(tarcieri): check for unnecessary leading zero bytes
+        Ok(Self { inner: bytes })
+    }
+}
+
+impl fmt::Display for MPInt {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:X}", self)
+    }
+}
+
+impl fmt::LowerHex for MPInt {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for byte in self.as_bytes() {
+            write!(f, "{:02x}", byte)?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::UpperHex for MPInt {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for byte in self.as_bytes() {
+            write!(f, "{:02X}", byte)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MPInt;
+    use hex_literal::hex;
+
+    #[test]
+    fn decode_0() {
+        assert!(MPInt::from_bytes(&hex!("00 00 00 00")).is_ok());
+    }
+
+    #[test]
+    fn decode_9a378f9b2e332a7() {
+        assert!(MPInt::from_bytes(&hex!("00 00 00 08 09 a3 78 f9 b2 e3 32 a7")).is_ok());
+    }
+
+    #[test]
+    fn decode_80() {
+        assert!(MPInt::from_bytes(&hex!("00 00 00 02 00 80")).is_ok());
+    }
+
+    // TODO(tarcieri): drop support for negative numbers?
+    #[test]
+    fn decode_neg_1234() {
+        assert!(MPInt::from_bytes(&hex!("00 00 00 02 ed cc")).is_ok());
+    }
+
+    // TODO(tarcieri): drop support for negative numbers?
+    #[test]
+    fn decode_neg_deadbeef() {
+        assert!(MPInt::from_bytes(&hex!("00 00 00 05 ff 21 52 41 11")).is_ok());
+    }
+}

--- a/ssh-key/src/public.rs
+++ b/ssh-key/src/public.rs
@@ -1,0 +1,429 @@
+//! SSH public key support.
+//!
+//! Support for decoding SSH public keys from the OpenSSH file format.
+
+mod openssh;
+
+use crate::{base64, Algorithm, Error, Result};
+use core::fmt;
+
+#[cfg(feature = "alloc")]
+use {
+    crate::MPInt,
+    alloc::{borrow::ToOwned, string::String},
+};
+
+#[cfg(feature = "sec1")]
+use {
+    crate::EcdsaCurve,
+    sec1::consts::{U32, U48, U66},
+};
+
+/// SSH public key.
+#[derive(Clone, Debug)]
+pub struct PublicKey {
+    /// Key data.
+    pub data: KeyData,
+
+    /// Comment on the key (e.g. email address)
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    pub comment: String,
+}
+
+impl PublicKey {
+    /// Parse an OpenSSH-formatted public key.
+    ///
+    /// OpenSSH-formatted public keys look like the following:
+    ///
+    /// ```text
+    /// ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILM+rvN+ot98qgEN796jTiQfZfG1KaT0PtFDJ/XFSqti foo@bar.com
+    /// ```
+    pub fn from_openssh(input: impl AsRef<[u8]>) -> Result<Self> {
+        let encapsulation = openssh::Encapsulation::parse(input.as_ref())?;
+        let data = KeyData::decode(base64::Decoder::new(encapsulation.base64_data)?)?;
+
+        // Verify that the algorithm in the Base64-encoded data matches the text
+        if encapsulation.algorithm_id != data.algorithm().as_str() {
+            return Err(Error::Algorithm);
+        }
+
+        Ok(Self {
+            data,
+            #[cfg(feature = "alloc")]
+            comment: encapsulation.comment.to_owned(),
+        })
+    }
+
+    /// Get the digital signature [`Algorithm`] used by this key.
+    pub fn algorithm(&self) -> Algorithm {
+        self.data.algorithm()
+    }
+}
+
+/// Public key data.
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[non_exhaustive]
+pub enum KeyData {
+    /// Digital Signature Algorithm (DSA) public key data.
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    Dsa(DsaPublicKey),
+
+    /// Elliptic Curve Digital Signature Algorithm (ECDSA) public key data.
+    #[cfg(feature = "sec1")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "sec1")))]
+    Ecdsa(EcdsaPublicKey),
+
+    /// Ed25519 public key data.
+    Ed25519(Ed25519PublicKey),
+
+    /// RSA public key data.
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    Rsa(RsaPublicKey),
+}
+
+impl KeyData {
+    /// Get the [`Algorithm`] for this public key type.
+    pub fn algorithm(&self) -> Algorithm {
+        match self {
+            #[cfg(feature = "alloc")]
+            Self::Dsa(_) => Algorithm::Dsa,
+            #[cfg(feature = "sec1")]
+            Self::Ecdsa(key) => key.algorithm(),
+            Self::Ed25519(_) => Algorithm::Ed25519,
+            #[cfg(feature = "alloc")]
+            Self::Rsa(_) => Algorithm::Rsa,
+        }
+    }
+
+    /// Get ECDSA public key if this key is the correct type.
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    pub fn dsa(&self) -> Option<&DsaPublicKey> {
+        match self {
+            Self::Dsa(key) => Some(key),
+            _ => None,
+        }
+    }
+
+    /// Get ECDSA public key if this key is the correct type.
+    #[cfg(feature = "sec1")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "sec1")))]
+    pub fn ecdsa(&self) -> Option<&EcdsaPublicKey> {
+        match self {
+            Self::Ecdsa(key) => Some(key),
+            _ => None,
+        }
+    }
+
+    /// Get Ed25519 public key if this key is the correct type.
+    pub fn ed25519(&self) -> Option<&Ed25519PublicKey> {
+        match self {
+            Self::Ed25519(key) => Some(key),
+            #[allow(unreachable_patterns)]
+            _ => None,
+        }
+    }
+
+    /// Get RSA public key if this key is the correct type.
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    pub fn rsa(&self) -> Option<&RsaPublicKey> {
+        match self {
+            Self::Rsa(key) => Some(key),
+            _ => None,
+        }
+    }
+
+    /// Is this key a DSA key?
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    pub fn is_dsa(&self) -> bool {
+        matches!(self, Self::Dsa(_))
+    }
+
+    /// Is this key an ECDSA key?
+    #[cfg(feature = "sec1")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "sec1")))]
+    pub fn is_ecdsa(&self) -> bool {
+        matches!(self, Self::Ecdsa(_))
+    }
+
+    /// Is this key an Ed25519 key?
+    pub fn is_ed25519(&self) -> bool {
+        matches!(self, Self::Ed25519(_))
+    }
+
+    /// Is this key an RSA key?
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    pub fn is_rsa(&self) -> bool {
+        matches!(self, Self::Rsa(_))
+    }
+
+    /// Decode data using the provided Base64 decoder.
+    fn decode(mut decoder: base64::Decoder<'_>) -> Result<Self> {
+        let result = match Algorithm::decode(&mut decoder)? {
+            #[cfg(feature = "alloc")]
+            Algorithm::Dsa => DsaPublicKey::decode(&mut decoder).map(Self::Dsa),
+            #[cfg(feature = "sec1")]
+            Algorithm::Ecdsa(curve) => {
+                let key = EcdsaPublicKey::decode(&mut decoder)?;
+
+                if key.curve() == curve {
+                    Ok(Self::Ecdsa(key))
+                } else {
+                    Err(Error::Algorithm)
+                }
+            }
+            Algorithm::Ed25519 => Ed25519PublicKey::decode(&mut decoder).map(Self::Ed25519),
+            #[cfg(feature = "alloc")]
+            Algorithm::Rsa => RsaPublicKey::decode(&mut decoder).map(Self::Rsa),
+            #[allow(unreachable_patterns)]
+            _ => return Err(Error::Algorithm),
+        };
+
+        if decoder.is_finished() {
+            result
+        } else {
+            Err(Error::Length)
+        }
+    }
+}
+
+/// Digital Signature Algorithm (DSA) public key.
+///
+/// Described in [FIPS 186-4](https://csrc.nist.gov/publications/detail/fips/186/4/final).
+// TODO(tarcieri): use `dsa::PublicKey`? (doesn't exist yet)
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct DsaPublicKey {
+    /// Prime modulus
+    pub p: MPInt,
+
+    /// Prime divisor of `p - 1`
+    pub q: MPInt,
+
+    /// Generator of a subgroup of order `q` in the multiplicative group
+    /// `GF(p)`, such that `1 < g < p`.
+    pub g: MPInt,
+
+    /// The public key, where `y = gˣ mod p`
+    pub y: MPInt,
+}
+
+#[cfg(feature = "alloc")]
+impl DsaPublicKey {
+    /// Decode DSA public key using the provided Base64 decoder.
+    fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+        let p = MPInt::decode(decoder)?;
+        let q = MPInt::decode(decoder)?;
+        let g = MPInt::decode(decoder)?;
+        let y = MPInt::decode(decoder)?;
+        Ok(Self { p, q, g, y })
+    }
+}
+
+/// Elliptic Curve Digital Signature Algorithm (ECDSA) public key.
+///
+/// Public keys are represented as [`sec1::EncodedPoint`] and require the
+/// `sec1` feature of this crate is enabled (which it is by default).
+///
+/// Described in [FIPS 186-4](https://csrc.nist.gov/publications/detail/fips/186/4/final).
+#[cfg(feature = "sec1")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sec1")))]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub enum EcdsaPublicKey {
+    /// NIST P-256 ECDSA public key.
+    NistP256(sec1::EncodedPoint<U32>),
+
+    /// NIST P-384 ECDSA public key.
+    NistP384(sec1::EncodedPoint<U48>),
+
+    /// NIST P-521 ECDSA public key.
+    NistP521(sec1::EncodedPoint<U66>),
+}
+
+#[cfg(feature = "sec1")]
+impl EcdsaPublicKey {
+    /// Maximum size of a SEC1-encoded ECDSA public key (i.e. curve point).
+    ///
+    /// This is the size of 2 * P-521 curve points (2 * 66 = 132) plus one
+    /// additional byte for the "tag".
+    const MAX_SIZE: usize = 133;
+
+    /// Parse an ECDSA public key from a SEC1-encoded point.
+    ///
+    /// Determines the key type from the SEC1 tag byte and length.
+    pub fn from_sec1_bytes(bytes: &[u8]) -> Result<Self> {
+        match bytes {
+            [tag, rest @ ..] => {
+                let point_size = match sec1::point::Tag::from_u8(*tag)? {
+                    sec1::point::Tag::CompressedEvenY | sec1::point::Tag::CompressedOddY => {
+                        rest.len()
+                    }
+                    sec1::point::Tag::Uncompressed => rest.len() / 2,
+                    _ => return Err(Error::Algorithm),
+                };
+
+                match point_size {
+                    32 => Ok(Self::NistP256(sec1::EncodedPoint::from_bytes(bytes)?)),
+                    48 => Ok(Self::NistP384(sec1::EncodedPoint::from_bytes(bytes)?)),
+                    66 => Ok(Self::NistP521(sec1::EncodedPoint::from_bytes(bytes)?)),
+                    _ => Err(Error::Length),
+                }
+            }
+            _ => Err(Error::Length),
+        }
+    }
+
+    /// Borrow the SEC1-encoded key data as bytes.
+    pub fn as_sec1_bytes(&self) -> &[u8] {
+        match self {
+            EcdsaPublicKey::NistP256(point) => point.as_bytes(),
+            EcdsaPublicKey::NistP384(point) => point.as_bytes(),
+            EcdsaPublicKey::NistP521(point) => point.as_bytes(),
+        }
+    }
+
+    /// Get the [`Algorithm`] for this public key type.
+    pub fn algorithm(&self) -> Algorithm {
+        Algorithm::Ecdsa(self.curve())
+    }
+
+    /// Get the [`EcdsaCurve`] for this key.
+    pub fn curve(&self) -> EcdsaCurve {
+        match self {
+            EcdsaPublicKey::NistP256(_) => EcdsaCurve::NistP256,
+            EcdsaPublicKey::NistP384(_) => EcdsaCurve::NistP384,
+            EcdsaPublicKey::NistP521(_) => EcdsaCurve::NistP521,
+        }
+    }
+
+    /// Decode ECDSA public key using the provided Base64 decoder.
+    fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+        let curve = EcdsaCurve::decode(decoder)?;
+
+        let mut buf = [0u8; Self::MAX_SIZE];
+        let key = Self::from_sec1_bytes(decoder.decode_byte_slice(&mut buf)?)?;
+
+        if key.curve() == curve {
+            Ok(key)
+        } else {
+            Err(Error::Algorithm)
+        }
+    }
+}
+
+#[cfg(feature = "sec1")]
+impl AsRef<[u8]> for EcdsaPublicKey {
+    fn as_ref(&self) -> &[u8] {
+        self.as_sec1_bytes()
+    }
+}
+
+#[cfg(feature = "sec1")]
+impl fmt::Display for EcdsaPublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:X}", self)
+    }
+}
+
+#[cfg(feature = "sec1")]
+impl fmt::LowerHex for EcdsaPublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for byte in self.as_sec1_bytes() {
+            write!(f, "{:02x}", byte)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(feature = "sec1")]
+impl fmt::UpperHex for EcdsaPublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for byte in self.as_sec1_bytes() {
+            write!(f, "{:02X}", byte)?;
+        }
+        Ok(())
+    }
+}
+
+/// Ed25519 public key.
+// TODO(tarcieri): use `ed25519::PublicKey`? (doesn't exist yet)
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+pub struct Ed25519PublicKey(pub [u8; Self::BYTE_SIZE]);
+
+impl Ed25519PublicKey {
+    /// Size of an Ed25519 public key in bytes.
+    pub const BYTE_SIZE: usize = 32;
+
+    /// Decode Ed25519 public key using the provided Base64 decoder.
+    fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+        // Validate length prefix
+        if decoder.decode_usize()? != Self::BYTE_SIZE {
+            return Err(Error::Length);
+        }
+
+        let mut bytes = [0u8; Self::BYTE_SIZE];
+        decoder.decode_into(&mut bytes)?;
+        Ok(Self(bytes))
+    }
+}
+
+impl AsRef<[u8; Self::BYTE_SIZE]> for Ed25519PublicKey {
+    fn as_ref(&self) -> &[u8; Self::BYTE_SIZE] {
+        &self.0
+    }
+}
+
+impl fmt::Display for Ed25519PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:X}", self)
+    }
+}
+
+impl fmt::LowerHex for Ed25519PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for byte in self.as_ref() {
+            write!(f, "{:02x}", byte)?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::UpperHex for Ed25519PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for byte in self.as_ref() {
+            write!(f, "{:02X}", byte)?;
+        }
+        Ok(())
+    }
+}
+
+/// RSA public key.
+///
+/// Described in [RFC4253 § 6.6](https://datatracker.ietf.org/doc/html/rfc4253#section-6.6):
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct RsaPublicKey {
+    /// Public exponent
+    pub e: MPInt,
+
+    /// Modulus
+    pub n: MPInt,
+}
+
+#[cfg(feature = "alloc")]
+impl RsaPublicKey {
+    /// Decode RSA public key using the provided Base64 decoder.
+    fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+        let e = MPInt::decode(decoder)?;
+        let n = MPInt::decode(decoder)?;
+        Ok(Self { e, n })
+    }
+}

--- a/ssh-key/src/public/openssh.rs
+++ b/ssh-key/src/public/openssh.rs
@@ -1,0 +1,100 @@
+//! Support for OpenSSH-formatted public keys
+//!
+//! These keys have the form:
+//!
+//! ```text
+//! <algorithm id> <base64 data> <comment>
+//! ```
+//!
+//! ## Example
+//!
+//! ```text
+//! ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILM+rvN+ot98qgEN796jTiQfZfG1KaT0PtFDJ/XFSqti user@example.com
+//! ```
+
+use crate::{Error, Result};
+use core::str;
+
+/// OpenSSH public key encapsulation.
+pub(crate) struct Encapsulation<'a> {
+    /// Algorithm identifier
+    pub(super) algorithm_id: &'a str,
+
+    /// Base64-encoded key data
+    pub(super) base64_data: &'a [u8],
+
+    /// Comment
+    #[cfg_attr(not(feature = "alloc"), allow(dead_code))]
+    pub(super) comment: &'a str,
+}
+
+impl<'a> Encapsulation<'a> {
+    /// Parse the given binary data.
+    pub(super) fn parse(mut bytes: &'a [u8]) -> Result<Self> {
+        let algorithm_id =
+            str::from_utf8(parse_segment(&mut bytes)?).map_err(|_| Error::CharacterEncoding)?;
+        let base64_data = parse_segment(&mut bytes)?;
+        let comment = str::from_utf8(bytes)
+            .map_err(|_| Error::CharacterEncoding)?
+            .trim_end();
+
+        if algorithm_id.is_empty() || base64_data.is_empty() || comment.is_empty() {
+            // TODO(tarcieri): better errors for these cases?
+            return Err(Error::Length);
+        }
+
+        Ok(Self {
+            algorithm_id,
+            base64_data,
+            comment,
+        })
+    }
+}
+
+/// Parse a segment of the public key.
+fn parse_segment<'a>(bytes: &mut &'a [u8]) -> Result<&'a [u8]> {
+    let start = *bytes;
+    let mut len = 0;
+
+    loop {
+        match *bytes {
+            [b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'+' | b'-' | b'/' | b'=', rest @ ..] => {
+                // Valid character; continue
+                *bytes = rest;
+                len += 1;
+            }
+            [b' ', rest @ ..] => {
+                // Encountered space; we're done
+                *bytes = rest;
+                return start.get(..len).ok_or(Error::Length);
+            }
+            [_, ..] => {
+                // Invalid character
+                // TODO(tarcieri): better error?
+                return Err(Error::CharacterEncoding);
+            }
+            [] => {
+                // Truncated public key
+                return Err(Error::Length);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Encapsulation;
+
+    const EXAMPLE_KEY: &str = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILM+rvN+ot98qgEN796jTiQfZfG1KaT0PtFDJ/XFSqti user@example.com";
+
+    #[test]
+    fn decode() {
+        let encapsulation = Encapsulation::parse(EXAMPLE_KEY.as_bytes()).unwrap();
+        assert_eq!(encapsulation.algorithm_id, "ssh-ed25519");
+        assert_eq!(
+            encapsulation.base64_data,
+            b"AAAAC3NzaC1lZDI1NTE5AAAAILM+rvN+ot98qgEN796jTiQfZfG1KaT0PtFDJ/XFSqti"
+        );
+        assert_eq!(encapsulation.comment, "user@example.com");
+    }
+}

--- a/ssh-key/tests/public_key.rs
+++ b/ssh-key/tests/public_key.rs
@@ -1,0 +1,205 @@
+//! SSH public key tests.
+
+use hex_literal::hex;
+use ssh_key::{Algorithm, PublicKey};
+
+#[cfg(feature = "sec1")]
+use ssh_key::EcdsaCurve;
+
+/// DSA OpenSSH-formatted public key
+#[cfg(feature = "alloc")]
+const OSSH_DSA_EXAMPLE: &str = include_str!("examples/id_dsa_1024.pub");
+
+/// ECDSA/P-256 OpenSSH-formatted public key
+#[cfg(feature = "sec1")]
+const OSSH_ECDSA_P256_EXAMPLE: &str = include_str!("examples/id_ecdsa_p256.pub");
+
+/// ECDSA/P-384 OpenSSH-formatted public key
+#[cfg(feature = "sec1")]
+const OSSH_ECDSA_P384_EXAMPLE: &str = include_str!("examples/id_ecdsa_p384.pub");
+
+/// ECDSA/P-521 OpenSSH-formatted public key
+#[cfg(feature = "sec1")]
+const OSSH_ECDSA_P521_EXAMPLE: &str = include_str!("examples/id_ecdsa_p521.pub");
+
+/// Ed25519 OpenSSH-formatted public key
+const OSSH_ED25519_EXAMPLE: &str = include_str!("examples/id_ed25519.pub");
+
+/// RSA (3072-bit) OpenSSH-formatted public key
+#[cfg(feature = "alloc")]
+const OSSH_RSA_3072_EXAMPLE: &str = include_str!("examples/id_rsa_3072.pub");
+
+/// RSA (4096-bit) OpenSSH-formatted public key
+#[cfg(feature = "alloc")]
+const OSSH_RSA_4096_EXAMPLE: &str = include_str!("examples/id_rsa_4096.pub");
+
+#[cfg(feature = "alloc")]
+#[test]
+fn decode_dsa_openssh() {
+    let key = PublicKey::from_openssh(OSSH_DSA_EXAMPLE).unwrap();
+    assert_eq!(key.data.algorithm(), Algorithm::Dsa);
+
+    let dsa_key = key.data.dsa().unwrap();
+    assert_eq!(
+        dsa_key.p.as_bytes(),
+        &hex!(
+            "00dc3d89250ed9462114cb2c8d4816e3a511aaff1b06b0e01de17c1cb04e581bcab97176471d89fd7ca1817
+             e3c48e2ccbafd2170f69e8e5c8b6ab69b9c5f45d95e1d9293e965227eee5b879b1123371c21b1db60f14b5e
+             5c05a4782ceb43a32f449647703063621e7a286bec95b16726c18b5e52383d00b297a6b03489b06068a5"
+        )
+    );
+    assert_eq!(
+        dsa_key.q.as_bytes(),
+        &hex!("00891815378597fe42d3fd261fe76df365845bbb87")
+    );
+    assert_eq!(
+        dsa_key.g.as_bytes(),
+        &hex!(
+            "4739b3908a8415466dc7b156fb98ecb71552a170ba0b3b7aa81bd81391de0a7ae7a1b45002dfeadc9225fbc
+             520a713fe4104a74bed53fd5915da736365afd3f09777bbccfbadf7ac2b087b7f4d95fabe47d72a46e95088
+             f9cd2a9fbf236b58a6982647f3c00430ad7352d47a25ebbe9477f0c3127da86ad7448644b76de5875c"
+        )
+    );
+    assert_eq!(
+        dsa_key.y.as_bytes(),
+        &hex!(
+            "6042a6b3fd861344cb21ccccd8719e25aa0be0980e79cbabf4877f5ef071f6039770352eac3d4c368f29daf
+             a57b475c78d44989f16577527e598334be6aae4abd750c36af80489d392697c1f32f3cf3c9a8b99bcddb53d
+             7a37e1a28fd53d4934131cf41c437c6734d1e04004adcd925b84b3956c30c3a3904eecb31400b0df48"
+        )
+    );
+
+    assert_eq!(key.comment, "user@example.com");
+}
+
+#[cfg(feature = "sec1")]
+#[test]
+fn decode_ecdsa_p256_openssh() {
+    let key = PublicKey::from_openssh(OSSH_ECDSA_P256_EXAMPLE).unwrap();
+    assert_eq!(key.data.algorithm(), Algorithm::Ecdsa(EcdsaCurve::NistP256));
+
+    let ecdsa_key = key.data.ecdsa().unwrap();
+    assert_eq!(ecdsa_key.curve(), EcdsaCurve::NistP256);
+    assert_eq!(
+        ecdsa_key.as_ref(),
+        &hex!(
+            "047c1fd8730ce53457be8d924098ec3648830f92aa8a2363ac656fdd4521fa6313e511f1891b4e9e5aaf8e1
+             42d06ad15a66a4257f3f051d84e8a0e2f91ba807047"
+        )
+    );
+
+    #[cfg(feature = "alloc")]
+    assert_eq!(key.comment, "user@example.com");
+}
+
+#[cfg(feature = "sec1")]
+#[test]
+fn decode_ecdsa_p384_openssh() {
+    let key = PublicKey::from_openssh(OSSH_ECDSA_P384_EXAMPLE).unwrap();
+    assert_eq!(key.data.algorithm(), Algorithm::Ecdsa(EcdsaCurve::NistP384));
+
+    let ecdsa_key = key.data.ecdsa().unwrap();
+    assert_eq!(ecdsa_key.curve(), EcdsaCurve::NistP384);
+    assert_eq!(
+        ecdsa_key.as_ref(),
+        &hex!(
+            "042e6e82dc5407f104a11117c7c05b1993c3ceb3db25fae68ba169502a4ff9395d9ad36b543e8014ff15d70
+             8e21f09f585aa6dfad575b79b943418b86198d9bcd9b07fff9399b15d43d34efaeb2e56b7b33cff880b242b
+             3e0b58af96c75841ec41"
+        )
+    );
+
+    #[cfg(feature = "alloc")]
+    assert_eq!(key.comment, "user@example.com");
+}
+
+#[cfg(feature = "sec1")]
+#[test]
+fn decode_ecdsa_p521_openssh() {
+    let key = PublicKey::from_openssh(OSSH_ECDSA_P521_EXAMPLE).unwrap();
+    assert_eq!(key.data.algorithm(), Algorithm::Ecdsa(EcdsaCurve::NistP521));
+
+    let ecdsa_key = key.data.ecdsa().unwrap();
+    assert_eq!(ecdsa_key.curve(), EcdsaCurve::NistP521);
+    assert_eq!(
+        ecdsa_key.as_ref(),
+        &hex!(
+            "04016136934f192b23d961fbf44c8184166002cea2c7d18b20ad018d046ef068d3e8250fd4e9f17ca6693a8
+             554c3269a6d9f5762a2f9a2cb8797d4b201de421d3dcc580103cb947a858bb7783df863f82951d96f91a792
+             5d7e2baad26e47e3f2fa5b07c8272848a4423b750d7ad2b8b692d66ddecaec5385086b1fd1b682ca291c88d
+             63762"
+        )
+    );
+
+    #[cfg(feature = "alloc")]
+    assert_eq!(key.comment, "user@example.com");
+}
+
+#[test]
+fn decode_ed25519_openssh() {
+    let key = PublicKey::from_openssh(OSSH_ED25519_EXAMPLE).unwrap();
+
+    assert_eq!(key.data.algorithm(), Algorithm::Ed25519);
+    assert_eq!(
+        key.data.ed25519().unwrap().as_ref(),
+        &hex!("b33eaef37ea2df7caa010defdea34e241f65f1b529a4f43ed14327f5c54aab62")
+    );
+
+    #[cfg(feature = "alloc")]
+    assert_eq!(key.comment, "user@example.com");
+}
+
+#[cfg(feature = "alloc")]
+#[test]
+fn decode_rsa_3072_openssh() {
+    let key = PublicKey::from_openssh(OSSH_RSA_3072_EXAMPLE).unwrap();
+    assert_eq!(key.data.algorithm(), Algorithm::Rsa);
+
+    let rsa_key = key.data.rsa().unwrap();
+    assert_eq!(rsa_key.e.as_bytes(), &hex!("010001"));
+    assert_eq!(
+        rsa_key.n.as_bytes(),
+        &hex!(
+            "00a68e478c9bc93726436b7f5e9e6f9a46e1b73bec1e8cb7754de2c6a5b6c455f2f012a7259afcf94181d69
+             e95d39a349e4d2b482a5372b28943731db75c73ce7bd9eec85010c94bfae56960118922f86a8b3655b357d2
+             4e7a679cd8a7d9bf6eae66f7f9a56fe3d090d0632218a682960d8aad93c01898780ead2dbefd70fb4703471
+             7e412e4fdae685292ec891e2423f7fe43df2f54329ab0a5d7561e582e42e86ebaee0c1e9eaf603d7ce70850
+             5d0ee090912e1fc3735eb5804ddf42b6133107a76e9a59cdfc6b65f43c6302cfbca8e7aa6f97457fa96d3b5
+             a26e8f41204d2cd42be119c684b0f02370899a71ae3c1e71331543cc3fb2b4268780011ae4ea934c0ff0770
+             8ee183e7e906fee489e8e1e57fce7a1c6df8fbaef39bbd1955dbd5ad1abffbe126f50205cb884af080ff3d7
+             0549d3174b85bd7f6624c3753cf235b650d0e4228f32be7b54a590d869fb7786559bb7a4d66f9d3a69c085e
+             fdf083a915d47a1d9161a08756b263b06e739d99f2890362abc96ade42cce8f939a40daff9"
+        )
+    );
+
+    assert_eq!(key.comment, "user@example.com");
+}
+
+#[cfg(feature = "alloc")]
+#[test]
+fn decode_rsa_4096_openssh() {
+    let key = PublicKey::from_openssh(OSSH_RSA_4096_EXAMPLE).unwrap();
+    assert_eq!(key.data.algorithm(), Algorithm::Rsa);
+
+    let rsa_key = key.data.rsa().unwrap();
+    assert_eq!(rsa_key.e.as_bytes(), &hex!("010001"));
+    assert_eq!(
+        rsa_key.n.as_bytes(),
+        &hex!(
+            "00b45911edc6ec5e7d2261a48c46ab889b1858306271123e6f02dc914cf3c0352492e8a6b7a7925added527
+             e547dcebff6d0c19c0bc9153975199f47f4964ed20f5aceed4e82556b228a0c1fbfaa85e6339ba2ff4094d9
+             4e2b09d43a3dd68225d0bbc858293cbf167b18d6374ebe79220a633d400176f1f6b46fd626acb252bf294aa
+             db2acd59626a023a8e5ec53ced8685164c72ca3a2ec646812c6e61ffcba740ff15c054f0691e3a8d52c79c4
+             4b7c1fc6c9704aed09ee0195bf09c5c5ba1173b7b1179be33fb3711d3b82e98f80521367a84303cb1236ebe
+             8fc095683420a4de652c071d592759d42a0c9d2e73313cdfb71a071c936659433481a406308820e173b934f
+             be877d873fec24d31a4d3bb9a3645055ca37bf710e214e5fc250d5964c66f18e4f05a3b93f42aa0753bd044
+             e45b456c0e62fdcc1fcadef72930dc8a7a96b3e27d8eecea139a00aaf2fe79063ccb78d26d537625bdf0c4c
+             8a68a04ed6f965eef7a6b1da5d8e26fc57f1047b97e2c594a9e420410977f22d1751b6d9498e8e457034049
+             3c336bf86563ef03a15bc49b0ba6fe73201f64f0413ddb4d0cc5f6cf43389907e1df29e0cc388040e3371d0
+             4814140f75cac08079431043222fb91f075d76be55cbe138e3b99a605c561c49dea50e253c8306c4f4f77d9
+             96f898db64c5d8a0a15c6efa28b0934bf0b6f2b01950d877230fe4401078420fd6dd3"
+        )
+    );
+
+    assert_eq!(key.comment, "user@example.com");
+}


### PR DESCRIPTION
Adds an initial `public` module with a set of public key types:

- `ecdsa-sha2-nistp256`
- `ecdsa-sha2-nistp384`
- `ecdsa-sha2-nistp521`
- `ssh-dss`
- `ssh-ed25519`
- `ssh-rsa`

Support is implemented for decoding OpenSSH-formatted public keys.