### PR TITLE
ssh-key: initial private key support (Ed25519-only)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -933,11 +933,12 @@ dependencies = [
 
 [[package]]
 name = "ssh-key"
-version = "0.1.0"
+version = "0.2.0-pre"
 dependencies = [
  "base64ct",
  "hex-literal",
  "sec1",
+ "zeroize",
 ]
 
 [[package]]

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssh-key"
-version = "0.1.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.0-pre" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of SSH key file format decoders/encoders as described
 in RFC4253 and RFC4716 as well as the OpenSSH key formats. Supports "heapless"
@@ -16,7 +16,8 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-base64ct = { version = "1.3", path = "../base64ct" }
+base64ct = { version = "1.3.1", path = "../base64ct" }
+zeroize = { version = "1", default-features = false }
 
 # optional dependencies
 sec1 = { version = "0.2", optional = true, default-features = false, path = "../sec1" }

--- a/ssh-key/src/algorithm.rs
+++ b/ssh-key/src/algorithm.rs
@@ -1,4 +1,12 @@
-//! Algorithm registry
+//! Algorithm support.
+
+#[cfg(feature = "alloc")]
+pub(crate) mod dsa;
+#[cfg(feature = "sec1")]
+pub(crate) mod ecdsa;
+pub(crate) mod ed25519;
+#[cfg(feature = "alloc")]
+pub(crate) mod rsa;
 
 use crate::{base64, Error, Result};
 use core::{fmt, str};
@@ -48,7 +56,6 @@ impl Algorithm {
     /// Decode algorithm from the given string identifier.
     ///
     /// # Supported algorithms
-    ///
     /// - `ecdsa-sha2-nistp256`
     /// - `ecdsa-sha2-nistp384`
     /// - `ecdsa-sha2-nistp521`
@@ -116,7 +123,58 @@ impl str::FromStr for Algorithm {
     type Err = Error;
 
     fn from_str(id: &str) -> Result<Self> {
-        Algorithm::new(id)
+        Self::new(id)
+    }
+}
+
+/// Cipher algorithms.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[non_exhaustive]
+pub enum CipherAlg {
+    /// None.
+    None,
+}
+
+impl CipherAlg {
+    /// Maximum size of cipher algorithms known to this crate in bytes.
+    const MAX_SIZE: usize = 4;
+
+    /// Decode cipher algorithm from the given `ciphername`.
+    ///
+    /// # Supported ciphernames
+    /// - `none`
+    pub fn new(ciphername: &str) -> Result<Self> {
+        match ciphername {
+            "none" => Ok(CipherAlg::None),
+            _ => Err(Error::Algorithm),
+        }
+    }
+
+    /// Get the string identifier which corresponds to this algorithm.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            CipherAlg::None => "none",
+        }
+    }
+
+    /// Decode cipher algorithm using the supplied Base64 decoder.
+    pub(crate) fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+        let mut buf = [0u8; Self::MAX_SIZE];
+        Self::new(decoder.decode_str(&mut buf)?)
+    }
+}
+
+impl fmt::Display for CipherAlg {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl str::FromStr for CipherAlg {
+    type Err = Error;
+
+    fn from_str(id: &str) -> Result<Self> {
+        Self::new(id)
     }
 }
 
@@ -182,5 +240,80 @@ impl str::FromStr for EcdsaCurve {
 
     fn from_str(id: &str) -> Result<Self> {
         EcdsaCurve::new(id)
+    }
+}
+
+/// Key Derivation Function (KDF) algorithms.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[non_exhaustive]
+pub enum KdfAlg {
+    /// None.
+    None,
+}
+
+impl KdfAlg {
+    /// Maximum size of KDF algorithms known to this crate in bytes.
+    const MAX_SIZE: usize = 4;
+
+    /// Decode KDF algorithm from the given `kdfname`.
+    ///
+    /// # Supported kdfnames
+    /// - `none`
+    pub fn new(kdfname: &str) -> Result<Self> {
+        match kdfname {
+            "none" => Ok(KdfAlg::None),
+            _ => Err(Error::Algorithm),
+        }
+    }
+
+    /// Get the string identifier which corresponds to this algorithm.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            KdfAlg::None => "none",
+        }
+    }
+
+    /// Decode KDF algorithm using the supplied Base64 decoder.
+    pub(crate) fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+        let mut buf = [0u8; Self::MAX_SIZE];
+        Self::new(decoder.decode_str(&mut buf)?)
+    }
+}
+
+impl fmt::Display for KdfAlg {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl str::FromStr for KdfAlg {
+    type Err = Error;
+
+    fn from_str(id: &str) -> Result<Self> {
+        Self::new(id)
+    }
+}
+
+/// Key Derivation Function (KDF) options.
+// TODO(tarcieri): stub!
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct KdfOptions {}
+
+impl KdfOptions {
+    /// Create new KDF options.
+    pub(crate) fn new(kdfoptions: &str) -> Result<Self> {
+        // TODO(tarcieri): support for KDF options
+        if kdfoptions.is_empty() {
+            Ok(Self {})
+        } else {
+            Err(Error::Algorithm)
+        }
+    }
+
+    /// Decode KDF options using the supplied Base64 decoder.
+    pub(crate) fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+        let mut buf = [0u8; 0];
+        Self::new(decoder.decode_str(&mut buf)?)
     }
 }

--- a/ssh-key/src/algorithm/dsa.rs
+++ b/ssh-key/src/algorithm/dsa.rs
@@ -1,0 +1,35 @@
+//! Digital Signature Algorithm (DSA).
+
+use crate::{base64, MPInt, Result};
+
+/// Digital Signature Algorithm (DSA) public key.
+///
+/// Described in [FIPS 186-4](https://csrc.nist.gov/publications/detail/fips/186/4/final).
+// TODO(tarcieri): use `dsa::PublicKey`? (doesn't exist yet)
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct DsaPublicKey {
+    /// Prime modulus
+    pub p: MPInt,
+
+    /// Prime divisor of `p - 1`
+    pub q: MPInt,
+
+    /// Generator of a subgroup of order `q` in the multiplicative group
+    /// `GF(p)`, such that `1 < g < p`.
+    pub g: MPInt,
+
+    /// The public key, where `y = gˣ mod p`
+    pub y: MPInt,
+}
+
+impl DsaPublicKey {
+    /// Decode DSA public key using the provided Base64 decoder.
+    pub(crate) fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+        let p = MPInt::decode(decoder)?;
+        let q = MPInt::decode(decoder)?;
+        let g = MPInt::decode(decoder)?;
+        let y = MPInt::decode(decoder)?;
+        Ok(Self { p, q, g, y })
+    }
+}

