### PR TITLE
base64ct v1.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "base64ct"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "base64",
  "proptest",

--- a/base64ct/CHANGELOG.md
+++ b/base64ct/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.3.2 (2021-12-26)
+### Fixed
+- `Decoder` unpadding ([#299])
+- Edge case when using `Decoder::new_wrapped` ([#300])
+
+[#299]: https://github.com/RustCrypto/formats/pull/299
+[#300]: https://github.com/RustCrypto/formats/pull/300
+
 ## 1.3.1 (2021-12-20)
 ### Added
 - `Decoder::new_wrapped` with support for line-wrapped Base64 ([#292], [#293], [#294])

--- a/base64ct/Cargo.toml
+++ b/base64ct/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base64ct"
-version = "1.3.1" # Also update html_root_url in lib.rs when bumping this
+version = "1.3.2" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Base64 (RFC 4648) which avoids any usages of
 data-dependent branches/LUTs and thereby provides portable "best effort"

--- a/base64ct/src/lib.rs
+++ b/base64ct/src/lib.rs
@@ -4,7 +4,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/base64ct/1.3.1"
+    html_root_url = "https://docs.rs/base64ct/1.3.2"
 )]
 #![doc = include_str!("../README.md")]
 

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-base64ct = { version = "1.3.1", path = "../base64ct" }
+base64ct = { version = "1.3.2", path = "../base64ct" }
 zeroize = { version = "1", default-features = false }
 
 # optional dependencies


### PR DESCRIPTION
### Fixed
- `Decoder` unpadding ([#299])
- Edge case when using `Decoder::new_wrapped` ([#300])

[#299]: https://github.com/RustCrypto/formats/pull/299
[#300]: https://github.com/RustCrypto/formats/pull/300