### PR TITLE
base16ct: re-organize crate

### DIFF
--- a/base16ct/src/lib.rs
+++ b/base16ct/src/lib.rs
@@ -82,8 +82,6 @@ pub fn decoded_len(bytes: &[u8]) -> Result<usize, Error> {
 }
 
 /// Get the length of Base16 (hex) produced by encoding the given bytes.
-///
-/// WARNING: this function will return `0` for lengths greater than `usize::MAX/2`!
 #[inline(always)]
 pub fn encoded_len(bytes: &[u8]) -> usize {
     bytes.len() * 2

--- a/base16ct/src/lib.rs
+++ b/base16ct/src/lib.rs
@@ -1,28 +1,57 @@
+//! Pure Rust implementation of Base16 ([RFC 4648], a.k.a. hex).
+//!
+//! Implements lower and upper case Base16 variants without data-dependent branches
+//! or lookup  tables, thereby providing portable "best effort" constant-time
+//! operation. Not constant-time with respect to message length (only data).
+//!
+//! Supports `no_std` environments and avoids heap allocations in the core API
+//! (but also provides optional `alloc` support for convenience).
+//!
+//! Based on code from: <https://github.com/Sc00bz/ConstTimeEncoding/blob/master/hex.cpp>
+//!
+//! # Examples
+//! ```
+//! let lower_hex_str = "abcd1234";
+//! let upper_hex_str = "ABCD1234";
+//! let mixed_hex_str = "abCD1234";
+//! let raw = b"\xab\xcd\x12\x34";
+//!
+//! let mut buf = [0u8; 16];
+//! // length of return slice can be different from the input buffer!
+//! let res = base16ct::lower::decode(lower_hex_str, &mut buf).unwrap();
+//! assert_eq!(res, raw);
+//! let res = base16ct::lower::encode(raw, &mut buf).unwrap();
+//! assert_eq!(res, lower_hex_str.as_bytes());
+//! // you also can use `encode_str` and `encode_string` to get
+//! // `&str` and `String` respectively
+//! let res: &str = base16ct::lower::encode_str(raw, &mut buf).unwrap();
+//! assert_eq!(res, lower_hex_str);
+//!
+//! let res = base16ct::upper::decode(upper_hex_str, &mut buf).unwrap();
+//! assert_eq!(res, raw);
+//! let res = base16ct::upper::encode(raw, &mut buf).unwrap();
+//! assert_eq!(res, upper_hex_str.as_bytes());
+//!
+//! // In cases when you don't know if input contains upper or lower
+//! // hex-encoded value, then use functions from the `mixed` module
+//! let res = base16ct::mixed::decode(lower_hex_str, &mut buf).unwrap();
+//! assert_eq!(res, raw);
+//! let res = base16ct::mixed::decode(upper_hex_str, &mut buf).unwrap();
+//! assert_eq!(res, raw);
+//! let res = base16ct::mixed::decode(mixed_hex_str, &mut buf).unwrap();
+//! assert_eq!(res, raw);
+//! ```
+//!
+//! [RFC 4648]: https://tools.ietf.org/html/rfc4648
+
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 #![doc(
-    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_root_url = "https://docs.rs/base16ct/0.0.0"
 )]
-#![doc = include_str!("../README.md")]
-
-//! # Implementation
-//!
-//! Implemented using integer arithmetic alone without any lookup tables or
-//! data-dependent branches, thereby providing portable "best effort"
-//! constant-time operation.
-//!
-//! Not constant-time with respect to message length (only data).
-//!
-//! Adapted from this C++ implementation:
-//!
-//! <https://github.com/Sc00bz/ConstTimeEncoding/blob/master/hex.cpp>
-//!
-//! Copyright (c) 2014 Steve "Sc00bz" Thomas (steve at tobtu dot com)
-//! Derived code is dual licensed MIT + Apache 2.0 (with permission from @Sc00bz)
 
 #[cfg(feature = "alloc")]
 #[macro_use]