--- a/ssh-key/src/algorithm/ecdsa.rs
+++ b/ssh-key/src/algorithm/ecdsa.rs
@@ -1,0 +1,124 @@
+//! Elliptic Curve Digital Signature Algorithm (ECDSA).
+
+use crate::{base64, Algorithm, EcdsaCurve, Error, Result};
+use core::fmt;
+use sec1::consts::{U32, U48, U66};
+
+/// Elliptic Curve Digital Signature Algorithm (ECDSA) public key.
+///
+/// Public keys are represented as [`sec1::EncodedPoint`] and require the
+/// `sec1` feature of this crate is enabled (which it is by default).
+///
+/// Described in [FIPS 186-4](https://csrc.nist.gov/publications/detail/fips/186/4/final).
+#[cfg_attr(docsrs, doc(cfg(feature = "sec1")))]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub enum EcdsaPublicKey {
+    /// NIST P-256 ECDSA public key.
+    NistP256(sec1::EncodedPoint<U32>),
+
+    /// NIST P-384 ECDSA public key.
+    NistP384(sec1::EncodedPoint<U48>),
+
+    /// NIST P-521 ECDSA public key.
+    NistP521(sec1::EncodedPoint<U66>),
+}
+
+impl EcdsaPublicKey {
+    /// Maximum size of a SEC1-encoded ECDSA public key (i.e. curve point).
+    ///
+    /// This is the size of 2 * P-521 curve points (2 * 66 = 132) plus one
+    /// additional byte for the "tag".
+    const MAX_SIZE: usize = 133;
+
+    /// Parse an ECDSA public key from a SEC1-encoded point.
+    ///
+    /// Determines the key type from the SEC1 tag byte and length.
+    pub fn from_sec1_bytes(bytes: &[u8]) -> Result<Self> {
+        match bytes {
+            [tag, rest @ ..] => {
+                let point_size = match sec1::point::Tag::from_u8(*tag)? {
+                    sec1::point::Tag::CompressedEvenY | sec1::point::Tag::CompressedOddY => {
+                        rest.len()
+                    }
+                    sec1::point::Tag::Uncompressed => rest.len() / 2,
+                    _ => return Err(Error::Algorithm),
+                };
+
+                match point_size {
+                    32 => Ok(Self::NistP256(sec1::EncodedPoint::from_bytes(bytes)?)),
+                    48 => Ok(Self::NistP384(sec1::EncodedPoint::from_bytes(bytes)?)),
+                    66 => Ok(Self::NistP521(sec1::EncodedPoint::from_bytes(bytes)?)),
+                    _ => Err(Error::Length),
+                }
+            }
+            _ => Err(Error::Length),
+        }
+    }
+
+    /// Borrow the SEC1-encoded key data as bytes.
+    pub fn as_sec1_bytes(&self) -> &[u8] {
+        match self {
+            EcdsaPublicKey::NistP256(point) => point.as_bytes(),
+            EcdsaPublicKey::NistP384(point) => point.as_bytes(),
+            EcdsaPublicKey::NistP521(point) => point.as_bytes(),
+        }
+    }
+
+    /// Get the [`Algorithm`] for this public key type.
+    pub fn algorithm(&self) -> Algorithm {
+        Algorithm::Ecdsa(self.curve())
+    }
+
+    /// Get the [`EcdsaCurve`] for this key.
+    pub fn curve(&self) -> EcdsaCurve {
+        match self {
+            EcdsaPublicKey::NistP256(_) => EcdsaCurve::NistP256,
+            EcdsaPublicKey::NistP384(_) => EcdsaCurve::NistP384,
+            EcdsaPublicKey::NistP521(_) => EcdsaCurve::NistP521,
+        }
+    }
+
+    /// Decode ECDSA public key using the provided Base64 decoder.
+    pub(crate) fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+        let curve = EcdsaCurve::decode(decoder)?;
+
+        let mut buf = [0u8; Self::MAX_SIZE];
+        let key = Self::from_sec1_bytes(decoder.decode_byte_slice(&mut buf)?)?;
+
+        if key.curve() == curve {
+            Ok(key)
+        } else {
+            Err(Error::Algorithm)
+        }
+    }
+}
+
+impl AsRef<[u8]> for EcdsaPublicKey {
+    fn as_ref(&self) -> &[u8] {
+        self.as_sec1_bytes()
+    }
+}
+
+impl fmt::Display for EcdsaPublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:X}", self)
+    }
+}
+
+impl fmt::LowerHex for EcdsaPublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for byte in self.as_sec1_bytes() {
+            write!(f, "{:02x}", byte)?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::UpperHex for EcdsaPublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for byte in self.as_sec1_bytes() {
+            write!(f, "{:02X}", byte)?;
+        }
+        Ok(())
+    }
+}

