### PR TITLE
ssh-key v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -933,7 +933,7 @@ dependencies = [
 
 [[package]]
 name = "ssh-key"
-version = "0.2.0-pre"
+version = "0.2.0"
 dependencies = [
  "base64ct",
  "hex-literal",

--- a/ssh-key/CHANGELOG.md
+++ b/ssh-key/CHANGELOG.md
@@ -4,5 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2021-12-29)
+### Added
+- OpenSSH private key decoder ([#297], [#301], [#307], [#311])
+- `MPInt::as_positive_bytes` ([#312])
+
+### Changed
+- `MPInt` validates the correct number of leading zeroes are used ([#312])
+
+[#297]: https://github.com/RustCrypto/formats/pull/297
+[#301]: https://github.com/RustCrypto/formats/pull/301
+[#307]: https://github.com/RustCrypto/formats/pull/307
+[#311]: https://github.com/RustCrypto/formats/pull/311
+[#312]: https://github.com/RustCrypto/formats/pull/312
+
 ## 0.1.0 (2021-12-02)
 - Initial release

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssh-key"
-version = "0.2.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of SSH key file format decoders/encoders as described
 in RFC4253 and RFC4716 as well as the OpenSSH key formats. Supports "heapless"

--- a/ssh-key/src/lib.rs
+++ b/ssh-key/src/lib.rs
@@ -5,7 +5,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/ssh-key/0.1.0"
+    html_root_url = "https://docs.rs/ssh-key/0.2.0"
 )]
 #![doc = include_str!("../README.md")]
 


### PR DESCRIPTION
### Added
- OpenSSH private key decoder ([#297], [#301], [#307], [#311])
- `MPInt::as_positive_bytes` ([#312])

### Changed
- `MPInt` validates the correct number of leading zeroes are used ([#312])

[#297]: https://github.com/RustCrypto/formats/pull/297
[#301]: https://github.com/RustCrypto/formats/pull/301
[#307]: https://github.com/RustCrypto/formats/pull/307
[#311]: https://github.com/RustCrypto/formats/pull/311
[#312]: https://github.com/RustCrypto/formats/pull/312