@@ -34,6 +63,53 @@ use core::fmt;
 
 #[cfg(feature = "alloc")]
 use alloc::{string::String, vec::Vec};
+
+/// Fucntion for decoding and encoding lower Base16 (hex)
+pub mod lower;
+/// Fucntion for decoding mixed Base16 (hex)
+pub mod mixed;
+/// Fucntion for decoding and encoding upper Base16 (hex)
+pub mod upper;
+
+/// Compute decoded length of the given hex-encoded input.
+#[inline(always)]
+pub fn decoded_len(bytes: &[u8]) -> Result<usize, Error> {
+    if bytes.len() & 1 == 0 {
+        Ok(bytes.len() / 2)
+    } else {
+        Err(Error::InvalidLength)
+    }
+}
+
+/// Get the length of Base16 (hex) produced by encoding the given bytes.
+///
+/// WARNING: this function will return `0` for lengths greater than `usize::MAX/2`!
+#[inline(always)]
+pub fn encoded_len(bytes: &[u8]) -> usize {
+    bytes.len() * 2
+}
+
+fn decode_inner<'a>(
+    src: &[u8],
+    dst: &'a mut [u8],
+    decode_nibble: impl Fn(u8) -> u16,
+) -> Result<&'a [u8], Error> {
+    let dst = dst
+        .get_mut(..decoded_len(src)?)
+        .ok_or(Error::InvalidLength)?;
+
+    let mut err: u16 = 0;
+    for (src, dst) in src.chunks_exact(2).zip(dst.iter_mut()) {
+        let byte = (decode_nibble(src[0]) << 4) | decode_nibble(src[1]);
+        err |= byte >> 8;
+        *dst = byte as u8;
+    }
+
+    match err {
+        0 => Ok(dst),
+        _ => Err(Error::InvalidEncoding),
+    }
+}
 
 /// Error type
 #[derive(Clone, Eq, PartialEq, Debug)]