--- a/ssh-key/src/algorithm/ed25519.rs
+++ b/ssh-key/src/algorithm/ed25519.rs
@@ -1,0 +1,144 @@
+//! Ed25519: Edwards Digital Signature Algorithm (EdDSA) over Curve25519.
+
+use crate::{base64, Error, Result};
+use core::fmt;
+use zeroize::{Zeroize, Zeroizing};
+
+/// Ed25519 public key.
+// TODO(tarcieri): use `ed25519::PublicKey`? (doesn't exist yet)
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+pub struct Ed25519PublicKey(pub [u8; Self::BYTE_SIZE]);
+
+impl Ed25519PublicKey {
+    /// Size of an Ed25519 public key in bytes.
+    pub const BYTE_SIZE: usize = 32;
+
+    /// Decode Ed25519 public key using the provided Base64 decoder.
+    pub(crate) fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+        // Validate length prefix
+        if decoder.decode_usize()? != Self::BYTE_SIZE {
+            return Err(Error::Length);
+        }
+
+        let mut bytes = [0u8; Self::BYTE_SIZE];
+        decoder.decode_into(&mut bytes)?;
+        Ok(Self(bytes))
+    }
+}
+
+impl AsRef<[u8; Self::BYTE_SIZE]> for Ed25519PublicKey {
+    fn as_ref(&self) -> &[u8; Self::BYTE_SIZE] {
+        &self.0
+    }
+}
+
+impl fmt::Display for Ed25519PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:X}", self)
+    }
+}
+
+impl fmt::LowerHex for Ed25519PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for byte in self.as_ref() {
+            write!(f, "{:02x}", byte)?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::UpperHex for Ed25519PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for byte in self.as_ref() {
+            write!(f, "{:02X}", byte)?;
+        }
+        Ok(())
+    }
+}
+
+/// Ed25519 private key.
+// TODO(tarcieri): use `ed25519::PrivateKey`? (doesn't exist yet)
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+pub struct Ed25519PrivateKey(pub [u8; Self::BYTE_SIZE]);
+
+impl Ed25519PrivateKey {
+    /// Size of an Ed25519 private key in bytes.
+    pub const BYTE_SIZE: usize = 32;
+}
+
+impl AsRef<[u8; Self::BYTE_SIZE]> for Ed25519PrivateKey {
+    fn as_ref(&self) -> &[u8; Self::BYTE_SIZE] {
+        &self.0
+    }
+}
+
+impl fmt::LowerHex for Ed25519PrivateKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for byte in self.as_ref() {
+            write!(f, "{:02x}", byte)?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::UpperHex for Ed25519PrivateKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for byte in self.as_ref() {
+            write!(f, "{:02X}", byte)?;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for Ed25519PrivateKey {
+    fn drop(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+/// Ed25519 keypairs.
+#[derive(Clone)]
+pub struct Ed25519Keypair {
+    /// Public key.
+    pub public: Ed25519PublicKey,
+
+    /// Private key.
+    pub private: Ed25519PrivateKey,
+}
+
+impl Ed25519Keypair {
+    /// Size of an Ed25519 keypair in bytes.
+    pub const BYTE_SIZE: usize = 64;
+
+    /// Decode Ed25519 private key using the provided Base64 decoder.
+    pub(crate) fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+        // Decode private key
+        let public = Ed25519PublicKey::decode(decoder)?;
+
+        // The OpenSSH serialization of Ed25519 keys is repetitive and includes
+        // a serialization of `private_key[32] || public_key[32]` immediately
+        // following the public key.
+        if decoder.decode_usize()? != Self::BYTE_SIZE {
+            return Err(Error::Length);
+        }
+
+        let mut bytes = Zeroizing::new([0u8; Self::BYTE_SIZE]);
+        decoder.decode_into(&mut *bytes)?;
+
+        let (priv_bytes, pub_bytes) = bytes.split_at(Ed25519PrivateKey::BYTE_SIZE);
+        if pub_bytes != public.as_ref() {
+            return Err(Error::FormatEncoding);
+        }
+
+        let private = Ed25519PrivateKey(priv_bytes.try_into()?);
+        Ok(Self { public, private })
+    }
+}
+
+impl fmt::Debug for Ed25519Keypair {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Ed25519Keypair")
+            .field("public", &self.public)
+            .finish_non_exhaustive()
+    }
+}

--- a/ssh-key/src/algorithm/rsa.rs
+++ b/ssh-key/src/algorithm/rsa.rs
@@ -1,0 +1,25 @@
+//! Rivest–Shamir–Adleman (RSA).
+
+use crate::{base64, MPInt, Result};
+
+/// RSA public key.
+///
+/// Described in [RFC4253 § 6.6](https://datatracker.ietf.org/doc/html/rfc4253#section-6.6):
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct RsaPublicKey {
+    /// Public exponent
+    pub e: MPInt,
+
+    /// Modulus
+    pub n: MPInt,
+}
+
+impl RsaPublicKey {
+    /// Decode RSA public key using the provided Base64 decoder.
+    pub(crate) fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+        let e = MPInt::decode(decoder)?;
+        let n = MPInt::decode(decoder)?;
+        Ok(Self { e, n })
+    }
+}

--- a/ssh-key/src/error.rs
+++ b/ssh-key/src/error.rs
@@ -23,11 +23,17 @@ pub enum Error {
     #[cfg_attr(docsrs, doc(cfg(feature = "sec1")))]
     Ecdsa(sec1::Error),
 
+    /// Other format encoding errors.
+    FormatEncoding,
+
     /// Invalid length.
     Length,
 
     /// Overflow errors.
     Overflow,
+
+    /// PEM encoding errors.
+    Pem,
 }
 
 impl fmt::Display for Error {
@@ -38,8 +44,10 @@ impl fmt::Display for Error {
             Error::CharacterEncoding => f.write_str("character encoding invalid"),
             #[cfg(feature = "sec1")]
             Error::Ecdsa(err) => write!(f, "ECDSA encoding error: {}", err),
+            Error::FormatEncoding => f.write_str("format encoding error"),
             Error::Length => f.write_str("length invalid"),
             Error::Overflow => f.write_str("internal overflow error"),
+            Error::Pem => f.write_str("PEM encoding error"),
         }
     }
 }
@@ -55,6 +63,12 @@ impl From<base64ct::Error> for Error {
 
 impl From<base64ct::InvalidLengthError> for Error {
     fn from(_: base64ct::InvalidLengthError) -> Error {
+        Error::Length
+    }
+}
+
+impl From<core::array::TryFromSliceError> for Error {
+    fn from(_: core::array::TryFromSliceError) -> Error {
         Error::Length
     }
 }

--- a/ssh-key/src/lib.rs
+++ b/ssh-key/src/lib.rs
@@ -1,3 +1,12 @@
+#![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![forbid(unsafe_code, clippy::unwrap_used)]
+#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_root_url = "https://docs.rs/ssh-key/0.1.0"
+)]
 #![doc = include_str!("../README.md")]
 
 //! ## Usage
@@ -18,7 +27,7 @@
 //! assert_eq!(key.comment, "foo@bar.com");
 //!
 //! // Key data
-//! if let Some(ed25519_key) = key.data.ed25519() {
+//! if let Some(ed25519_key) = key.key_data.ed25519() {
 //!     assert_eq!(
 //!         ed25519_key.as_ref(),
 //!         [
@@ -33,22 +42,13 @@
 //! # }
 //! ```
 
-#![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc(
-    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/ssh-key/0.1.0"
-)]
-#![forbid(unsafe_code, clippy::unwrap_used)]
-#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
-
 #[cfg(feature = "alloc")]
 #[macro_use]
 extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
+pub mod private;
 pub mod public;
 
 mod algorithm;
@@ -59,8 +59,9 @@ mod error;
 mod mpint;
 
 pub use crate::{
-    algorithm::{Algorithm, EcdsaCurve},
+    algorithm::{Algorithm, CipherAlg, EcdsaCurve, KdfAlg, KdfOptions},
     error::{Error, Result},
+    private::PrivateKey,
     public::PublicKey,
 };
 

