### PR TITLE
Add AES ECB PKCS7 support to PKCS5

### DIFF
--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -34,7 +34,8 @@ hex-literal = "0.3"
 [features]
 alloc = []
 3des = ["pbes2", "des"]
-des-insecure = ["pbes2", "des"]
+des-insecure = ["pbes2", "des", "ecb"]
+ecb = ["block-modes"]
 pbes2 = ["aes", "block-modes", "hmac", "pbkdf2", "scrypt", "sha2"]
 sha1 = ["pbes2", "sha-1"]
 

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -34,8 +34,8 @@ hex-literal = "0.3"
 [features]
 alloc = []
 3des = ["pbes2", "des"]
-des-insecure = ["pbes2", "des", "ecb"]
-ecb = ["block-modes"]
+aes-ecb-insecure = ["block-modes"]
+des-insecure = ["pbes2", "des"]
 pbes2 = ["aes", "block-modes", "hmac", "pbkdf2", "scrypt", "sha2"]
 sha1 = ["pbes2", "sha-1"]
 

--- a/pkcs5/src/pbes2.rs
+++ b/pkcs5/src/pbes2.rs
@@ -27,7 +27,7 @@ pub const AES_128_CBC_OID: ObjectIdentifier = ObjectIdentifier::new("2.16.840.1.
 
 /// 128-bit Advanced Encryption Standard (AES) algorithm with Electronic Code
 /// Book (ECB) mode of operation.
-#[cfg(feature = "ecb")]
+#[cfg(feature = "aes-ecb-insecure")]
 pub const AES_128_ECB_OID: ObjectIdentifier = ObjectIdentifier::new("2.16.840.1.101.3.4.1.1");
 
 /// 192-bit Advanced Encryption Standard (AES) algorithm with Cipher-Block
@@ -36,7 +36,7 @@ pub const AES_192_CBC_OID: ObjectIdentifier = ObjectIdentifier::new("2.16.840.1.
 
 /// 192-bit Advanced Encryption Standard (AES) algorithm with Electronic Code
 /// Book (ECB) mode of operation.
-#[cfg(feature = "ecb")]
+#[cfg(feature = "aes-ecb-insecure")]
 pub const AES_192_ECB_OID: ObjectIdentifier = ObjectIdentifier::new("2.16.840.1.101.3.4.1.21");
 
 /// 256-bit Advanced Encryption Standard (AES) algorithm with Cipher-Block
@@ -45,7 +45,7 @@ pub const AES_256_CBC_OID: ObjectIdentifier = ObjectIdentifier::new("2.16.840.1.
 
 /// 256-bit Advanced Encryption Standard (AES) algorithm with Electronic Code Book
 /// (ECB) mode of operation.
-#[cfg(feature = "ecb")]
+#[cfg(feature = "aes-ecb-insecure")]
 pub const AES_256_ECB_OID: ObjectIdentifier = ObjectIdentifier::new("2.16.840.1.101.3.4.1.41");
 
 /// DES operating in CBC mode
@@ -254,7 +254,7 @@ pub enum EncryptionScheme<'a> {
     },
 
     /// AES-128 in ECB mode
-    #[cfg(feature = "ecb")]
+    #[cfg(feature = "aes-ecb-insecure")]
     Aes128Ecb,
 
     /// AES-192 in CBC mode
@@ -264,7 +264,7 @@ pub enum EncryptionScheme<'a> {
     },
 
     /// AES-192 in ECB mode
-    #[cfg(feature = "ecb")]
+    #[cfg(feature = "aes-ecb-insecure")]
     Aes192Ecb,
 
     /// AES-256 in CBC mode
@@ -274,7 +274,7 @@ pub enum EncryptionScheme<'a> {
     },
 
     /// AES-256 in ECB mode
-    #[cfg(feature = "ecb")]
+    #[cfg(feature = "aes-ecb-insecure")]
     Aes256Ecb,
 
     /// 3-Key Triple DES in CBC mode