@@ -56,173 +132,3 @@ impl fmt::Display for Error {
 
 #[cfg(feature = "std")]
 impl std::error::Error for Error {}
-
-/// Base16 encoding (a.k.a. hexadecimal)
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, PartialEq, PartialOrd, Ord)]
-pub struct Base16 {
-    /// Upper or lower case
-    case: Case,
-}
-
-impl Base16 {
-    /// Lower case hex: 0-9 a-f
-    pub fn lower_case() -> Base16 {
-        Base16 { case: Case::Lower }
-    }
-
-    /// Upper case hex: 0-9 A-F
-    pub fn upper_case() -> Base16 {
-        Base16 { case: Case::Upper }
-    }
-}
-
-impl Base16 {
-    /// Decode a Base16 (hex) string into the provided destination buffer.
-    pub fn decode<'a>(&self, src: impl AsRef<[u8]>, dst: &'a mut [u8]) -> Result<&'a [u8], Error> {
-        let src = src.as_ref();
-
-        let dst_length = Self::decoded_len(src)?;
-        if dst_length > dst.len() {
-            return Err(Error::InvalidLength);
-        }
-
-        let mut err: usize = 0;
-
-        for (i, dst_byte) in dst.iter_mut().enumerate().take(dst_length) {
-            let src_offset = i * 2;
-            let byte = (self.case.decode_nibble(src[src_offset]) << 4)
-                | self.case.decode_nibble(src[src_offset + 1]);
-            err |= byte >> 8;
-            *dst_byte = byte as u8;
-        }
-
-        if err == 0 {
-            Ok(&dst[..dst_length])
-        } else {
-            Err(Error::InvalidEncoding)
-        }
-    }
-
-    /// Decode a Base16 (hex) string into a byte vector.
-    #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-    pub fn decode_vec(&self, input: impl AsRef<[u8]>) -> Result<Vec<u8>, Error> {
-        let mut output = vec![0u8; Self::decoded_len(input.as_ref())?];
-        self.decode(input, &mut output)?;
-        Ok(output)
-    }
-
-    /// Compute decoded length of the given input.
-    pub fn decoded_len(bytes: &[u8]) -> Result<usize, Error> {
-        if bytes.len() & 1 == 0 {
-            Ok(bytes.len() >> 1)
-        } else {
-            Err(Error::InvalidLength)
-        }
-    }
-
-    /// Encode the input byte slice as Base16 (hex).
-    ///
-    /// Writes the result into the provided destination slice, returning an
-    /// ASCII-encoded Base16 (hex) string value.
-    pub fn encode<'a>(&self, src: &[u8], dst: &'a mut [u8]) -> Result<&'a [u8], Error> {
-        if Self::encoded_len(src) > dst.len() {
-            return Err(Error::InvalidLength);
-        }
-
-        for (i, src_byte) in src.iter().enumerate() {
-            let offset = i * 2;
-            dst[offset] = self.case.encode_nibble(src_byte >> 4);
-            dst[offset + 1] = self.case.encode_nibble(src_byte & 0x0f);
-        }
-
-        Ok(&dst[..(src.len() * 2)])
-    }
-
-    /// Encode input byte slice into a [`String`] containing Base16 (hex).
-    ///
-    /// # Panics
-    /// If `input` length is greater than `usize::MAX/2`.
-    #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-    pub fn encode_string(&self, input: &[u8]) -> String {
-        let elen = Self::encoded_len(input);
-        let mut dst = vec![0u8; elen];
-        let res = self.encode(input, &mut dst).expect("encoding error");
-
-        debug_assert_eq!(elen, res.len());
-        String::from_utf8(dst).expect("character encoding error")
-    }
-
-    /// Get the length of Base16 (hex) produced by encoding the given bytes.
-    ///
-    /// WARNING: this function will return `0` for lengths greater than `usize::MAX/2`!
-    pub fn encoded_len(bytes: &[u8]) -> usize {
-        bytes.len() * 2
-    }
-}
-
-/// Lower or upper case encoders
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
-enum Case {
-    Lower,
-    Upper,
-}
-
-impl Case {
-    /// Decode a single nibble of hex (lower or upper case)
-    #[inline]
-    fn decode_nibble(self, src: u8) -> usize {
-        // 0-9  0x30-0x39
-        // A-F  0x41-0x46 or a-f  0x61-0x66
-        let byte = src as isize;
-        let mut ret: isize = -1;
-
-        // 0-9  0x30-0x39
-        // if (byte > 0x2f && byte < 0x3a) ret += byte - 0x30 + 1; // -47
-        ret += (((0x2fisize - byte) & (byte - 0x3a)) >> 8) & (byte - 47);
-
-        ret += match self {
-            Case::Lower => {
-                // a-f  0x61-0x66
-                // if (byte > 0x60 && byte < 0x67) ret += byte - 0x61 + 10 + 1; // -86
-                (((0x60isize - byte) & (byte - 0x67)) >> 8) & (byte - 86)
-            }
-            Case::Upper => {
-                // A-F  0x41-0x46
-                // if (byte > 0x40 && byte < 0x47) ret += byte - 0x41 + 10 + 1; // -54
-                (((0x40isize - byte) & (byte - 0x47)) >> 8) & (byte - 54)
-            }
-        };
-
-        ret as usize
-    }
-
-    /// Encode a single nibble of hex
-    #[inline]
-    fn encode_nibble(self, src: u8) -> u8 {
-        let mut ret = src as isize + 0x30;
-
-        ret += match self {
-            Case::Lower => {
-                // 0-9  0x30-0x39
-                // a-f  0x61-0x66
-                ((0x39isize - ret) >> 8) & (0x61isize - 0x3a)
-            }
-            Case::Upper => {
-                // 0-9  0x30-0x39
-                // A-F  0x41-0x46
-                ((0x39isize - ret) >> 8) & (0x41isize - 0x3a)
-            }
-        };
-
-        ret as u8
-    }
-}
-
-impl Default for Case {
-    /// Default: lower case
-    fn default() -> Case {
-        Case::Lower
-    }
-}