--- a/ssh-key/src/private.rs
+++ b/ssh-key/src/private.rs
@@ -1,0 +1,150 @@
+//! SSH private key support.
+//!
+//! Support for decoding SSH private keys from the OpenSSH file format:
+//!
+//! <https://github.com/openssh/openssh-portable/blob/master/PROTOCOL.key>
+
+mod openssh;
+
+pub use crate::algorithm::ed25519::{Ed25519Keypair, Ed25519PrivateKey};
+
+use crate::{base64, public, Algorithm, CipherAlg, Error, KdfAlg, KdfOptions, Result};
+
+#[cfg(feature = "alloc")]
+use alloc::string::String;
+
+/// SSH private key.
+#[derive(Clone, Debug)]
+pub struct PrivateKey {
+    /// Cipher algorithm (a.k.a. `ciphername`).
+    pub cipher_alg: CipherAlg,
+
+    /// KDF algorithm.
+    pub kdf_alg: KdfAlg,
+
+    /// KDF options.
+    pub kdf_options: KdfOptions,
+
+    /// Key data.
+    pub key_data: KeyData,
+
+    /// Comment on the key (e.g. email address).
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    pub comment: String,
+}
+
+impl PrivateKey {
+    /// Magic string used to identify keys in this format.
+    pub const AUTH_MAGIC: &'static [u8] = b"openssh-key-v1\0";
+
+    /// Parse an OpenSSH-formatted private key.
+    ///
+    /// OpenSSH-formatted private keys begin with the following:
+    ///
+    /// ```text
+    /// -----BEGIN OPENSSH PRIVATE KEY-----
+    /// ```
+    pub fn from_openssh(input: impl AsRef<[u8]>) -> Result<Self> {
+        let encapsulation = openssh::Encapsulation::decode(input.as_ref())?;
+        let mut decoder = base64::Decoder::new_wrapped(
+            encapsulation.base64_data,
+            openssh::Encapsulation::LINE_WIDTH,
+        )?;
+
+        let mut auth_magic = [0u8; Self::AUTH_MAGIC.len()];
+        decoder.decode_into(&mut auth_magic)?;
+
+        if auth_magic != Self::AUTH_MAGIC {
+            return Err(Error::FormatEncoding);
+        }
+
+        let cipher_alg = CipherAlg::decode(&mut decoder)?;
+        let kdf_alg = KdfAlg::decode(&mut decoder)?;
+        let kdf_options = KdfOptions::decode(&mut decoder)?;
+        let nkeys = decoder.decode_u32()? as usize;
+
+        // TODO(tarcieri): support more than one key?
+        if nkeys != 1 {
+            return Err(Error::Length);
+        }
+
+        for _ in 0..nkeys {
+            // TODO(tarcieri): validate decoded length
+            let _len = decoder.decode_u32()? as usize;
+            let _pubkey = public::KeyData::decode(&mut decoder)?;
+        }
+
+        // Begin decoding unencrypted list of N private keys
+        // See OpenSSH PROTOCOL.key § 3
+        // TODO(tarcieri): validate decoded length
+        let _len = decoder.decode_u32()? as usize;
+        let checkint1 = decoder.decode_u32()?;
+        let checkint2 = decoder.decode_u32()?;
+
+        if checkint1 != checkint2 {
+            // TODO(tarcieri): treat this as a cryptographic error?
+            return Err(Error::FormatEncoding);
+        }
+
+        let key_data = KeyData::decode(&mut decoder)?;
+
+        #[cfg(feature = "alloc")]
+        let comment = decoder.decode_string()?;
+
+        // TODO(tarcieri): parse/validate padding bytes?
+        Ok(Self {
+            cipher_alg,
+            kdf_alg,
+            kdf_options,
+            key_data,
+            #[cfg(feature = "alloc")]
+            comment,
+        })
+    }
+
+    /// Get the digital signature [`Algorithm`] used by this key.
+    pub fn algorithm(&self) -> Algorithm {
+        self.key_data.algorithm()
+    }
+}
+
+/// Private key data.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub enum KeyData {
+    /// Ed25519 private key data.
+    Ed25519(Ed25519Keypair),
+}
+
+impl KeyData {
+    /// Get the [`Algorithm`] for this private key.
+    pub fn algorithm(&self) -> Algorithm {
+        match self {
+            Self::Ed25519(_) => Algorithm::Ed25519,
+        }
+    }
+
+    /// Get Ed25519 private key if this key is the correct type.
+    pub fn ed25519(&self) -> Option<&Ed25519Keypair> {
+        match self {
+            Self::Ed25519(key) => Some(key),
+            #[allow(unreachable_patterns)]
+            _ => None,
+        }
+    }
+
+    /// Is this key an Ed25519 key?
+    pub fn is_ed25519(&self) -> bool {
+        matches!(self, Self::Ed25519(_))
+    }
+
+    /// Decode data using the provided Base64 decoder.
+    fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+        match Algorithm::decode(decoder)? {
+            Algorithm::Ed25519 => Ed25519Keypair::decode(decoder).map(Self::Ed25519),
+            #[allow(unreachable_patterns)]
+            _ => Err(Error::Algorithm),
+        }
+    }
+}

--- a/ssh-key/src/private/openssh.rs
+++ b/ssh-key/src/private/openssh.rs
@@ -1,0 +1,76 @@
+//! Support for OpenSSH-formatted private keys.
+//!
+//! These keys are PEM-encoded and begin with the following:
+//!
+//! ```text
+//! -----BEGIN OPENSSH PRIVATE KEY-----
+//! ```
+
+use crate::{Error, Result};
+
+/// Carriage return
+pub(crate) const CHAR_CR: u8 = 0x0d;
+
+/// Line feed
+pub(crate) const CHAR_LF: u8 = 0x0a;
+
+/// Pre-encapsulation boundary.
+const PRE_ENCAPSULATION_BOUNDARY: &[u8] = b"-----BEGIN OPENSSH PRIVATE KEY-----";
+
+/// Post-encapsulation boundary.
+const POST_ENCAPSULATION_BOUNDARY: &[u8] = b"-----END OPENSSH PRIVATE KEY-----";
+
+/// OpenSSH private key encapsulation parser.
+pub(super) struct Encapsulation<'a> {
+    /// Base64-encoded key data
+    pub(super) base64_data: &'a [u8],
+}
+
+impl<'a> Encapsulation<'a> {
+    /// Width at which the Base64 is line wrapped.
+    pub(super) const LINE_WIDTH: usize = 70;
+
+    /// Parse the given PEM-encapsulated data.
+    pub(super) fn decode(input: &'a [u8]) -> Result<Self> {
+        // Parse pre-encapsulation boundary (including label)
+        let input = input
+            .strip_prefix(PRE_ENCAPSULATION_BOUNDARY)
+            .ok_or(Error::Pem)
+            .and_then(strip_leading_eol)?;
+
+        // Parse post-encapsulation boundary and optional trailing newline
+        let base64_data = strip_trailing_eol(input)
+            .unwrap_or(input)
+            .strip_suffix(POST_ENCAPSULATION_BOUNDARY)
+            .ok_or(Error::Pem)
+            .and_then(strip_trailing_eol)?;
+
+        Ok(Self { base64_data })
+    }
+}
+
+/// Strip a newline (`eol`) from the beginning of the provided byte slice.
+///
+/// The newline is considered mandatory and a decoding error will occur if it
+/// is not present.
+pub(crate) fn strip_leading_eol(bytes: &[u8]) -> Result<&[u8]> {
+    match bytes {
+        [CHAR_LF, rest @ ..] => Ok(rest),
+        [CHAR_CR, CHAR_LF, rest @ ..] => Ok(rest),
+        [CHAR_CR, rest @ ..] => Ok(rest),
+        _ => Err(Error::Pem),
+    }
+}
+
+/// Strip a newline (`eol`) from the end of the provided byte slice.
+///
+/// The newline is considered mandatory and a decoding error will occur if it
+/// is not present.
+pub(crate) fn strip_trailing_eol(bytes: &[u8]) -> Result<&[u8]> {
+    match bytes {
+        [head @ .., CHAR_CR, CHAR_LF] => Ok(head),
+        [head @ .., CHAR_LF] => Ok(head),
+        [head @ .., CHAR_CR] => Ok(head),
+        _ => Err(Error::Pem),
+    }
+}

