### PR TITLE
Fix and test min versions build

### DIFF
--- a/.github/workflows/base16ct.yml
+++ b/.github/workflows/base16ct.yml
@@ -35,8 +35,13 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - run: cargo install cargo-hack
-      - run: cargo hack build --release --target ${{ matrix.target }} --feature-powerset --exclude-features std
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features std
+
+  minimal-versions:
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest
@@ -52,8 +57,8 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-      - run: cargo install cargo-hack
-      - run: cargo hack test --release --feature-powerset
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo hack test --feature-powerset
 
   bench:
     runs-on: ubuntu-latest

--- a/.github/workflows/base64ct.yml
+++ b/.github/workflows/base64ct.yml
@@ -35,8 +35,13 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - run: cargo install cargo-hack
-      - run: cargo hack build --release --target ${{ matrix.target }} --feature-powerset --exclude-features std
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features std
+
+  minimal-versions:
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest
@@ -52,8 +57,8 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-      - run: cargo install cargo-hack
-      - run: cargo hack test --release --feature-powerset
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo hack test --feature-powerset
 
   bench:
     runs-on: ubuntu-latest

--- a/.github/workflows/const-oid.yml
+++ b/.github/workflows/const-oid.yml
@@ -35,8 +35,13 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - run: cargo install cargo-hack
-      - run: cargo hack build --release --target ${{ matrix.target }} --feature-powerset --exclude-features std
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features std
+
+  minimal-versions:
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest
@@ -52,5 +57,5 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-      - run: cargo install cargo-hack
-      - run: cargo hack test --release --feature-powerset
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo hack test --feature-powerset

--- a/.github/workflows/der.yml
+++ b/.github/workflows/der.yml
@@ -36,8 +36,13 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - run: cargo install cargo-hack
-      - run: cargo hack build --release --target ${{ matrix.target }} --feature-powerset --exclude-features std
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features std
+
+  minimal-versions:
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     strategy:
@@ -61,13 +66,14 @@ jobs:
             platform: ubuntu-latest
             rust: stable
 
+          # temporary disable, since cargo-hack installation does not work yet
           # 64-bit Windows
-          - target: x86_64-pc-windows-msvc
-            platform: windows-latest
-            rust: 1.57.0 # MSRV
-          - target: x86_64-pc-windows-msvc
-            platform: windows-latest
-            rust: stable
+          #- target: x86_64-pc-windows-msvc
+          #  platform: windows-latest
+          #  rust: 1.57.0 # MSRV
+          #- target: x86_64-pc-windows-msvc
+          #  platform: windows-latest
+          #  rust: stable
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v1
@@ -78,8 +84,8 @@ jobs:
           profile: minimal
           override: true
       - run: ${{ matrix.deps }}
-      - run: cargo install cargo-hack
-      - run: cargo hack test --release --feature-powerset
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo hack test --feature-powerset
 
   derive:
     runs-on: ubuntu-latest
@@ -95,6 +101,6 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
           profile: minimal
-      - run: cargo install cargo-hack
-      - run: cargo hack test --release --feature-powerset
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo hack test --feature-powerset
         working-directory: der/derive

--- a/.github/workflows/pem-rfc7468.yml
+++ b/.github/workflows/pem-rfc7468.yml
@@ -36,8 +36,13 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - run: cargo install cargo-hack
-      - run: cargo hack build --release --target ${{ matrix.target }} --feature-powerset --exclude-features std
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features std
+
+  minimal-versions:
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest
@@ -53,5 +58,5 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-      - run: cargo install cargo-hack
-      - run: cargo hack test --release --feature-powerset
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo hack test --feature-powerset

--- a/.github/workflows/pkcs1.yml
+++ b/.github/workflows/pkcs1.yml
@@ -39,8 +39,13 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - run: cargo install cargo-hack
-      - run: cargo hack build --release --target ${{ matrix.target }} --feature-powerset --exclude-features std
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features std
+
+  minimal-versions:
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest
@@ -56,5 +61,5 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-      - run: cargo install cargo-hack
-      - run: cargo hack test --release --feature-powerset
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo hack test --feature-powerset

--- a/.github/workflows/pkcs10.yml
+++ b/.github/workflows/pkcs10.yml
@@ -42,8 +42,13 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - run: cargo build --release --target ${{ matrix.target }} --no-default-features
-      - run: cargo build --release --target ${{ matrix.target }} --no-default-features --features pem
+      - run: cargo build --target ${{ matrix.target }} --no-default-features
+      - run: cargo build --target ${{ matrix.target }} --no-default-features --features pem
+
+  minimal-versions:
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest
@@ -59,7 +64,5 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-      - run: cargo test --release --no-default-features
-      - run: cargo test --release
-      - run: cargo test --release --features pem
-      - run: cargo test --release --all-features
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo hack test --feature-powerset

