### PR TITLE
ssh-key: add `FromStr` impls to key types

### DIFF
--- a/ssh-key/src/private.rs
+++ b/ssh-key/src/private.rs
@@ -26,6 +26,7 @@ use crate::{
     base64::{self, Decode},
     public, Algorithm, CipherAlg, Error, KdfAlg, KdfOptions, Result,
 };
+use core::str::FromStr;
 
 #[cfg(feature = "alloc")]
 use alloc::string::String;
@@ -123,6 +124,14 @@ impl PrivateKey {
     /// Get the digital signature [`Algorithm`] used by this key.
     pub fn algorithm(&self) -> Algorithm {
         self.key_data.algorithm()
+    }
+}
+
+impl FromStr for PrivateKey {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        Self::from_openssh(s)
     }
 }
 

--- a/ssh-key/src/public.rs
+++ b/ssh-key/src/public.rs
@@ -21,6 +21,7 @@ use crate::{
     base64::{self, Decode},
     Algorithm, Error, Result,
 };
+use core::str::FromStr;
 
 #[cfg(feature = "alloc")]
 use alloc::{borrow::ToOwned, string::String};
@@ -69,6 +70,14 @@ impl PublicKey {
     /// Get the digital signature [`Algorithm`] used by this key.
     pub fn algorithm(&self) -> Algorithm {
         self.key_data.algorithm()
+    }
+}
+
+impl FromStr for PublicKey {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        Self::from_openssh(s)
     }
 }
 


### PR DESCRIPTION
The `PublicKey` and `PrivateKey` types both have inherent `from_openssh` methods with the goal of potentially supporting some earlier legacy formats in addition to the most current OpenSSH formats.

However, they didn't previously have `FromStr`. This commit adds a `FromStr` thunk which calls `from_openssh`.