### PR TITLE
base64ct: add bounds for `Encoding`/`Variant` ZSTs

### DIFF
--- a/base64ct/src/encoding.rs
+++ b/base64ct/src/encoding.rs
@@ -4,7 +4,7 @@ use crate::{
     errors::{Error, InvalidEncodingError, InvalidLengthError},
     variant::Variant,
 };
-use core::str;
+use core::{fmt::Debug, str};
 
 #[cfg(feature = "alloc")]
 use alloc::{string::String, vec::Vec};
@@ -16,7 +16,7 @@ const PAD: u8 = b'=';
 ///
 /// This trait must be imported to make use of any Base64 variant defined
 /// in this crate.
-pub trait Encoding {
+pub trait Encoding: 'static + Copy + Clone + Debug + Send + Sized + Sync {
     /// Decode a Base64 string into the provided destination buffer.
     fn decode(src: impl AsRef<[u8]>, dst: &mut [u8]) -> Result<&[u8], Error>;
 

--- a/base64ct/src/variant.rs
+++ b/base64ct/src/variant.rs
@@ -1,6 +1,6 @@
 //! Base64 variants
 
-use core::ops::Range;
+use core::{fmt::Debug, ops::Range};
 
 pub mod bcrypt;
 pub mod crypt;
@@ -8,7 +8,7 @@ pub mod standard;
 pub mod url;
 
 /// Core encoder/decoder functions for a particular Base64 variant
-pub trait Variant {
+pub trait Variant: 'static + Copy + Clone + Debug + Send + Sized + Sync {
     /// Unpadded equivalent of this variant.
     ///
     /// For variants that are unpadded to begin with, this should be `Self`.

--- a/base64ct/src/variant/bcrypt.rs
+++ b/base64ct/src/variant/bcrypt.rs
@@ -8,6 +8,7 @@ use super::{Decode, Encode, Variant};
 /// ./         [A-Z]      [a-z]     [0-9]
 /// 0x2e-0x2f, 0x41-0x5a, 0x61-0x7a, 0x30-0x39
 /// ```
+#[derive(Copy, Clone, Debug)]
 pub struct Base64Bcrypt;
 
 impl Variant for Base64Bcrypt {

--- a/base64ct/src/variant/crypt.rs
+++ b/base64ct/src/variant/crypt.rs
@@ -8,6 +8,7 @@ use super::{Decode, Encode, Variant};
 /// [.-9]      [A-Z]      [a-z]
 /// 0x2e-0x39, 0x41-0x5a, 0x61-0x7a
 /// ```
+#[derive(Copy, Clone, Debug)]
 pub struct Base64Crypt;
 
 impl Variant for Base64Crypt {

--- a/base64ct/src/variant/standard.rs
+++ b/base64ct/src/variant/standard.rs
@@ -8,6 +8,7 @@ use super::{Decode, Encode, Variant};
 /// [A-Z]      [a-z]      [0-9]      +     /
 /// 0x41-0x5a, 0x61-0x7a, 0x30-0x39, 0x2b, 0x2f
 /// ```
+#[derive(Copy, Clone, Debug)]
 pub struct Base64;
 
 impl Variant for Base64 {
@@ -24,6 +25,7 @@ impl Variant for Base64 {
 /// [A-Z]      [a-z]      [0-9]      +     /
 /// 0x41-0x5a, 0x61-0x7a, 0x30-0x39, 0x2b, 0x2f
 /// ```
+#[derive(Copy, Clone, Debug)]
 pub struct Base64Unpadded;
 
 impl Variant for Base64Unpadded {

--- a/base64ct/src/variant/url.rs
+++ b/base64ct/src/variant/url.rs
@@ -8,6 +8,7 @@ use super::{Decode, Encode, Variant};
 /// [A-Z]      [a-z]      [0-9]      -     _
 /// 0x41-0x5a, 0x61-0x7a, 0x30-0x39, 0x2d, 0x5f
 /// ```
+#[derive(Copy, Clone, Debug)]
 pub struct Base64Url;
 
 impl Variant for Base64Url {
@@ -24,6 +25,7 @@ impl Variant for Base64Url {
 /// [A-Z]      [a-z]      [0-9]      -     _
 /// 0x41-0x5a, 0x61-0x7a, 0x30-0x39, 0x2d, 0x5f
 /// ```
+#[derive(Copy, Clone, Debug)]
 pub struct Base64UrlUnpadded;
 
 impl Variant for Base64UrlUnpadded {


### PR DESCRIPTION
Deriving traits like `Copy`, `Clone`, and `Debug` on types which include an encoding as a generic parameter is presently problematic because there are no trait bounds specified.

These traits, `Encoding` and the sealed `Variant` which receives a blanket impl of the former, are not intended to be implemented by types outside of this crate. While adding bounds is technically a breaking change, it would be highly unexpected for this to have any real-world impact as external crates should only be consuming these traits and using them with the encoding ZSTs defined in this crate.