--- a/base16ct/src/lower.rs
+++ b/base16ct/src/lower.rs
@@ -1,0 +1,95 @@
+use crate::{decoded_len, encoded_len, Error};
+#[cfg(feature = "alloc")]
+use crate::{String, Vec};
+
+/// Decode a lower Base16 (hex) string into the provided destination buffer.
+pub fn decode(src: impl AsRef<[u8]>, dst: &mut [u8]) -> Result<&[u8], Error> {
+    let src = src.as_ref();
+    let dst = dst
+        .get_mut(..decoded_len(src)?)
+        .ok_or(Error::InvalidLength)?;
+
+    let mut err: u16 = 0;
+    for (src, dst) in src.chunks_exact(2).zip(dst.iter_mut()) {
+        let byte = (decode_nibble(src[0]) << 4) | decode_nibble(src[1]);
+        err |= byte >> 8;
+        *dst = byte as u8;
+    }
+
+    match err {
+        0 => Ok(dst),
+        _ => Err(Error::InvalidEncoding),
+    }
+}
+
+/// Decode a lower Base16 (hex) string into a byte vector.
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+pub fn decode_vec(input: impl AsRef<[u8]>) -> Result<Vec<u8>, Error> {
+    let mut output = vec![0u8; decoded_len(input.as_ref())?];
+    decode(input, &mut output)?;
+    Ok(output)
+}
+
+/// Encode the input byte slice as lower Base16.
+///
+/// Writes the result into the provided destination slice, returning an
+/// ASCII-encoded lower Base16 (hex) string value.
+pub fn encode<'a>(src: &[u8], dst: &'a mut [u8]) -> Result<&'a [u8], Error> {
+    let dst = dst
+        .get_mut(..encoded_len(src))
+        .ok_or(Error::InvalidLength)?;
+    for (src, dst) in src.iter().zip(dst.chunks_exact_mut(2)) {
+        dst[0] = encode_nibble(src >> 4);
+        dst[1] = encode_nibble(src & 0x0f);
+    }
+    Ok(dst)
+}
+
+/// Encode input byte slice into a [`&str`] containing lower Base16 (hex).
+pub fn encode_str<'a>(src: &[u8], dst: &'a mut [u8]) -> Result<&'a str, Error> {
+    encode(src, dst).map(|r| unsafe { core::str::from_utf8_unchecked(r) })
+}
+
+/// Encode input byte slice into a [`String`] containing lower Base16 (hex).
+///
+/// # Panics
+/// If `input` length is greater than `usize::MAX/2`.
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+pub fn encode_string(input: &[u8]) -> String {
+    let elen = encoded_len(input);
+    let mut dst = vec![0u8; elen];
+    let res = encode(input, &mut dst).expect("encoding error");
+
+    debug_assert_eq!(elen, res.len());
+    unsafe { String::from_utf8_unchecked(dst) }
+}
+
+/// Decode a single nibble of lower hex
+#[inline(always)]
+fn decode_nibble(src: u8) -> u16 {
+    // 0-9  0x30-0x39
+    // A-F  0x41-0x46 or a-f  0x61-0x66
+    let byte = src as i16;
+    let mut ret: i16 = -1;
+
+    // 0-9  0x30-0x39
+    // if (byte > 0x2f && byte < 0x3a) ret += byte - 0x30 + 1; // -47
+    ret += (((0x2fi16 - byte) & (byte - 0x3a)) >> 8) & (byte - 47);
+    // a-f  0x61-0x66
+    // if (byte > 0x60 && byte < 0x67) ret += byte - 0x61 + 10 + 1; // -86
+    ret += (((0x60i16 - byte) & (byte - 0x67)) >> 8) & (byte - 86);
+
+    ret as u16
+}
+
+/// Encode a single nibble of hex
+#[inline(always)]
+fn encode_nibble(src: u8) -> u8 {
+    let mut ret = src as i16 + 0x30;
+    // 0-9  0x30-0x39
+    // a-f  0x61-0x66
+    ret += ((0x39i16 - ret) >> 8) & (0x61i16 - 0x3a);
+    ret as u8
+}

