### PR TITLE
ssh-key: `Decode` trait

### DIFF
--- a/ssh-key/src/algorithm.rs
+++ b/ssh-key/src/algorithm.rs
@@ -8,7 +8,10 @@ pub(crate) mod ed25519;
 #[cfg(feature = "alloc")]
 pub(crate) mod rsa;
 
-use crate::{base64, Error, Result};
+use crate::{
+    base64::{self, Decode},
+    Error, Result,
+};
 use core::{fmt, str};
 
 /// ECDSA with SHA-256 + NIST P-256
@@ -105,9 +108,10 @@ impl Algorithm {
     pub fn is_rsa(self) -> bool {
         self == Algorithm::Rsa
     }
+}
 
-    /// Decode algorithm using the supplied Base64 decoder.
-    pub(crate) fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+impl Decode for Algorithm {
+    fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
         let mut buf = [0u8; Self::MAX_SIZE];
         Self::new(decoder.decode_str(&mut buf)?)
     }
@@ -156,9 +160,10 @@ impl CipherAlg {
             CipherAlg::None => "none",
         }
     }
+}
 
-    /// Decode cipher algorithm using the supplied Base64 decoder.
-    pub(crate) fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+impl Decode for CipherAlg {
+    fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
         let mut buf = [0u8; Self::MAX_SIZE];
         Self::new(decoder.decode_str(&mut buf)?)
     }
@@ -193,7 +198,6 @@ pub enum EcdsaCurve {
 
 impl EcdsaCurve {
     /// Maximum size of a curve identifier known to this crate in bytes.
-    #[cfg(feature = "ecdsa")]
     const MAX_SIZE: usize = 8;
 
     /// Decode elliptic curve from the given string identifier.
@@ -220,10 +224,10 @@ impl EcdsaCurve {
             EcdsaCurve::NistP521 => "nistp521",
         }
     }
+}
 
-    /// Decode ECDSA curve type using the supplied Base64 decoder.
-    #[cfg(feature = "ecdsa")]
-    pub(crate) fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+impl Decode for EcdsaCurve {
+    fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
         let mut buf = [0u8; Self::MAX_SIZE];
         Self::new(decoder.decode_str(&mut buf)?)
     }
@@ -272,9 +276,10 @@ impl KdfAlg {
             KdfAlg::None => "none",
         }
     }
+}
 
-    /// Decode KDF algorithm using the supplied Base64 decoder.
-    pub(crate) fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+impl Decode for KdfAlg {
+    fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
         let mut buf = [0u8; Self::MAX_SIZE];
         Self::new(decoder.decode_str(&mut buf)?)
     }
@@ -310,9 +315,10 @@ impl KdfOptions {
             Err(Error::Algorithm)
         }
     }
+}
 
-    /// Decode KDF options using the supplied Base64 decoder.
-    pub(crate) fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+impl Decode for KdfOptions {
+    fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
         let mut buf = [0u8; 0];
         Self::new(decoder.decode_str(&mut buf)?)
     }

--- a/ssh-key/src/algorithm/dsa.rs
+++ b/ssh-key/src/algorithm/dsa.rs
@@ -1,6 +1,9 @@
 //! Digital Signature Algorithm (DSA).
 
-use crate::{base64, MPInt, Result};
+use crate::{
+    base64::{self, Decode},
+    MPInt, Result,
+};
 
 /// Digital Signature Algorithm (DSA) public key.
 ///
@@ -23,9 +26,9 @@ pub struct DsaPublicKey {
     pub y: MPInt,
 }
 
