### PR TITLE
pkcs1: add error conversion support to `pkcs8::spki::Error`

### DIFF
--- a/pkcs1/src/error.rs
+++ b/pkcs1/src/error.rs
@@ -65,6 +65,16 @@ impl From<pkcs8::Error> for Error {
 }
 
 #[cfg(feature = "pkcs8")]
+impl From<Error> for pkcs8::spki::Error {
+    fn from(err: Error) -> pkcs8::spki::Error {
+        match err {
+            Error::Asn1(e) => pkcs8::spki::Error::Asn1(e),
+            _ => pkcs8::spki::Error::KeyMalformed,
+        }
+    }
+}
+
+#[cfg(feature = "pkcs8")]
 impl From<pkcs8::spki::Error> for Error {
     fn from(err: pkcs8::spki::Error) -> Error {
         Error::Pkcs8(pkcs8::Error::PublicKey(err))


### PR DESCRIPTION
Allows coercing `pkcs1::Error` to `pkcs8::spki::Error` using `?`.

This is useful for decoding PKCS#1-encoded data inside of the `spki` crate's traits.