--- a/.github/workflows/pkcs5.yml
+++ b/.github/workflows/pkcs5.yml
@@ -38,8 +38,13 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - run: cargo install cargo-hack
-      - run: cargo hack build --release --target ${{ matrix.target }} --feature-powerset --exclude-features std
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features std
+
+  minimal-versions:
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest
@@ -55,5 +60,5 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-      - run: cargo install cargo-hack
-      - run: cargo hack test --release --feature-powerset
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo hack test --feature-powerset

--- a/.github/workflows/pkcs7.yml
+++ b/.github/workflows/pkcs7.yml
@@ -37,8 +37,13 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - run: cargo install cargo-hack
-      - run: cargo hack build --release --target ${{ matrix.target }} --feature-powerset
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset
+
+  minimal-versions:
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest
@@ -54,5 +59,5 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-      - run: cargo install cargo-hack
-      - run: cargo hack test --release --feature-powerset
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo hack test --feature-powerset

--- a/.github/workflows/pkcs8.yml
+++ b/.github/workflows/pkcs8.yml
@@ -40,8 +40,13 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - run: cargo install cargo-hack
-      - run: cargo hack build --release --target ${{ matrix.target }} --feature-powerset --exclude-features std,rand
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features std,rand
+
+  minimal-versions:
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest
@@ -57,5 +62,5 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-      - run: cargo install cargo-hack
-      - run: cargo hack test --release --feature-powerset
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo hack test --feature-powerset

--- a/.github/workflows/sec1.yml
+++ b/.github/workflows/sec1.yml
@@ -39,8 +39,13 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - run: cargo install cargo-hack
-      - run: cargo hack build --release --target ${{ matrix.target }} --feature-powerset --exclude-features std
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features std
+
+  minimal-versions:
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest
@@ -56,5 +61,5 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-      - run: cargo install cargo-hack
-      - run: cargo hack test --release --feature-powerset
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo hack test --feature-powerset

--- a/.github/workflows/spki.yml
+++ b/.github/workflows/spki.yml
@@ -38,8 +38,13 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - run: cargo install cargo-hack
-      - run: cargo hack build --release --target ${{ matrix.target }} --feature-powerset --exclude-features std
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features std
+
+  minimal-versions:
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest
@@ -55,5 +60,5 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-      - run: cargo install cargo-hack
-      - run: cargo hack test --release --feature-powerset
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo hack test --feature-powerset

--- a/.github/workflows/ssh-key.yml
+++ b/.github/workflows/ssh-key.yml
@@ -37,8 +37,13 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - run: cargo install cargo-hack
-      - run: cargo hack build --release --target ${{ matrix.target }} --feature-powerset --exclude-features std
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features std
+
+  minimal-versions:
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest
@@ -54,5 +59,5 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-      - run: cargo install cargo-hack
-      - run: cargo hack test --release --feature-powerset
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo hack test --feature-powerset

--- a/.github/workflows/tai64.yml
+++ b/.github/workflows/tai64.yml
@@ -35,8 +35,13 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - run: cargo install cargo-hack
-      - run: cargo hack build --release --target ${{ matrix.target }} --feature-powerset --exclude-features std,default
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features std,default
+
+  minimal-versions:
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest
@@ -52,5 +57,5 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-      - run: cargo install cargo-hack
-      - run: cargo hack test --release --feature-powerset
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo hack test --feature-powerset

--- a/.github/workflows/tls_codec.yml
+++ b/.github/workflows/tls_codec.yml
@@ -36,8 +36,13 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - run: cargo install cargo-hack
-      - run: cargo hack build --release --target ${{ matrix.target }} --feature-powerset --exclude-features std,default,derive,serde_serialize
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features std,default,derive,serde_serialize
+
+  minimal-versions:
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest
@@ -66,5 +71,5 @@ jobs:
           profile: minimal
           override: true
       - run: ${{ matrix.deps }}
-      - run: cargo install cargo-hack
-      - run: cargo hack test --release --feature-powerset
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo hack test --feature-powerset

--- a/.github/workflows/x501.yml
+++ b/.github/workflows/x501.yml
@@ -37,8 +37,13 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - run: cargo install cargo-hack
-      - run: cargo hack build --release --target ${{ matrix.target }} --feature-powerset --exclude-features std
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features std
+
+  minimal-versions:
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest
@@ -54,5 +59,5 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-      - run: cargo install cargo-hack
-      - run: cargo hack test --release --feature-powerset
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo hack test --feature-powerset

