### PR TITLE
der: remove `bigint` feature

### DIFF
--- a/.github/workflows/der.yml
+++ b/.github/workflows/der.yml
@@ -38,12 +38,11 @@ jobs:
           override: true
       - run: cargo build --target ${{ matrix.target }} --release
       - run: cargo build --target ${{ matrix.target }} --release --features alloc
-      - run: cargo build --target ${{ matrix.target }} --release --features bigint
       - run: cargo build --target ${{ matrix.target }} --release --features derive
       - run: cargo build --target ${{ matrix.target }} --release --features oid
       - run: cargo build --target ${{ matrix.target }} --release --features pem
       - run: cargo build --target ${{ matrix.target }} --release --features time
-      - run: cargo build --target ${{ matrix.target }} --release --features alloc,bigint,derive,oid,pem,time
+      - run: cargo build --target ${{ matrix.target }} --release --features alloc,derive,oid,pem,time
 
   test:
     strategy:
@@ -85,7 +84,6 @@ jobs:
           override: true
       - run: ${{ matrix.deps }}
       - run: cargo test --target ${{ matrix.target }} --release
-      - run: cargo test --target ${{ matrix.target }} --release --features bigint
       - run: cargo test --target ${{ matrix.target }} --release --features oid
       - run: cargo test --target ${{ matrix.target }} --release --features pem
       - run: cargo test --target ${{ matrix.target }} --release --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,15 +251,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-bigint"
-version = "0.4.0-pre"
-source = "git+https://github.com/RustCrypto/crypto-bigint.git#085a8857f9437f3726c507d1622be4a200360494"
-dependencies = [
- "generic-array",
- "subtle",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,7 +286,6 @@ name = "der"
 version = "0.6.0-pre"
 dependencies = [
  "const-oid",
- "crypto-bigint",
  "der_derive",
  "hex-literal",
  "pem-rfc7468",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,3 @@ members = [
     "tls_codec/derive",
     "x509"
 ]
-
-[patch.crates-io]
-crypto-bigint = { git = "https://github.com/RustCrypto/crypto-bigint.git" }

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -17,7 +17,6 @@ rust-version = "1.57"
 
 [dependencies]
 const-oid = { version = "0.8", optional = true, path = "../const-oid" }
-crypto-bigint = { version = "=0.4.0-pre", optional = true, default-features = false, features = ["generic-array"] }
 der_derive = { version = "0.5", optional = true, path = "derive" }
 pem-rfc7468 = { version = "0.3", optional = true, path = "../pem-rfc7468" }
 time = { version = "0.3", optional = true, default-features = false }
@@ -29,7 +28,6 @@ proptest = "1"
 [features]
 alloc = []
 derive = ["der_derive"]
-bigint = ["crypto-bigint"]
 oid = ["const-oid"]
 pem = ["alloc", "pem-rfc7468/alloc"]
 std = ["alloc"]

--- a/der/src/asn1/integer/bigint.rs
+++ b/der/src/asn1/integer/bigint.rs
@@ -6,9 +6,6 @@ use crate::{
     Length, Result, Tag,
 };
 
-#[cfg(feature = "bigint")]
-use crypto_bigint::{generic_array::GenericArray, ArrayEncoding, UInt};
-
 /// "Big" unsigned ASN.1 `INTEGER` type.
 ///
 /// Provides direct access to the underlying big endian bytes which comprise an
@@ -92,62 +89,6 @@ impl<'a> TryFrom<Any<'a>> for UIntBytes<'a> {
 }
 
 impl<'a> FixedTag for UIntBytes<'a> {
-    const TAG: Tag = Tag::Integer;
-}
-
-#[cfg(feature = "bigint")]
-#[cfg_attr(docsrs, doc(cfg(feature = "bigint")))]
-impl<'a, const LIMBS: usize> TryFrom<Any<'a>> for UInt<LIMBS>
-where
-    UInt<LIMBS>: ArrayEncoding,
-{
-    type Error = Error;
-
-    fn try_from(any: Any<'a>) -> Result<UInt<LIMBS>> {
-        UIntBytes::try_from(any)?.try_into()
-    }
-}
-
-#[cfg(feature = "bigint")]
-#[cfg_attr(docsrs, doc(cfg(feature = "bigint")))]
-impl<'a, const LIMBS: usize> TryFrom<UIntBytes<'a>> for UInt<LIMBS>
-where
-    UInt<LIMBS>: ArrayEncoding,
-{
-    type Error = Error;
-
-    fn try_from(bytes: UIntBytes<'a>) -> Result<UInt<LIMBS>> {
-        let mut array = GenericArray::default();
-        let offset = array.len().saturating_sub(bytes.len().try_into()?);
-        array[offset..].copy_from_slice(bytes.as_bytes());
-        Ok(UInt::from_be_byte_array(array))
-    }
-}
-
-#[cfg(feature = "bigint")]
-#[cfg_attr(docsrs, doc(cfg(feature = "bigint")))]
-impl<const LIMBS: usize> EncodeValue for UInt<LIMBS>
-where
-    UInt<LIMBS>: ArrayEncoding,
-{
-    fn value_len(&self) -> Result<Length> {
-        // TODO(tarcieri): more efficient length calculation
-        let array = self.to_be_byte_array();
-        UIntBytes::new(&array)?.value_len()
-    }
-
-    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        let array = self.to_be_byte_array();
-        UIntBytes::new(&array)?.encode_value(encoder)
-    }
-}
-
-#[cfg(feature = "bigint")]
-#[cfg_attr(docsrs, doc(cfg(feature = "bigint")))]
-impl<const LIMBS: usize> FixedTag for UInt<LIMBS>
-where
-    UInt<LIMBS>: ArrayEncoding,
-{
     const TAG: Tag = Tag::Integer;
 }
 

--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-der = { version = "=0.6.0-pre", features = ["bigint", "oid"], path = "../der" }
+der = { version = "=0.6.0-pre", features = ["oid"], path = "../der" }
 
 # optional dependencies
 pkcs8 = { version = "=0.9.0-pre", optional = true, default-features = false, path = "../pkcs8" }


### PR DESCRIPTION
Removes the optional dependency on `crypto-bigint`, with the goal of reversing the relationship between the two and having `crypto-bigint` pull in `der` as an optional dependency.