--- a/ssh-key/src/public.rs
+++ b/ssh-key/src/public.rs
@@ -4,26 +4,22 @@
 
 mod openssh;
 
+pub use crate::algorithm::ed25519::Ed25519PublicKey;
+#[cfg(feature = "alloc")]
+pub use crate::algorithm::{dsa::DsaPublicKey, rsa::RsaPublicKey};
+#[cfg(feature = "sec1")]
+pub use crate::{algorithm::ecdsa::EcdsaPublicKey, EcdsaCurve};
+
 use crate::{base64, Algorithm, Error, Result};
-use core::fmt;
 
 #[cfg(feature = "alloc")]
-use {
-    crate::MPInt,
-    alloc::{borrow::ToOwned, string::String},
-};
-
-#[cfg(feature = "sec1")]
-use {
-    crate::EcdsaCurve,
-    sec1::consts::{U32, U48, U66},
-};
+use alloc::{borrow::ToOwned, string::String};
 
 /// SSH public key.
 #[derive(Clone, Debug)]
 pub struct PublicKey {
     /// Key data.
-    pub data: KeyData,
+    pub key_data: KeyData,
 
     /// Comment on the key (e.g. email address)
     #[cfg(feature = "alloc")]
@@ -40,16 +36,21 @@ impl PublicKey {
     /// ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILM+rvN+ot98qgEN796jTiQfZfG1KaT0PtFDJ/XFSqti foo@bar.com
     /// ```
     pub fn from_openssh(input: impl AsRef<[u8]>) -> Result<Self> {
-        let encapsulation = openssh::Encapsulation::parse(input.as_ref())?;
-        let data = KeyData::decode(base64::Decoder::new(encapsulation.base64_data)?)?;
+        let encapsulation = openssh::Encapsulation::decode(input.as_ref())?;
+        let mut decoder = base64::Decoder::new(encapsulation.base64_data)?;
+        let key_data = KeyData::decode(&mut decoder)?;
+
+        if !decoder.is_finished() {
+            return Err(Error::Length);
+        }
 
         // Verify that the algorithm in the Base64-encoded data matches the text
-        if encapsulation.algorithm_id != data.algorithm().as_str() {
+        if encapsulation.algorithm_id != key_data.algorithm().as_str() {
             return Err(Error::Algorithm);
         }
 
         Ok(Self {
-            data,
+            key_data,
             #[cfg(feature = "alloc")]
             comment: encapsulation.comment.to_owned(),
         })
@@ -57,7 +58,7 @@ impl PublicKey {
 
     /// Get the digital signature [`Algorithm`] used by this key.
     pub fn algorithm(&self) -> Algorithm {
-        self.data.algorithm()
+        self.key_data.algorithm()
     }
 }
 
@@ -85,7 +86,7 @@ pub enum KeyData {
 }
 
 impl KeyData {
-    /// Get the [`Algorithm`] for this public key type.
+    /// Get the [`Algorithm`] for this public key.
     pub fn algorithm(&self) -> Algorithm {
         match self {
             #[cfg(feature = "alloc")]
@@ -164,266 +165,20 @@ impl KeyData {
     }
 
     /// Decode data using the provided Base64 decoder.
-    fn decode(mut decoder: base64::Decoder<'_>) -> Result<Self> {
-        let result = match Algorithm::decode(&mut decoder)? {
+    pub(crate) fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+        match Algorithm::decode(decoder)? {
             #[cfg(feature = "alloc")]
-            Algorithm::Dsa => DsaPublicKey::decode(&mut decoder).map(Self::Dsa),
+            Algorithm::Dsa => DsaPublicKey::decode(decoder).map(Self::Dsa),
             #[cfg(feature = "sec1")]
-            Algorithm::Ecdsa(curve) => {
-                let key = EcdsaPublicKey::decode(&mut decoder)?;
-
-                if key.curve() == curve {
-                    Ok(Self::Ecdsa(key))
-                } else {
-                    Err(Error::Algorithm)
-                }
-            }
-            Algorithm::Ed25519 => Ed25519PublicKey::decode(&mut decoder).map(Self::Ed25519),
+            Algorithm::Ecdsa(curve) => match EcdsaPublicKey::decode(decoder)? {
+                key if key.curve() == curve => Ok(Self::Ecdsa(key)),
+                _ => Err(Error::Algorithm),
+            },
+            Algorithm::Ed25519 => Ed25519PublicKey::decode(decoder).map(Self::Ed25519),
             #[cfg(feature = "alloc")]
-            Algorithm::Rsa => RsaPublicKey::decode(&mut decoder).map(Self::Rsa),
+            Algorithm::Rsa => RsaPublicKey::decode(decoder).map(Self::Rsa),
             #[allow(unreachable_patterns)]
-            _ => return Err(Error::Algorithm),
-        };
-
-        if decoder.is_finished() {
-            result
-        } else {
-            Err(Error::Length)
+            _ => Err(Error::Algorithm),
         }
-    }
-}
-
-/// Digital Signature Algorithm (DSA) public key.
-///
-/// Described in [FIPS 186-4](https://csrc.nist.gov/publications/detail/fips/186/4/final).
-// TODO(tarcieri): use `dsa::PublicKey`? (doesn't exist yet)
-#[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
-pub struct DsaPublicKey {
-    /// Prime modulus
-    pub p: MPInt,
-
-    /// Prime divisor of `p - 1`
-    pub q: MPInt,
-
-    /// Generator of a subgroup of order `q` in the multiplicative group
-    /// `GF(p)`, such that `1 < g < p`.
-    pub g: MPInt,
-
-    /// The public key, where `y = gˣ mod p`
-    pub y: MPInt,
-}
-
-#[cfg(feature = "alloc")]
-impl DsaPublicKey {
-    /// Decode DSA public key using the provided Base64 decoder.
-    fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
-        let p = MPInt::decode(decoder)?;
-        let q = MPInt::decode(decoder)?;
-        let g = MPInt::decode(decoder)?;
-        let y = MPInt::decode(decoder)?;
-        Ok(Self { p, q, g, y })
-    }
-}
-
-/// Elliptic Curve Digital Signature Algorithm (ECDSA) public key.
-///
-/// Public keys are represented as [`sec1::EncodedPoint`] and require the
-/// `sec1` feature of this crate is enabled (which it is by default).
-///
-/// Described in [FIPS 186-4](https://csrc.nist.gov/publications/detail/fips/186/4/final).
-#[cfg(feature = "sec1")]
-#[cfg_attr(docsrs, doc(cfg(feature = "sec1")))]
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
-pub enum EcdsaPublicKey {
-    /// NIST P-256 ECDSA public key.
-    NistP256(sec1::EncodedPoint<U32>),
-
-    /// NIST P-384 ECDSA public key.
-    NistP384(sec1::EncodedPoint<U48>),
-
-    /// NIST P-521 ECDSA public key.
-    NistP521(sec1::EncodedPoint<U66>),
-}
-
-#[cfg(feature = "sec1")]
-impl EcdsaPublicKey {
-    /// Maximum size of a SEC1-encoded ECDSA public key (i.e. curve point).
-    ///
-    /// This is the size of 2 * P-521 curve points (2 * 66 = 132) plus one
-    /// additional byte for the "tag".
-    const MAX_SIZE: usize = 133;
-
-    /// Parse an ECDSA public key from a SEC1-encoded point.
-    ///
-    /// Determines the key type from the SEC1 tag byte and length.
-    pub fn from_sec1_bytes(bytes: &[u8]) -> Result<Self> {
-        match bytes {
-            [tag, rest @ ..] => {
-                let point_size = match sec1::point::Tag::from_u8(*tag)? {
-                    sec1::point::Tag::CompressedEvenY | sec1::point::Tag::CompressedOddY => {
-                        rest.len()
-                    }
-                    sec1::point::Tag::Uncompressed => rest.len() / 2,
-                    _ => return Err(Error::Algorithm),
-                };
-
-                match point_size {
-                    32 => Ok(Self::NistP256(sec1::EncodedPoint::from_bytes(bytes)?)),
-                    48 => Ok(Self::NistP384(sec1::EncodedPoint::from_bytes(bytes)?)),
-                    66 => Ok(Self::NistP521(sec1::EncodedPoint::from_bytes(bytes)?)),
-                    _ => Err(Error::Length),
-                }
-            }
-            _ => Err(Error::Length),
-        }
-    }
-
-    /// Borrow the SEC1-encoded key data as bytes.
-    pub fn as_sec1_bytes(&self) -> &[u8] {
-        match self {
-            EcdsaPublicKey::NistP256(point) => point.as_bytes(),
-            EcdsaPublicKey::NistP384(point) => point.as_bytes(),
-            EcdsaPublicKey::NistP521(point) => point.as_bytes(),
-        }
-    }
-
-    /// Get the [`Algorithm`] for this public key type.
-    pub fn algorithm(&self) -> Algorithm {
-        Algorithm::Ecdsa(self.curve())
-    }
-
-    /// Get the [`EcdsaCurve`] for this key.
-    pub fn curve(&self) -> EcdsaCurve {
-        match self {
-            EcdsaPublicKey::NistP256(_) => EcdsaCurve::NistP256,
-            EcdsaPublicKey::NistP384(_) => EcdsaCurve::NistP384,
-            EcdsaPublicKey::NistP521(_) => EcdsaCurve::NistP521,
-        }
-    }
-
-    /// Decode ECDSA public key using the provided Base64 decoder.
-    fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
-        let curve = EcdsaCurve::decode(decoder)?;
-
-        let mut buf = [0u8; Self::MAX_SIZE];
-        let key = Self::from_sec1_bytes(decoder.decode_byte_slice(&mut buf)?)?;
-
-        if key.curve() == curve {
-            Ok(key)
-        } else {
-            Err(Error::Algorithm)
-        }
-    }
-}
-
-#[cfg(feature = "sec1")]
-impl AsRef<[u8]> for EcdsaPublicKey {
-    fn as_ref(&self) -> &[u8] {
-        self.as_sec1_bytes()
-    }
-}
-
-#[cfg(feature = "sec1")]
-impl fmt::Display for EcdsaPublicKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:X}", self)
-    }
-}
-
-#[cfg(feature = "sec1")]
-impl fmt::LowerHex for EcdsaPublicKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for byte in self.as_sec1_bytes() {
-            write!(f, "{:02x}", byte)?;
-        }
-        Ok(())
-    }
-}
-
-#[cfg(feature = "sec1")]
-impl fmt::UpperHex for EcdsaPublicKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for byte in self.as_sec1_bytes() {
-            write!(f, "{:02X}", byte)?;
-        }
-        Ok(())
-    }
-}
-
-/// Ed25519 public key.
-// TODO(tarcieri): use `ed25519::PublicKey`? (doesn't exist yet)
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
-pub struct Ed25519PublicKey(pub [u8; Self::BYTE_SIZE]);
-
-impl Ed25519PublicKey {
-    /// Size of an Ed25519 public key in bytes.
-    pub const BYTE_SIZE: usize = 32;
-
-    /// Decode Ed25519 public key using the provided Base64 decoder.
-    fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
-        // Validate length prefix
-        if decoder.decode_usize()? != Self::BYTE_SIZE {
-            return Err(Error::Length);
-        }
-
-        let mut bytes = [0u8; Self::BYTE_SIZE];
-        decoder.decode_into(&mut bytes)?;
-        Ok(Self(bytes))
-    }
-}
-
-impl AsRef<[u8; Self::BYTE_SIZE]> for Ed25519PublicKey {
-    fn as_ref(&self) -> &[u8; Self::BYTE_SIZE] {
-        &self.0
-    }
-}
-
-impl fmt::Display for Ed25519PublicKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:X}", self)
-    }
-}
-
-impl fmt::LowerHex for Ed25519PublicKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for byte in self.as_ref() {
-            write!(f, "{:02x}", byte)?;
-        }
-        Ok(())
-    }
-}
-
-impl fmt::UpperHex for Ed25519PublicKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for byte in self.as_ref() {
-            write!(f, "{:02X}", byte)?;
-        }
-        Ok(())
-    }
-}
-
-/// RSA public key.
-///
-/// Described in [RFC4253 § 6.6](https://datatracker.ietf.org/doc/html/rfc4253#section-6.6):
-#[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
-pub struct RsaPublicKey {
-    /// Public exponent
-    pub e: MPInt,
-
-    /// Modulus
-    pub n: MPInt,
-}
-
-#[cfg(feature = "alloc")]
-impl RsaPublicKey {
-    /// Decode RSA public key using the provided Base64 decoder.
-    fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
-        let e = MPInt::decode(decoder)?;
-        let n = MPInt::decode(decoder)?;
-        Ok(Self { e, n })
     }
 }

