### PR TITLE
ssh-key: ECDSA private key support

### DIFF
--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -26,8 +26,9 @@ sec1 = { version = "0.2", optional = true, default-features = false, path = "../
 hex-literal = "0.3"
 
 [features]
-default = ["alloc", "sec1"]
+default = ["alloc", "ecdsa"]
 alloc = []
+ecdsa = ["sec1"]
 std = ["alloc", "base64ct/std"]
 
 [package.metadata.docs.rs]

--- a/ssh-key/src/algorithm.rs
+++ b/ssh-key/src/algorithm.rs
@@ -2,7 +2,7 @@
 
 #[cfg(feature = "alloc")]
 pub(crate) mod dsa;
-#[cfg(feature = "sec1")]
+#[cfg(feature = "ecdsa")]
 pub(crate) mod ecdsa;
 pub(crate) mod ed25519;
 #[cfg(feature = "alloc")]
@@ -193,7 +193,7 @@ pub enum EcdsaCurve {
 
 impl EcdsaCurve {
     /// Maximum size of a curve identifier known to this crate in bytes.
-    #[cfg(feature = "sec1")]
+    #[cfg(feature = "ecdsa")]
     const MAX_SIZE: usize = 8;
 
     /// Decode elliptic curve from the given string identifier.
@@ -222,7 +222,7 @@ impl EcdsaCurve {
     }
 
     /// Decode ECDSA curve type using the supplied Base64 decoder.
-    #[cfg(feature = "sec1")]
+    #[cfg(feature = "ecdsa")]
     pub(crate) fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
         let mut buf = [0u8; Self::MAX_SIZE];
         Self::new(decoder.decode_str(&mut buf)?)

--- a/ssh-key/src/algorithm/ecdsa.rs
+++ b/ssh-key/src/algorithm/ecdsa.rs
@@ -3,6 +3,7 @@
 use crate::{base64, Algorithm, EcdsaCurve, Error, Result};
 use core::fmt;
 use sec1::consts::{U32, U48, U66};
+use zeroize::Zeroize;
 
 /// Elliptic Curve Digital Signature Algorithm (ECDSA) public key.
 ///
@@ -10,7 +11,7 @@ use sec1::consts::{U32, U48, U66};
 /// `sec1` feature of this crate is enabled (which it is by default).
 ///
 /// Described in [FIPS 186-4](https://csrc.nist.gov/publications/detail/fips/186/4/final).
-#[cfg_attr(docsrs, doc(cfg(feature = "sec1")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub enum EcdsaPublicKey {
     /// NIST P-256 ECDSA public key.
@@ -26,8 +27,9 @@ pub enum EcdsaPublicKey {
 impl EcdsaPublicKey {
     /// Maximum size of a SEC1-encoded ECDSA public key (i.e. curve point).
     ///
-    /// This is the size of 2 * P-521 curve points (2 * 66 = 132) plus one
-    /// additional byte for the "tag".
+    /// This is the size of 2 * P-521 field elements (2 * 66 = 132) which
+    /// represent the affine coordinates of a curve point plus one additional
+    /// byte for the SEC1 "tag" identifying the curve point encoding.
     const MAX_SIZE: usize = 133;
 
     /// Parse an ECDSA public key from a SEC1-encoded point.
@@ -120,5 +122,171 @@ impl fmt::UpperHex for EcdsaPublicKey {
             write!(f, "{:02X}", byte)?;
         }
         Ok(())
+    }
+}
+
+/// ECDSA private key.
+#[derive(Clone)]
+pub struct EcdsaPrivateKey<const SIZE: usize> {
+    /// Byte array containing serialized big endian private scalar.
+    bytes: [u8; SIZE],
+}
+
+impl<const SIZE: usize> EcdsaPrivateKey<SIZE> {
+    /// Convert to the inner byte array.
+    pub fn into_bytes(self) -> [u8; SIZE] {
+        self.bytes
+    }
+
+    /// Decode Ecdsa private key using the provided Base64 decoder.
+    pub(crate) fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+        let len = decoder.decode_usize()?;
+
+        if len == SIZE + 1 {
+            // Strip leading zero
+            // TODO(tarcieri): make sure leading zero was necessary
+            if decoder.decode_u8()? != 0 {
+                return Err(Error::FormatEncoding);
+            }
+        }
+
+        let mut bytes = [0u8; SIZE];
+        decoder.decode_into(&mut bytes)?;
+        Ok(Self { bytes })
+    }
+}
+
+impl<const SIZE: usize> AsRef<[u8; SIZE]> for EcdsaPrivateKey<SIZE> {
+    fn as_ref(&self) -> &[u8; SIZE] {
+        &self.bytes
+    }
+}
+
+impl<const SIZE: usize> fmt::Debug for EcdsaPrivateKey<SIZE> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Ed25519PrivateKey").finish_non_exhaustive()
+    }
+}
+
+impl<const SIZE: usize> fmt::LowerHex for EcdsaPrivateKey<SIZE> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for byte in self.as_ref() {
+            write!(f, "{:02x}", byte)?;
+        }
+        Ok(())
+    }
+}
+
+impl<const SIZE: usize> fmt::UpperHex for EcdsaPrivateKey<SIZE> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for byte in self.as_ref() {
+            write!(f, "{:02X}", byte)?;
+        }
+        Ok(())
+    }
+}
+
+impl<const SIZE: usize> Drop for EcdsaPrivateKey<SIZE> {
+    fn drop(&mut self) {
+        self.bytes.zeroize();
+    }
+}
+
+/// ECDSA keypairs.
+#[derive(Clone, Debug)]
+pub enum EcdsaKeypair {
+    /// NIST P-256 ECDSA keypair.
+    NistP256 {
+        /// Public key.
+        public: sec1::EncodedPoint<U32>,
+
+        /// Private key.
+        private: EcdsaPrivateKey<32>,
+    },
+
+    /// NIST P-384 ECDSA keypair.
+    NistP384 {
+        /// Public key.
+        public: sec1::EncodedPoint<U48>,
+
+        /// Private key.
+        private: EcdsaPrivateKey<48>,
+    },
+
+    /// NIST P-521 ECDSA keypair.
+    NistP521 {
+        /// Public key.
+        public: sec1::EncodedPoint<U66>,
+
+        /// Private key.
+        private: EcdsaPrivateKey<66>,
+    },
+}
+
+impl EcdsaKeypair {
+    /// Get the [`Algorithm`] for this public key type.
+    pub fn algorithm(&self) -> Algorithm {
+        Algorithm::Ecdsa(self.curve())
+    }
+
+    /// Get the [`EcdsaCurve`] for this key.
+    pub fn curve(&self) -> EcdsaCurve {
+        match self {
+            Self::NistP256 { .. } => EcdsaCurve::NistP256,
+            Self::NistP384 { .. } => EcdsaCurve::NistP384,
+            Self::NistP521 { .. } => EcdsaCurve::NistP521,
+        }
+    }
+
+    /// Get the bytes representing the public key.
+    pub fn public_key_bytes(&self) -> &[u8] {
+        match self {
+            Self::NistP256 { public, .. } => public.as_ref(),
+            Self::NistP384 { public, .. } => public.as_ref(),
+            Self::NistP521 { public, .. } => public.as_ref(),
+        }
+    }
+
+    /// Get the bytes representing the private key.
+    pub fn private_key_bytes(&self) -> &[u8] {
+        match self {
+            Self::NistP256 { private, .. } => private.as_ref(),
+            Self::NistP384 { private, .. } => private.as_ref(),
+            Self::NistP521 { private, .. } => private.as_ref(),
+        }
+    }
+
+    /// Decode Ecdsa private key using the provided Base64 decoder.
+    pub(crate) fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+        match EcdsaPublicKey::decode(decoder)? {
+            EcdsaPublicKey::NistP256(public) => {
+                let private = EcdsaPrivateKey::<32>::decode(decoder)?;
+                Ok(Self::NistP256 { public, private })
+            }
+            EcdsaPublicKey::NistP384(public) => {
+                let private = EcdsaPrivateKey::<48>::decode(decoder)?;
+                Ok(Self::NistP384 { public, private })
+            }
+            EcdsaPublicKey::NistP521(public) => {
+                let private = EcdsaPrivateKey::<66>::decode(decoder)?;
+                Ok(Self::NistP521 { public, private })
+            }
+        }
+    }
+}
+
+impl From<EcdsaKeypair> for EcdsaPublicKey {
+    fn from(keypair: EcdsaKeypair) -> EcdsaPublicKey {
+        EcdsaPublicKey::from(&keypair)
+    }
+}
+
+impl From<&EcdsaKeypair> for EcdsaPublicKey {
+    fn from(keypair: &EcdsaKeypair) -> EcdsaPublicKey {
+        match keypair {
+            EcdsaKeypair::NistP256 { public, .. } => EcdsaPublicKey::NistP256(*public),
+            EcdsaKeypair::NistP384 { public, .. } => EcdsaPublicKey::NistP384(*public),
+            EcdsaKeypair::NistP521 { public, .. } => EcdsaPublicKey::NistP521(*public),
+        }
     }
 }

