### PR TITLE
ssh-key: DSA private key support

### DIFF
--- a/ssh-key/src/algorithm/dsa.rs
+++ b/ssh-key/src/algorithm/dsa.rs
@@ -4,35 +4,103 @@ use crate::{
     base64::{self, Decode},
     MPInt, Result,
 };
+use core::fmt;
+use zeroize::Zeroize;
 
 /// Digital Signature Algorithm (DSA) public key.
 ///
-/// Described in [FIPS 186-4](https://csrc.nist.gov/publications/detail/fips/186/4/final).
-// TODO(tarcieri): use `dsa::PublicKey`? (doesn't exist yet)
+/// Described in [FIPS 186-4 § 4.1](https://csrc.nist.gov/publications/detail/fips/186/4/final).
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct DsaPublicKey {
-    /// Prime modulus
+    /// Prime modulus.
     pub p: MPInt,
 
-    /// Prime divisor of `p - 1`
+    /// Prime divisor of `p - 1`.
     pub q: MPInt,
 
     /// Generator of a subgroup of order `q` in the multiplicative group
     /// `GF(p)`, such that `1 < g < p`.
     pub g: MPInt,
 
-    /// The public key, where `y = gˣ mod p`
+    /// The public key, where `y = gˣ mod p`.
     pub y: MPInt,
 }
 
 impl Decode for DsaPublicKey {
-    /// Decode DSA public key using the provided Base64 decoder.
     fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
         let p = MPInt::decode(decoder)?;
         let q = MPInt::decode(decoder)?;
         let g = MPInt::decode(decoder)?;
         let y = MPInt::decode(decoder)?;
         Ok(Self { p, q, g, y })
+    }
+}
+
+/// Digital Signature Algorithm (DSA) private key.
+///
+/// Described in [FIPS 186-4 § 4.1](https://csrc.nist.gov/publications/detail/fips/186/4/final).
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+#[derive(Clone)]
+pub struct DsaPrivateKey {
+    /// Integer representing a DSA private key.
+    inner: MPInt,
+}
+
+impl DsaPrivateKey {
+    /// Get the serialized private key as bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        self.inner.as_bytes()
+    }
+
+    /// Get the inner [`MPInt`].
+    pub fn as_mpint(&self) -> &MPInt {
+        &self.inner
+    }
+}
+
+impl AsRef<[u8]> for DsaPrivateKey {
+    fn as_ref(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}
+
+impl Decode for DsaPrivateKey {
+    fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+        Ok(Self {
+            inner: MPInt::decode(decoder)?,
+        })
+    }
+}
+
+impl Drop for DsaPrivateKey {
+    fn drop(&mut self) {
+        self.inner.zeroize();
+    }
+}
+
+/// Dsa keypairs.
+#[derive(Clone)]
+pub struct DsaKeypair {
+    /// Public key.
+    pub public: DsaPublicKey,
+
+    /// Private key.
+    pub private: DsaPrivateKey,
+}
+
+impl Decode for DsaKeypair {
+    fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+        let public = DsaPublicKey::decode(decoder)?;
+        let private = DsaPrivateKey::decode(decoder)?;
+        Ok(DsaKeypair { public, private })
+    }
+}
+
+impl fmt::Debug for DsaKeypair {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DsaKeypair")
+            .field("public", &self.public)
+            .finish_non_exhaustive()
     }
 }

--- a/ssh-key/src/algorithm/ecdsa.rs
+++ b/ssh-key/src/algorithm/ecdsa.rs
@@ -142,7 +142,7 @@ impl<const SIZE: usize> EcdsaPrivateKey<SIZE> {
         self.bytes
     }
 
-    /// Decode Ecdsa private key using the provided Base64 decoder.
+    /// Decode ECDSA private key using the provided Base64 decoder.
     fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
         let len = decoder.decode_usize()?;
 

--- a/ssh-key/src/mpint.rs
+++ b/ssh-key/src/mpint.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 use alloc::vec::Vec;
 use core::fmt;
+use zeroize::Zeroize;
 
 /// Multiple precision integer, a.k.a. "mpint".
 ///
@@ -74,6 +75,12 @@ impl TryFrom<Vec<u8>> for MPInt {
     fn try_from(bytes: Vec<u8>) -> Result<Self> {
         // TODO(tarcieri): check for unnecessary leading zero bytes
         Ok(Self { inner: bytes })
+    }
+}
+
+impl Zeroize for MPInt {
+    fn zeroize(&mut self) {
+        self.inner.zeroize();
     }
 }
 

