### PR TITLE
spki v0.5.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "base64ct",
  "der",

--- a/spki/CHANGELOG.md
+++ b/spki/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.4 (2022-01-05)
+### Added
+- `Error::KeyMalformed` variant ([#318])
+
+[#318]: https://github.com/RustCrypto/formats/pull/318
+
 ## 0.5.3 (2021-12-19)
 ### Added
 - Impl `ValueOrd` for `AlgorithmIdentifier` ([#289])

--- a/spki/Cargo.toml
+++ b/spki/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spki"
-version = "0.5.3" # Also update html_root_url in lib.rs when bumping this
+version = "0.5.4" # Also update html_root_url in lib.rs when bumping this
 description = """
 X.509 Subject Public Key Info (RFC5280) describing public keys as well as their
 associated AlgorithmIdentifiers (i.e. OIDs)

--- a/spki/LICENSE-MIT
+++ b/spki/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2021 The RustCrypto Project Developers
+Copyright (c) 2021-2022 The RustCrypto Project Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/spki/src/lib.rs
+++ b/spki/src/lib.rs
@@ -23,7 +23,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/spki/0.5.3"
+    html_root_url = "https://docs.rs/spki/0.5.4"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Added
- `Error::KeyMalformed` variant ([#318])

[#318]: https://github.com/RustCrypto/formats/pull/318