--- a/base16ct/src/mixed.rs
+++ b/base16ct/src/mixed.rs
@@ -1,25 +1,10 @@
+use crate::{decode_inner, Error};
 #[cfg(feature = "alloc")]
-use crate::Vec;
-use crate::{decoded_len, Error};
+use crate::{decoded_len, Vec};
 
 /// Decode a mixed Base16 (hex) string into the provided destination buffer.
 pub fn decode(src: impl AsRef<[u8]>, dst: &mut [u8]) -> Result<&[u8], Error> {
-    let src = src.as_ref();
-    let dst = dst
-        .get_mut(..decoded_len(src)?)
-        .ok_or(Error::InvalidLength)?;
-
-    let mut err: u16 = 0;
-    for (src, dst) in src.chunks_exact(2).zip(dst.iter_mut()) {
-        let byte = (decode_nibble(src[0]) << 4) | decode_nibble(src[1]);
-        err |= byte >> 8;
-        *dst = byte as u8;
-    }
-
-    match err {
-        0 => Ok(dst),
-        _ => Err(Error::InvalidEncoding),
-    }
+    decode_inner(src.as_ref(), dst, decode_nibble)
 }
 
 /// Decode a mixed Base16 (hex) string into a byte vector.

--- a/base16ct/src/mixed.rs
+++ b/base16ct/src/mixed.rs
@@ -1,0 +1,53 @@
+#[cfg(feature = "alloc")]
+use crate::Vec;
+use crate::{decoded_len, Error};
+
+/// Decode a mixed Base16 (hex) string into the provided destination buffer.
+pub fn decode(src: impl AsRef<[u8]>, dst: &mut [u8]) -> Result<&[u8], Error> {
+    let src = src.as_ref();
+    let dst = dst
+        .get_mut(..decoded_len(src)?)
+        .ok_or(Error::InvalidLength)?;
+
+    let mut err: u16 = 0;
+    for (src, dst) in src.chunks_exact(2).zip(dst.iter_mut()) {
+        let byte = (decode_nibble(src[0]) << 4) | decode_nibble(src[1]);
+        err |= byte >> 8;
+        *dst = byte as u8;
+    }
+
+    match err {
+        0 => Ok(dst),
+        _ => Err(Error::InvalidEncoding),
+    }
+}
+
+/// Decode a mixed Base16 (hex) string into a byte vector.
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+pub fn decode_vec(input: impl AsRef<[u8]>) -> Result<Vec<u8>, Error> {
+    let mut output = vec![0u8; decoded_len(input.as_ref())?];
+    decode(input, &mut output)?;
+    Ok(output)
+}
+
+/// Decode a single nibble of lower hex
+#[inline(always)]
+fn decode_nibble(src: u8) -> u16 {
+    // 0-9  0x30-0x39
+    // A-F  0x41-0x46 or a-f  0x61-0x66
+    let byte = src as i16;
+    let mut ret: i16 = -1;
+
+    // 0-9  0x30-0x39
+    // if (byte > 0x2f && byte < 0x3a) ret += byte - 0x30 + 1; // -47
+    ret += (((0x2fi16 - byte) & (byte - 0x3a)) >> 8) & (byte - 47);
+    // A-F  0x41-0x46
+    // if (byte > 0x40 && byte < 0x47) ret += byte - 0x41 + 10 + 1; // -54
+    ret += (((0x40i16 - byte) & (byte - 0x47)) >> 8) & (byte - 54);
+    // a-f  0x61-0x66
+    // if (byte > 0x60 && byte < 0x67) ret += byte - 0x61 + 10 + 1; // -86
+    ret += (((0x60i16 - byte) & (byte - 0x67)) >> 8) & (byte - 86);
+
+    ret as u16
+}

