### PR TITLE
der: impl `From`/`FromIterator` for `SetOfVec`

### DIFF
--- a/der/src/asn1/set_of.rs
+++ b/der/src/asn1/set_of.rs
@@ -267,6 +267,47 @@ where
     const TAG: Tag = Tag::Set;
 }
 
+/// Construct a [`SetOfVec`] from a [`Vec`], sorting the elements using the
+/// [`DerOrd`] trait.
+///
+/// # Panics
+///
+/// The current implementation will panic if [`DerOrd::der_cmp`] returns an
+/// error.
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+impl<T> From<Vec<T>> for SetOfVec<T>
+where
+    T: Clone + DerOrd,
+{
+    fn from(mut vec: Vec<T>) -> SetOfVec<T> {
+        // TODO(tarcieri): avoid panics
+        vec.sort_by(|a, b| a.der_cmp(b).expect("der_cmp error"));
+        SetOfVec { inner: vec }
+    }
+}
+
+/// Construct a [`SetOfVec`] from an iterator, determining the ordering using
+/// the [`DerOrd`] trait.
+///
+/// # Panics
+///
+/// The current implementation will panic if [`DerOrd::der_cmp`] returns an
+/// error.
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+impl<T> FromIterator<T> for SetOfVec<T>
+where
+    T: Clone + DerOrd,
+{
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+    {
+        iter.into_iter().collect::<Vec<T>>().into()
+    }
+}
+
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<T> ValueOrd for SetOfVec<T>


### PR DESCRIPTION
Adds impls of these traits for `SetOfVec`, which sort elements using `DerOrd`. The `FromIterator` impl is composed in terms of the `From<Vec<T>>` impl, which collects the elements into a `Vec`, then sorts them with `sort_by`.

One problem is `DerOrd::der_cmp` is fallible, so in order to use it with `sort_by` the only option is to panic if it returns an `Err`. I'm not sure if this can be resolved short of shipping a custom sort function or getting something like `try_sort_by` added to `core`. FWIW I proposed the latter here:

https://internals.rust-lang.org/t/fallible-sorting/16066