@@ -297,13 +297,13 @@ impl<'a> EncryptionScheme<'a> {
     pub fn key_size(&self) -> usize {
         match self {
             Self::Aes128Cbc { .. } => 16,
-            #[cfg(feature = "ecb")]
+            #[cfg(feature = "aes-ecb-insecure")]
             Self::Aes128Ecb => 16,
             Self::Aes192Cbc { .. } => 24,
-            #[cfg(feature = "ecb")]
+            #[cfg(feature = "aes-ecb-insecure")]
             Self::Aes192Ecb => 24,
             Self::Aes256Cbc { .. } => 32,
-            #[cfg(feature = "ecb")]
+            #[cfg(feature = "aes-ecb-insecure")]
             Self::Aes256Ecb => 32,
             #[cfg(feature = "des-insecure")]
             Self::DesCbc { .. } => 8,
@@ -316,13 +316,13 @@ impl<'a> EncryptionScheme<'a> {
     pub fn oid(&self) -> ObjectIdentifier {
         match self {
             Self::Aes128Cbc { .. } => AES_128_CBC_OID,
-            #[cfg(feature = "ecb")]
+            #[cfg(feature = "aes-ecb-insecure")]
             Self::Aes128Ecb => AES_128_ECB_OID,
             Self::Aes192Cbc { .. } => AES_192_CBC_OID,
-            #[cfg(feature = "ecb")]
+            #[cfg(feature = "aes-ecb-insecure")]
             Self::Aes192Ecb => AES_192_ECB_OID,
             Self::Aes256Cbc { .. } => AES_256_CBC_OID,
-            #[cfg(feature = "ecb")]
+            #[cfg(feature = "aes-ecb-insecure")]
             Self::Aes256Ecb => AES_256_ECB_OID,
             #[cfg(feature = "des-insecure")]
             Self::DesCbc { .. } => DES_CBC_OID,
@@ -351,7 +351,7 @@ impl<'a> TryFrom<AlgorithmIdentifier<'a>> for EncryptionScheme<'a> {
     fn try_from(alg: AlgorithmIdentifier<'a>) -> der::Result<Self> {
         // TODO(tarcieri): support for non-AES algorithms?
 
-        #[cfg(feature = "ecb")]
+        #[cfg(feature = "aes-ecb-insecure")]
         match alg.oid {
             AES_128_ECB_OID => return Ok(Self::Aes128Ecb),
             AES_192_ECB_OID => return Ok(Self::Aes192Ecb),
@@ -403,13 +403,13 @@ impl<'a> TryFrom<EncryptionScheme<'a>> for AlgorithmIdentifier<'a> {
     fn try_from(scheme: EncryptionScheme<'a>) -> der::Result<Self> {
         let parameters = match scheme {
             EncryptionScheme::Aes128Cbc { iv } => Some(iv),
-            #[cfg(feature = "ecb")]
+            #[cfg(feature = "aes-ecb-insecure")]
             EncryptionScheme::Aes128Ecb => None,
             EncryptionScheme::Aes192Cbc { iv } => Some(iv),
-            #[cfg(feature = "ecb")]
+            #[cfg(feature = "aes-ecb-insecure")]
             EncryptionScheme::Aes192Ecb => None,
             EncryptionScheme::Aes256Cbc { iv } => Some(iv),
-            #[cfg(feature = "ecb")]
+            #[cfg(feature = "aes-ecb-insecure")]
             EncryptionScheme::Aes256Ecb => None,
             #[cfg(feature = "des-insecure")]
             EncryptionScheme::DesCbc { iv } => Some(iv),

--- a/pkcs5/src/pbes2/encryption.rs
+++ b/pkcs5/src/pbes2/encryption.rs
@@ -56,13 +56,9 @@ pub fn encrypt_in_place<'b>(
                 .map_err(|_| Error::EncryptFailed)
         }
         #[cfg(feature = "aes-ecb-insecure")]
-        EncryptionScheme::Aes128Ecb => {
-            let cipher = Aes128Ecb::new_from_slices(encryption_key.as_slice(), Default::default())
-                .map_err(|_| es.to_alg_params_invalid())?;
-            cipher
-                .encrypt(buffer, pos)
-                .map_err(|_| Error::EncryptFailed)
-        }
+        EncryptionScheme::Aes128Ecb => Err(Error::UnsupportedAlgorithm {
+            oid: super::AES_128_ECB_OID,
+        }),
         EncryptionScheme::Aes192Cbc { iv } => {
             let cipher = Aes192Cbc::new_from_slices(encryption_key.as_slice(), iv)
                 .map_err(|_| es.to_alg_params_invalid())?;
@@ -71,13 +67,9 @@ pub fn encrypt_in_place<'b>(
                 .map_err(|_| Error::EncryptFailed)
         }
         #[cfg(feature = "aes-ecb-insecure")]
-        EncryptionScheme::Aes192Ecb => {
-            let cipher = Aes192Ecb::new_from_slices(encryption_key.as_slice(), Default::default())
-                .map_err(|_| es.to_alg_params_invalid())?;
-            cipher
-                .encrypt(buffer, pos)
-                .map_err(|_| Error::EncryptFailed)
-        }
+        EncryptionScheme::Aes192Ecb => Err(Error::UnsupportedAlgorithm {
+            oid: super::AES_192_ECB_OID,
+        }),
         EncryptionScheme::Aes256Cbc { iv } => {
             let cipher = Aes256Cbc::new_from_slices(encryption_key.as_slice(), iv)
                 .map_err(|_| es.to_alg_params_invalid())?;
@@ -86,13 +78,9 @@ pub fn encrypt_in_place<'b>(
                 .map_err(|_| Error::EncryptFailed)
         }
         #[cfg(feature = "aes-ecb-insecure")]
-        EncryptionScheme::Aes256Ecb => {
-            let cipher = Aes256Ecb::new_from_slices(encryption_key.as_slice(), Default::default())
-                .map_err(|_| es.to_alg_params_invalid())?;
-            cipher
-                .encrypt(buffer, pos)
-                .map_err(|_| Error::EncryptFailed)
-        }
+        EncryptionScheme::Aes256Ecb => Err(Error::UnsupportedAlgorithm {
+            oid: super::AES_256_ECB_OID,
+        }),
         #[cfg(feature = "3des")]
         EncryptionScheme::DesEde3Cbc { iv } => {
             let cipher = DesEde3Cbc::new_from_slices(encryption_key.as_slice(), iv)

--- a/pkcs5/src/pbes2/encryption.rs
+++ b/pkcs5/src/pbes2/encryption.rs
@@ -2,7 +2,7 @@
 
 use super::{EncryptionScheme, Kdf, Parameters, Pbkdf2Params, Pbkdf2Prf, ScryptParams};
 use crate::{Error, Result};
-use block_modes::{block_padding::Pkcs7, BlockMode, Cbc};
+use block_modes::{block_padding::Pkcs7, BlockMode, Cbc, Ecb};
 use hmac::{
     digest::{
         block_buffer::Eager,
@@ -16,8 +16,14 @@ use pbkdf2::pbkdf2;
 use scrypt::scrypt;
 
 type Aes128Cbc = Cbc<aes::Aes128, Pkcs7>;
+#[cfg(feature = "ecb")]
+type Aes128Ecb = Ecb<aes::Aes128, Pkcs7>;
 type Aes192Cbc = Cbc<aes::Aes192, Pkcs7>;
+#[cfg(feature = "ecb")]
+type Aes192Ecb = Ecb<aes::Aes192, Pkcs7>;
 type Aes256Cbc = Cbc<aes::Aes256, Pkcs7>;
+#[cfg(feature = "ecb")]
+type Aes256Ecb = Ecb<aes::Aes256, Pkcs7>;
 
 #[cfg(feature = "des-insecure")]
 type DesCbc = Cbc<des::Des, Pkcs7>;
@@ -49,6 +55,14 @@ pub fn encrypt_in_place<'b>(
                 .encrypt(buffer, pos)
                 .map_err(|_| Error::EncryptFailed)
         }
+        #[cfg(feature = "ecb")]
+        EncryptionScheme::Aes128Ecb => {
+            let cipher = Aes128Ecb::new_from_slices(encryption_key.as_slice(), Default::default())
+                .map_err(|_| es.to_alg_params_invalid())?;
+            cipher
+                .encrypt(buffer, pos)
+                .map_err(|_| Error::EncryptFailed)
+        }
         EncryptionScheme::Aes192Cbc { iv } => {
             let cipher = Aes192Cbc::new_from_slices(encryption_key.as_slice(), iv)
                 .map_err(|_| es.to_alg_params_invalid())?;
@@ -56,8 +70,24 @@ pub fn encrypt_in_place<'b>(
                 .encrypt(buffer, pos)
                 .map_err(|_| Error::EncryptFailed)
         }
+        #[cfg(feature = "ecb")]
+        EncryptionScheme::Aes192Ecb => {
+            let cipher = Aes192Ecb::new_from_slices(encryption_key.as_slice(), Default::default())
+                .map_err(|_| es.to_alg_params_invalid())?;
+            cipher
+                .encrypt(buffer, pos)
+                .map_err(|_| Error::EncryptFailed)
+        }
         EncryptionScheme::Aes256Cbc { iv } => {
             let cipher = Aes256Cbc::new_from_slices(encryption_key.as_slice(), iv)
+                .map_err(|_| es.to_alg_params_invalid())?;
+            cipher
+                .encrypt(buffer, pos)
+                .map_err(|_| Error::EncryptFailed)
+        }
+        #[cfg(feature = "ecb")]
+        EncryptionScheme::Aes256Ecb => {
+            let cipher = Aes256Ecb::new_from_slices(encryption_key.as_slice(), Default::default())
                 .map_err(|_| es.to_alg_params_invalid())?;
             cipher
                 .encrypt(buffer, pos)
@@ -94,13 +124,31 @@ pub fn decrypt_in_place<'a>(
                 .map_err(|_| es.to_alg_params_invalid())?;
             cipher.decrypt(buffer).map_err(|_| Error::DecryptFailed)
         }
+        #[cfg(feature = "ecb")]
+        EncryptionScheme::Aes128Ecb => {
+            let cipher = Aes128Ecb::new_from_slices(encryption_key.as_slice(), Default::default())
+                .map_err(|_| es.to_alg_params_invalid())?;
+            cipher.decrypt(buffer).map_err(|_| Error::DecryptFailed)
+        }
         EncryptionScheme::Aes192Cbc { iv } => {
             let cipher = Aes192Cbc::new_from_slices(encryption_key.as_slice(), iv)
                 .map_err(|_| es.to_alg_params_invalid())?;
             cipher.decrypt(buffer).map_err(|_| Error::DecryptFailed)
         }
+        #[cfg(feature = "ecb")]
+        EncryptionScheme::Aes192Ecb => {
+            let cipher = Aes192Ecb::new_from_slices(encryption_key.as_slice(), Default::default())
+                .map_err(|_| es.to_alg_params_invalid())?;
+            cipher.decrypt(buffer).map_err(|_| Error::DecryptFailed)
+        }
         EncryptionScheme::Aes256Cbc { iv } => {
             let cipher = Aes256Cbc::new_from_slices(encryption_key.as_slice(), iv)
+                .map_err(|_| es.to_alg_params_invalid())?;
+            cipher.decrypt(buffer).map_err(|_| Error::DecryptFailed)
+        }
+        #[cfg(feature = "ecb")]
+        EncryptionScheme::Aes256Ecb => {
+            let cipher = Aes256Ecb::new_from_slices(encryption_key.as_slice(), Default::default())
                 .map_err(|_| es.to_alg_params_invalid())?;
             cipher.decrypt(buffer).map_err(|_| Error::DecryptFailed)
         }

--- a/pkcs5/src/pbes2/encryption.rs
+++ b/pkcs5/src/pbes2/encryption.rs
@@ -16,13 +16,13 @@ use pbkdf2::pbkdf2;
 use scrypt::scrypt;
 
 type Aes128Cbc = Cbc<aes::Aes128, Pkcs7>;
-#[cfg(feature = "ecb")]
+#[cfg(feature = "aes-ecb-insecure")]
 type Aes128Ecb = Ecb<aes::Aes128, Pkcs7>;
 type Aes192Cbc = Cbc<aes::Aes192, Pkcs7>;
-#[cfg(feature = "ecb")]
+#[cfg(feature = "aes-ecb-insecure")]
 type Aes192Ecb = Ecb<aes::Aes192, Pkcs7>;
 type Aes256Cbc = Cbc<aes::Aes256, Pkcs7>;
-#[cfg(feature = "ecb")]
+#[cfg(feature = "aes-ecb-insecure")]
 type Aes256Ecb = Ecb<aes::Aes256, Pkcs7>;
 
 #[cfg(feature = "des-insecure")]
@@ -55,7 +55,7 @@ pub fn encrypt_in_place<'b>(
                 .encrypt(buffer, pos)
                 .map_err(|_| Error::EncryptFailed)
         }
-        #[cfg(feature = "ecb")]
+        #[cfg(feature = "aes-ecb-insecure")]
         EncryptionScheme::Aes128Ecb => {
             let cipher = Aes128Ecb::new_from_slices(encryption_key.as_slice(), Default::default())
                 .map_err(|_| es.to_alg_params_invalid())?;
@@ -70,7 +70,7 @@ pub fn encrypt_in_place<'b>(
                 .encrypt(buffer, pos)
                 .map_err(|_| Error::EncryptFailed)
         }
-        #[cfg(feature = "ecb")]
+        #[cfg(feature = "aes-ecb-insecure")]
         EncryptionScheme::Aes192Ecb => {
             let cipher = Aes192Ecb::new_from_slices(encryption_key.as_slice(), Default::default())
                 .map_err(|_| es.to_alg_params_invalid())?;
@@ -85,7 +85,7 @@ pub fn encrypt_in_place<'b>(
                 .encrypt(buffer, pos)
                 .map_err(|_| Error::EncryptFailed)
         }
-        #[cfg(feature = "ecb")]
+        #[cfg(feature = "aes-ecb-insecure")]
         EncryptionScheme::Aes256Ecb => {
             let cipher = Aes256Ecb::new_from_slices(encryption_key.as_slice(), Default::default())
                 .map_err(|_| es.to_alg_params_invalid())?;
@@ -124,7 +124,7 @@ pub fn decrypt_in_place<'a>(
                 .map_err(|_| es.to_alg_params_invalid())?;
             cipher.decrypt(buffer).map_err(|_| Error::DecryptFailed)
         }
-        #[cfg(feature = "ecb")]
+        #[cfg(feature = "aes-ecb-insecure")]
         EncryptionScheme::Aes128Ecb => {
             let cipher = Aes128Ecb::new_from_slices(encryption_key.as_slice(), Default::default())
                 .map_err(|_| es.to_alg_params_invalid())?;
@@ -135,7 +135,7 @@ pub fn decrypt_in_place<'a>(
                 .map_err(|_| es.to_alg_params_invalid())?;
             cipher.decrypt(buffer).map_err(|_| Error::DecryptFailed)
         }
-        #[cfg(feature = "ecb")]
+        #[cfg(feature = "aes-ecb-insecure")]
         EncryptionScheme::Aes192Ecb => {
             let cipher = Aes192Ecb::new_from_slices(encryption_key.as_slice(), Default::default())
                 .map_err(|_| es.to_alg_params_invalid())?;
@@ -146,7 +146,7 @@ pub fn decrypt_in_place<'a>(
                 .map_err(|_| es.to_alg_params_invalid())?;
             cipher.decrypt(buffer).map_err(|_| Error::DecryptFailed)
         }
-        #[cfg(feature = "ecb")]
+        #[cfg(feature = "aes-ecb-insecure")]
         EncryptionScheme::Aes256Ecb => {
             let cipher = Aes256Ecb::new_from_slices(encryption_key.as_slice(), Default::default())
                 .map_err(|_| es.to_alg_params_invalid())?;


### PR DESCRIPTION
The most ergonomic way to make use of the ciphers is with a `pbes2::Parameters` struct, and to interoperate with a program written to use Java's default "AES" cipher I need AES in ECB mode with PKCS7 padding.

The ECB cipher modes are feature-gated because they shouldn't be encouraged for new code.