### PR TITLE
ssh-key: README.md fixup

### DIFF
--- a/ssh-key/README.md
+++ b/ssh-key/README.md
@@ -14,17 +14,14 @@
 Pure Rust implementation of SSH key file format decoders/encoders as described
 in [RFC4253] and [RFC4716] as well as OpenSSH's [PROTOCOL.key] format specification.
 
-Supports "heapless" `no_std` embedded targets with an optional `alloc` feature
-(Ed25519 and ECDSA only).
-
 ## Features
 
 - [x] Constant-time Base64 decoding using the `base64ct` crate
 - [x] `no_std` support including support for "heapless" (no-`alloc`) targets
 - [x] Parsing OpenSSH-formatted public and private keys with the following algorithms:
   - [x] DSA (`no_std` + `alloc`)
-  - [x] ECDSA (`no_std` stack-only)
-  - [x] Ed25519 (`no_std` stack-only)
+  - [x] ECDSA (`no_std` "heapless")
+  - [x] Ed25519 (`no_std` "heapless")
   - [x] RSA (`no_std` + `alloc`)
 - [x] Built-in zeroize support for private keys
 


### PR DESCRIPTION
Removes a line which duplicates information from the newly added "Features" section