### PR TITLE
base64ct: add `unused_qualifications` lint

### DIFF
--- a/base64ct/src/lib.rs
+++ b/base64ct/src/lib.rs
@@ -1,12 +1,17 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![warn(missing_docs, rust_2018_idioms)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_root_url = "https://docs.rs/base64ct/1.3.3"
 )]
 #![doc = include_str!("../README.md")]
+#![warn(
+    missing_docs,
+    rust_2018_idioms,
+    unused_lifetimes,
+    unused_qualifications
+)]
 
 //! # Usage
 //!


### PR DESCRIPTION
Enables the lint for unused qualifications, and fixes up the places where they occur.

Additionally adds an `unused_lifetimes` lint, but there were no occurrences of unused lifetimes that needed correcting.

Finally, adds some additional checks and documentation for `InvalidLength` cases.