--- a/ssh-key/tests/private_key.rs
+++ b/ssh-key/tests/private_key.rs
@@ -1,0 +1,27 @@
+//! SSH private key tests.
+
+use hex_literal::hex;
+use ssh_key::{Algorithm, PrivateKey};
+
+/// Ed25519 OpenSSH-formatted private key
+const OSSH_ED25519_EXAMPLE: &str = include_str!("examples/id_ed25519");
+
+#[test]
+fn decode_ed25519_openssh() {
+    let ossh_key = PrivateKey::from_openssh(OSSH_ED25519_EXAMPLE).unwrap();
+
+    assert_eq!(Algorithm::Ed25519, ossh_key.key_data.algorithm());
+    let ed25519_keypair = ossh_key.key_data.ed25519().unwrap();
+
+    assert_eq!(
+        &hex!("b33eaef37ea2df7caa010defdea34e241f65f1b529a4f43ed14327f5c54aab62"),
+        ed25519_keypair.public.as_ref(),
+    );
+    assert_eq!(
+        &hex!("b606c222d10c16dae16c70a4d45173472ec617e05c656920d26e56c08fb591ed"),
+        ed25519_keypair.private.as_ref(),
+    );
+
+    #[cfg(feature = "alloc")]
+    assert_eq!(ossh_key.comment, "user@example.com");
+}

