### PR TITLE
docs: fixed internal links

### DIFF
--- a/base64ct/src/decoder.rs
+++ b/base64ct/src/decoder.rs
@@ -26,7 +26,7 @@ const CHAR_LF: u8 = 0x0a;
 /// Stateful Base64 decoder with support for buffered, incremental decoding.
 ///
 /// The `E` type parameter can be any type which impls [`Encoding`] such as
-/// [`Base64`] or [`Base64Unpadded`].
+/// [Base64][`crate::variant::standard::Base64`] or [Base64Unpadded][`crate::variant::standard::Base64Unpadded`].
 ///
 /// Internally it uses a sealed `Variant` trait which is an implementation
 /// detail of this crate, and leverages a [blanket impl] of [`Encoding`].

--- a/base64ct/src/encoder.rs
+++ b/base64ct/src/encoder.rs
@@ -13,7 +13,7 @@ use crate::{Base64, Base64Unpadded};
 /// Stateful Base64 encoder with support for buffered, incremental encoding.
 ///
 /// The `E` type parameter can be any type which impls [`Encoding`] such as
-/// [`Base64`] or [`Base64Unpadded`].
+/// [Base64][`crate::variant::standard::Base64`] or [Base64Unpadded][`crate::variant::standard::Base64Unpadded`].
 ///
 /// Internally it uses a sealed `Variant` trait which is an implementation
 /// detail of this crate, and leverages a [blanket impl] of [`Encoding`].

--- a/pem-rfc7468/src/decoder.rs
+++ b/pem-rfc7468/src/decoder.rs
@@ -133,7 +133,7 @@ impl<'i> Decoder<'i> {
         self.base64.is_finished()
     }
 
-    /// Convert into the inner [`base64::Decoder`].
+    /// Convert into the inner [Base64Decoder][`crate::Base64Decoder`].
     pub fn into_base64_decoder(self) -> Base64Decoder<'i> {
         self.base64
     }

--- a/pkcs1/src/traits.rs
+++ b/pkcs1/src/traits.rs
@@ -20,7 +20,7 @@ use der::Document;
 #[cfg(feature = "pem")]
 use zeroize::Zeroizing;
 
-/// Parse an [`RsaPrivateKey`] from a PKCS#1-encoded document.
+/// Parse an [RsaPrivateKey][`crate::private_key::RsaPrivateKey`] from a PKCS#1-encoded document.
 pub trait DecodeRsaPrivateKey: Sized {
     /// Deserialize PKCS#1 private key from ASN.1 DER-encoded data
     /// (binary format).
@@ -58,13 +58,13 @@ pub trait DecodeRsaPrivateKey: Sized {
     }
 }
 
-/// Parse a [`RsaPublicKey`] from a PKCS#1-encoded document.
+/// Parse a [RsaPublicKey][`crate::public_key::RsaPublicKey`] from a PKCS#1-encoded document.
 pub trait DecodeRsaPublicKey: Sized {
-    /// Deserialize object from ASN.1 DER-encoded [`RsaPublicKey`]
+    /// Deserialize object from ASN.1 DER-encoded [RsaPublicKey][`crate::public_key::RsaPublicKey`]
     /// (binary format).
     fn from_pkcs1_der(bytes: &[u8]) -> Result<Self>;
 
-    /// Deserialize PEM-encoded [`RsaPublicKey`].
+    /// Deserialize PEM-encoded [RsaPublicKey][`crate::public_key::RsaPublicKey`].
     ///
     /// Keys in this format begin with the following:
     ///
@@ -77,7 +77,7 @@ pub trait DecodeRsaPublicKey: Sized {
         RsaPublicKeyDocument::from_pkcs1_pem(s).and_then(|doc| Self::from_pkcs1_der(doc.as_der()))
     }
 
-    /// Load [`RsaPublicKey`] from an ASN.1 DER-encoded file on the local
+    /// Load [RsaPublicKey][`crate::public_key::RsaPublicKey`] from an ASN.1 DER-encoded file on the local
     /// filesystem (binary format).
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
@@ -86,7 +86,7 @@ pub trait DecodeRsaPublicKey: Sized {
             .and_then(|doc| Self::from_pkcs1_der(doc.as_der()))
     }
 
-    /// Load [`RsaPublicKey`] from a PEM-encoded file on the local filesystem.
+    /// Load [RsaPublicKey][`crate::public_key::RsaPublicKey`] from a PEM-encoded file on the local filesystem.
     #[cfg(all(feature = "pem", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
@@ -96,7 +96,7 @@ pub trait DecodeRsaPublicKey: Sized {
     }
 }
 
-/// Serialize a [`RsaPrivateKey`] to a PKCS#1 encoded document.
+/// Serialize a [RsaPrivateKey][`crate::private_key::RsaPrivateKey`] to a PKCS#1 encoded document.
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub trait EncodeRsaPrivateKey {
@@ -125,7 +125,7 @@ pub trait EncodeRsaPrivateKey {
     }
 }
 
-/// Serialize a [`RsaPublicKey`] to a PKCS#1-encoded document.
+/// Serialize a [RsaPublicKey][`crate::public_key::RsaPublicKey`] to a PKCS#1-encoded document.
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub trait EncodeRsaPublicKey {


### PR DESCRIPTION
This pr fixes some dead internal links in the base64ct, pem_rfc7468 & pkcs1 crate.

x509 has deadlinks too but fixing them seems to be irrelevant, until #414 is merged.