### PR TITLE
der: replace/remove panicking `SetOfVec` APIs

### DIFF
--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -326,6 +326,7 @@
 //! [`Utf8String`]: asn1::Utf8String
 
 #[cfg(feature = "alloc")]
+#[cfg_attr(test, macro_use)]
 extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;


### PR DESCRIPTION
Removes the panicking `From` and `FromIterator` impls on `SetOfVec`, replacing it with a `TryFrom` impl that can gracefully handle sorting errors when using `DerOrd`.

Also adds a test for the sorting implementation.