--- a/base16ct/src/upper.rs
+++ b/base16ct/src/upper.rs
@@ -1,0 +1,80 @@
+use crate::{decode_inner, encoded_len, Error};
+#[cfg(feature = "alloc")]
+use crate::{String, Vec};
+
+/// Decode an upper Base16 (hex) string into the provided destination buffer.
+pub fn decode(src: impl AsRef<[u8]>, dst: &mut [u8]) -> Result<&[u8], Error> {
+    decode_inner(src.as_ref(), dst, decode_nibble)
+}
+
+/// Decode an upper Base16 (hex) string into a byte vector.
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+pub fn decode_vec(input: impl AsRef<[u8]>) -> Result<Vec<u8>, Error> {
+    let mut output = vec![0u8; decoded_len(input.as_ref())?];
+    decode(input, &mut output)?;
+    Ok(output)
+}
+
+/// Encode the input byte slice as upper Base16.
+///
+/// Writes the result into the provided destination slice, returning an
+/// ASCII-encoded upper Base16 (hex) string value.
+pub fn encode<'a>(src: &[u8], dst: &'a mut [u8]) -> Result<&'a [u8], Error> {
+    let dst = dst
+        .get_mut(..encoded_len(src))
+        .ok_or(Error::InvalidLength)?;
+    for (src, dst) in src.iter().zip(dst.chunks_exact_mut(2)) {
+        dst[0] = encode_nibble(src >> 4);
+        dst[1] = encode_nibble(src & 0x0f);
+    }
+    Ok(dst)
+}
+
+/// Encode input byte slice into a [`&str`] containing upper Base16 (hex).
+pub fn encode_str<'a>(src: &[u8], dst: &'a mut [u8]) -> Result<&'a str, Error> {
+    encode(src, dst).map(|r| unsafe { core::str::from_utf8_unchecked(r) })
+}
+
+/// Encode input byte slice into a [`String`] containing upper Base16 (hex).
+///
+/// # Panics
+/// If `input` length is greater than `usize::MAX/2`.
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+pub fn encode_string(input: &[u8]) -> String {
+    let elen = encoded_len(input);
+    let mut dst = vec![0u8; elen];
+    let res = encode(input, &mut dst).expect("encoding error");
+
+    debug_assert_eq!(elen, res.len());
+    unsafe { crate::String::from_utf8_unchecked(dst) }
+}
+
+/// Decode a single nibble of upper hex
+#[inline(always)]
+fn decode_nibble(src: u8) -> u16 {
+    // 0-9  0x30-0x39
+    // A-F  0x41-0x46 or a-f  0x61-0x66
+    let byte = src as i16;
+    let mut ret: i16 = -1;
+
+    // 0-9  0x30-0x39
+    // if (byte > 0x2f && byte < 0x3a) ret += byte - 0x30 + 1; // -47
+    ret += (((0x2fi16 - byte) & (byte - 0x3a)) >> 8) & (byte - 47);
+    // A-F  0x41-0x46
+    // if (byte > 0x40 && byte < 0x47) ret += byte - 0x41 + 10 + 1; // -54
+    ret += (((0x40i16 - byte) & (byte - 0x47)) >> 8) & (byte - 54);
+
+    ret as u16
+}
+
+/// Encode a single nibble of hex
+#[inline(always)]
+fn encode_nibble(src: u8) -> u8 {
+    let mut ret = src as i16 + 0x30;
+    // 0-9  0x30-0x39
+    // A-F  0x41-0x46
+    ret += ((0x39i16 - ret) >> 8) & (0x41i16 - 0x3a);
+    ret as u8
+}