--- a/ssh-key/tests/public_key.rs
+++ b/ssh-key/tests/public_key.rs
@@ -36,129 +36,137 @@ const OSSH_RSA_4096_EXAMPLE: &str = include_str!("examples/id_rsa_4096.pub");
 #[cfg(feature = "alloc")]
 #[test]
 fn decode_dsa_openssh() {
-    let key = PublicKey::from_openssh(OSSH_DSA_EXAMPLE).unwrap();
-    assert_eq!(key.data.algorithm(), Algorithm::Dsa);
+    let ossh_key = PublicKey::from_openssh(OSSH_DSA_EXAMPLE).unwrap();
+    assert_eq!(Algorithm::Dsa, ossh_key.key_data.algorithm());
 
-    let dsa_key = key.data.dsa().unwrap();
+    let dsa_key = ossh_key.key_data.dsa().unwrap();
     assert_eq!(
-        dsa_key.p.as_bytes(),
         &hex!(
             "00dc3d89250ed9462114cb2c8d4816e3a511aaff1b06b0e01de17c1cb04e581bcab97176471d89fd7ca1817
              e3c48e2ccbafd2170f69e8e5c8b6ab69b9c5f45d95e1d9293e965227eee5b879b1123371c21b1db60f14b5e
              5c05a4782ceb43a32f449647703063621e7a286bec95b16726c18b5e52383d00b297a6b03489b06068a5"
-        )
+        ),
+        dsa_key.p.as_bytes(),
     );
     assert_eq!(
+        &hex!("00891815378597fe42d3fd261fe76df365845bbb87"),
         dsa_key.q.as_bytes(),
-        &hex!("00891815378597fe42d3fd261fe76df365845bbb87")
     );
     assert_eq!(
-        dsa_key.g.as_bytes(),
         &hex!(
             "4739b3908a8415466dc7b156fb98ecb71552a170ba0b3b7aa81bd81391de0a7ae7a1b45002dfeadc9225fbc
              520a713fe4104a74bed53fd5915da736365afd3f09777bbccfbadf7ac2b087b7f4d95fabe47d72a46e95088
              f9cd2a9fbf236b58a6982647f3c00430ad7352d47a25ebbe9477f0c3127da86ad7448644b76de5875c"
-        )
+        ),
+        dsa_key.g.as_bytes(),
     );
     assert_eq!(
-        dsa_key.y.as_bytes(),
         &hex!(
             "6042a6b3fd861344cb21ccccd8719e25aa0be0980e79cbabf4877f5ef071f6039770352eac3d4c368f29daf
              a57b475c78d44989f16577527e598334be6aae4abd750c36af80489d392697c1f32f3cf3c9a8b99bcddb53d
              7a37e1a28fd53d4934131cf41c437c6734d1e04004adcd925b84b3956c30c3a3904eecb31400b0df48"
-        )
+        ),
+        dsa_key.y.as_bytes(),
     );
 
-    assert_eq!(key.comment, "user@example.com");
+    assert_eq!("user@example.com", ossh_key.comment);
 }
 
 #[cfg(feature = "sec1")]
 #[test]
 fn decode_ecdsa_p256_openssh() {
-    let key = PublicKey::from_openssh(OSSH_ECDSA_P256_EXAMPLE).unwrap();
-    assert_eq!(key.data.algorithm(), Algorithm::Ecdsa(EcdsaCurve::NistP256));
-
-    let ecdsa_key = key.data.ecdsa().unwrap();
-    assert_eq!(ecdsa_key.curve(), EcdsaCurve::NistP256);
+    let ossh_key = PublicKey::from_openssh(OSSH_ECDSA_P256_EXAMPLE).unwrap();
     assert_eq!(
-        ecdsa_key.as_ref(),
+        Algorithm::Ecdsa(EcdsaCurve::NistP256),
+        ossh_key.key_data.algorithm(),
+    );
+
+    let ecdsa_key = ossh_key.key_data.ecdsa().unwrap();
+    assert_eq!(EcdsaCurve::NistP256, ecdsa_key.curve(),);
+    assert_eq!(
         &hex!(
             "047c1fd8730ce53457be8d924098ec3648830f92aa8a2363ac656fdd4521fa6313e511f1891b4e9e5aaf8e1
              42d06ad15a66a4257f3f051d84e8a0e2f91ba807047"
-        )
+        ),
+        ecdsa_key.as_ref(),
     );
 
     #[cfg(feature = "alloc")]
-    assert_eq!(key.comment, "user@example.com");
+    assert_eq!("user@example.com", ossh_key.comment);
 }
 
 #[cfg(feature = "sec1")]
 #[test]
 fn decode_ecdsa_p384_openssh() {
-    let key = PublicKey::from_openssh(OSSH_ECDSA_P384_EXAMPLE).unwrap();
-    assert_eq!(key.data.algorithm(), Algorithm::Ecdsa(EcdsaCurve::NistP384));
-
-    let ecdsa_key = key.data.ecdsa().unwrap();
-    assert_eq!(ecdsa_key.curve(), EcdsaCurve::NistP384);
+    let ossh_key = PublicKey::from_openssh(OSSH_ECDSA_P384_EXAMPLE).unwrap();
     assert_eq!(
-        ecdsa_key.as_ref(),
+        Algorithm::Ecdsa(EcdsaCurve::NistP384),
+        ossh_key.key_data.algorithm(),
+    );
+
+    let ecdsa_key = ossh_key.key_data.ecdsa().unwrap();
+    assert_eq!(EcdsaCurve::NistP384, ecdsa_key.curve(),);
+    assert_eq!(
         &hex!(
             "042e6e82dc5407f104a11117c7c05b1993c3ceb3db25fae68ba169502a4ff9395d9ad36b543e8014ff15d70
              8e21f09f585aa6dfad575b79b943418b86198d9bcd9b07fff9399b15d43d34efaeb2e56b7b33cff880b242b
              3e0b58af96c75841ec41"
-        )
+        ),
+        ecdsa_key.as_ref(),
     );
 
     #[cfg(feature = "alloc")]
