### PR TITLE
pkcs10+x501: bump versions to 0.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs10"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "der",
  "hex-literal",
@@ -1202,7 +1202,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "x501"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "der",
  "hex-literal",

--- a/pkcs10/Cargo.toml
+++ b/pkcs10/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs10"
-version = "0.1.0"
+version = "0.0.0"
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #10:
 Certification Request Syntax Specification (RFC 5208).
@@ -21,7 +21,7 @@ hex-literal = "0.3"
 [dependencies]
 der = { version = "0.6.0-pre.0", features = ["oid", "derive", "alloc"], path = "../der" }
 spki = { version = "0.6.0-pre", path = "../spki" }
-x501 = { version = "0.1.0", path = "../x501" }
+x501 = { version = "0.0.0", path = "../x501" }
 
 [features]
 pem = ["der/pem", "spki/pem"]

--- a/pkcs10/src/lib.rs
+++ b/pkcs10/src/lib.rs
@@ -4,7 +4,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/pkcs10/0.3.0"
+    html_root_url = "https://docs.rs/pkcs10/0.0.0"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]

--- a/x501/Cargo.toml
+++ b/x501/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x501"
-version = "0.1.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.0.0" # Also update html_root_url in lib.rs when bumping this
 edition = "2021"
 description = "Pure Rust implementation of some of the types defined in X.501"
 authors = ["RustCrypto Developers"]

--- a/x501/src/lib.rs
+++ b/x501/src/lib.rs
@@ -4,7 +4,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/x501/0.1.0"
+    html_root_url = "https://docs.rs/x501/0.0.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]

--- a/x509/Cargo.toml
+++ b/x509/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.56"
 [dependencies]
 der = { version = "=0.6.0-pre.0", features = ["derive", "alloc"], path = "../der" }
 spki = { version = "=0.6.0-pre", path = "../spki" }
-x501 = { version = "0.1.0", path = "../x501" }
+x501 = { version = "0.0.0", path = "../x501" }
 
 [dev-dependencies]
 hex-literal = "0.3"


### PR DESCRIPTION
This allows them to be incremented in the release PRs