### PR TITLE
der_derive: extract `choice::variant` module

### DIFF
--- a/der/derive/src/attributes.rs
+++ b/der/derive/src/attributes.rs
@@ -14,7 +14,7 @@ pub(crate) const ATTR_NAME: &str = "asn1";
 const PARSE_ERR_MSG: &str = "error parsing `asn1` attribute";
 
 /// Attributes on a `struct` or `enum` type.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub(crate) struct TypeAttrs {
     /// Tagging mode for this type: `EXPLICIT` or `IMPLICIT`, supplied as
     /// `#[asn1(tag_mode = "...")]`.
@@ -54,7 +54,7 @@ impl TypeAttrs {
 }
 
 /// Field-level attributes.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub(crate) struct FieldAttrs {
     /// Value of the `#[asn1(type = "...")]` attribute if provided.
     pub asn1_type: Option<Asn1Type>,
@@ -81,8 +81,9 @@ pub(crate) struct FieldAttrs {
 }
 
 impl FieldAttrs {
-    /// is_optional return true when either an optional or default ASN.1 attribute is associated
-    /// with a field. Default signifies optionality due to omission of default values in DER encodings.
+    /// Return true when either an optional or default ASN.1 attribute is associated
+    /// with a field. Default signifies optionality due to omission of default values in
+    /// DER encodings.
     fn is_optional(&self) -> bool {
         self.optional || self.default.is_some()
     }

--- a/der/derive/src/choice/variant.rs
+++ b/der/derive/src/choice/variant.rs
@@ -1,0 +1,121 @@
+//! Choice variant IR and lowerings
+
+use crate::{FieldAttrs, Tag, TypeAttrs};
+use proc_macro2::TokenStream;
+use proc_macro_error::abort;
+use quote::quote;
+use syn::{Fields, Ident, Variant};
+
+/// "IR" for a variant of a derived `Choice`.
+pub(super) struct ChoiceVariant {
+    /// Variant name.
+    pub(super) ident: Ident,
+
+    /// "Field" (in this case variant)-level attributes.
+    pub(super) attrs: FieldAttrs,
+
+    /// Tag for the ASN.1 type.
+    pub(super) tag: Tag,
+}
+
+impl ChoiceVariant {
+    /// Create a new [`ChoiceVariant`] from the input [`Variant`].
+    pub(super) fn new(input: &Variant, type_attrs: &TypeAttrs) -> Self {
+        let ident = input.ident.clone();
+        let attrs = FieldAttrs::parse(&input.attrs, type_attrs);
+
+        if attrs.extensible {
+            abort!(&ident, "`extensible` is not allowed on CHOICE");
+        }
+
+        // Validate that variant is a 1-element tuple struct
+        match &input.fields {
+            // TODO(tarcieri): handle 0 bindings for ASN.1 NULL
+            Fields::Unnamed(fields) if fields.unnamed.len() == 1 => (),
+            _ => abort!(&ident, "enum variant must be a 1-element tuple struct"),
+        }
+
+        let tag = attrs
+            .tag()
+            .unwrap_or_else(|| abort!(&ident, "no #[asn1(type=...)] specified for enum variant",));
+
+        Self { ident, attrs, tag }
+    }
+
+    /// Derive a match arm of the impl body for `TryFrom<der::asn1::Any<'_>>`.
+    pub(super) fn to_decode_tokens(&self) -> TokenStream {
+        let tag = self.tag.to_tokens();
+        let ident = &self.ident;
+        let decoder = self.attrs.decoder();
+        quote! {
+            #tag => Ok(Self::#ident(#decoder.try_into()?)),
+        }
+    }
+
+    /// Derive a match arm for the impl body for `der::Encodable::encode`.
+    pub(super) fn to_encode_tokens(&self) -> TokenStream {
+        let ident = &self.ident;
+        let binding = quote!(variant);
+        let encoder = self.attrs.encoder(&binding);
+        quote! {
+            Self::#ident(#binding) => #encoder,
+        }
+    }
+
+    /// Derive a match arm for the impl body for `der::Encodable::encode`.
+    pub(super) fn to_encoded_len_tokens(&self) -> TokenStream {
+        let ident = &self.ident;
+        quote! {
+            Self::#ident(variant) => variant.encoded_len(),
+        }
+    }
+
+    /// Derive a match arm for the impl body for `der::Tagged::tag`.
+    pub(super) fn to_tagged_tokens(&self) -> TokenStream {
+        let ident = &self.ident;
+        let tag = self.tag.to_tokens();
+        quote! {
+            Self::#ident(_) => #tag,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ChoiceVariant;
+    use crate::{Asn1Type, FieldAttrs, Tag};
+    use proc_macro2::Span;
+    use syn::Ident;
+
+    #[test]
+    fn simple() {
+        let span = Span::call_site();
+
+        let variant = ChoiceVariant {
+            ident: Ident::new("ExampleVariant", span),
+            attrs: FieldAttrs::default(),
+            tag: Tag::Universal(Asn1Type::Utf8String),
+        };
+
+        // TODO(tarcieri): better comparison, possibly using `quote!`
+        assert_eq!(
+            variant.to_decode_tokens().to_string(),
+            ":: der :: Tag :: Utf8String => Ok (Self :: ExampleVariant (decoder . decode () ? . try_into () ?)) ,"
+        );
+
+        assert_eq!(
+            variant.to_encode_tokens().to_string(),
+            "Self :: ExampleVariant (variant) => encoder . encode (variant) ? ,"
+        );
+
+        assert_eq!(
+            variant.to_encoded_len_tokens().to_string(),
+            "Self :: ExampleVariant (variant) => variant . encoded_len () ,"
+        );
+
+        assert_eq!(
+            variant.to_tagged_tokens().to_string(),
+            "Self :: ExampleVariant (_) => :: der :: Tag :: Utf8String ,"
+        )
+    }
+}


### PR DESCRIPTION
Refactors the `choice` module in a similar way to how the `sequence` module was refactored in #337.

This makes it easier to extend and test. Additionally, this PR includes an initial set of basic tests for `ChoiceVariant` lowerings.