### PR TITLE
ssh-key: initial `PublicKey` encoder w\ Ed25519 support

### DIFF
--- a/ssh-key/src/algorithm.rs
+++ b/ssh-key/src/algorithm.rs
@@ -1,7 +1,7 @@
 //! Algorithm support.
 
 use crate::{
-    base64::{self, Decode},
+    base64::{self, Decode, Encode},
     Error, Result,
 };
 use core::{fmt, str};
@@ -106,6 +106,16 @@ impl Decode for Algorithm {
     fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
         let mut buf = [0u8; Self::MAX_SIZE];
         Self::new(decoder.decode_str(&mut buf)?)
+    }
+}
+
+impl Encode for Algorithm {
+    fn encoded_len(&self) -> Result<usize> {
+        Ok(4 + self.as_str().len())
+    }
+
+    fn encode(&self, encoder: &mut base64::Encoder<'_>) -> Result<()> {
+        encoder.encode_str(self.as_str())
     }
 }
 

--- a/ssh-key/src/error.rs
+++ b/ssh-key/src/error.rs
@@ -85,6 +85,14 @@ impl From<core::str::Utf8Error> for Error {
     }
 }
 
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+impl From<alloc::string::FromUtf8Error> for Error {
+    fn from(_: alloc::string::FromUtf8Error) -> Error {
+        Error::CharacterEncoding
+    }
+}
+
 #[cfg(feature = "ecdsa")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
 impl From<sec1::Error> for Error {

--- a/ssh-key/src/public/ed25519.rs
+++ b/ssh-key/src/public/ed25519.rs
@@ -3,7 +3,7 @@
 //! Edwards Digital Signature Algorithm (EdDSA) over Curve25519.
 
 use crate::{
-    base64::{self, Decode},
+    base64::{self, Decode, Encode},
     Error, Result,
 };
 use core::fmt;
@@ -34,6 +34,16 @@ impl Decode for Ed25519PublicKey {
         let mut bytes = [0u8; Self::BYTE_SIZE];
         decoder.decode_into(&mut bytes)?;
         Ok(Self(bytes))
+    }
+}
+
+impl Encode for Ed25519PublicKey {
+    fn encoded_len(&self) -> Result<usize> {
+        Ok(4 + Self::BYTE_SIZE)
+    }
+
+    fn encode(&self, encoder: &mut base64::Encoder<'_>) -> Result<()> {
+        encoder.encode_byte_slice(self.as_ref())
     }
 }
 

--- a/ssh-key/tests/public_key.rs
+++ b/ssh-key/tests/public_key.rs
@@ -212,3 +212,10 @@ fn decode_rsa_4096_openssh() {
 
     assert_eq!("user@example.com", ossh_key.comment);
 }
+
+#[cfg(feature = "alloc")]
+#[test]
+fn encode_ed25519_openssh() {
+    let ossh_key = PublicKey::from_openssh(OSSH_ED25519_EXAMPLE).unwrap();
+    assert_eq!(OSSH_ED25519_EXAMPLE.trim_end(), &ossh_key.to_string())
+}


### PR DESCRIPTION
Adds initial support for encoding `PublicKey` data in OpenSSH format.

Uses the new buffered `base64ct::Encoder` type.

Ed25519 keys are supported with a `no_std`-friendly profile.