### PR TITLE
base64ct: impl `std::io::Read` for `Decoder`

### DIFF
--- a/base64ct/src/encoder.rs
+++ b/base64ct/src/encoder.rs
@@ -7,6 +7,9 @@ use crate::{
 };
 use core::{cmp, marker::PhantomData, str};
 
+#[cfg(docsrs)]
+use crate::{Base64, Base64Unpadded};
+
 /// Stateful Base64 encoder with support for buffered, incremental encoding.
 ///
 /// The `E` type parameter can be any type which impls [`Encoding`] such as

--- a/base64ct/src/errors.rs
+++ b/base64ct/src/errors.rs
@@ -73,4 +73,14 @@ impl From<core::str::Utf8Error> for Error {
 }
 
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+impl From<Error> for std::io::Error {
+    fn from(err: Error) -> std::io::Error {
+        // TODO(tarcieri): better customize `ErrorKind`?
+        std::io::Error::new(std::io::ErrorKind::InvalidData, err)
+    }
+}
+
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {}


### PR DESCRIPTION
Conditionally impls the `Read` trait when the `std` feature is enabled.