### PR TITLE
der: impl `ValueOrd` for `SetOf` and `SetOfVec`

### DIFF
--- a/der/src/arrayvec.rs
+++ b/der/src/arrayvec.rs
@@ -121,4 +121,11 @@ impl<'a, T> Iterator for Iter<'a, T> {
             None
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.elements.len() - self.position;
+        (len, Some(len))
+    }
 }
+
+impl<'a, T> ExactSizeIterator for Iter<'a, T> {}

--- a/der/src/asn1/set_of.rs
+++ b/der/src/asn1/set_of.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `SET OF` support.
 
 use crate::{
-    arrayvec, ArrayVec, Decodable, DecodeValue, Decoder, DerOrd, Encodable, EncodeValue, Encoder,
-    ErrorKind, FixedTag, Length, Result, Tag,
+    arrayvec, ord::iter_cmp, ArrayVec, Decodable, DecodeValue, Decoder, DerOrd, Encodable,
+    EncodeValue, Encoder, ErrorKind, FixedTag, Length, Result, Tag, ValueOrd,
 };
 use core::cmp::Ordering;
 
@@ -126,6 +126,15 @@ where
     const TAG: Tag = Tag::Set;
 }
 
+impl<T, const N: usize> ValueOrd for SetOf<T, N>
+where
+    T: Clone + DerOrd,
+{
+    fn value_cmp(&self, other: &Self) -> Result<Ordering> {
+        iter_cmp(self.iter(), other.iter())
+    }
+}
+
 /// Iterator over the elements of an [`SetOf`].
 #[derive(Clone, Debug)]
 pub struct SetOfIter<'a, T> {
@@ -140,6 +149,8 @@ impl<'a, T> Iterator for SetOfIter<'a, T> {
         self.inner.next()
     }
 }
+
+impl<'a, T> ExactSizeIterator for SetOfIter<'a, T> {}
 
 /// ASN.1 `SET OF` backed by a [`Vec`].
 ///
@@ -254,4 +265,15 @@ where
     T: Clone + DerOrd,
 {
     const TAG: Tag = Tag::Set;
+}
+
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+impl<T> ValueOrd for SetOfVec<T>
+where
+    T: Clone + DerOrd,
+{
+    fn value_cmp(&self, other: &Self) -> Result<Ordering> {
+        iter_cmp(self.iter(), other.iter())
+    }
 }

--- a/der/src/ord.rs
+++ b/der/src/ord.rs
@@ -51,3 +51,21 @@ where
         Ok(self.cmp(other))
     }
 }
+
+/// Compare the order of two iterators using [`DerCmp`] on the values.
+pub(crate) fn iter_cmp<'a, I, T: 'a>(a: I, b: I) -> Result<Ordering>
+where
+    I: Iterator<Item = &'a T> + ExactSizeIterator,
+    T: DerOrd,
+{
+    let length_ord = a.len().cmp(&b.len());
+
+    for (value1, value2) in a.zip(b) {
+        match value1.der_cmp(value2)? {
+            Ordering::Equal => (),
+            other => return Ok(other),
+        }
+    }
+
+    Ok(length_ord)
+}


### PR DESCRIPTION
Adds impls which make it possible to compare the DER encoded orderings of `SET OF` types.