### PR TITLE
base16ct: add `HexDisplay` type

### DIFF
--- a/base16ct/src/display.rs
+++ b/base16ct/src/display.rs
@@ -1,0 +1,35 @@
+use core::fmt;
+
+/// `core::fmt` presenter for binary data encoded as hexadecimal (Base16).
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct HexDisplay<'a>(pub &'a [u8]);
+
+impl fmt::Display for HexDisplay<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:X}", self)
+    }
+}
+
+impl fmt::UpperHex for HexDisplay<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut hex = [0u8; 2];
+
+        for &byte in self.0 {
+            f.write_str(crate::upper::encode_str(&[byte], &mut hex)?)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl fmt::LowerHex for HexDisplay<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut hex = [0u8; 2];
+
+        for &byte in self.0 {
+            f.write_str(crate::lower::encode_str(&[byte], &mut hex)?)?;
+        }
+
+        Ok(())
+    }
+}

--- a/base16ct/src/error.rs
+++ b/base16ct/src/error.rs
@@ -1,0 +1,32 @@
+use core::fmt;
+
+/// Result type with the `base16ct` crate's [`Error`] type.
+pub type Result<T> = core::result::Result<T, Error>;
+
+/// Error type
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub enum Error {
+    /// Invalid encoding of provided Base16 string.
+    InvalidEncoding,
+
+    /// Insufficient output buffer length.
+    InvalidLength,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::InvalidEncoding => f.write_str("invalid Base16 encoding"),
+            Error::InvalidLength => f.write_str("invalid Base16 length"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
+
+impl From<Error> for core::fmt::Error {
+    fn from(_: Error) -> core::fmt::Error {
+        core::fmt::Error::default()
+    }
+}

--- a/base16ct/src/lib.rs
+++ b/base16ct/src/lib.rs
@@ -59,21 +59,29 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
-use core::fmt;
+/// Function for decoding and encoding lower Base16 (hex)
+pub mod lower;
+/// Function for decoding mixed Base16 (hex)
+pub mod mixed;
+/// Function for decoding and encoding upper Base16 (hex)
+pub mod upper;
+
+/// Display formatter for hex.
+mod display;
+/// Error types.
+mod error;
+
+pub use crate::{
+    display::HexDisplay,
+    error::{Error, Result},
+};
 
 #[cfg(feature = "alloc")]
 use alloc::{string::String, vec::Vec};
 
-/// Fucntion for decoding and encoding lower Base16 (hex)
-pub mod lower;
-/// Fucntion for decoding mixed Base16 (hex)
-pub mod mixed;
-/// Fucntion for decoding and encoding upper Base16 (hex)
-pub mod upper;
-
 /// Compute decoded length of the given hex-encoded input.
 #[inline(always)]
-pub fn decoded_len(bytes: &[u8]) -> Result<usize, Error> {
+pub fn decoded_len(bytes: &[u8]) -> Result<usize> {
     if bytes.len() & 1 == 0 {
         Ok(bytes.len() / 2)
     } else {
@@ -91,7 +99,7 @@ fn decode_inner<'a>(
     src: &[u8],
     dst: &'a mut [u8],
     decode_nibble: impl Fn(u8) -> u16,
-) -> Result<&'a [u8], Error> {
+) -> Result<&'a [u8]> {
     let dst = dst
         .get_mut(..decoded_len(src)?)
         .ok_or(Error::InvalidLength)?;
@@ -108,25 +116,3 @@ fn decode_inner<'a>(
         _ => Err(Error::InvalidEncoding),
     }
 }
-
-/// Error type
-#[derive(Clone, Eq, PartialEq, Debug)]
-pub enum Error {
-    /// Invalid encoding of provided Base16 string.
-    InvalidEncoding,
-
-    /// Insufficient output buffer length.
-    InvalidLength,
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Error::InvalidEncoding => f.write_str("invalid Base16 encoding"),
-            Error::InvalidLength => f.write_str("invalid Base16 length"),
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}

--- a/base16ct/tests/lib.rs
+++ b/base16ct/tests/lib.rs
@@ -145,3 +145,19 @@ fn encode_and_decode_various_lengths() {
         assert_eq!(decoded.as_slice(), &data[..i]);
     }
 }
+
+#[test]
+fn hex_display_upper() {
+    for vector in HEX_TEST_VECTORS {
+        let hex = format!("{:X}", base16ct::HexDisplay(vector.raw));
+        assert_eq!(hex.as_bytes(), vector.upper_hex);
+    }
+}
+
+#[test]
+fn hex_display_lower() {
+    for vector in HEX_TEST_VECTORS {
+        let hex = format!("{:x}", base16ct::HexDisplay(vector.raw));
+        assert_eq!(hex.as_bytes(), vector.lower_hex);
+    }
+}


### PR DESCRIPTION
Adds a `HexDisplay` wrapper type with impls of `Display`, `UpperHex`, and `LowerHex` from `core::fmt` which can be used to display a byte slice using a constant-time hex encoder.