### PR TITLE
der_derive: have `Sequence` macro derive `DecodeValue`

### DIFF
--- a/der/derive/src/sequence.rs
+++ b/der/derive/src/sequence.rs
@@ -84,9 +84,13 @@ impl DeriveSequence {
         }
 
         quote! {
-            impl<#lt_params> ::der::Decodable<#lifetime> for #ident<#lt_params> {
-                fn decode(decoder: &mut ::der::Decoder<#lifetime>) -> ::der::Result<Self> {
-                    decoder.sequence(|decoder| {
+            impl<#lt_params> ::der::DecodeValue<#lifetime> for #ident<#lt_params> {
+                fn decode_value(
+                    decoder: &mut ::der::Decoder<#lifetime>,
+                    length: ::der::Length,
+                ) -> ::der::Result<Self> {
+                    use ::der::DecodeValue;
+                    ::der::asn1::SequenceRef::decode_value(decoder, length)?.decode_body(|decoder| {
                         #(#decode_body)*
 
                         Ok(Self {


### PR DESCRIPTION
The proc macro previously derived the `Decode` trait, which is not composable with context-specific fields, which depend on the `DecodeValue` trait in order to support IMPLICIT fields.

This commit changes the custom derive macro for `Sequence` to produce a `DecodeValue` impl instead of `Decode`. This leverages the newly introduced `SequenceRef` type from #374.