### PR TITLE
Bump `crypto-bigint` to v0.4.0-pre; MSRV 1.57

### DIFF
--- a/.github/workflows/der.yml
+++ b/.github/workflows/der.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.57.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -52,7 +52,7 @@ jobs:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
             platform: ubuntu-latest
-            rust: 1.56.0 # MSRV
+            rust: 1.57.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             platform: ubuntu-latest
@@ -62,7 +62,7 @@ jobs:
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
             platform: ubuntu-latest
-            rust: 1.56.0 # MSRV
+            rust: 1.57.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             platform: ubuntu-latest
             rust: stable
@@ -70,7 +70,7 @@ jobs:
           # 64-bit Windows
           - target: x86_64-pc-windows-msvc
             platform: windows-latest
-            rust: 1.56.0 # MSRV
+            rust: 1.57.0 # MSRV
           - target: x86_64-pc-windows-msvc
             platform: windows-latest
             rust: stable
@@ -95,7 +95,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.57.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/pkcs1.yml
+++ b/.github/workflows/pkcs1.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.57.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.57.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/pkcs5.yml
+++ b/.github/workflows/pkcs5.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.57.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.57.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/pkcs7.yml
+++ b/.github/workflows/pkcs7.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.57.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -44,7 +44,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.57.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/pkcs8.yml
+++ b/.github/workflows/pkcs8.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.57.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -56,7 +56,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.57.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/sec1.yml
+++ b/.github/workflows/sec1.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.57.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.57.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/spki.yml
+++ b/.github/workflows/spki.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.57.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.57.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/ssh-key.yml
+++ b/.github/workflows/ssh-key.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.57.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.57.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.56.0
+        toolchain: 1.57.0
         components: clippy
         override: true
         profile: minimal

