### PR TITLE
Implement context-specific tags on #[derive(Sequence)]

### DIFF
--- a/der/derive/src/sequence.rs
+++ b/der/derive/src/sequence.rs
@@ -277,4 +277,51 @@ mod tests {
         assert_eq!(public_key_field.attrs.optional, true);
         assert_eq!(public_key_field.attrs.tag_mode, TagMode::Explicit);
     }
+
+    /// `IMPLICIT` tagged example
+    #[test]
+    fn implicit_example() {
+        let input = parse_quote! {
+            #[asn1(tag_mode = "IMPLICIT")]
+            pub struct ImplicitSequence<'a> {
+                #[asn1(context_specific = "0", type = "BIT STRING")]
+                bit_string: BitString<'a>,
+
+                #[asn1(context_specific = "1", type = "GeneralizedTime")]
+                time: GeneralizedTime,
+
+                #[asn1(context_specific = "2", type = "UTF8String")]
+                utf8_string: String,
+            }
+        };
+
+        let ir = DeriveSequence::new(input);
+        assert_eq!(ir.ident, "ImplicitSequence");
+        assert_eq!(ir.lifetime.unwrap().to_string(), "'a");
+        assert_eq!(ir.fields.len(), 3);
+
+        let bit_string = &ir.fields[0];
+        assert_eq!(bit_string.ident, "bit_string");
+        assert_eq!(bit_string.attrs.asn1_type, Some(Asn1Type::BitString));
+        assert_eq!(
+            bit_string.attrs.context_specific,
+            Some("0".parse().unwrap())
+        );
+        assert_eq!(bit_string.attrs.tag_mode, TagMode::Implicit);
+
+        let time = &ir.fields[1];
+        assert_eq!(time.ident, "time");
+        assert_eq!(time.attrs.asn1_type, Some(Asn1Type::GeneralizedTime));
+        assert_eq!(time.attrs.context_specific, Some("1".parse().unwrap()));
+        assert_eq!(time.attrs.tag_mode, TagMode::Implicit);
+
+        let utf8_string = &ir.fields[2];
+        assert_eq!(utf8_string.ident, "utf8_string");
+        assert_eq!(utf8_string.attrs.asn1_type, Some(Asn1Type::Utf8String));
+        assert_eq!(
+            utf8_string.attrs.context_specific,
+            Some("2".parse().unwrap())
+        );
+        assert_eq!(utf8_string.attrs.tag_mode, TagMode::Implicit);
+    }
 }

--- a/der/derive/src/tag.rs
+++ b/der/derive/src/tag.rs
@@ -106,7 +106,7 @@ impl Display for TagMode {
 
 /// ASN.1 tag numbers (i.e. lower 5 bits of a [`Tag`]).
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
-pub(crate) struct TagNumber(u8);
+pub(crate) struct TagNumber(pub u8);
 
 impl TagNumber {
     /// Maximum tag number supported (inclusive).

--- a/der/tests/derive.rs
+++ b/der/tests/derive.rs
@@ -353,6 +353,28 @@ mod sequence {
     const ALGORITHM_IDENTIFIER_DER: &[u8] =
         &hex!("30 13 06 07 2a 86 48 ce 3d 02 01 06 08 2a 86 48 ce 3d 03 01 07");
 
+    #[derive(Sequence)]
+    #[asn1(tag_mode = "IMPLICIT")]
+    pub struct TypeCheckExpandedSequenceFieldAttributeCombinations<'a> {
+        pub simple: bool,
+        #[asn1(type = "BIT STRING")]
+        pub typed: &'a [u8],
+        #[asn1(context_specific = "0")]
+        pub context_specific: bool,
+        #[asn1(optional = "true")]
+        pub optional: Option<bool>,
+        #[asn1(default = "default_false_example")]
+        pub default: bool,
+        #[asn1(type = "BIT STRING", context_specific = "1")]
+        pub typed_context_specific: &'a [u8],
+        #[asn1(context_specific = "2", optional = "true")]
+        pub context_specific_optional: Option<bool>,
+        #[asn1(context_specific = "3", default = "default_false_example")]
+        pub context_specific_default: bool,
+        #[asn1(type = "BIT STRING", context_specific = "4", optional = "true")]
+        pub typed_context_specific_optional: Option<&'a [u8]>,
+    }
+
     #[test]
     fn idp_test() {
         let idp = IssuingDistributionPointExample::from_der(&hex!("30038101FF")).unwrap();


### PR DESCRIPTION
This also adds a context-specific tag test to the code for #[derive(Choice)], and cleans up the tests in these files.

If you'd like I would be happy to add more tests to cover the interactions between the various options, but I admit that I'm not an ASN.1 expert so I would need some guidance as to how these options interact so that I could formulate the correct desugaring.

Closes #322.