--- a/ssh-key/src/algorithm/ed25519.rs
+++ b/ssh-key/src/algorithm/ed25519.rs
@@ -58,17 +58,28 @@ impl fmt::UpperHex for Ed25519PublicKey {
 
 /// Ed25519 private key.
 // TODO(tarcieri): use `ed25519::PrivateKey`? (doesn't exist yet)
-#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
-pub struct Ed25519PrivateKey(pub [u8; Self::BYTE_SIZE]);
+#[derive(Clone)]
+pub struct Ed25519PrivateKey([u8; Self::BYTE_SIZE]);
 
 impl Ed25519PrivateKey {
     /// Size of an Ed25519 private key in bytes.
     pub const BYTE_SIZE: usize = 32;
+
+    /// Convert to the inner byte array.
+    pub fn into_bytes(self) -> [u8; Self::BYTE_SIZE] {
+        self.0
+    }
 }
 
 impl AsRef<[u8; Self::BYTE_SIZE]> for Ed25519PrivateKey {
     fn as_ref(&self) -> &[u8; Self::BYTE_SIZE] {
         &self.0
+    }
+}
+
+impl fmt::Debug for Ed25519PrivateKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Ed25519PrivateKey").finish_non_exhaustive()
     }
 }
 

--- a/ssh-key/src/base64.rs
+++ b/ssh-key/src/base64.rs
@@ -40,6 +40,14 @@ impl<'i> Decoder<'i> {
         Ok(self.inner.decode(out)?)
     }
 
