### PR TITLE
tls_codec: preliminary `no_std` support

### DIFF
--- a/.github/workflows/tls_codec.yml
+++ b/.github/workflows/tls_codec.yml
@@ -40,6 +40,25 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --release --features serde_serialize
       - run: cargo build --target ${{ matrix.target }} --release --all-features
 
+  no_std:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.56.0 # MSRV
+          - stable
+        target:
+          - thumbv7em-none-eabi
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          target: ${{ matrix.target }}
+          override: true
+      - run: cargo build --target ${{ matrix.target }} --no-default-features --release
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/tls_codec/Cargo.toml
+++ b/tls_codec/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-zeroize = { version = "1", features = ["zeroize_derive"] }
+zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
 
 # optional dependencies
 serde = { version = "1.0", features = ["derive"], optional = true }
@@ -21,9 +21,15 @@ tls_codec_derive = { version = "=0.2.0-pre.3", path = "derive", optional = true 
 criterion = "0.3"
 
 [features]
-derive = [ "tls_codec_derive" ]
+default = [ "std" ]
+derive = [ "std", "tls_codec_derive" ]
 serde_serialize = [ "serde" ]
+std = []
 
 [[bench]]
 name = "tls_vec"
 harness = false
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/tls_codec/src/arrays.rs
+++ b/tls_codec/src/arrays.rs
@@ -1,9 +1,15 @@
 //! Implement the TLS codec for some byte arrays.
 
-use super::{Deserialize, Error, Serialize, Size};
-use std::io::{Read, Write};
+use crate::{Deserialize, Serialize, Size};
+
+#[cfg(feature = "std")]
+use {
+    crate::Error,
+    std::io::{Read, Write},
+};
 
 impl<const LEN: usize> Serialize for [u8; LEN] {
+    #[cfg(feature = "std")]
     #[inline]
     fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
         let written = writer.write(self)?;
@@ -19,6 +25,7 @@ impl<const LEN: usize> Serialize for [u8; LEN] {
 }
 
 impl<const LEN: usize> Deserialize for [u8; LEN] {
+    #[cfg(feature = "std")]
     #[inline]
     fn tls_deserialize<R: Read>(bytes: &mut R) -> Result<Self, Error> {
         let mut out = [0u8; LEN];

--- a/tls_codec/src/lib.rs
+++ b/tls_codec/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc = include_str!("../README.md")]
 
 //! ## Usage
@@ -13,14 +15,24 @@
 //! assert_eq!(&[77, 88, 1, 99], v.as_slice());
 //! ```
 
-use std::{
-    fmt::Display,
-    io::{Read, Write},
+#[cfg_attr(feature = "std", macro_use)]
+extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;
+
+use alloc::string::String;
+use core::fmt::{self, Display};
+#[cfg(feature = "std")]
+use {
+    alloc::vec::Vec,
+    std::io::{Read, Write},
 };
 
 mod arrays;
 mod primitives;
 mod tls_vec;
+
 pub use tls_vec::{
     SecretTlsVecU16, SecretTlsVecU32, SecretTlsVecU8, TlsByteSliceU16, TlsByteSliceU32,
     TlsByteSliceU8, TlsByteVecU16, TlsByteVecU32, TlsByteVecU8, TlsSliceU16, TlsSliceU32,
@@ -52,14 +64,17 @@ pub enum Error {
     EndOfStream,
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for Error {}
 
 impl Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_fmt(format_args!("{:?}", self))
     }
 }
 
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl From<std::io::Error> for Error {
     fn from(e: std::io::Error) -> Self {
         match e.kind() {
@@ -85,9 +100,13 @@ pub trait Size {
 pub trait Serialize: Size {
     /// Serialize `self` and write it to the `writer`.
     /// The function returns the number of bytes written to `writer`.
+    #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, Error>;
 
     /// Serialize `self` and return it as a byte vector.
+    #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn tls_serialize_detached(&self) -> Result<Vec<u8>, Error> {
         let mut buffer = Vec::with_capacity(self.tls_serialized_len());
         let written = self.tls_serialize(&mut buffer)?;
@@ -117,6 +136,8 @@ pub trait Deserialize: Size {
     /// and returns the populated struct.
     ///
     /// In order to get the amount of bytes read, use [`Size::tls_serialized_len`].
+    #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn tls_deserialize<R: Read>(bytes: &mut R) -> Result<Self, Error>
     where
         Self: Sized;

--- a/tls_codec/src/primitives.rs
+++ b/tls_codec/src/primitives.rs
@@ -2,6 +2,7 @@
 
 use super::{Deserialize, Error, Serialize, Size};
 
+#[cfg(feature = "std")]
 use std::io::{Read, Write};
 
 impl<T: Size> Size for Option<T> {
@@ -22,6 +23,7 @@ impl<T: Size> Size for &Option<T> {
 }
 
 impl<T: Serialize> Serialize for Option<T> {
+    #[cfg(feature = "std")]
     fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
         match self {
             Some(e) => {
@@ -38,12 +40,14 @@ impl<T: Serialize> Serialize for Option<T> {
 }
 
 impl<T: Serialize> Serialize for &Option<T> {
+    #[cfg(feature = "std")]
     fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
         (*self).tls_serialize(writer)
     }
 }
 
 impl<T: Deserialize> Deserialize for Option<T> {
+    #[cfg(feature = "std")]
     #[inline]
     fn tls_deserialize<R: Read>(bytes: &mut R) -> Result<Self, Error> {
         let mut some_or_none = [0u8; 1];
@@ -64,6 +68,7 @@ impl<T: Deserialize> Deserialize for Option<T> {
 macro_rules! impl_unsigned {
     ($t:ty, $bytes:literal) => {
         impl Deserialize for $t {
+            #[cfg(feature = "std")]
             #[inline]
             fn tls_deserialize<R: Read>(bytes: &mut R) -> Result<Self, Error> {
                 let mut x = (0 as $t).to_be_bytes();
@@ -73,6 +78,7 @@ macro_rules! impl_unsigned {
         }
 
         impl Serialize for $t {
+            #[cfg(feature = "std")]
             #[inline]
             fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
                 let written = writer.write(&self.to_be_bytes())?;
@@ -81,6 +87,7 @@ macro_rules! impl_unsigned {
         }
 
         impl Serialize for &$t {
+            #[cfg(feature = "std")]
             #[inline]
             fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
                 (*self).tls_serialize(writer)
@@ -108,8 +115,8 @@ impl_unsigned!(u16, 2);
 impl_unsigned!(u32, 4);
 impl_unsigned!(u64, 8);
 
-impl From<std::array::TryFromSliceError> for Error {
-    fn from(_: std::array::TryFromSliceError) -> Self {
+impl From<core::array::TryFromSliceError> for Error {
+    fn from(_: core::array::TryFromSliceError) -> Self {
         Self::InvalidInput
     }
 }
@@ -120,6 +127,7 @@ where
     T: Deserialize,
     U: Deserialize,
 {
+    #[cfg(feature = "std")]
     #[inline(always)]
     fn tls_deserialize<R: Read>(bytes: &mut R) -> Result<Self, Error> {
         Ok((T::tls_deserialize(bytes)?, U::tls_deserialize(bytes)?))
@@ -131,6 +139,7 @@ where
     T: Serialize,
     U: Serialize,
 {
+    #[cfg(feature = "std")]
     #[inline(always)]
     fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
         let written = self.0.tls_serialize(writer)?;
@@ -155,6 +164,7 @@ where
     U: Deserialize,
     V: Deserialize,
 {
+    #[cfg(feature = "std")]
     #[inline(always)]
     fn tls_deserialize<R: Read>(bytes: &mut R) -> Result<Self, Error> {
         Ok((
@@ -171,6 +181,7 @@ where
     U: Serialize,
     V: Serialize,
 {
+    #[cfg(feature = "std")]
     #[inline(always)]
     fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
         let mut written = self.0.tls_serialize(writer)?;
@@ -199,6 +210,7 @@ impl Size for () {
 }
 
 impl Deserialize for () {
+    #[cfg(feature = "std")]
     #[inline(always)]
     fn tls_deserialize<R: Read>(_: &mut R) -> Result<(), Error> {
         Ok(())
@@ -206,6 +218,7 @@ impl Deserialize for () {
 }
 
 impl Serialize for () {
+    #[cfg(feature = "std")]
     fn tls_serialize<W: Write>(&self, _: &mut W) -> Result<usize, Error> {
         Ok(0)
     }


### PR DESCRIPTION
Adds initial support for `no_std` targets (currently with a hard `alloc` dependency) by gating all `std`-related functionality on a newly added eponymous crate feature.

Unfortunately all serialization/deserialization is currently performed in terms of the `Read` and `Write` traits from `std::io`, so this doesn't result in something immediately useful on `no_std` targets. However, it does provide the initial boilerplate and first steps towards making that possible.