### PR TITLE
base64ct v1.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "base64ct"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "base64",
  "proptest",

--- a/base64ct/CHANGELOG.md
+++ b/base64ct/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.3.0 (2021-12-02)
+### Added
+- Stateful `Decoder` type ([#266])
+
+[#266]: https://github.com/RustCrypto/formats/pull/266
+
 ## 1.2.0 (2021-11-03)
 ### Changed
 - Rust 2021 edition upgrade; MSRV 1.56 ([#136])

--- a/base64ct/Cargo.toml
+++ b/base64ct/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base64ct"
-version = "1.2.0" # Also update html_root_url in lib.rs when bumping this
+version = "1.3.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Base64 (RFC 4648) which avoids any usages of
 data-dependent branches/LUTs and thereby provides portable "best effort"

--- a/base64ct/src/lib.rs
+++ b/base64ct/src/lib.rs
@@ -60,7 +60,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/base64ct/1.2.0"
+    html_root_url = "https://docs.rs/base64ct/1.3.0"
 )]
 #![warn(missing_docs, rust_2018_idioms)]
 

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-base64ct = { version = "1", path = "../base64ct" } # TODO: bump to 1.3.0 before release
+base64ct = { version = "1.3", path = "../base64ct" }
 
 # optional dependencies
 sec1 = { version = "0.2", optional = true, default-features = false, path = "../sec1" }


### PR DESCRIPTION
### Added
- Stateful `Decoder` type ([#266])

[#266]: https://github.com/RustCrypto/formats/pull/266