+    /// Decodes a single byte.
+    #[cfg(feature = "ecdsa")]
+    pub(crate) fn decode_u8(&mut self) -> Result<u8> {
+        let mut buf = [0];
+        self.decode_into(&mut buf)?;
+        Ok(buf[0])
+    }
+
     /// Decodes a `uint32` as described in [RFC4251 § 5]:
     ///
     /// > Represents a 32-bit unsigned integer.  Stored as four bytes in the

--- a/ssh-key/src/error.rs
+++ b/ssh-key/src/error.rs
@@ -19,8 +19,8 @@ pub enum Error {
     CharacterEncoding,
 
     /// ECDSA key encoding errors.
-    #[cfg(feature = "sec1")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "sec1")))]
+    #[cfg(feature = "ecdsa")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
     Ecdsa(sec1::Error),
 
     /// Other format encoding errors.
@@ -42,7 +42,7 @@ impl fmt::Display for Error {
             Error::Algorithm => f.write_str("unknown or unsupported algorithm"),
             Error::Base64(err) => write!(f, "Base64 encoding error: {}", err),
             Error::CharacterEncoding => f.write_str("character encoding invalid"),
-            #[cfg(feature = "sec1")]
+            #[cfg(feature = "ecdsa")]
             Error::Ecdsa(err) => write!(f, "ECDSA encoding error: {}", err),
             Error::FormatEncoding => f.write_str("format encoding error"),
             Error::Length => f.write_str("length invalid"),
@@ -85,8 +85,8 @@ impl From<core::str::Utf8Error> for Error {
     }
 }
 
-#[cfg(feature = "sec1")]
-#[cfg_attr(docsrs, doc(cfg(feature = "sec1")))]
+#[cfg(feature = "ecdsa")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
 impl From<sec1::Error> for Error {
     fn from(err: sec1::Error) -> Error {
         Error::Ecdsa(err)

--- a/ssh-key/src/lib.rs
+++ b/ssh-key/src/lib.rs
@@ -68,6 +68,6 @@ pub use crate::{
 #[cfg(feature = "alloc")]
 pub use crate::mpint::MPInt;
 
-#[cfg(feature = "sec1")]
-#[cfg_attr(docsrs, doc(cfg(feature = "sec1")))]
+#[cfg(feature = "ecdsa")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
 pub use sec1;

--- a/ssh-key/src/public.rs
+++ b/ssh-key/src/public.rs
@@ -7,7 +7,7 @@ mod openssh;
 pub use crate::algorithm::ed25519::Ed25519PublicKey;
 #[cfg(feature = "alloc")]
 pub use crate::algorithm::{dsa::DsaPublicKey, rsa::RsaPublicKey};
-#[cfg(feature = "sec1")]
+#[cfg(feature = "ecdsa")]
 pub use crate::{algorithm::ecdsa::EcdsaPublicKey, EcdsaCurve};
 
 use crate::{base64, Algorithm, Error, Result};
@@ -72,8 +72,8 @@ pub enum KeyData {
     Dsa(DsaPublicKey),
 
     /// Elliptic Curve Digital Signature Algorithm (ECDSA) public key data.
-    #[cfg(feature = "sec1")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "sec1")))]
+    #[cfg(feature = "ecdsa")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
     Ecdsa(EcdsaPublicKey),
 
     /// Ed25519 public key data.
@@ -91,7 +91,7 @@ impl KeyData {
         match self {
             #[cfg(feature = "alloc")]
             Self::Dsa(_) => Algorithm::Dsa,
-            #[cfg(feature = "sec1")]
+            #[cfg(feature = "ecdsa")]
             Self::Ecdsa(key) => key.algorithm(),
             Self::Ed25519(_) => Algorithm::Ed25519,
             #[cfg(feature = "alloc")]
@@ -110,8 +110,8 @@ impl KeyData {
     }
 
     /// Get ECDSA public key if this key is the correct type.
-    #[cfg(feature = "sec1")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "sec1")))]
+    #[cfg(feature = "ecdsa")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
     pub fn ecdsa(&self) -> Option<&EcdsaPublicKey> {
         match self {
             Self::Ecdsa(key) => Some(key),
@@ -146,8 +146,8 @@ impl KeyData {
     }
 
     /// Is this key an ECDSA key?
-    #[cfg(feature = "sec1")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "sec1")))]
+    #[cfg(feature = "ecdsa")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
     pub fn is_ecdsa(&self) -> bool {
         matches!(self, Self::Ecdsa(_))
     }
@@ -169,7 +169,7 @@ impl KeyData {
         match Algorithm::decode(decoder)? {
             #[cfg(feature = "alloc")]
             Algorithm::Dsa => DsaPublicKey::decode(decoder).map(Self::Dsa),
-            #[cfg(feature = "sec1")]
+            #[cfg(feature = "ecdsa")]
             Algorithm::Ecdsa(curve) => match EcdsaPublicKey::decode(decoder)? {
                 key if key.curve() == curve => Ok(Self::Ecdsa(key)),
                 _ => Err(Error::Algorithm),

--- a/ssh-key/tests/private_key.rs
+++ b/ssh-key/tests/private_key.rs
@@ -3,16 +3,120 @@
 use hex_literal::hex;
 use ssh_key::{Algorithm, PrivateKey};
 
+#[cfg(feature = "ecdsa")]
+use ssh_key::EcdsaCurve;
+
 /// Ed25519 OpenSSH-formatted private key
 const OSSH_ED25519_EXAMPLE: &str = include_str!("examples/id_ed25519");
+
+/// ECDSA/P-256 OpenSSH-formatted public key
+#[cfg(feature = "ecdsa")]
+const OSSH_ECDSA_P256_EXAMPLE: &str = include_str!("examples/id_ecdsa_p256");
+
+/// ECDSA/P-384 OpenSSH-formatted public key
+#[cfg(feature = "ecdsa")]
+const OSSH_ECDSA_P384_EXAMPLE: &str = include_str!("examples/id_ecdsa_p384");
+
+/// ECDSA/P-521 OpenSSH-formatted public key
+#[cfg(feature = "ecdsa")]
+const OSSH_ECDSA_P521_EXAMPLE: &str = include_str!("examples/id_ecdsa_p521");
+
+#[cfg(feature = "ecdsa")]
+#[test]
+fn decode_ecdsa_p256_openssh() {
+    let ossh_key = PrivateKey::from_openssh(OSSH_ECDSA_P256_EXAMPLE).unwrap();
+    assert_eq!(
+        Algorithm::Ecdsa(EcdsaCurve::NistP256),
+        ossh_key.key_data.algorithm(),
+    );
+
+    let ecdsa_keypair = ossh_key.key_data.ecdsa().unwrap();
+    assert_eq!(EcdsaCurve::NistP256, ecdsa_keypair.curve());
+    assert_eq!(
+        &hex!(
+            "047c1fd8730ce53457be8d924098ec3648830f92aa8a2363ac656fdd4521fa6313e511f1891b4e9e5aaf8e1
+             42d06ad15a66a4257f3f051d84e8a0e2f91ba807047"
+        ),
+        ecdsa_keypair.public_key_bytes(),
+    );
+    assert_eq!(
+        &hex!("ca78a64774bfae37123224937f0398960189707aca0a8645ceb4359c423ba079"),
+        ecdsa_keypair.private_key_bytes(),
+    );
+
+    #[cfg(feature = "alloc")]
+    assert_eq!("user@example.com", ossh_key.comment);
+}
+
+#[cfg(feature = "ecdsa")]
+#[test]
+fn decode_ecdsa_p384_openssh() {
+    let ossh_key = PrivateKey::from_openssh(OSSH_ECDSA_P384_EXAMPLE).unwrap();
+    assert_eq!(
+        Algorithm::Ecdsa(EcdsaCurve::NistP384),
+        ossh_key.key_data.algorithm(),
+    );
+
+    let ecdsa_keypair = ossh_key.key_data.ecdsa().unwrap();
+    assert_eq!(EcdsaCurve::NistP384, ecdsa_keypair.curve());
+    assert_eq!(
+        &hex!(
+            "042e6e82dc5407f104a11117c7c05b1993c3ceb3db25fae68ba169502a4ff9395d9ad36b543e8014ff15d70
+             8e21f09f585aa6dfad575b79b943418b86198d9bcd9b07fff9399b15d43d34efaeb2e56b7b33cff880b242b
+             3e0b58af96c75841ec41"
+        ),
+        ecdsa_keypair.public_key_bytes(),
+    );
+    assert_eq!(
+        &hex!(
+            "0377d9e9328b2925196977320a2bfe013801897fa0287848af817bdc7f400e8801fd0f9c057d106914b389c
+             b156f600b"
+        ),
+        ecdsa_keypair.private_key_bytes(),
+    );
+
+    #[cfg(feature = "alloc")]
+    assert_eq!("user@example.com", ossh_key.comment);
+}
+
+#[cfg(feature = "ecdsa")]
+#[test]
+fn decode_ecdsa_p521_openssh() {
+    let ossh_key = PrivateKey::from_openssh(OSSH_ECDSA_P521_EXAMPLE).unwrap();
+    assert_eq!(
+        Algorithm::Ecdsa(EcdsaCurve::NistP521),
+        ossh_key.key_data.algorithm(),
+    );
+
+    let ecdsa_keypair = ossh_key.key_data.ecdsa().unwrap();
+    assert_eq!(EcdsaCurve::NistP521, ecdsa_keypair.curve());
+    assert_eq!(
+        &hex!(
+            "04016136934f192b23d961fbf44c8184166002cea2c7d18b20ad018d046ef068d3e8250fd4e9f17ca6693a8
+             554c3269a6d9f5762a2f9a2cb8797d4b201de421d3dcc580103cb947a858bb7783df863f82951d96f91a792
+             5d7e2baad26e47e3f2fa5b07c8272848a4423b750d7ad2b8b692d66ddecaec5385086b1fd1b682ca291c88d
+             63762"
+        ),
+        ecdsa_keypair.public_key_bytes(),
+    );
+    assert_eq!(
+        &hex!(
+            "01ec905f2ab7a9169f161f09e567fcab225bbe6276727a5f2724535c2b663d7ad8e32527d7f5998a992240c
+             bb90cec3ed67fe902bced588beb972c7716e0927cda82"
+        ),
+        ecdsa_keypair.private_key_bytes(),
+    );
+
+    #[cfg(feature = "alloc")]
+    assert_eq!("user@example.com", ossh_key.comment);
+}
 
 #[test]
 fn decode_ed25519_openssh() {
     let ossh_key = PrivateKey::from_openssh(OSSH_ED25519_EXAMPLE).unwrap();
-
     assert_eq!(Algorithm::Ed25519, ossh_key.key_data.algorithm());
-    let ed25519_keypair = ossh_key.key_data.ed25519().unwrap();
 
+    let ed25519_keypair = ossh_key.key_data.ed25519().unwrap();
     assert_eq!(
         &hex!("b33eaef37ea2df7caa010defdea34e241f65f1b529a4f43ed14327f5c54aab62"),
         ed25519_keypair.public.as_ref(),

--- a/ssh-key/tests/public_key.rs
+++ b/ssh-key/tests/public_key.rs
@@ -3,7 +3,7 @@
 use hex_literal::hex;
 use ssh_key::{Algorithm, PublicKey};
 
-#[cfg(feature = "sec1")]
+#[cfg(feature = "ecdsa")]
 use ssh_key::EcdsaCurve;
 
 /// DSA OpenSSH-formatted public key
@@ -11,15 +11,15 @@ use ssh_key::EcdsaCurve;
 const OSSH_DSA_EXAMPLE: &str = include_str!("examples/id_dsa_1024.pub");
 
 /// ECDSA/P-256 OpenSSH-formatted public key
-#[cfg(feature = "sec1")]
+#[cfg(feature = "ecdsa")]
 const OSSH_ECDSA_P256_EXAMPLE: &str = include_str!("examples/id_ecdsa_p256.pub");
 
 /// ECDSA/P-384 OpenSSH-formatted public key
-#[cfg(feature = "sec1")]
+#[cfg(feature = "ecdsa")]
 const OSSH_ECDSA_P384_EXAMPLE: &str = include_str!("examples/id_ecdsa_p384.pub");
 
 /// ECDSA/P-521 OpenSSH-formatted public key
-#[cfg(feature = "sec1")]
+#[cfg(feature = "ecdsa")]
 const OSSH_ECDSA_P521_EXAMPLE: &str = include_str!("examples/id_ecdsa_p521.pub");
 
 /// Ed25519 OpenSSH-formatted public key
@@ -72,7 +72,7 @@ fn decode_dsa_openssh() {
     assert_eq!("user@example.com", ossh_key.comment);
 }
 
-#[cfg(feature = "sec1")]
+#[cfg(feature = "ecdsa")]
 #[test]
 fn decode_ecdsa_p256_openssh() {
     let ossh_key = PublicKey::from_openssh(OSSH_ECDSA_P256_EXAMPLE).unwrap();
@@ -82,7 +82,7 @@ fn decode_ecdsa_p256_openssh() {
     );
 
     let ecdsa_key = ossh_key.key_data.ecdsa().unwrap();
-    assert_eq!(EcdsaCurve::NistP256, ecdsa_key.curve(),);
+    assert_eq!(EcdsaCurve::NistP256, ecdsa_key.curve());
     assert_eq!(
         &hex!(
             "047c1fd8730ce53457be8d924098ec3648830f92aa8a2363ac656fdd4521fa6313e511f1891b4e9e5aaf8e1
@@ -95,7 +95,7 @@ fn decode_ecdsa_p256_openssh() {
     assert_eq!("user@example.com", ossh_key.comment);
 }
 
-#[cfg(feature = "sec1")]
+#[cfg(feature = "ecdsa")]
 #[test]
 fn decode_ecdsa_p384_openssh() {
     let ossh_key = PublicKey::from_openssh(OSSH_ECDSA_P384_EXAMPLE).unwrap();
@@ -105,7 +105,7 @@ fn decode_ecdsa_p384_openssh() {
     );
 
     let ecdsa_key = ossh_key.key_data.ecdsa().unwrap();
-    assert_eq!(EcdsaCurve::NistP384, ecdsa_key.curve(),);
+    assert_eq!(EcdsaCurve::NistP384, ecdsa_key.curve());
     assert_eq!(
         &hex!(
             "042e6e82dc5407f104a11117c7c05b1993c3ceb3db25fae68ba169502a4ff9395d9ad36b543e8014ff15d70
@@ -119,7 +119,7 @@ fn decode_ecdsa_p384_openssh() {
     assert_eq!("user@example.com", ossh_key.comment);
 }
 
-#[cfg(feature = "sec1")]
+#[cfg(feature = "ecdsa")]
 #[test]
 fn decode_ecdsa_p521_openssh() {
     let ossh_key = PublicKey::from_openssh(OSSH_ECDSA_P521_EXAMPLE).unwrap();


### PR DESCRIPTION
Support for decoding ECDSA private keys into an `EcdsaKeypair` type.

Tested against vectors for the NIST P-256, P-384, and P-521 elliptic curves.