### PR TITLE
Derive `EncodeValue` for `Choice`

### DIFF
--- a/der/derive/src/choice.rs
+++ b/der/derive/src/choice.rs
@@ -76,14 +76,14 @@ impl DeriveChoice {
         let mut can_decode_body = Vec::new();
         let mut decode_body = Vec::new();
         let mut encode_body = Vec::new();
-        let mut encoded_len_body = Vec::new();
+        let mut value_len_body = Vec::new();
         let mut tagged_body = Vec::new();
 
         for variant in &self.variants {
             can_decode_body.push(variant.tag.to_tokens());
             decode_body.push(variant.to_decode_tokens());
-            encode_body.push(variant.to_encode_tokens());
-            encoded_len_body.push(variant.to_encoded_len_tokens());
+            encode_body.push(variant.to_encode_value_tokens());
+            value_len_body.push(variant.to_value_len_tokens());
             tagged_body.push(variant.to_tagged_tokens());
         }
 
@@ -107,16 +107,16 @@ impl DeriveChoice {
                 }
             }
 
-            impl<#lt_params> ::der::Encodable for #ident<#lt_params> {
-                fn encode(&self, encoder: &mut ::der::Encoder<'_>) -> ::der::Result<()> {
+            impl<#lt_params> ::der::EncodeValue for #ident<#lt_params> {
+                fn encode_value(&self, encoder: &mut ::der::Encoder<'_>) -> ::der::Result<()> {
                     match self {
                         #(#encode_body)*
                     }
                 }
 
-                fn encoded_len(&self) -> ::der::Result<::der::Length> {
+                fn value_len(&self) -> ::der::Result<::der::Length> {
                     match self {
-                        #(#encoded_len_body)*
+                        #(#value_len_body)*
                     }
                 }
             }

--- a/der/derive/src/choice/variant.rs
+++ b/der/derive/src/choice/variant.rs
@@ -52,21 +52,21 @@ impl ChoiceVariant {
         }
     }
 
-    /// Derive a match arm for the impl body for `der::Encodable::encode`.
-    pub(super) fn to_encode_tokens(&self) -> TokenStream {
+    /// Derive a match arm for the impl body for `der::EncodeValue::encode_value`.
+    pub(super) fn to_encode_value_tokens(&self) -> TokenStream {
         let ident = &self.ident;
         let binding = quote!(variant);
-        let encoder = self.attrs.encoder(&binding);
+        let encoder = self.attrs.value_encode(&binding);
         quote! {
             Self::#ident(#binding) => #encoder,
         }
     }
 
-    /// Derive a match arm for the impl body for `der::Encodable::encode`.
-    pub(super) fn to_encoded_len_tokens(&self) -> TokenStream {
+    /// Derive a match arm for the impl body for `der::EncodeValue::value_len`.
+    pub(super) fn to_value_len_tokens(&self) -> TokenStream {
         let ident = &self.ident;
         quote! {
-            Self::#ident(variant) => variant.encoded_len(),
+            Self::#ident(variant) => variant.value_len(),
         }
     }
 
@@ -110,17 +110,17 @@ mod tests {
         );
 
         assert_eq!(
-            variant.to_encode_tokens().to_string(),
+            variant.to_encode_value_tokens().to_string(),
             quote! {
-                Self::ExampleVariant(variant) => encoder.encode(variant)?,
+                Self::ExampleVariant(variant) => encoder.encode_value(variant)?,
             }
             .to_string()
         );
 
         assert_eq!(
-            variant.to_encoded_len_tokens().to_string(),
+            variant.to_value_len_tokens().to_string(),
             quote! {
-                Self::ExampleVariant(variant) => variant.encoded_len(),
+                Self::ExampleVariant(variant) => variant.value_len(),
             }
             .to_string()
         );
@@ -159,17 +159,17 @@ mod tests {
         );
 
         assert_eq!(
-            variant.to_encode_tokens().to_string(),
+            variant.to_encode_value_tokens().to_string(),
             quote! {
-                Self::ImplicitVariant(variant) => encoder.encode(variant)?,
+                Self::ImplicitVariant(variant) => encoder.encode_value(variant)?,
             }
             .to_string()
         );
 
         assert_eq!(
-            variant.to_encoded_len_tokens().to_string(),
+            variant.to_value_len_tokens().to_string(),
             quote! {
-                Self::ImplicitVariant(variant) => variant.encoded_len(),
+                Self::ImplicitVariant(variant) => variant.value_len(),
             }
             .to_string()
         );


### PR DESCRIPTION
This enables `Choice` values to be used as a field in a `Sequence`.

Signed-off-by: Nathaniel McCallum <nathaniel@profian.com>