### PR TITLE
spki: add `Error::KeyMalformed` variant

### DIFF
--- a/spki/src/error.rs
+++ b/spki/src/error.rs
@@ -16,6 +16,12 @@ pub enum Error {
     /// ASN.1 DER-related errors.
     Asn1(der::Error),
 
+    /// Malformed cryptographic key contained in a SPKI document.
+    ///
+    /// This is intended for relaying errors related to the raw data contained
+    /// in [`SubjectPublicKeyInfo::subject_public_key`][`crate::SubjectPublicKeyInfo::subject_public_key`].
+    KeyMalformed,
+
     /// Unknown algorithm OID.
     OidUnknown {
         /// Unrecognized OID value found in e.g. a SPKI `AlgorithmIdentifier`.
@@ -30,6 +36,7 @@ impl fmt::Display for Error {
                 f.write_str("AlgorithmIdentifier parameters missing")
             }
             Error::Asn1(err) => write!(f, "ASN.1 error: {}", err),
+            Error::KeyMalformed => f.write_str("SPKI cryptographic key data malformed"),
             Error::OidUnknown { oid } => {
                 write!(f, "unknown/unsupported algorithm OID: {}", oid)
             }


### PR DESCRIPTION
Adds an error variant similar to `pkcs8::Error::KeyMalformed` for relaying that binary data contained in `subject_public_key` is in some way malformed beyond what errors can be communicated via `Error::Asn1` for DER decoding errors.

This is useful if DER decoding succeeds but something else is wrong, e.g. an elliptic curve public key is not a valid solution to the curve equation.