-impl DsaPublicKey {
+impl Decode for DsaPublicKey {
     /// Decode DSA public key using the provided Base64 decoder.
-    pub(crate) fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+    fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
         let p = MPInt::decode(decoder)?;
         let q = MPInt::decode(decoder)?;
         let g = MPInt::decode(decoder)?;

--- a/ssh-key/src/algorithm/ed25519.rs
+++ b/ssh-key/src/algorithm/ed25519.rs
@@ -1,6 +1,9 @@
 //! Ed25519: Edwards Digital Signature Algorithm (EdDSA) over Curve25519.
 
-use crate::{base64, Error, Result};
+use crate::{
+    base64::{self, Decode},
+    Error, Result,
+};
 use core::fmt;
 use zeroize::{Zeroize, Zeroizing};
 
@@ -12,9 +15,16 @@ pub struct Ed25519PublicKey(pub [u8; Self::BYTE_SIZE]);
 impl Ed25519PublicKey {
     /// Size of an Ed25519 public key in bytes.
     pub const BYTE_SIZE: usize = 32;
+}
 
-    /// Decode Ed25519 public key using the provided Base64 decoder.
-    pub(crate) fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+impl AsRef<[u8; Self::BYTE_SIZE]> for Ed25519PublicKey {
+    fn as_ref(&self) -> &[u8; Self::BYTE_SIZE] {
+        &self.0
+    }
+}
+
+impl Decode for Ed25519PublicKey {
+    fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
         // Validate length prefix
         if decoder.decode_usize()? != Self::BYTE_SIZE {
             return Err(Error::Length);
@@ -23,12 +33,6 @@ impl Ed25519PublicKey {
         let mut bytes = [0u8; Self::BYTE_SIZE];
         decoder.decode_into(&mut bytes)?;
         Ok(Self(bytes))
-    }
-}
-
-impl AsRef<[u8; Self::BYTE_SIZE]> for Ed25519PublicKey {
-    fn as_ref(&self) -> &[u8; Self::BYTE_SIZE] {
-        &self.0
     }
 }
 
@@ -120,9 +124,10 @@ pub struct Ed25519Keypair {
 impl Ed25519Keypair {
     /// Size of an Ed25519 keypair in bytes.
     pub const BYTE_SIZE: usize = 64;
+}
 
-    /// Decode Ed25519 private key using the provided Base64 decoder.
-    pub(crate) fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+impl Decode for Ed25519Keypair {
+    fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
         // Decode private key
         let public = Ed25519PublicKey::decode(decoder)?;
 

--- a/ssh-key/src/algorithm/rsa.rs
+++ b/ssh-key/src/algorithm/rsa.rs
@@ -1,6 +1,9 @@
 //! Rivest–Shamir–Adleman (RSA).
 
-use crate::{base64, MPInt, Result};
+use crate::{
+    base64::{self, Decode},
+    MPInt, Result,
+};
 
 /// RSA public key.
 ///
@@ -15,9 +18,8 @@ pub struct RsaPublicKey {
     pub n: MPInt,
 }
 
-impl RsaPublicKey {
-    /// Decode RSA public key using the provided Base64 decoder.
-    pub(crate) fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+impl Decode for RsaPublicKey {
+    fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
         let e = MPInt::decode(decoder)?;
         let n = MPInt::decode(decoder)?;
         Ok(Self { e, n })

--- a/ssh-key/src/base64.rs
+++ b/ssh-key/src/base64.rs
@@ -9,6 +9,12 @@ use core::str;
 #[cfg(feature = "alloc")]
 use alloc::{string::String, vec::Vec};
 
+/// Decoder trait.
+pub(crate) trait Decode: Sized {
+    /// Attempt to decode a value of this type using the provided [`Decoder`].
+    fn decode(decoder: &mut Decoder<'_>) -> Result<Self>;
+}
+
 /// Stateful Base64 decoder.
 pub(crate) struct Decoder<'i> {
     inner: base64ct::Decoder<'i, base64ct::Base64>,

--- a/ssh-key/src/mpint.rs
+++ b/ssh-key/src/mpint.rs
@@ -1,6 +1,9 @@
 //! Multiple precision integer
 
-use crate::{base64, Error, Result};
+use crate::{
+    base64::{self, Decode},
+    Error, Result,
+};
 use alloc::vec::Vec;
 use core::fmt;
 
@@ -51,16 +54,17 @@ impl MPInt {
     pub fn as_bytes(&self) -> &[u8] {
         self.inner.as_ref()
     }
-
-    /// Decode multiple-precision integer using the supplied Base64 decoder.
-    pub(crate) fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
-        decoder.decode_byte_vec()?.try_into()
-    }
 }
 
 impl AsRef<[u8]> for MPInt {
     fn as_ref(&self) -> &[u8] {
         self.as_bytes()
+    }
+}
+
+impl Decode for MPInt {
+    fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+        decoder.decode_byte_vec()?.try_into()
     }
 }
 

--- a/ssh-key/src/private.rs
+++ b/ssh-key/src/private.rs
@@ -10,7 +10,10 @@ mod openssh;
 pub use crate::algorithm::ecdsa::{EcdsaKeypair, EcdsaPrivateKey};
 pub use crate::algorithm::ed25519::{Ed25519Keypair, Ed25519PrivateKey};
 
-use crate::{base64, public, Algorithm, CipherAlg, Error, KdfAlg, KdfOptions, Result};
+use crate::{
+    base64::{self, Decode},
+    public, Algorithm, CipherAlg, Error, KdfAlg, KdfOptions, Result,
+};
 
 #[cfg(feature = "alloc")]
 use alloc::string::String;
@@ -157,8 +160,9 @@ impl KeypairData {
     pub fn is_ed25519(&self) -> bool {
         matches!(self, Self::Ed25519(_))
     }
+}
 
-    /// Decode data using the provided Base64 decoder.
+impl Decode for KeypairData {
     fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
         match Algorithm::decode(decoder)? {
             #[cfg(feature = "ecdsa")]

--- a/ssh-key/src/public.rs
+++ b/ssh-key/src/public.rs
@@ -10,7 +10,10 @@ pub use crate::algorithm::{dsa::DsaPublicKey, rsa::RsaPublicKey};
 #[cfg(feature = "ecdsa")]
 pub use crate::{algorithm::ecdsa::EcdsaPublicKey, EcdsaCurve};
 
-use crate::{base64, Algorithm, Error, Result};
+use crate::{
+    base64::{self, Decode},
+    Algorithm, Error, Result,
+};
 
 #[cfg(feature = "alloc")]
 use alloc::{borrow::ToOwned, string::String};
@@ -163,9 +166,10 @@ impl KeyData {
     pub fn is_rsa(&self) -> bool {
         matches!(self, Self::Rsa(_))
     }
+}
 
-    /// Decode data using the provided Base64 decoder.
-    pub(crate) fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+impl Decode for KeyData {
+    fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
         match Algorithm::decode(decoder)? {
             #[cfg(feature = "alloc")]
             Algorithm::Dsa => DsaPublicKey::decode(decoder).map(Self::Dsa),


### PR DESCRIPTION
Adds an internal `Decode` trait which encapsulates the same-shaped `fn decode` method used to decode various types throughout the crate.