### PR TITLE
base16ct: add benches

### DIFF
--- a/base16ct/benches/mod.rs
+++ b/base16ct/benches/mod.rs
@@ -1,0 +1,69 @@
+#![feature(test)]
+extern crate test;
+
+use test::{black_box, Bencher};
+
+#[bench]
+fn decode_lower(b: &mut Bencher) {
+    let input = vec![b'1'; 1 << 14];
+    let mut buf = vec![0u8; 1 << 13];
+
+    b.iter(|| {
+        let input = black_box(&input[..]);
+        let res = base16ct::lower::decode(input, &mut buf).unwrap();
+        black_box(res);
+    });
+    b.bytes = input.len() as u64;
+}
+
+#[bench]
+fn decode_upper(b: &mut Bencher) {
+    let input = vec![b'1'; 1 << 14];
+    let mut buf = vec![0u8; 1 << 13];
+
+    b.iter(|| {
+        let input = black_box(&input[..]);
+        let res = base16ct::upper::decode(input, &mut buf).unwrap();
+        black_box(res);
+    });
+    b.bytes = input.len() as u64;
+}
+
+#[bench]
+fn decode_mixed(b: &mut Bencher) {
+    let input = vec![b'1'; 1 << 14];
+    let mut buf = vec![0u8; 1 << 13];
+
+    b.iter(|| {
+        let input = black_box(&input[..]);
+        let res = base16ct::mixed::decode(input, &mut buf).unwrap();
+        black_box(res);
+    });
+    b.bytes = input.len() as u64;
+}
+
+#[bench]
+fn encode_lower(b: &mut Bencher) {
+    let input = vec![0x42; 1 << 14];
+    let mut buf = vec![0u8; 1 << 15];
+
+    b.iter(|| {
+        let input = black_box(&input[..]);
+        let res = base16ct::lower::encode(input, &mut buf).unwrap();
+        black_box(res);
+    });
+    b.bytes = input.len() as u64;
+}
+
+#[bench]
+fn encode_upper(b: &mut Bencher) {
+    let input = vec![0x42; 1 << 14];
+    let mut buf = vec![0u8; 1 << 15];
+
+    b.iter(|| {
+        let input = black_box(&input[..]);
+        let res = base16ct::upper::encode(input, &mut buf).unwrap();
+        black_box(res);
+    });
+    b.bytes = input.len() as u64;
+}


### PR DESCRIPTION
Results on AMD Ryzen 7 2700x with default build parameters:
```
test decode_lower ... bench:       6,906 ns/iter (+/- 366) = 2372 MB/s
test decode_mixed ... bench:       4,934 ns/iter (+/- 122) = 3320 MB/s
test decode_upper ... bench:       6,960 ns/iter (+/- 290) = 2354 MB/s
test encode_lower ... bench:      22,188 ns/iter (+/- 777) = 738 MB/s
test encode_upper ... bench:      22,073 ns/iter (+/- 678) = 742 MB/s

// hex v0.4 for comparison:
test hex_decode_to_slice ... bench:      34,859 ns/iter (+/- 565) = 470 MB/s
test hex_encode_to_slice ... bench:      23,880 ns/iter (+/- 413) = 686 MB/s
```
Weirdly enough the mixed decoding is the fastest, even though it requires more operations. Also we can see results of the lacking auto-vectorization.

With `-C target-cpu=native`:
```
test decode_lower ... bench:       2,924 ns/iter (+/- 50) = 5603 MB/s
test decode_mixed ... bench:       4,004 ns/iter (+/- 102) = 4091 MB/s
test decode_upper ... bench:       2,932 ns/iter (+/- 65) = 5587 MB/s
test encode_lower ... bench:       3,213 ns/iter (+/- 42) = 5099 MB/s
test encode_upper ... bench:       3,213 ns/iter (+/- 50) = 5099 MB/s

// hex v0.4 for comparison:
test hex_decode_to_slice ... bench:      34,037 ns/iter (+/- 330) = 481 MB/s
test hex_encode_to_slice ... bench:      23,876 ns/iter (+/- 185) = 686 MB/s
```