### PR TITLE
base16ct v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "base16ct"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "base64"

--- a/base16ct/CHANGELOG.md
+++ b/base16ct/CHANGELOG.md
@@ -4,5 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.1 (2022-01-15)
+### Added
+- `HexDisplay` type ([#329])
+
+[#329]: https://github.com/RustCrypto/formats/pull/329
+
 ## 0.1.0 (2022-01-12)
 - Initial release

--- a/base16ct/Cargo.toml
+++ b/base16ct/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base16ct"
-version = "0.1.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.1.1" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Base16 a.k.a hexadecimal (RFC 4648) which avoids
 any usages of data-dependent branches/LUTs and thereby provides portable

--- a/base16ct/src/lib.rs
+++ b/base16ct/src/lib.rs
@@ -50,7 +50,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
-    html_root_url = "https://docs.rs/base16ct/0.1.0"
+    html_root_url = "https://docs.rs/base16ct/0.1.1"
 )]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
### Added
- `HexDisplay` type ([#329])

[#329]: https://github.com/RustCrypto/formats/pull/329