### PR TITLE
der: make `OrdIsValueOrd` into sealed trait

### DIFF
--- a/der/src/asn1/boolean.rs
+++ b/der/src/asn1/boolean.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `BOOLEAN` support.
 
 use crate::{
-    asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, ErrorKind, FixedTag,
-    Length, OrdIsValueOrd, Result, Tag,
+    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error,
+    ErrorKind, FixedTag, Length, Result, Tag,
 };
 
 /// Byte used to encode `true` in ASN.1 DER. From X.690 Section 11.1:

--- a/der/src/asn1/generalized_time.rs
+++ b/der/src/asn1/generalized_time.rs
@@ -3,8 +3,8 @@
 use crate::{
     asn1::Any,
     datetime::{self, DateTime},
-    ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, FixedTag, Length, OrdIsValueOrd,
-    Result, Tag,
+    ord::OrdIsValueOrd,
+    ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, FixedTag, Length, Result, Tag,
 };
 use core::time::Duration;
 

--- a/der/src/asn1/ia5_string.rs
+++ b/der/src/asn1/ia5_string.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `IA5String` support.
 
 use crate::{
-    asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, FixedTag, Length,
-    OrdIsValueOrd, Result, StrSlice, Tag,
+    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error,
+    FixedTag, Length, Result, StrSlice, Tag,
 };
 use core::{fmt, str};
 

--- a/der/src/asn1/null.rs
+++ b/der/src/asn1/null.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `NULL` support.
 
 use crate::{
-    asn1::Any, ByteSlice, DecodeValue, Decoder, Encodable, EncodeValue, Encoder, Error, ErrorKind,
-    FixedTag, Length, OrdIsValueOrd, Result, Tag,
+    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, Decoder, Encodable, EncodeValue,
+    Encoder, Error, ErrorKind, FixedTag, Length, Result, Tag,
 };
 
 /// ASN.1 `NULL` type.

--- a/der/src/asn1/octet_string.rs
+++ b/der/src/asn1/octet_string.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `OCTET STRING` support.
 
 use crate::{
-    asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, ErrorKind, FixedTag,
-    Length, OrdIsValueOrd, Result, Tag,
+    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error,
+    ErrorKind, FixedTag, Length, Result, Tag,
 };
 
 /// ASN.1 `OCTET STRING` type.

--- a/der/src/asn1/oid.rs
+++ b/der/src/asn1/oid.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `OBJECT IDENTIFIER`
 
 use crate::{
-    asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, FixedTag, Length,
-    OrdIsValueOrd, Result, Tag, Tagged,
+    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error,
+    FixedTag, Length, Result, Tag, Tagged,
 };
 use const_oid::ObjectIdentifier;
 

--- a/der/src/asn1/printable_string.rs
+++ b/der/src/asn1/printable_string.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `PrintableString` support.
 
 use crate::{
-    asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, FixedTag, Length,
-    OrdIsValueOrd, Result, StrSlice, Tag,
+    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error,
+    FixedTag, Length, Result, StrSlice, Tag,
 };
 use core::{fmt, str};
 

--- a/der/src/asn1/utc_time.rs
+++ b/der/src/asn1/utc_time.rs
@@ -3,8 +3,8 @@
 use crate::{
     asn1::Any,
     datetime::{self, DateTime},
-    ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, FixedTag, Length, OrdIsValueOrd,
-    Result, Tag,
+    ord::OrdIsValueOrd,
+    ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, FixedTag, Length, Result, Tag,
 };
 use core::time::Duration;
 

--- a/der/src/asn1/utf8_string.rs
+++ b/der/src/asn1/utf8_string.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `UTF8String` support.
 
 use crate::{
-    asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, FixedTag, Length,
-    OrdIsValueOrd, Result, StrSlice, Tag,
+    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error,
+    FixedTag, Length, Result, StrSlice, Tag,
 };
 use core::{fmt, str};
 

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -360,7 +360,7 @@ pub use crate::{
     error::{Error, ErrorKind, Result},
     header::Header,
     length::Length,
-    ord::{DerOrd, OrdIsValueOrd, ValueOrd},
+    ord::{DerOrd, ValueOrd},
     tag::{Class, FixedTag, Tag, TagMode, TagNumber, Tagged},
     value::{DecodeValue, EncodeValue},
 };

--- a/x509/src/attribute.rs
+++ b/x509/src/attribute.rs
@@ -2,7 +2,7 @@
 
 use der::{
     asn1::{Any, ObjectIdentifier},
-    OrdIsValueOrd, Sequence,
+    Sequence, ValueOrd,
 };
 
 /// Attribute type/value pairs as defined in [RFC 5280 Section 4.1.2.4].
@@ -18,7 +18,7 @@ use der::{
 /// ```
 ///
 /// [RFC 5280 Section 4.1.2.4]: https://tools.ietf.org/html/rfc5280#section-4.1.2.4
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Sequence)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Sequence, ValueOrd)]
 pub struct AttributeTypeAndValue<'a> {
     /// OID describing the type of the attribute
     pub oid: ObjectIdentifier,
@@ -26,5 +26,3 @@ pub struct AttributeTypeAndValue<'a> {
     /// Value of the attribute
     pub value: Any<'a>,
 }
-
-impl OrdIsValueOrd for AttributeTypeAndValue<'_> {}


### PR DESCRIPTION
While this trait is useful for defining the `ValueOrd` impl for various ASN.1 universal types within the `der` crate itself, it is easily abused outside the context of the `der` crate.

`ValueOrd` handles comparing DER serializations for ordering. The `OrdIsValueOrd` is tempting in that it makes it appear that `Ord` can be used instead, but this only works in hyper-specific cases where `Ord` is identical to `ValueOrd`, which is primarily the ASN.1 universal types.

To prevent misuse, this commit seals the trait to force downstream users to impl `ValueOrd`.