### PR TITLE
pkcs8: add error conversion support to `pkcs8::spki::Error`

### DIFF
--- a/pkcs8/src/error.rs
+++ b/pkcs8/src/error.rs
@@ -71,3 +71,13 @@ impl From<spki::Error> for Error {
         Error::PublicKey(err)
     }
 }
+
+impl From<Error> for spki::Error {
+    fn from(err: Error) -> spki::Error {
+        match err {
+            Error::Asn1(e) => spki::Error::Asn1(e),
+            Error::PublicKey(e) => e,
+            _ => spki::Error::KeyMalformed,
+        }
+    }
+}


### PR DESCRIPTION
Allows coercing `pkcs8::Error` to `pkcs8::spki::Error` using `?`.