### PR TITLE
base64ct: simplify incremental decoder

### DIFF
--- a/base64ct/tests/proptests.rs
+++ b/base64ct/tests/proptests.rs
@@ -33,10 +33,8 @@ proptest! {
 
         for chunk in bytes.chunks(chunk_size) {
             prop_assert!(!decoder.is_finished());
-            match decoder.decode_partial(&mut buffer[..chunk_size]) {
-                Ok(Some(decoded)) => prop_assert_eq!(chunk, decoded),
-                other => panic!("decode failed: {:?}", other),
-            }
+            let decoded = decoder.decode(&mut buffer[..chunk.len()]).unwrap();
+            prop_assert_eq!(chunk, decoded);
         }
 
         prop_assert!(decoder.is_finished());

--- a/ssh-key/src/base64.rs
+++ b/ssh-key/src/base64.rs
@@ -28,7 +28,7 @@ impl<'i> Decoder<'i> {
     /// - `Ok(bytes)` if the expected amount of data was read
     /// - `Err(Error::Length)` if the exact amount of data couldn't be read
     pub(crate) fn decode_into<'o>(&mut self, out: &'o mut [u8]) -> Result<&'o [u8]> {
-        Ok(self.inner.decode_exact(out)?)
+        Ok(self.inner.decode(out)?)
     }
 
     /// Decodes a `uint32` as described in [RFC4251 § 5]:


### PR DESCRIPTION
Consolidates the `decode_partial` and `decode_exact` methods into a single `decode` method, since that's all that's needed (for now).

Makes the `BlockBuffer` persistent which simplifies the implementation somewhat.