### PR TITLE
der: use type's tag by default on derive(Choice)

### DIFF
--- a/der/derive/src/attributes.rs
+++ b/der/derive/src/attributes.rs
@@ -277,7 +277,7 @@ impl FieldAttrs {
                     let encoder_obj = ty.encoder(binding);
                     quote!(#encoder_obj.encode_value(encoder))
                 })
-                .unwrap_or_else(|| quote!(encoder.encode_value(#binding)?)),
+                .unwrap_or_else(|| quote!(#binding.encode_value(encoder))),
         }
     }
 }


### PR DESCRIPTION
By default, presume that a choice enum's type implements FixedTag. For
many cases, this means that no `#[asn1(...)]` is required at all. In
particular, this means that deriving `Choice` for `SEQUENCE` types
without a context-specific tag is now possible.   

Signed-off-by: Nathaniel McCallum <nathaniel@profian.com>