--- a/base16ct/src/upper.rs
+++ b/base16ct/src/upper.rs
@@ -1,6 +1,6 @@
 use crate::{decode_inner, encoded_len, Error};
 #[cfg(feature = "alloc")]
-use crate::{String, Vec};
+use crate::{decoded_len, String, Vec};
 
 /// Decode an upper Base16 (hex) string into the provided destination buffer.
 pub fn decode(src: impl AsRef<[u8]>, dst: &mut [u8]) -> Result<&[u8], Error> {
@@ -45,7 +45,7 @@ pub fn encode_str<'a>(src: &[u8], dst: &'a mut [u8]) -> Result<&'a str, Error> {
 pub fn encode_string(input: &[u8]) -> String {
     let elen = encoded_len(input);
     let mut dst = vec![0u8; elen];
-    let res = encode(input, &mut dst).expect("encoding error");
+    let res = encode(input, &mut dst).expect("dst length is correct");
 
     debug_assert_eq!(elen, res.len());
     unsafe { crate::String::from_utf8_unchecked(dst) }

--- a/base16ct/tests/lib.rs
+++ b/base16ct/tests/lib.rs
@@ -1,84 +1,147 @@
 //! Integration tests.
 
-#![cfg(feature = "alloc")]
-
-use base16ct::{Base16, Error};
-
 /// Hexadecimal test vectors
 struct HexVector {
     /// Raw bytes
     raw: &'static [u8],
-
-    /// Hex encoded
-    hex: &'static [u8],
+    /// Lower hex encoded
+    lower_hex: &'static [u8],
+    /// Upper hex encoded
+    upper_hex: &'static [u8],
 }
 
 const HEX_TEST_VECTORS: &[HexVector] = &[
-    HexVector { raw: b"", hex: b"" },
+    HexVector {
+        raw: b"",
+        lower_hex: b"",
+        upper_hex: b"",
+    },
     HexVector {
         raw: b"\0",
-        hex: b"00",
+        lower_hex: b"00",
+        upper_hex: b"00",
     },
     HexVector {
         raw: b"***",
-        hex: b"2a2a2a",
+        lower_hex: b"2a2a2a",
+        upper_hex: b"2A2A2A",
     },
     HexVector {
         raw: b"\x01\x02\x03\x04",
-        hex: b"01020304",
+        lower_hex: b"01020304",
+        upper_hex: b"01020304",
     },
     HexVector {
         raw: b"\xAD\xAD\xAD\xAD\xAD",
-        hex: b"adadadadad",
+        lower_hex: b"adadadadad",
+        upper_hex: b"ADADADADAD",
     },
     HexVector {
         raw: b"\xFF\xFF\xFF\xFF\xFF",
-        hex: b"ffffffffff",
+        lower_hex: b"ffffffffff",
+        upper_hex: b"FFFFFFFFFF",
     },
 ];
 
 #[test]
-fn encode_test_vectors() {
+fn lower_encode() {
     for vector in HEX_TEST_VECTORS {
         // 10 is the size of the largest encoded test vector
         let mut buf = [0u8; 10];
-        let out = Base16::lower_case().encode(vector.raw, &mut buf).unwrap();
-        assert_eq!(vector.hex, out);
+        let out = base16ct::lower::encode(vector.raw, &mut buf).unwrap();
+        assert_eq!(vector.lower_hex, out);
     }
 }
 
 #[test]
-fn decode_test_vectors() {
+fn lower_decode() {
     for vector in HEX_TEST_VECTORS {
         // 5 is the size of the largest decoded test vector
         let mut buf = [0u8; 5];
-        let out = Base16::lower_case().decode(vector.hex, &mut buf).unwrap();
+        let out = base16ct::lower::decode(vector.lower_hex, &mut buf).unwrap();
         assert_eq!(vector.raw, out);
     }
 }
 
 #[test]
-fn reject_odd_size_input() {
+fn lower_reject_odd_size_input() {
     let mut out = [0u8; 3];
     assert_eq!(
-        Error::InvalidLength,
-        Base16::lower_case()
-            .decode(b"12345", &mut out)
-            .err()
-            .unwrap(),
+        Err(base16ct::Error::InvalidLength),
+        base16ct::lower::decode(b"12345", &mut out),
     )
 }
 
 #[test]
+fn upper_encode() {
+    for vector in HEX_TEST_VECTORS {
+        // 10 is the size of the largest encoded test vector
+        let mut buf = [0u8; 10];
+        let out = base16ct::upper::encode(vector.raw, &mut buf).unwrap();
+        assert_eq!(vector.upper_hex, out);
+    }
+}
+
+#[test]
+fn upper_decode() {
+    for vector in HEX_TEST_VECTORS {
+        // 5 is the size of the largest decoded test vector
+        let mut buf = [0u8; 5];
+        let out = base16ct::upper::decode(vector.upper_hex, &mut buf).unwrap();
+        assert_eq!(vector.raw, out);
+    }
+}
+
+#[test]
+fn upper_reject_odd_size_input() {
+    let mut out = [0u8; 3];
+    assert_eq!(
+        Err(base16ct::Error::InvalidLength),
+        base16ct::upper::decode(b"12345", &mut out),
+    )
+}
+
+#[test]
+fn mixed_decode() {
+    for vector in HEX_TEST_VECTORS {
+        // 5 is the size of the largest decoded test vector
+        let mut buf = [0u8; 5];
+        let out = base16ct::mixed::decode(vector.upper_hex, &mut buf).unwrap();
+        assert_eq!(vector.raw, out);
+        let out = base16ct::mixed::decode(vector.lower_hex, &mut buf).unwrap();
+        assert_eq!(vector.raw, out);
+    }
+}
+
+#[test]
+fn mixed_reject_odd_size_input() {
+    let mut out = [0u8; 3];
+    assert_eq!(
+        Err(base16ct::Error::InvalidLength),
+        base16ct::mixed::decode(b"12345", &mut out),
+    )
+}
+
+#[test]
+#[cfg(feature = "alloc")]
 fn encode_and_decode_various_lengths() {
     let data = [b'X'; 64];
 
     for i in 0..data.len() {
-        let encoded = Base16::lower_case().encode_string(&data[..i]);
+        let encoded = base16ct::lower::encode_string(&data[..i]);
+        let decoded = base16ct::lower::decode_vec(encoded).unwrap();
+        assert_eq!(decoded.as_slice(), &data[..i]);
 
-        // Make sure it round trips
-        let decoded = Base16::lower_case().decode_vec(encoded).unwrap();
+        let encoded = base16ct::upper::encode_string(&data[..i]);
+        let decoded = base16ct::upper::decode_vec(encoded).unwrap();
+        assert_eq!(decoded.as_slice(), &data[..i]);
 
+        let encoded = base16ct::lower::encode_string(&data[..i]);
+        let decoded = base16ct::mixed::decode_vec(encoded).unwrap();
+        assert_eq!(decoded.as_slice(), &data[..i]);
+
+        let encoded = base16ct::upper::encode_string(&data[..i]);
+        let decoded = base16ct::mixed::decode_vec(encoded).unwrap();
         assert_eq!(decoded.as_slice(), &data[..i]);
     }
 }


### PR DESCRIPTION
Code re-organized into free-standing functions inside 3 modules: mixed, lower, and upper. The former has only decoding functions, while the latter two have both decoding and encoding functions. Also added `encode_str` functions which return `&str` instead of `&[u8]`. I wonder if it could be useful to have `decode_in_place` functions like in `base64ct`.

Unfortunately, even though decoding functions [get auto-vectorized](https://rust.godbolt.org/z/f9Ws54bzY) properly with default build parameters, we are not so lucky with encoding functions: https://rust.godbolt.org/z/TxM6v1W45 It could be worth to help compiler with it somehow.