--- a/.github/workflows/x509.yml
+++ b/.github/workflows/x509.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.57.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -45,7 +45,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.57.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,9 +252,8 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
+version = "0.4.0-pre"
+source = "git+https://github.com/RustCrypto/crypto-bigint.git#085a8857f9437f3726c507d1622be4a200360494"
 dependencies = [
  "generic-array",
  "subtle",
@@ -293,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.5.1"
+version = "0.6.0-pre"
 dependencies = [
  "const-oid",
  "crypto-bigint",
@@ -533,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs1"
-version = "0.3.3"
+version = "0.4.0-pre"
 dependencies = [
  "der",
  "hex-literal",
@@ -543,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs5"
-version = "0.4.0"
+version = "0.5.0-pre"
 dependencies = [
  "aes",
  "block-modes",
@@ -560,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs7"
-version = "0.3.0"
+version = "0.4.0-pre"
 dependencies = [
  "der",
  "hex-literal",
@@ -569,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.8.0"
+version = "0.9.0-pre"
 dependencies = [
  "der",
  "hex-literal",
@@ -856,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.2.1"
+version = "0.3.0-pre"
 dependencies = [
  "der",
  "generic-array",
@@ -938,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.5.4"
+version = "0.6.0-pre"
 dependencies = [
  "base64ct",
  "der",
@@ -948,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "ssh-key"
-version = "0.2.0"
+version = "0.3.0-pre"
 dependencies = [
  "base64ct",
  "hex-literal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ members = [
     "tls_codec/derive",
     "x509"
 ]
+
+[patch.crates-io]
+crypto-bigint = { git = "https://github.com/RustCrypto/crypto-bigint.git" }

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der"
-version = "0.5.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.6.0-pre" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust embedded-friendly implementation of the Distinguished Encoding Rules
 (DER) for Abstract Syntax Notation One (ASN.1) as described in ITU X.690 with
@@ -13,11 +13,11 @@ categories = ["cryptography", "data-structures", "encoding", "no-std", "parsing"
 keywords = ["asn1", "crypto", "itu", "pkcs"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [dependencies]
 const-oid = { version = "0.7", optional = true, path = "../const-oid" }
-crypto-bigint = { version = "0.3", optional = true, default-features = false, features = ["generic-array"] }
+crypto-bigint = { version = "=0.4.0-pre", optional = true, default-features = false, features = ["generic-array"] }
 der_derive = { version = "0.5", optional = true, path = "derive" }
 pem-rfc7468 = { version = "0.3", optional = true, path = "../pem-rfc7468" }
 time = { version = "0.3", optional = true, default-features = false }

--- a/der/README.md
+++ b/der/README.md
@@ -46,7 +46,7 @@ form, and will return errors if non-canonical productions are encountered.
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.56** at a minimum.
+This crate requires **Rust 1.57** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -76,7 +76,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/formats/actions/workflows/der.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/formats/actions/workflows/der.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.57+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -1,4 +1,18 @@
+#![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc = include_str!("../README.md")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_root_url = "https://docs.rs/der/0.6.0-pre"
+)]
+#![forbid(unsafe_code, clippy::unwrap_used)]
+#![warn(
+    missing_docs,
+    rust_2018_idioms,
+    unused_lifetimes,
+    unused_qualifications
+)]
 
 //! # Usage
 //! ## [`Decodable`] and [`Encodable`] traits
@@ -310,21 +324,6 @@
 //! [`UIntBytes`]: asn1::UIntBytes
 //! [`UtcTime`]: asn1::UtcTime
 //! [`Utf8String`]: asn1::Utf8String
-
-#![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc(
-    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/der/0.5.1"
-)]
-#![forbid(unsafe_code, clippy::unwrap_used)]
-#![warn(
-    missing_docs,
-    rust_2018_idioms,
-    unused_lifetimes,
-    unused_qualifications
-)]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs1"
-version = "0.3.3" # Also update html_root_url in lib.rs when bumping this
+version = "0.4.0-pre" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #1:
 RSA Cryptography Specifications Version 2.2 (RFC 8017)
@@ -12,13 +12,13 @@ categories = ["cryptography", "data-structures", "encoding", "no-std", "parser-i
 keywords = ["crypto", "key", "pem", "pkcs", "rsa"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [dependencies]
-der = { version = "0.5", features = ["bigint", "oid"], path = "../der" }
+der = { version = "=0.6.0-pre", features = ["bigint", "oid"], path = "../der" }
 
 # optional dependencies
-pkcs8 = { version = "0.8", optional = true, default-features = false, path = "../pkcs8" }
+pkcs8 = { version = "=0.9.0-pre", optional = true, default-features = false, path = "../pkcs8" }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/pkcs1/README.md
+++ b/pkcs1/README.md
@@ -31,7 +31,7 @@ PEM encoded RSA public keys begin with:
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.56** at a minimum.
+This crate requires **Rust 1.57** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -58,7 +58,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/pkcs1/badge.svg
 [docs-link]: https://docs.rs/pkcs1/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.57+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 [build-image]: https://github.com/RustCrypto/formats/workflows/pkcs1/badge.svg?branch=master&event=push

--- a/pkcs1/src/lib.rs
+++ b/pkcs1/src/lib.rs
@@ -4,7 +4,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/pkcs1/0.3.3"
+    html_root_url = "https://docs.rs/pkcs1/0.4.0-pre"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs5"
-version = "0.4.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.5.0-pre" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #5:
 Password-Based Cryptography Specification Version 2.1 (RFC 8018)
@@ -12,11 +12,11 @@ categories = ["cryptography", "data-structures", "encoding", "no-std"]
 keywords = ["crypto", "key", "pkcs", "password"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [dependencies]
-der = { version = "0.5", features = ["oid"], path = "../der" }
-spki = { version = "0.5", path = "../spki" }
+der = { version = "=0.6.0-pre", features = ["oid"], path = "../der" }
+spki = { version = "=0.6.0-pre", path = "../spki" }
 
 # optional dependencies
 aes = { version = "0.7", optional = true }

--- a/pkcs5/README.md
+++ b/pkcs5/README.md
@@ -14,7 +14,7 @@ Password-Based Cryptography Specification Version 2.1 ([RFC 8018]).
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.56** at a minimum.
+This crate requires **Rust 1.57** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -43,7 +43,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/formats/actions/workflows/pkcs5.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/formats/actions/workflows/pkcs5.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.57+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 

--- a/pkcs5/src/lib.rs
+++ b/pkcs5/src/lib.rs
@@ -1,4 +1,13 @@
+#![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc = include_str!("../README.md")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_root_url = "https://docs.rs/pkcs5/0.5.0-pre"
+)]
+#![forbid(unsafe_code, clippy::unwrap_used)]
+#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
 //! # Usage
 //!
@@ -8,16 +17,6 @@
 //! [`AlgorithmIdentifier`] fields.
 //!
 //! [RFC 8018]: https://tools.ietf.org/html/rfc8018
-
-#![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc(
-    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/pkcs5/0.4.0"
-)]
-#![forbid(unsafe_code, clippy::unwrap_used)]
-#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
 #[cfg(all(feature = "alloc", feature = "pbes2"))]
 extern crate alloc;

--- a/pkcs7/Cargo.toml
+++ b/pkcs7/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs7"
-version = "0.3.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.4.0-pre" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #7:
 PKCS #7: Cryptographic Message Syntax Version 1.5 (RFC 5652)
@@ -12,11 +12,11 @@ categories = ["cryptography", "data-structures", "encoding", "no-std", "parser-i
 keywords = ["crypto", "pkcs"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [dependencies]
-der = { version = "0.5", features = ["oid"], path = "../der" }
-spki = { version = "0.5", path = "../spki" }
+der = { version = "=0.6.0-pre", features = ["oid"], path = "../der" }
+spki = { version = "=0.6.0-pre", path = "../spki" }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/pkcs7/README.md
+++ b/pkcs7/README.md
@@ -12,6 +12,13 @@ Cryptographic Message Syntax v1.5 ([RFC 5652] and [RFC 8933]).
 
 [Documentation][docs-link]
 
+## Minimum Supported Rust Version
+
+This crate requires **Rust 1.57** at a minimum.
+
+We may change the MSRV in the future, but it will be accompanied by a minor
+version bump.
+
 ## License
 
 Licensed under either of:
@@ -34,7 +41,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/pkcs7/badge.svg
 [docs-link]: https://docs.rs/pkcs7/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.57+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 [build-image]: https://github.com/RustCrypto/formats/workflows/pkcs7/badge.svg?branch=master&event=push

--- a/pkcs7/src/lib.rs
+++ b/pkcs7/src/lib.rs
@@ -1,10 +1,11 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc = include_str!("../README.md")]
+#![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/pkcs7/0.3.0"
+    html_root_url = "https://docs.rs/pkcs7/0.4.0-pre"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs8"
-version = "0.8.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.9.0-pre" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #8:
 Private-Key Information Syntax Specification (RFC 5208), with additional
@@ -13,15 +13,15 @@ categories = ["cryptography", "data-structures", "encoding", "no-std", "parser-i
 keywords = ["crypto", "key", "pkcs", "private"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [dependencies]
-der = { version = "0.5", features = ["oid"], path = "../der" }
-spki = { version = "0.5", path = "../spki" }
+der = { version = "=0.6.0-pre", features = ["oid"], path = "../der" }
+spki = { version = "=0.6.0-pre", path = "../spki" }
 
 # optional dependencies
 rand_core = { version = "0.6", optional = true, default-features = false }
-pkcs5 = { version = "0.4", optional = true, path = "../pkcs5" }
+pkcs5 = { version = "=0.5.0-pre", optional = true, path = "../pkcs5" }
 subtle = { version = "2", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false, features = ["alloc"] }
 

--- a/pkcs8/README.md
+++ b/pkcs8/README.md
@@ -54,7 +54,7 @@ algorithm, including the ones listed above or other algorithms.
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.56** at a minimum.
+This crate requires **Rust 1.57** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -81,7 +81,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/pkcs8/badge.svg
 [docs-link]: https://docs.rs/pkcs8/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.57+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 [build-image]: https://github.com/RustCrypto/formats/workflows/pkcs8/badge.svg?branch=master&event=push

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -1,4 +1,13 @@
+#![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc = include_str!("../README.md")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_root_url = "https://docs.rs/pkcs8/0.9.0-pre"
+)]
+#![forbid(unsafe_code, clippy::unwrap_used)]
+#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
 //! ## About this crate
 //! This library provides generalized PKCS#8 support designed to work with a
@@ -63,16 +72,6 @@
 //! [RFC 7914]: https://datatracker.ietf.org/doc/html/rfc7914
 //! [PKCS#5v2 Password Based Encryption Scheme 2 (RFC 8018)]: https://tools.ietf.org/html/rfc8018#section-6.2
 //! [scrypt]: https://en.wikipedia.org/wiki/Scrypt
-
-#![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc(
-    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/pkcs8/0.8.0"
-)]
-#![forbid(unsafe_code, clippy::unwrap_used)]
-#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sec1"
-version = "0.2.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.3.0-pre" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of SEC1: Elliptic Curve Cryptography encoding formats
 including ASN.1 DER-serialized private keys as well as the
