### PR TITLE
der_derive: remove static lifetime from ENUMERATED's derived `DecodeValue`

### DIFF
--- a/der/derive/src/enumerated.rs
+++ b/der/derive/src/enumerated.rs
@@ -95,7 +95,7 @@ impl DeriveEnumerated {
         }
 
         quote! {
-            impl ::der::DecodeValue<'static> for #ident {
+            impl ::der::DecodeValue<'_> for #ident {
                 fn decode_value(
                     decoder: &mut ::der::Decoder<'_>,
                     length: ::der::Length


### PR DESCRIPTION
Closes #296