### PR TITLE
Add `#[asn1(constructed = "true")]`

### DIFF
--- a/der/derive/src/attributes.rs
+++ b/der/derive/src/attributes.rs
@@ -179,19 +179,16 @@ impl FieldAttrs {
 
     /// Get the expected [`Tag`] for this field.
     pub fn tag(&self) -> Option<Tag> {
-        match self.tag_mode {
-            TagMode::Explicit => self.asn1_type.map(Tag::Universal),
-            TagMode::Implicit => self
-                .context_specific
-                .map(|tag_number| {
-                    Some(Tag::ContextSpecific {
-                        constructed: self.constructed,
-                        number: tag_number,
-                    })
-                })
-                .unwrap_or_else(|| {
-                    abort_call_site!("implicit tagging requires an associated `tag_number`")
-                }),
+        match self.context_specific {
+            Some(tag_number) => Some(Tag::ContextSpecific {
+                constructed: self.constructed,
+                number: tag_number,
+            }),
+
+            None => match self.tag_mode {
+                TagMode::Explicit => self.asn1_type.map(Tag::Universal),
+                TagMode::Implicit => abort_call_site!("implicit tagging requires a `tag_number`"),
+            },
         }
     }
 

--- a/der/derive/src/lib.rs
+++ b/der/derive/src/lib.rs
@@ -93,6 +93,11 @@
 //! - `UTCTime`: performs an intermediate conversion to [`der::asn1::UtcTime`]
 //! - `UTF8String`: performs an intermediate conversion to [`der::asn1::Utf8String`]
 //!
+//! ### `#[asn1(constructed = "...")]` attribute: support for constructed inner types
+//!
+//! This attribute can be used to specify that an "inner" type is constructed. It is most
+//! commonly used when a `CHOICE` has a constructed inner type.
+//!
 //! Note: please open a GitHub Issue if you would like to request support
 //! for additional ASN.1 types.
 //!

--- a/der/derive/src/sequence/field.rs
+++ b/der/derive/src/sequence/field.rs
@@ -280,6 +280,7 @@ mod tests {
             extensible: false,
             optional: false,
             tag_mode: TagMode::Explicit,
+            constructed: false,
         };
 
         let field_type = Ident::new("String", span);
@@ -319,6 +320,7 @@ mod tests {
             extensible: false,
             optional: false,
             tag_mode: TagMode::Implicit,
+            constructed: false,
         };
 
         let field_type = Ident::new("String", span);


### PR DESCRIPTION
This allows for deriving `Choice` over constructed types.

Signed-off-by: Nathaniel McCallum <nathaniel@profian.com>