### PR TITLE
[WIP] der: generic `Document` type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,6 +303,7 @@ dependencies = [
  "pem-rfc7468",
  "proptest",
  "time",
+ "zeroize",
 ]
 
 [[package]]

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -21,6 +21,7 @@ der_derive = { version = "=0.6.0-pre.1", optional = true, path = "derive" }
 flagset = { version = "0.4.3", optional = true }
 pem-rfc7468 = { version = "=0.4.0-pre.0", optional = true, path = "../pem-rfc7468" }
 time = { version = "0.3", optional = true, default-features = false }
+zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -367,7 +367,7 @@ pub use crate::{
 };
 
 #[cfg(feature = "alloc")]
-pub use document::{Document, Sensitivity};
+pub use document::Document;
 
 #[cfg(feature = "bigint")]
 #[cfg_attr(docsrs, doc(cfg(feature = "bigint")))]

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -367,7 +367,7 @@ pub use crate::{
 };
 
 #[cfg(feature = "alloc")]
-pub use document::Document;
+pub use document::{Document, Sensitivity};
 
 #[cfg(feature = "bigint")]
 #[cfg_attr(docsrs, doc(cfg(feature = "bigint")))]


### PR DESCRIPTION
Changes `Document` from a trait into a generic type.

The previous approach necessitated a lot of repetitive boilerplate for each "document" type. Using a generic type eliminates the boilerplate.

The definition was somewhat tricky due to the lifetime on `Decodable<'a>`. For more context, see #421.