-    assert_eq!(key.comment, "user@example.com");
+    assert_eq!("user@example.com", ossh_key.comment);
 }
 
 #[cfg(feature = "sec1")]
 #[test]
 fn decode_ecdsa_p521_openssh() {
-    let key = PublicKey::from_openssh(OSSH_ECDSA_P521_EXAMPLE).unwrap();
-    assert_eq!(key.data.algorithm(), Algorithm::Ecdsa(EcdsaCurve::NistP521));
+    let ossh_key = PublicKey::from_openssh(OSSH_ECDSA_P521_EXAMPLE).unwrap();
+    assert_eq!(
+        Algorithm::Ecdsa(EcdsaCurve::NistP521),
+        ossh_key.key_data.algorithm(),
+    );
 
-    let ecdsa_key = key.data.ecdsa().unwrap();
+    let ecdsa_key = ossh_key.key_data.ecdsa().unwrap();
     assert_eq!(ecdsa_key.curve(), EcdsaCurve::NistP521);
     assert_eq!(
-        ecdsa_key.as_ref(),
         &hex!(
             "04016136934f192b23d961fbf44c8184166002cea2c7d18b20ad018d046ef068d3e8250fd4e9f17ca6693a8
              554c3269a6d9f5762a2f9a2cb8797d4b201de421d3dcc580103cb947a858bb7783df863f82951d96f91a792
              5d7e2baad26e47e3f2fa5b07c8272848a4423b750d7ad2b8b692d66ddecaec5385086b1fd1b682ca291c88d
              63762"
-        )
+        ),
+        ecdsa_key.as_ref(),
     );
 
     #[cfg(feature = "alloc")]
-    assert_eq!(key.comment, "user@example.com");
+    assert_eq!("user@example.com", ossh_key.comment);
 }
 
 #[test]
 fn decode_ed25519_openssh() {
-    let key = PublicKey::from_openssh(OSSH_ED25519_EXAMPLE).unwrap();
+    let ossh_key = PublicKey::from_openssh(OSSH_ED25519_EXAMPLE).unwrap();
 
-    assert_eq!(key.data.algorithm(), Algorithm::Ed25519);
+    assert_eq!(Algorithm::Ed25519, ossh_key.key_data.algorithm());
     assert_eq!(
-        key.data.ed25519().unwrap().as_ref(),
-        &hex!("b33eaef37ea2df7caa010defdea34e241f65f1b529a4f43ed14327f5c54aab62")
+        &hex!("b33eaef37ea2df7caa010defdea34e241f65f1b529a4f43ed14327f5c54aab62"),
+        ossh_key.key_data.ed25519().unwrap().as_ref(),
     );
 
     #[cfg(feature = "alloc")]
-    assert_eq!(key.comment, "user@example.com");
+    assert_eq!("user@example.com", ossh_key.comment);
 }
 
 #[cfg(feature = "alloc")]
 #[test]
 fn decode_rsa_3072_openssh() {
-    let key = PublicKey::from_openssh(OSSH_RSA_3072_EXAMPLE).unwrap();
-    assert_eq!(key.data.algorithm(), Algorithm::Rsa);
+    let ossh_key = PublicKey::from_openssh(OSSH_RSA_3072_EXAMPLE).unwrap();
+    assert_eq!(Algorithm::Rsa, ossh_key.key_data.algorithm());
 
-    let rsa_key = key.data.rsa().unwrap();
-    assert_eq!(rsa_key.e.as_bytes(), &hex!("010001"));
+    let rsa_key = ossh_key.key_data.rsa().unwrap();
+    assert_eq!(&hex!("010001"), rsa_key.e.as_bytes());
     assert_eq!(
-        rsa_key.n.as_bytes(),
         &hex!(
             "00a68e478c9bc93726436b7f5e9e6f9a46e1b73bec1e8cb7754de2c6a5b6c455f2f012a7259afcf94181d69
              e95d39a349e4d2b482a5372b28943731db75c73ce7bd9eec85010c94bfae56960118922f86a8b3655b357d2
@@ -169,22 +177,22 @@ fn decode_rsa_3072_openssh() {
              8ee183e7e906fee489e8e1e57fce7a1c6df8fbaef39bbd1955dbd5ad1abffbe126f50205cb884af080ff3d7
              0549d3174b85bd7f6624c3753cf235b650d0e4228f32be7b54a590d869fb7786559bb7a4d66f9d3a69c085e
              fdf083a915d47a1d9161a08756b263b06e739d99f2890362abc96ade42cce8f939a40daff9"
-        )
+        ),
+        rsa_key.n.as_bytes(),
     );
 
-    assert_eq!(key.comment, "user@example.com");
+    assert_eq!("user@example.com", ossh_key.comment);
 }
 
 #[cfg(feature = "alloc")]
 #[test]
 fn decode_rsa_4096_openssh() {
-    let key = PublicKey::from_openssh(OSSH_RSA_4096_EXAMPLE).unwrap();
-    assert_eq!(key.data.algorithm(), Algorithm::Rsa);
+    let ossh_key = PublicKey::from_openssh(OSSH_RSA_4096_EXAMPLE).unwrap();
+    assert_eq!(Algorithm::Rsa, ossh_key.key_data.algorithm());
 
-    let rsa_key = key.data.rsa().unwrap();
-    assert_eq!(rsa_key.e.as_bytes(), &hex!("010001"));
+    let rsa_key = ossh_key.key_data.rsa().unwrap();
+    assert_eq!(&hex!("010001"), rsa_key.e.as_bytes());
     assert_eq!(
-        rsa_key.n.as_bytes(),
         &hex!(
             "00b45911edc6ec5e7d2261a48c46ab889b1858306271123e6f02dc914cf3c0352492e8a6b7a7925added527
              e547dcebff6d0c19c0bc9153975199f47f4964ed20f5aceed4e82556b228a0c1fbfaa85e6339ba2ff4094d9
@@ -198,8 +206,9 @@ fn decode_rsa_4096_openssh() {
              3c336bf86563ef03a15bc49b0ba6fe73201f64f0413ddb4d0cc5f6cf43389907e1df29e0cc388040e3371d0
              4814140f75cac08079431043222fb91f075d76be55cbe138e3b99a605c561c49dea50e253c8306c4f4f77d9
              96f898db64c5d8a0a15c6efa28b0934bf0b6f2b01950d877230fe4401078420fd6dd3"
-        )
+        ),
+        rsa_key.n.as_bytes(),
     );
 
-    assert_eq!(key.comment, "user@example.com");
+    assert_eq!("user@example.com", ossh_key.comment);
 }


### PR DESCRIPTION
Adds initial support for decoding private keys from the OpenSSH private key format:

https://github.com/openssh/openssh-portable/blob/master/PROTOCOL.key

This commit implements initial support for Ed25519 private keys, however the larger goal is to implement support for DSA, ECDSA, and RSA as well, which will occur in follow-up commits.