--- a/.github/workflows/x509.yml
+++ b/.github/workflows/x509.yml
@@ -39,8 +39,13 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - run: cargo install cargo-hack
-      - run: cargo hack build --release --target ${{ matrix.target }} --feature-powerset --exclude-features std
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features std
+
+  minimal-versions:
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest
@@ -56,5 +61,5 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-      - run: cargo install cargo-hack
-      - run: cargo hack test --release --feature-powerset
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo hack test --feature-powerset

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,12 +4,12 @@ version = 3
 
 [[package]]
 name = "aes"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6c3373fb58bb23c6ed0f191f915f0e9459c6929fc430c0d74b8237c521953a"
+checksum = "bfe0133578c0986e1fe3dfcd4af1cc5b2dd6c3dbf534d69916ce16a2701d40ba"
 dependencies = [
  "cfg-if",
- "cipher 0.4.0",
+ "cipher 0.4.2",
  "cpufeatures",
 ]
 
@@ -122,11 +122,11 @@ dependencies = [
 
 [[package]]
 name = "cbc"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531051805c8ee7ea043a698cf0682318e76d8189c0445d4da2b9abb512024b98"
+checksum = "a2c68b1d4a461fc5641967e1b255c976579a87ef000c043850ca1aff89faa128"
 dependencies = [
- "cipher 0.4.0",
+ "cipher 0.4.2",
 ]
 
 [[package]]
@@ -146,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4f3e8c9be82c31c331bc9db0fd70a1068f8a288d980b2414dcaa25ab17ac1e0"
+checksum = "035bd298db1557b73a277e9c599c5a50e0d2e6ee9dcac78f3f951cb2f7d88d8c"
 dependencies = [
  "crypto-common",
  "inout",
@@ -263,11 +263,12 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4600d695eb3f6ce1cd44e6e291adceb2cc3ab12f20a33777ecd0bf6eba34e06"
+checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
 dependencies = [
  "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -317,18 +318,18 @@ dependencies = [
 
 [[package]]
 name = "des"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d961b09f113791a8b11d677b9ccfdf2a8f79c2bd49e8ab8ef9fdfadcae683528"
+checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
 dependencies = [
- "cipher 0.4.0",
+ "cipher 0.4.2",
 ]
 
 [[package]]
 name = "digest"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb780dce4f9a8f5c087362b3a4595936b2019e7c8b30f2c3e9a7e94e6ae9837"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -406,9 +407,9 @@ checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
 name = "hmac"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddca131f3e7f2ce2df364b57949a9d47915cfbd35e46cfee355ccebbf794d6a2"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
 ]
@@ -470,9 +471,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e74d72e0f9b65b5b4ca49a346af3976df0f9c61d550727f349ecd559f251a26c"
+checksum = "06e509672465a0504304aa87f9f176f2b2b716ed8fb105ebe5c02dc6dce96a94"
 
 [[package]]
 name = "log"
@@ -718,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -946,9 +947,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
@@ -957,9 +958,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cc229fb94bcb689ffc39bd4ded842f6ff76885efede7c6d1ffb62582878bea"
+checksum = "c77f4e7f65455545c2153c1253d25056825e77ee2533f0e41deb65a93a34852f"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -968,9 +969,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c3bd8169c58782adad9290a9af5939994036b76187f7b4f0e6de91dbbfc0ec"
+checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,6 @@ members = [
     "x501",
     "x509"
 ]
+
+[profile.dev]
+opt-level = 2

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -20,10 +20,10 @@ const-oid = { version = "0.8", optional = true, path = "../const-oid" }
 der_derive = { version = "=0.6.0-pre.1", optional = true, path = "derive" }
 flagset = { version = "0.4.3", optional = true }
 pem-rfc7468 = { version = "=0.4.0-pre.0", optional = true, path = "../pem-rfc7468" }
-time = { version = "0.3", optional = true, default-features = false }
+time = { version = "0.3.4", optional = true, default-features = false }
 
 [dev-dependencies]
-hex-literal = "0.3"
+hex-literal = "0.3.3"
 proptest = "1"
 
 [features]

--- a/der/derive/Cargo.toml
+++ b/der/derive/Cargo.toml
@@ -19,4 +19,4 @@ proc-macro = true
 proc-macro2 = "1"
 proc-macro-error = "1"
 quote = "1"
-syn = { version = "1", features = ["extra-traits"] }
+syn = { version = "1.0.58", features = ["extra-traits"] }

--- a/der/tests/derive.rs
+++ b/der/tests/derive.rs
@@ -407,26 +407,22 @@ mod sequence {
     #[test]
     fn extension_test() {
         let ext1 = ExtensionExample::from_der(&hex!(
-            "
-            300F        //  0  15: SEQUENCE {
-            0603551D13  //  2   3:   OBJECT IDENTIFIER basicConstraints (2 5 29 19)
-            0101FF      //  7   1:   BOOLEAN TRUE
-            0405        //  10   5:   OCTET STRING, encapsulates {
-            3003        //  12   3:     SEQUENCE {
-            0101FF      //  14   1:       BOOLEAN TRUE
-            "
+            "300F"        //  0  15: SEQUENCE {
+            "0603551D13"  //  2   3:   OBJECT IDENTIFIER basicConstraints (2 5 29 19)
+            "0101FF"      //  7   1:   BOOLEAN TRUE
+            "0405"        //  10   5:   OCTET STRING, encapsulates {
+            "3003"        //  12   3:     SEQUENCE {
+            "0101FF"      //  14   1:       BOOLEAN TRUE
         ))
         .unwrap();
         assert_eq!(ext1.critical, true);
 
         let ext2 = ExtensionExample::from_der(&hex!(
-            "
-            301F                                            //  0  31: SEQUENCE {
-            0603551D23                                      //  2   3:   OBJECT IDENTIFIER authorityKeyIdentifier (2 5 29 35)
-            0418                                            //  7  24:   OCTET STRING, encapsulates {
-            3016                                            //  9  22:     SEQUENCE {
-            8014E47D5FD15C9586082C05AEBE75B665A7D95DA866    // 11  20:       [0] E4 7D 5F D1 5C 95 86 08 2C 05 AE BE 75 B6 65 A7 D9 5D A8 66
-            "
+            "301F"                                            //  0  31: SEQUENCE {
+            "0603551D23"                                      //  2   3:   OBJECT IDENTIFIER authorityKeyIdentifier (2 5 29 35)
+            "0418"                                            //  7  24:   OCTET STRING, encapsulates {
+            "3016"                                            //  9  22:     SEQUENCE {
+            "8014E47D5FD15C9586082C05AEBE75B665A7D95DA866"    // 11  20:       [0] E4 7D 5F D1 5C 95 86 08 2C 05 AE BE 75 B6 65 A7 D9 5D A8 66
         ))
         .unwrap();
         assert_eq!(ext2.critical, false);

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -19,14 +19,14 @@ der = { version = "=0.6.0-pre.1", features = ["oid"], path = "../der" }
 spki = { version = "=0.6.0-pre.0", path = "../spki" }
 
 # optional dependencies
-cbc = { version = "0.1", optional = true }
-aes = { version = "0.8", optional = true, default-features = false }
-des = { version = "0.8", optional = true, default-features = false }
-hmac = { version = "0.12", optional = true, default-features = false }
+cbc = { version = "0.1.1", optional = true }
+aes = { version = "0.8.1", optional = true, default-features = false }
+des = { version = "0.8.1", optional = true, default-features = false }
+hmac = { version = "0.12.1", optional = true, default-features = false }
 pbkdf2 = { version = "0.10", optional = true, default-features = false }
 scrypt = { version = "0.8", optional = true, default-features = false }
-sha1 = { version = "0.10", optional = true, default-features = false }
-sha2 = { version = "0.10", optional = true, default-features = false }
+sha1 = { version = "0.10.1", optional = true, default-features = false }
+sha2 = { version = "0.10.2", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -17,11 +17,11 @@ rust-version = "1.57"
 
 [dependencies]
 der = { version = "=0.6.0-pre.1", features = ["oid"], path = "../der" }
-generic-array = { version = "0.14", default-features = false }
+generic-array = { version = "0.14.4", default-features = false }
 
 # optional dependencies
 pkcs8 = { version = "=0.9.0-pre", optional = true, default-features = false, path = "../pkcs8" }
-serde = { version = "1", optional = true, default-features = false }
+serde = { version = "1.0.16", optional = true, default-features = false }
 subtle = { version = "2", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 

--- a/tls_codec/Cargo.toml
+++ b/tls_codec/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
+zeroize = { version = "1", default-features = false, features = ["alloc"] }
 
 # optional dependencies
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/tls_codec/derive/Cargo.toml
+++ b/tls_codec/derive/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.56"
 proc-macro = true
 
 [dependencies]
-syn = { version = "1.0", features = ["parsing"] }
+syn = { version = "1.0.3", features = ["parsing"] }
 quote = "1.0"
 proc-macro2 = "1.0"
 


### PR DESCRIPTION
All fixed crates except `tls_codec(_derive)` are on the pre versions, so I haven't mentioned the fix in changelogs.

@tarcieri
I will leave for you to decide whether a patch release for `tls_codec` is needed or not.

Closes #439