@@ -13,14 +13,14 @@ categories = ["cryptography", "data-structures", "encoding", "no-std", "parser-i
 keywords = ["crypto", "key", "elliptic-curve", "secg"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [dependencies]
-der = { version = "0.5", features = ["oid"], path = "../der" }
+der = { version = "=0.6.0-pre", features = ["oid"], path = "../der" }
 generic-array = { version = "0.14", default-features = false }
 
 # optional dependencies
-pkcs8 = { version = "0.8", optional = true, default-features = false, path = "../pkcs8" }
+pkcs8 = { version = "=0.9.0-pre", optional = true, default-features = false, path = "../pkcs8" }
 serde = { version = "1", optional = true, default-features = false }
 subtle = { version = "2", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }

--- a/sec1/README.md
+++ b/sec1/README.md
@@ -18,7 +18,7 @@ formats including ASN.1 DER-serialized private keys (also described in
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.56** at a minimum.
+This crate requires **Rust 1.57** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -45,7 +45,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/sec1/badge.svg
 [docs-link]: https://docs.rs/sec1/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.57+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 [build-image]: https://github.com/RustCrypto/formats/workflows/sec1/badge.svg?branch=master&event=push

--- a/sec1/src/lib.rs
+++ b/sec1/src/lib.rs
@@ -1,4 +1,13 @@
+#![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc = include_str!("../README.md")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_root_url = "https://docs.rs/sec1/0.3.0-pre"
+)]
+#![forbid(unsafe_code, clippy::unwrap_used)]
+#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
 //! ## `serde` support
 //!
@@ -8,16 +17,6 @@
 //! Additionally, when both the `alloc` and `serde` features are enabled, the
 //! serializers/deserializers will autodetect if a "human friendly" textual
 //! encoding is being used, and if so encode the points as hexadecimal.
-
-#![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc(
-    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/sec1/0.2.1"
-)]
-#![forbid(unsafe_code, clippy::unwrap_used)]
-#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/spki/Cargo.toml
+++ b/spki/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spki"
-version = "0.5.4" # Also update html_root_url in lib.rs when bumping this
+version = "0.6.0-pre" # Also update html_root_url in lib.rs when bumping this
 description = """
 X.509 Subject Public Key Info (RFC5280) describing public keys as well as their
 associated AlgorithmIdentifiers (i.e. OIDs)
@@ -12,10 +12,10 @@ categories = ["cryptography", "data-structures", "encoding", "no-std"]
 keywords = ["crypto", "x509"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [dependencies]
-der = { version = "0.5", features = ["oid"], path = "../der" }
+der = { version = "=0.6.0-pre", features = ["oid"], path = "../der" }
 
 # Optional dependencies
 sha2 = { version = "0.10", optional = true, default-features = false }

--- a/spki/README.md
+++ b/spki/README.md
@@ -16,7 +16,7 @@ Specified in [RFC 5280 § 4.1].
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.56** at a minimum.
+This crate requires **Rust 1.57** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -45,7 +45,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/formats/actions/workflows/spki.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/formats/actions/workflows/spki.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.57+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 

--- a/spki/src/lib.rs
+++ b/spki/src/lib.rs
@@ -1,4 +1,13 @@
+#![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc = include_str!("../README.md")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_root_url = "https://docs.rs/spki/0.6.0-pre"
+)]
+#![forbid(unsafe_code, clippy::unwrap_used)]
+#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
 //! # Usage
 //! The following example demonstrates how to use an OID as the `parameters`
@@ -17,16 +26,6 @@
 //!     parameters: Some(Any::from(&params_oid))
 //! };
 //! ```
-
-#![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc(
-    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/spki/0.5.4"
-)]
-#![forbid(unsafe_code, clippy::unwrap_used)]
-#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssh-key"
-version = "0.2.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.3.0-pre" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of SSH key file format decoders/encoders as described
 in RFC4253 and RFC4716 as well as the OpenSSH key formats. Supports "heapless"
@@ -13,14 +13,14 @@ categories = ["cryptography", "data-structures", "encoding", "no-std", "parser-i
 keywords = ["crypto", "key", "openssh", "ssh"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [dependencies]
 base64ct = { version = "1.3.3", path = "../base64ct" }
 zeroize = { version = "1", default-features = false }
 
 # optional dependencies
-sec1 = { version = "0.2", optional = true, default-features = false, path = "../sec1" }
+sec1 = { version = "=0.3.0-pre", optional = true, default-features = false, path = "../sec1" }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/ssh-key/README.md
+++ b/ssh-key/README.md
@@ -34,7 +34,7 @@ in [RFC4253] and [RFC4716] as well as OpenSSH's [PROTOCOL.key] format specificat
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.56** at a minimum.
+This crate requires **Rust 1.57** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -61,7 +61,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/ssh-key/badge.svg
 [docs-link]: https://docs.rs/ssh-key/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.57+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 [build-image]: https://github.com/RustCrypto/formats/actions/workflows/ssh-key.yml/badge.svg

--- a/ssh-key/src/lib.rs
+++ b/ssh-key/src/lib.rs
@@ -1,13 +1,13 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![forbid(unsafe_code, clippy::unwrap_used)]
-#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+#![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/ssh-key/0.2.0"
+    html_root_url = "https://docs.rs/ssh-key/0.3.0-pre"
 )]
-#![doc = include_str!("../README.md")]
+#![forbid(unsafe_code, clippy::unwrap_used)]
+#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
 //! ## Usage
 //!

--- a/x509/Cargo.toml
+++ b/x509/Cargo.toml
@@ -15,8 +15,8 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-der = { version = "0.5", features = ["derive", "alloc"], path = "../der" }
-spki = { version = "0.5", path = "../spki" }
+der = { version = "=0.6.0-pre", features = ["derive", "alloc"], path = "../der" }
+spki = { version = "=0.6.0-pre", path = "../spki" }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/x509/README.md
+++ b/x509/README.md
@@ -21,7 +21,7 @@ development.
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.56** at a minimum.
+This crate requires **Rust 1.57** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -50,7 +50,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/formats/actions/workflows/x509.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/formats/actions/workflows/x509.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.57+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 


### PR DESCRIPTION
The new version leverages `const_panic` which was stabilized in 1.57.

As this is a breaking change, it also bumps the version numbers of all of the dependent crates.

This is the first in a series of `const_panic` improvements and not the only reason for bumping MSRV to 1.57.