### PR TITLE
const-oid v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.8.0-pre"
+version = "0.8.0"
 dependencies = [
  "hex-literal",
 ]

--- a/const-oid/CHANGELOG.md
+++ b/const-oid/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.0 (2022-01-17)
+### Changed
+- Leverage `const_panic`; MSRV 1.57 ([#341])
+
+[#341]: https://github.com/RustCrypto/formats/pull/341
+
 ## 0.7.1 (2021-11-30)
 ### Changed
 - Increase `MAX_SIZE` to 39 ([#258])

--- a/const-oid/Cargo.toml
+++ b/const-oid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "const-oid"
-version = "0.8.0-pre"
+version = "0.8.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """

--- a/const-oid/LICENSE-MIT
+++ b/const-oid/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2020 The RustCrypto Project Developers
+Copyright (c) 2020-2022 The RustCrypto Project Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/const-oid/src/lib.rs
+++ b/const-oid/src/lib.rs
@@ -4,7 +4,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/const-oid/0.8.0-pre"
+    html_root_url = "https://docs.rs/const-oid/0.8.0"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms)]

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-const-oid = { version = "=0.8.0-pre", optional = true, path = "../const-oid" }
+const-oid = { version = "0.8", optional = true, path = "../const-oid" }
 crypto-bigint = { version = "=0.4.0-pre", optional = true, default-features = false, features = ["generic-array"] }
 der_derive = { version = "0.5", optional = true, path = "derive" }
 pem-rfc7468 = { version = "0.3", optional = true, path = "../pem-rfc7468" }


### PR DESCRIPTION
### Changed
- Leverage `const_panic`; MSRV 1.57 ([#341])

[#341]: https://github.com/RustCrypto/formats/pull/341