### PR TITLE
Pass `Header` to `DecodeValue`

### DIFF
--- a/der/derive/src/enumerated.rs
+++ b/der/derive/src/enumerated.rs
@@ -98,9 +98,9 @@ impl DeriveEnumerated {
             impl ::der::DecodeValue<'_> for #ident {
                 fn decode_value(
                     decoder: &mut ::der::Decoder<'_>,
-                    length: ::der::Length
+                    header: ::der::Header
                 ) -> ::der::Result<Self> {
-                    <#repr as ::der::DecodeValue>::decode_value(decoder, length)?.try_into()
+                    <#repr as ::der::DecodeValue>::decode_value(decoder, header)?.try_into()
                 }
             }
 

--- a/der/derive/src/sequence.rs
+++ b/der/derive/src/sequence.rs
@@ -87,10 +87,10 @@ impl DeriveSequence {
             impl<#lt_params> ::der::DecodeValue<#lifetime> for #ident<#lt_params> {
                 fn decode_value(
                     decoder: &mut ::der::Decoder<#lifetime>,
-                    length: ::der::Length,
+                    header: ::der::Header,
                 ) -> ::der::Result<Self> {
                     use ::der::DecodeValue;
-                    ::der::asn1::SequenceRef::decode_value(decoder, length)?.decode_body(|decoder| {
+                    ::der::asn1::SequenceRef::decode_value(decoder, header)?.decode_body(|decoder| {
                         #(#decode_body)*
 
                         Ok(Self {

--- a/der/src/asn1/bit_string.rs
+++ b/der/src/asn1/bit_string.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     asn1::Any, ByteSlice, DecodeValue, Decoder, DerOrd, EncodeValue, Encoder, Error, ErrorKind,
-    FixedTag, Length, Result, Tag, ValueOrd,
+    FixedTag, Header, Length, Result, Tag, ValueOrd,
 };
 use core::{cmp::Ordering, iter::FusedIterator};
 
@@ -116,9 +116,14 @@ impl<'a> BitString<'a> {
 }
 
 impl<'a> DecodeValue<'a> for BitString<'a> {
-    fn decode_value(decoder: &mut Decoder<'a>, encoded_len: Length) -> Result<Self> {
+    fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> Result<Self> {
+        let header = Header {
+            tag: header.tag,
+            length: (header.length - Length::ONE)?,
+        };
+
         let unused_bits = decoder.byte()?;
-        let inner = ByteSlice::decode_value(decoder, (encoded_len - Length::ONE)?)?;
+        let inner = ByteSlice::decode_value(decoder, header)?;
         Self::new(unused_bits, inner.as_bytes())
     }
 }

--- a/der/src/asn1/boolean.rs
+++ b/der/src/asn1/boolean.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error,
-    ErrorKind, FixedTag, Length, Result, Tag,
+    ErrorKind, FixedTag, Header, Length, Result, Tag,
 };
 
 /// Byte used to encode `true` in ASN.1 DER. From X.690 Section 11.1:
@@ -15,8 +15,8 @@ const TRUE_OCTET: u8 = 0b11111111;
 const FALSE_OCTET: u8 = 0b00000000;
 
 impl<'a> DecodeValue<'a> for bool {
-    fn decode_value(decoder: &mut Decoder<'a>, length: Length) -> Result<Self> {
-        if length != Length::ONE {
+    fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> Result<Self> {
+        if header.length != Length::ONE {
             return Err(decoder.error(ErrorKind::Length { tag: Self::TAG }));
         }
 

--- a/der/src/asn1/context_specific.rs
+++ b/der/src/asn1/context_specific.rs
@@ -72,7 +72,7 @@ impl<T> ContextSpecific<T> {
     {
         Self::decode_with(decoder, tag_number, |decoder| {
             let header = Header::decode(decoder)?;
-            let value = T::decode_value(decoder, header.length)?;
+            let value = T::decode_value(decoder, header)?;
 
             if header.tag.is_constructed() != value.tag().is_constructed() {
                 return Err(header.tag.non_canonical_error());

--- a/der/src/asn1/generalized_time.rs
+++ b/der/src/asn1/generalized_time.rs
@@ -4,7 +4,8 @@ use crate::{
     asn1::Any,
     datetime::{self, DateTime},
     ord::OrdIsValueOrd,
-    ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, FixedTag, Length, Result, Tag,
+    ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, FixedTag, Header, Length, Result,
+    Tag,
 };
 use core::time::Duration;
 
@@ -73,8 +74,8 @@ impl GeneralizedTime {
 }
 
 impl DecodeValue<'_> for GeneralizedTime {
-    fn decode_value(decoder: &mut Decoder<'_>, length: Length) -> Result<Self> {
-        match *ByteSlice::decode_value(decoder, length)?.as_bytes() {
+    fn decode_value(decoder: &mut Decoder<'_>, header: Header) -> Result<Self> {
+        match *ByteSlice::decode_value(decoder, header)?.as_bytes() {
             // RFC 5280 requires mandatory seconds and Z-normalized time zone
             [y1, y2, y3, y4, mon1, mon2, day1, day2, hour1, hour2, min1, min2, sec1, sec2, b'Z'] => {
                 let year = datetime::decode_decimal(Self::TAG, y1, y2)? as u16 * 100
@@ -159,8 +160,8 @@ impl TryFrom<Any<'_>> for GeneralizedTime {
 }
 
 impl DecodeValue<'_> for DateTime {
-    fn decode_value(decoder: &mut Decoder<'_>, length: Length) -> Result<Self> {
-        Ok(GeneralizedTime::decode_value(decoder, length)?.into())
+    fn decode_value(decoder: &mut Decoder<'_>, header: Header) -> Result<Self> {
+        Ok(GeneralizedTime::decode_value(decoder, header)?.into())
     }
 }
 
@@ -183,8 +184,8 @@ impl OrdIsValueOrd for DateTime {}
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl DecodeValue<'_> for SystemTime {
-    fn decode_value(decoder: &mut Decoder<'_>, length: Length) -> Result<Self> {
-        Ok(GeneralizedTime::decode_value(decoder, length)?.into())
+    fn decode_value(decoder: &mut Decoder<'_>, header: Header) -> Result<Self> {
+        Ok(GeneralizedTime::decode_value(decoder, header)?.into())
     }
 }
 
@@ -259,8 +260,8 @@ impl OrdIsValueOrd for SystemTime {}
 #[cfg(feature = "time")]
 #[cfg_attr(docsrs, doc(cfg(feature = "time")))]
 impl DecodeValue<'_> for PrimitiveDateTime {
-    fn decode_value(decoder: &mut Decoder<'_>, length: Length) -> Result<Self> {
-        GeneralizedTime::decode_value(decoder, length)?.try_into()
+    fn decode_value(decoder: &mut Decoder<'_>, header: Header) -> Result<Self> {
+        GeneralizedTime::decode_value(decoder, header)?.try_into()
     }
 }
 

--- a/der/src/asn1/ia5_string.rs
+++ b/der/src/asn1/ia5_string.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error,
-    FixedTag, Length, Result, StrSlice, Tag,
+    FixedTag, Header, Length, Result, StrSlice, Tag,
 };
 use core::{fmt, str};
 
@@ -74,8 +74,8 @@ impl AsRef<[u8]> for Ia5String<'_> {
 }
 
 impl<'a> DecodeValue<'a> for Ia5String<'a> {
-    fn decode_value(decoder: &mut Decoder<'a>, length: Length) -> Result<Self> {
-        Self::new(ByteSlice::decode_value(decoder, length)?.as_bytes())
+    fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> Result<Self> {
+        Self::new(ByteSlice::decode_value(decoder, header)?.as_bytes())
     }
 }
 

--- a/der/src/asn1/integer.rs
+++ b/der/src/asn1/integer.rs
@@ -5,8 +5,8 @@ mod int;
 mod uint;
 
 use crate::{
-    asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, FixedTag, Length,
-    Result, Tag, ValueOrd,
+    asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, FixedTag, Header,
+    Length, Result, Tag, ValueOrd,
 };
 use core::{cmp::Ordering, mem};
 
@@ -14,8 +14,8 @@ macro_rules! impl_int_encoding {
     ($($int:ty => $uint:ty),+) => {
         $(
             impl<'a> DecodeValue<'a> for $int {
-                fn decode_value(decoder: &mut Decoder<'a>, length: Length) -> Result<Self> {
-                    let bytes = ByteSlice::decode_value(decoder, length)?.as_bytes();
+                fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> Result<Self> {
+                    let bytes = ByteSlice::decode_value(decoder, header)?.as_bytes();
 
                     let result = if is_highest_bit_set(bytes) {
                         <$uint>::from_be_bytes(int::decode_to_array(bytes)?) as $int
@@ -24,7 +24,7 @@ macro_rules! impl_int_encoding {
                     };
 
                     // Ensure we compute the same encoded length as the original any value
-                    if length != result.value_len()? {
+                    if header.length != result.value_len()? {
                         return Err(Self::TAG.non_canonical_error());
                     }
 
@@ -75,12 +75,12 @@ macro_rules! impl_uint_encoding {
     ($($uint:ty),+) => {
         $(
             impl<'a> DecodeValue<'a> for $uint {
-                fn decode_value(decoder: &mut Decoder<'a>, length: Length) -> Result<Self> {
-                    let bytes = ByteSlice::decode_value(decoder, length)?.as_bytes();
+                fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> Result<Self> {
+                    let bytes = ByteSlice::decode_value(decoder, header)?.as_bytes();
                     let result = Self::from_be_bytes(uint::decode_to_array(bytes)?);
 
                     // Ensure we compute the same encoded length as the original any value
-                    if length != result.value_len()? {
+                    if header.length != result.value_len()? {
                         return Err(Self::TAG.non_canonical_error());
                     }
 

--- a/der/src/asn1/integer/bigint.rs
+++ b/der/src/asn1/integer/bigint.rs
@@ -3,7 +3,7 @@
 use super::uint;
 use crate::{
     asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, ErrorKind, FixedTag,
-    Length, Result, Tag,
+    Header, Length, Result, Tag,
 };
 
 /// "Big" unsigned ASN.1 `INTEGER` type.
@@ -46,12 +46,12 @@ impl<'a> UIntBytes<'a> {
 }
 
 impl<'a> DecodeValue<'a> for UIntBytes<'a> {
-    fn decode_value(decoder: &mut Decoder<'a>, length: Length) -> Result<Self> {
-        let bytes = ByteSlice::decode_value(decoder, length)?.as_bytes();
+    fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> Result<Self> {
+        let bytes = ByteSlice::decode_value(decoder, header)?.as_bytes();
         let result = Self::new(uint::decode_to_slice(bytes)?)?;
 
         // Ensure we compute the same encoded length as the original any value.
-        if result.value_len()? != length {
+        if result.value_len()? != header.length {
             return Err(Self::TAG.non_canonical_error());
         }
 

--- a/der/src/asn1/null.rs
+++ b/der/src/asn1/null.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, Decoder, Encodable, EncodeValue,
-    Encoder, Error, ErrorKind, FixedTag, Length, Result, Tag,
+    Encoder, Error, ErrorKind, FixedTag, Header, Length, Result, Tag,
 };
 
 /// ASN.1 `NULL` type.
@@ -10,8 +10,8 @@ use crate::{
 pub struct Null;
 
 impl DecodeValue<'_> for Null {
-    fn decode_value(decoder: &mut Decoder<'_>, length: Length) -> Result<Self> {
-        if length.is_zero() {
+    fn decode_value(decoder: &mut Decoder<'_>, header: Header) -> Result<Self> {
+        if header.length.is_zero() {
             Ok(Null)
         } else {
             Err(decoder.error(ErrorKind::Length { tag: Self::TAG }))
@@ -64,8 +64,8 @@ impl<'a> From<()> for Any<'a> {
 }
 
 impl DecodeValue<'_> for () {
-    fn decode_value(decoder: &mut Decoder<'_>, length: Length) -> Result<Self> {
-        Null::decode_value(decoder, length)?;
+    fn decode_value(decoder: &mut Decoder<'_>, header: Header) -> Result<Self> {
+        Null::decode_value(decoder, header)?;
         Ok(())
     }
 }

--- a/der/src/asn1/octet_string.rs
+++ b/der/src/asn1/octet_string.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error,
-    ErrorKind, FixedTag, Length, Result, Tag,
+    ErrorKind, FixedTag, Header, Length, Result, Tag,
 };
 
 /// ASN.1 `OCTET STRING` type.
@@ -43,10 +43,9 @@ impl AsRef<[u8]> for OctetString<'_> {
 }
 
 impl<'a> DecodeValue<'a> for OctetString<'a> {
-    fn decode_value(decoder: &mut Decoder<'a>, length: Length) -> Result<Self> {
-        Ok(Self {
-            inner: ByteSlice::decode_value(decoder, length)?,
-        })
+    fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> Result<Self> {
+        let inner = ByteSlice::decode_value(decoder, header)?;
+        Ok(Self { inner })
     }
 }
 

--- a/der/src/asn1/oid.rs
+++ b/der/src/asn1/oid.rs
@@ -2,13 +2,13 @@
 
 use crate::{
     asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error,
-    FixedTag, Length, Result, Tag, Tagged,
+    FixedTag, Header, Length, Result, Tag, Tagged,
 };
 use const_oid::ObjectIdentifier;
 
 impl DecodeValue<'_> for ObjectIdentifier {
-    fn decode_value(decoder: &mut Decoder<'_>, length: Length) -> Result<Self> {
-        let bytes = ByteSlice::decode_value(decoder, length)?.as_bytes();
+    fn decode_value(decoder: &mut Decoder<'_>, header: Header) -> Result<Self> {
+        let bytes = ByteSlice::decode_value(decoder, header)?.as_bytes();
         Ok(Self::from_bytes(bytes)?)
     }
 }

--- a/der/src/asn1/printable_string.rs
+++ b/der/src/asn1/printable_string.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error,
-    FixedTag, Length, Result, StrSlice, Tag,
+    FixedTag, Header, Length, Result, StrSlice, Tag,
 };
 use core::{fmt, str};
 
@@ -107,8 +107,8 @@ impl AsRef<[u8]> for PrintableString<'_> {
 }
 
 impl<'a> DecodeValue<'a> for PrintableString<'a> {
-    fn decode_value(decoder: &mut Decoder<'a>, length: Length) -> Result<Self> {
-        Self::new(ByteSlice::decode_value(decoder, length)?.as_bytes())
+    fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> Result<Self> {
+        Self::new(ByteSlice::decode_value(decoder, header)?.as_bytes())
     }
 }
 

--- a/der/src/asn1/sequence.rs
+++ b/der/src/asn1/sequence.rs
@@ -2,8 +2,8 @@
 //! `SEQUENCE`s to Rust structs.
 
 use crate::{
-    ByteSlice, Decodable, DecodeValue, Decoder, Encodable, EncodeValue, Encoder, FixedTag, Length,
-    Result, Tag,
+    ByteSlice, Decodable, DecodeValue, Decoder, Encodable, EncodeValue, Encoder, FixedTag, Header,
+    Length, Result, Tag,
 };
 
 /// ASN.1 `SEQUENCE` trait.
@@ -75,9 +75,9 @@ impl<'a> SequenceRef<'a> {
 }
 
 impl<'a> DecodeValue<'a> for SequenceRef<'a> {
-    fn decode_value(decoder: &mut Decoder<'a>, length: Length) -> Result<Self> {
+    fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> Result<Self> {
         let offset = decoder.position();
-        let body = ByteSlice::decode_value(decoder, length)?;
+        let body = ByteSlice::decode_value(decoder, header)?;
         Ok(Self { body, offset })
     }
 }

--- a/der/src/asn1/sequence_of.rs
+++ b/der/src/asn1/sequence_of.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     arrayvec, ord::iter_cmp, ArrayVec, Decodable, DecodeValue, Decoder, DerOrd, Encodable,
-    EncodeValue, Encoder, ErrorKind, FixedTag, Length, Result, Tag, ValueOrd,
+    EncodeValue, Encoder, ErrorKind, FixedTag, Header, Length, Result, Tag, ValueOrd,
 };
 use core::cmp::Ordering;
 
@@ -66,8 +66,8 @@ impl<'a, T, const N: usize> DecodeValue<'a> for SequenceOf<T, N>
 where
     T: Decodable<'a>,
 {
-    fn decode_value(decoder: &mut Decoder<'a>, length: Length) -> Result<Self> {
-        let end_pos = (decoder.position() + length)?;
+    fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> Result<Self> {
+        let end_pos = (decoder.position() + header.length)?;
         let mut sequence_of = Self::new();
 
         while decoder.position() < end_pos {
@@ -134,8 +134,8 @@ impl<'a, T, const N: usize> DecodeValue<'a> for [T; N]
 where
     T: Decodable<'a>,
 {
-    fn decode_value(decoder: &mut Decoder<'a>, length: Length) -> Result<Self> {
-        SequenceOf::decode_value(decoder, length)?
+    fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> Result<Self> {
+        SequenceOf::decode_value(decoder, header)?
             .inner
             .try_into_array()
     }
@@ -178,8 +178,8 @@ impl<'a, T> DecodeValue<'a> for Vec<T>
 where
     T: Decodable<'a>,
 {
-    fn decode_value(decoder: &mut Decoder<'a>, length: Length) -> Result<Self> {
-        let end_pos = (decoder.position() + length)?;
+    fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> Result<Self> {
+        let end_pos = (decoder.position() + header.length)?;
         let mut sequence_of = Self::new();
 
         while decoder.position() < end_pos {

--- a/der/src/asn1/set_of.rs
+++ b/der/src/asn1/set_of.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     arrayvec, ord::iter_cmp, ArrayVec, Decodable, DecodeValue, Decoder, DerOrd, Encodable,
-    EncodeValue, Encoder, ErrorKind, FixedTag, Length, Result, Tag, ValueOrd,
+    EncodeValue, Encoder, ErrorKind, FixedTag, Header, Length, Result, Tag, ValueOrd,
 };
 use core::cmp::Ordering;
 
@@ -85,8 +85,8 @@ impl<'a, T, const N: usize> DecodeValue<'a> for SetOf<T, N>
 where
     T: Clone + Decodable<'a> + DerOrd,
 {
-    fn decode_value(decoder: &mut Decoder<'a>, length: Length) -> Result<Self> {
-        let end_pos = (decoder.position() + length)?;
+    fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> Result<Self> {
+        let end_pos = (decoder.position() + header.length)?;
         let mut result = Self::new();
 
         while decoder.position() < end_pos {
@@ -222,8 +222,8 @@ impl<'a, T> DecodeValue<'a> for SetOfVec<T>
 where
     T: Clone + Decodable<'a> + DerOrd,
 {
-    fn decode_value(decoder: &mut Decoder<'a>, length: Length) -> Result<Self> {
-        let end_pos = (decoder.position() + length)?;
+    fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> Result<Self> {
+        let end_pos = (decoder.position() + header.length)?;
         let mut result = Self::new();
 
         while decoder.position() < end_pos {

--- a/der/src/asn1/utc_time.rs
+++ b/der/src/asn1/utc_time.rs
@@ -4,7 +4,8 @@ use crate::{
     asn1::Any,
     datetime::{self, DateTime},
     ord::OrdIsValueOrd,
-    ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, FixedTag, Length, Result, Tag,
+    ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, FixedTag, Header, Length, Result,
+    Tag,
 };
 use core::time::Duration;
 
@@ -79,8 +80,8 @@ impl UtcTime {
 }
 
 impl DecodeValue<'_> for UtcTime {
-    fn decode_value(decoder: &mut Decoder<'_>, length: Length) -> Result<Self> {
-        match *ByteSlice::decode_value(decoder, length)?.as_bytes() {
+    fn decode_value(decoder: &mut Decoder<'_>, header: Header) -> Result<Self> {
+        match *ByteSlice::decode_value(decoder, header)?.as_bytes() {
             // RFC 5280 requires mandatory seconds and Z-normalized time zone
             [year1, year2, mon1, mon2, day1, day2, hour1, hour2, min1, min2, sec1, sec2, b'Z'] => {
                 let year = datetime::decode_decimal(Self::TAG, year1, year2)?;

--- a/der/src/asn1/utf8_string.rs
+++ b/der/src/asn1/utf8_string.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error,
-    FixedTag, Length, Result, StrSlice, Tag,
+    FixedTag, Header, Length, Result, StrSlice, Tag,
 };
 use core::{fmt, str};
 
@@ -70,8 +70,8 @@ impl AsRef<[u8]> for Utf8String<'_> {
 }
 
 impl<'a> DecodeValue<'a> for Utf8String<'a> {
-    fn decode_value(decoder: &mut Decoder<'a>, length: Length) -> Result<Self> {
-        Self::new(ByteSlice::decode_value(decoder, length)?.as_bytes())
+    fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> Result<Self> {
+        Self::new(ByteSlice::decode_value(decoder, header)?.as_bytes())
     }
 }
 

--- a/der/src/byte_slice.rs
+++ b/der/src/byte_slice.rs
@@ -2,7 +2,8 @@
 //! library-level length limitation i.e. `Length::max()`.
 
 use crate::{
-    str_slice::StrSlice, DecodeValue, Decoder, DerOrd, EncodeValue, Encoder, Error, Length, Result,
+    str_slice::StrSlice, DecodeValue, Decoder, DerOrd, EncodeValue, Encoder, Error, Header, Length,
+    Result,
 };
 use core::cmp::Ordering;
 
@@ -55,8 +56,8 @@ impl AsRef<[u8]> for ByteSlice<'_> {
 }
 
 impl<'a> DecodeValue<'a> for ByteSlice<'a> {
-    fn decode_value(decoder: &mut Decoder<'a>, length: Length) -> Result<Self> {
-        decoder.bytes(length).and_then(Self::new)
+    fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> Result<Self> {
+        decoder.bytes(header.length).and_then(Self::new)
     }
 }
 

--- a/der/src/decodable.rs
+++ b/der/src/decodable.rs
@@ -31,6 +31,6 @@ where
     fn decode(decoder: &mut Decoder<'a>) -> Result<T> {
         let header = Header::decode(decoder)?;
         header.tag.assert_eq(T::TAG)?;
-        T::decode_value(decoder, header.length)
+        T::decode_value(decoder, header)
     }
 }

--- a/der/src/str_slice.rs
+++ b/der/src/str_slice.rs
@@ -1,7 +1,7 @@
 //! Common handling for types backed by `str` slices with enforcement of a
 //! library-level length limitation i.e. `Length::max()`.
 
-use crate::{ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Length, Result};
+use crate::{ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Header, Length, Result};
 use core::str;
 
 /// String slice newtype which respects the [`Length::max`] limit.
@@ -63,8 +63,8 @@ impl AsRef<[u8]> for StrSlice<'_> {
 }
 
 impl<'a> DecodeValue<'a> for StrSlice<'a> {
-    fn decode_value(decoder: &mut Decoder<'a>, length: Length) -> Result<Self> {
-        Self::from_bytes(ByteSlice::decode_value(decoder, length)?.as_bytes())
+    fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> Result<Self> {
+        Self::from_bytes(ByteSlice::decode_value(decoder, header)?.as_bytes())
     }
 }
 

--- a/der/src/value.rs
+++ b/der/src/value.rs
@@ -9,7 +9,7 @@ use crate::Tag;
 /// and [`Length`].
 pub trait DecodeValue<'a>: Sized {
     /// Attempt to decode this message using the provided [`Decoder`].
-    fn decode_value(decoder: &mut Decoder<'a>, length: Length) -> Result<Self>;
+    fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> Result<Self>;
 }
 
 /// Encode the value part of a Tag-Length-Value encoded field, sans the [`Tag`]

--- a/pkcs7/src/content_type.rs
+++ b/pkcs7/src/content_type.rs
@@ -1,5 +1,5 @@
 use der::asn1::ObjectIdentifier;
-use der::{DecodeValue, Decoder, EncodeValue, Encoder, ErrorKind, FixedTag, Length, Tag};
+use der::{DecodeValue, Decoder, EncodeValue, Encoder, ErrorKind, FixedTag, Header, Length, Tag};
 
 /// Indicates the type of content.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -46,8 +46,8 @@ impl ContentType {
 }
 
 impl<'a> DecodeValue<'a> for ContentType {
-    fn decode_value(decoder: &mut Decoder<'a>, length: Length) -> der::Result<ContentType> {
-        let oid = ObjectIdentifier::decode_value(decoder, length)?;
+    fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> der::Result<ContentType> {
+        let oid = ObjectIdentifier::decode_value(decoder, header)?;
         ContentType::from_oid(oid).ok_or_else(|| decoder.error(ErrorKind::OidUnknown { oid }))
     }
 }

--- a/pkcs7/src/data_content.rs
+++ b/pkcs7/src/data_content.rs
@@ -1,7 +1,9 @@
 //! `data` content type [RFC 5652 § 4](https://datatracker.ietf.org/doc/html/rfc5652#section-4)
 
 use core::convert::{From, TryFrom};
-use der::{asn1::OctetString, DecodeValue, Decoder, EncodeValue, Encoder, FixedTag, Length, Tag};
+use der::{
+    asn1::OctetString, DecodeValue, Decoder, EncodeValue, Encoder, FixedTag, Header, Length, Tag,
+};
 
 /// The content that is just an octet string.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -29,8 +31,8 @@ impl<'a> From<DataContent<'a>> for &'a [u8] {
 }
 
 impl<'a> DecodeValue<'a> for DataContent<'a> {
-    fn decode_value(decoder: &mut Decoder<'a>, length: Length) -> der::Result<DataContent<'a>> {
-        Ok(OctetString::decode_value(decoder, length)?
+    fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> der::Result<DataContent<'a>> {
+        Ok(OctetString::decode_value(decoder, header)?
             .as_bytes()
             .into())
     }

--- a/pkcs7/src/encrypted_data_content.rs
+++ b/pkcs7/src/encrypted_data_content.rs
@@ -2,8 +2,8 @@
 
 use crate::enveloped_data_content::EncryptedContentInfo;
 use der::{
-    Decodable, DecodeValue, Decoder, Encodable, EncodeValue, Encoder, FixedTag, Length, Sequence,
-    Tag,
+    Decodable, DecodeValue, Decoder, Encodable, EncodeValue, Encoder, FixedTag, Header, Length,
+    Sequence, Tag,
 };
 
 /// Syntax version of the `encrypted-data` content type.
@@ -41,8 +41,8 @@ impl TryFrom<u8> for Version {
 }
 
 impl<'a> DecodeValue<'a> for Version {
-    fn decode_value(decoder: &mut Decoder<'a>, length: Length) -> der::Result<Version> {
-        Version::try_from(u8::decode_value(decoder, length)?)
+    fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> der::Result<Version> {
+        Version::try_from(u8::decode_value(decoder, header)?)
     }
 }
 

--- a/sec1/src/parameters.rs
+++ b/sec1/src/parameters.rs
@@ -1,6 +1,6 @@
 use der::{
     asn1::{Any, ObjectIdentifier},
-    DecodeValue, Decoder, EncodeValue, Encoder, FixedTag, Length, Tag,
+    DecodeValue, Decoder, EncodeValue, Encoder, FixedTag, Header, Length, Tag,
 };
 
 /// Elliptic curve parameters as described in
@@ -28,8 +28,8 @@ pub enum EcParameters {
 }
 
 impl DecodeValue<'_> for EcParameters {
-    fn decode_value(decoder: &mut Decoder<'_>, length: Length) -> der::Result<Self> {
-        ObjectIdentifier::decode_value(decoder, length).map(Self::NamedCurve)
+    fn decode_value(decoder: &mut Decoder<'_>, header: Header) -> der::Result<Self> {
+        ObjectIdentifier::decode_value(decoder, header).map(Self::NamedCurve)
     }
 }
 

--- a/x509/src/general_name.rs
+++ b/x509/src/general_name.rs
@@ -3,7 +3,7 @@
 use alloc::string::ToString;
 use alloc::vec::Vec;
 use der::asn1::{Any, ContextSpecific, Ia5String, ObjectIdentifier, OctetString};
-use der::{Decodable, DecodeValue, Decoder, ErrorKind, Length, Sequence, TagMode, TagNumber};
+use der::{Decodable, DecodeValue, Decoder, ErrorKind, Header, Sequence, TagMode, TagNumber};
 use x501::name::Name;
 
 /// OtherName as defined in [RFC 5280 Section 4.2.1.6] in support of the Subject Alternative Name extension.
@@ -25,7 +25,7 @@ pub struct OtherName<'a> {
 }
 
 impl<'a> DecodeValue<'a> for OtherName<'a> {
-    fn decode_value(decoder: &mut Decoder<'a>, _length: Length) -> der::Result<Self> {
+    fn decode_value(decoder: &mut Decoder<'a>, _header: Header) -> der::Result<Self> {
         let type_id = decoder.decode()?;
         let value = decoder.decode()?;
         Ok(Self { type_id, value })

--- a/x509/src/pkix_extensions.rs
+++ b/x509/src/pkix_extensions.rs
@@ -9,9 +9,10 @@ use der::asn1::{
     Any, BitString, ContextSpecific, GeneralizedTime, Ia5String, Null, ObjectIdentifier,
     OctetString, UIntBytes, Utf8String,
 };
+use der::Header;
 use der::{
     Choice, Decodable, DecodeValue, Decoder, Encodable, EncodeValue, Enumerated, ErrorKind,
-    FixedTag, Length, Sequence, Tag, TagMode, TagNumber,
+    FixedTag, Sequence, Tag, TagMode, TagNumber,
 };
 use x501::attr::AttributeTypeAndValue;
 use x501::name::RelativeDistinguishedName;
@@ -823,7 +824,7 @@ const FULL_NAME_TAG: TagNumber = TagNumber::new(0);
 const NAME_RELATIVE_TO_ISSUER_TAG: TagNumber = TagNumber::new(1);
 
 impl<'a> DecodeValue<'a> for DistributionPointName<'a> {
-    fn decode_value(decoder: &mut Decoder<'a>, _length: Length) -> der::Result<Self> {
+    fn decode_value(decoder: &mut Decoder<'a>, _header: Header) -> der::Result<Self> {
         let t = decoder.peek_tag()?;
         let o = t.octet();
         // Context specific support always returns an Option<>, just ignore since OPTIONAL does not apply here

--- a/x509/src/trust_anchor_format.rs
+++ b/x509/src/trust_anchor_format.rs
@@ -3,7 +3,7 @@
 use crate::{Certificate, CertificatePolicies, Extensions, NameConstraints};
 use der::asn1::{BitString, ContextSpecific, OctetString, Utf8String};
 use der::{
-    DecodeValue, Decoder, Encodable, EncodeValue, ErrorKind, FixedTag, Length, Sequence, Tag,
+    DecodeValue, Decoder, Encodable, EncodeValue, ErrorKind, FixedTag, Header, Sequence, Tag,
     TagMode, TagNumber,
 };
 use spki::SubjectPublicKeyInfo;
@@ -48,7 +48,7 @@ pub struct TrustAnchorInfo<'a> {
 // impl<'a> ::der::Decodable<'a> for TrustAnchorInfo<'a> {
 //     fn decode(decoder: &mut ::der::Decoder<'a>) -> ::der::Result<Self> {
 impl<'a> DecodeValue<'a> for TrustAnchorInfo<'a> {
-    fn decode_value(decoder: &mut Decoder<'a>, _length: Length) -> der::Result<Self> {
+    fn decode_value(decoder: &mut Decoder<'a>, _header: Header) -> der::Result<Self> {
         let version = match decoder.decode()? {
             Some(v) => Some(v),
             _ => Some(1),
@@ -196,7 +196,7 @@ pub enum TrustAnchorChoice<'a> {
 const TAC_TA_INFO_TAG: TagNumber = TagNumber::new(2);
 
 impl<'a> DecodeValue<'a> for TrustAnchorChoice<'a> {
-    fn decode_value(decoder: &mut Decoder<'a>, _length: Length) -> der::Result<Self> {
+    fn decode_value(decoder: &mut Decoder<'a>, _header: Header) -> der::Result<Self> {
         let t = decoder.peek_tag()?;
         let o = t.octet();
         // Context specific support always returns an Option<>, just ignore since OPTIONAL does not apply here

--- a/x509/tests/trust_anchor_format.rs
+++ b/x509/tests/trust_anchor_format.rs
@@ -13,7 +13,7 @@ fn decode_ta1() {
 
     let mut decoder = Decoder::new(der_encoded_tac).unwrap();
     let header = decoder.peek_header().unwrap();
-    let tac = TrustAnchorChoice::decode_value(&mut decoder, header.length).unwrap();
+    let tac = TrustAnchorChoice::decode_value(&mut decoder, header).unwrap();
     let reencoded_tac = tac.to_vec().unwrap();
     println!("Original : {:02X?}", der_encoded_cert);
     println!("Reencoded: {:02X?}", reencoded_tac);
@@ -129,7 +129,7 @@ fn decode_ta2() {
 
     let mut decoder = Decoder::new(der_encoded_tac).unwrap();
     let header = decoder.peek_header().unwrap();
-    let tac = TrustAnchorChoice::decode_value(&mut decoder, header.length).unwrap();
+    let tac = TrustAnchorChoice::decode_value(&mut decoder, header).unwrap();
     let reencoded_tac = tac.to_vec().unwrap();
     println!("Original : {:02X?}", der_encoded_cert);
     println!("Reencoded: {:02X?}", reencoded_tac);
@@ -233,7 +233,7 @@ fn decode_ta3() {
 
     let mut decoder = Decoder::new(der_encoded_tac).unwrap();
     let header = decoder.peek_header().unwrap();
-    let tac = TrustAnchorChoice::decode_value(&mut decoder, header.length).unwrap();
+    let tac = TrustAnchorChoice::decode_value(&mut decoder, header).unwrap();
     let reencoded_tac = tac.to_vec().unwrap();
     println!("Original : {:02X?}", der_encoded_cert);
     println!("Reencoded: {:02X?}", reencoded_tac);
@@ -352,7 +352,7 @@ fn decode_ta4() {
 
     let mut decoder = Decoder::new(der_encoded_tac).unwrap();
     let header = decoder.peek_header().unwrap();
-    let tac = TrustAnchorChoice::decode_value(&mut decoder, header.length).unwrap();
+    let tac = TrustAnchorChoice::decode_value(&mut decoder, header).unwrap();
     let reencoded_tac = tac.to_vec().unwrap();
     println!("Original : {:02X?}", der_encoded_cert);
     println!("Reencoded: {:02X?}", reencoded_tac);


### PR DESCRIPTION
This makes it possible to implement `DecodeValue` for tagless types such
as `CHOICE` and `ANY`.

Signed-off-by: Nathaniel McCallum <nathaniel@profian.com>