### PR TITLE
pkcs1: add error conversion support for pkcs8::Error

### DIFF
--- a/pkcs1/src/error.rs
+++ b/pkcs1/src/error.rs
@@ -47,6 +47,17 @@ impl From<der::Error> for Error {
 }
 
 #[cfg(feature = "pkcs8")]
+impl From<Error> for pkcs8::Error {
+    fn from(err: Error) -> pkcs8::Error {
+        match err {
+            Error::Asn1(e) => pkcs8::Error::Asn1(e),
+            Error::Crypto | Error::Version => pkcs8::Error::KeyMalformed,
+            Error::Pkcs8(e) => e,
+        }
+    }
+}
+
+#[cfg(feature = "pkcs8")]
 impl From<pkcs8::Error> for Error {
     fn from(err: pkcs8::Error) -> Error {
         Error::Pkcs8(err)


### PR DESCRIPTION
Allows coercing `pkcs1::Error` to `pkcs8::Error` using `?`.

This is useful for decoding PKCS#1-encoded data inside of the `pkcs8` traits.