--- a/ssh-key/src/public.rs
+++ b/ssh-key/src/public.rs
@@ -102,7 +102,7 @@ impl KeyData {
         }
     }
 
-    /// Get ECDSA public key if this key is the correct type.
+    /// Get DSA public key if this key is the correct type.
     #[cfg(feature = "alloc")]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn dsa(&self) -> Option<&DsaPublicKey> {

--- a/ssh-key/tests/private_key.rs
+++ b/ssh-key/tests/private_key.rs
@@ -6,6 +6,10 @@ use ssh_key::{Algorithm, PrivateKey};
 #[cfg(feature = "ecdsa")]
 use ssh_key::EcdsaCurve;
 
+/// DSA OpenSSH-formatted public key
+#[cfg(feature = "alloc")]
+const OSSH_DSA_EXAMPLE: &str = include_str!("examples/id_dsa_1024");
+
 /// Ed25519 OpenSSH-formatted private key
 const OSSH_ED25519_EXAMPLE: &str = include_str!("examples/id_ed25519");
 
@@ -20,6 +24,49 @@ const OSSH_ECDSA_P384_EXAMPLE: &str = include_str!("examples/id_ecdsa_p384");
 /// ECDSA/P-521 OpenSSH-formatted public key
 #[cfg(feature = "ecdsa")]
 const OSSH_ECDSA_P521_EXAMPLE: &str = include_str!("examples/id_ecdsa_p521");
+
+#[cfg(feature = "alloc")]
+#[test]
+fn decode_dsa_openssh() {
+    let ossh_key = PrivateKey::from_openssh(OSSH_DSA_EXAMPLE).unwrap();
+    assert_eq!(Algorithm::Dsa, ossh_key.key_data.algorithm());
+
+    let dsa_keypair = ossh_key.key_data.dsa().unwrap();
+    assert_eq!(
+        &hex!(
+            "00dc3d89250ed9462114cb2c8d4816e3a511aaff1b06b0e01de17c1cb04e581bcab97176471d89fd7ca1817
+             e3c48e2ccbafd2170f69e8e5c8b6ab69b9c5f45d95e1d9293e965227eee5b879b1123371c21b1db60f14b5e
+             5c05a4782ceb43a32f449647703063621e7a286bec95b16726c18b5e52383d00b297a6b03489b06068a5"
+        ),
+        dsa_keypair.public.p.as_bytes(),
+    );
+    assert_eq!(
+        &hex!("00891815378597fe42d3fd261fe76df365845bbb87"),
+        dsa_keypair.public.q.as_bytes(),
+    );
+    assert_eq!(
+        &hex!(
+            "4739b3908a8415466dc7b156fb98ecb71552a170ba0b3b7aa81bd81391de0a7ae7a1b45002dfeadc9225fbc
+             520a713fe4104a74bed53fd5915da736365afd3f09777bbccfbadf7ac2b087b7f4d95fabe47d72a46e95088
+             f9cd2a9fbf236b58a6982647f3c00430ad7352d47a25ebbe9477f0c3127da86ad7448644b76de5875c"
+        ),
+        dsa_keypair.public.g.as_bytes(),
+    );
+    assert_eq!(
+        &hex!(
+            "6042a6b3fd861344cb21ccccd8719e25aa0be0980e79cbabf4877f5ef071f6039770352eac3d4c368f29daf
+             a57b475c78d44989f16577527e598334be6aae4abd750c36af80489d392697c1f32f3cf3c9a8b99bcddb53d
+             7a37e1a28fd53d4934131cf41c437c6734d1e04004adcd925b84b3956c30c3a3904eecb31400b0df48"
+        ),
+        dsa_keypair.public.y.as_bytes(),
+    );
+    assert_eq!(
+        &hex!("0c377ac449e770d89a3557743cbd050396114b62"),
+        dsa_keypair.private.as_bytes()
+    );
+
+    assert_eq!("user@example.com", ossh_key.comment);
+}
 
 #[cfg(feature = "ecdsa")]
 #[test]


### PR DESCRIPTION
Support for decoding DSA private keys into a `DsaKeypair` type.

Gated on the `alloc` feature.