### PR TITLE
tls codec: variable-length vectors

### DIFF
--- a/tls_codec/Cargo.toml
+++ b/tls_codec/Cargo.toml
@@ -30,6 +30,10 @@ std = []
 name = "tls_vec"
 harness = false
 
+[[bench]]
+name = "quic_vec"
+harness = false
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/tls_codec/benches/quic_vec.rs
+++ b/tls_codec/benches/quic_vec.rs
@@ -1,0 +1,90 @@
+use criterion::{criterion_group, criterion_main};
+use criterion::{BatchSize, Criterion};
+
+fn vector(c: &mut Criterion) {
+    use tls_codec::*;
+    c.bench_function("TLS Serialize VL Vector", |b| {
+        b.iter_batched(
+            || vec![77u8; 65535],
+            |long_vector| {
+                let _serialized_long_vec = long_vector.tls_serialize_detached().unwrap();
+            },
+            BatchSize::SmallInput,
+        )
+    });
+    c.bench_function("TLS Deserialize VL Vector", |b| {
+        b.iter_batched(
+            || {
+                let long_vector = vec![77u8; 65535];
+                long_vector.tls_serialize_detached().unwrap()
+            },
+            |serialized_long_vec| {
+                let _deserialized_long_vec =
+                    Vec::<u8>::tls_deserialize(&mut serialized_long_vec.as_slice()).unwrap();
+            },
+            BatchSize::SmallInput,
+        )
+    });
+}
+
+fn byte_vector(c: &mut Criterion) {
+    use tls_codec::*;
+    c.bench_function("TLS Serialize VL Byte Vector", |b| {
+        b.iter_batched(
+            || VLBytes::new(vec![77u8; 65535]),
+            |long_vector| {
+                let _serialized_long_vec = long_vector.tls_serialize_detached().unwrap();
+            },
+            BatchSize::SmallInput,
+        )
+    });
+    c.bench_function("TLS Deserialize VL Byte Vector", |b| {
+        b.iter_batched(
+            || {
+                let long_vector = vec![77u8; 65535];
+                VLByteSlice(&long_vector).tls_serialize_detached().unwrap()
+            },
+            |serialized_long_vec| {
+                let _deserialized_long_vec =
+                    VLBytes::tls_deserialize(&mut serialized_long_vec.as_slice()).unwrap();
+            },
+            BatchSize::SmallInput,
+        )
+    });
+}
+
+fn byte_slice(c: &mut Criterion) {
+    use tls_codec::*;
+    c.bench_function("TLS Serialize VL Byte Slice", |b| {
+        b.iter_batched(
+            || vec![77u8; 65535],
+            |long_vector| {
+                let _serialized_long_vec =
+                    VLByteSlice(&long_vector).tls_serialize_detached().unwrap();
+            },
+            BatchSize::SmallInput,
+        )
+    });
+}
+
+fn slice(c: &mut Criterion) {
+    use tls_codec::*;
+    c.bench_function("TLS Serialize VL Slice", |b| {
+        b.iter_batched(
+            || vec![77u8; 65535],
+            |long_vector| {
+                let _serialized_long_vec = (&long_vector).tls_serialize_detached().unwrap();
+            },
+            BatchSize::SmallInput,
+        )
+    });
+}
+fn benchmark(c: &mut Criterion) {
+    vector(c);
+    slice(c);
+    byte_vector(c);
+    byte_slice(c);
+}
+
+criterion_group!(benches, benchmark);
+criterion_main!(benches);

--- a/tls_codec/derive/tests/decode.rs
+++ b/tls_codec/derive/tests/decode.rs
@@ -1,4 +1,4 @@
-use tls_codec::{Deserialize, Serialize, TlsSliceU16, TlsVecU16, TlsVecU32, TlsVecU8};
+use tls_codec::{Deserialize, Serialize, TlsSliceU16, TlsVecU16, TlsVecU32, TlsVecU8, VLBytes};
 use tls_codec_derive::{TlsDeserialize, TlsSerialize, TlsSize};
 
 #[derive(TlsDeserialize, Debug, PartialEq, Clone, Copy, TlsSize, TlsSerialize)]
@@ -316,4 +316,32 @@ fn enum_with_custom_serialized_field() {
     let serialized = x.tls_serialize_detached().unwrap();
     let deserialized = EnumWithCustomSerializedField::tls_deserialize(&mut &*serialized).unwrap();
     assert_eq!(deserialized, x);
+}
+
+// Variable length vectors
+#[derive(Debug, PartialEq, TlsDeserialize, TlsSerialize, TlsSize)]
+struct MyContainer {
+    value: Vec<u8>,
+}
+
+#[derive(Debug, PartialEq, TlsDeserialize, TlsSerialize, TlsSize)]
+struct MyByteContainer {
+    value: VLBytes,
+}
+
+#[test]
+fn simple_variable_length_struct() {
+    let val = MyContainer {
+        value: vec![1, 2, 3, 4, 5, 6, 7, 8, 9],
+    };
+    let serialized = val.tls_serialize_detached().unwrap();
+    let deserialized = MyContainer::tls_deserialize(&mut &*serialized).unwrap();
+    assert_eq!(deserialized, val);
+
+    let val = MyByteContainer {
+        value: VLBytes::new(vec![1, 2, 3, 4, 5, 6, 7, 8, 9]),
+    };
+    let serialized = val.tls_serialize_detached().unwrap();
+    let deserialized = MyByteContainer::tls_deserialize(&mut &*serialized).unwrap();
+    assert_eq!(deserialized, val);
 }

--- a/tls_codec/src/lib.rs
+++ b/tls_codec/src/lib.rs
@@ -34,6 +34,7 @@ use {
 
 mod arrays;
 mod primitives;
+mod quic_vec;
 mod tls_vec;
 
 pub use tls_vec::{
@@ -41,6 +42,8 @@ pub use tls_vec::{
     TlsByteSliceU8, TlsByteVecU16, TlsByteVecU32, TlsByteVecU8, TlsSliceU16, TlsSliceU32,
     TlsSliceU8, TlsVecU16, TlsVecU32, TlsVecU8,
 };
+
+pub use quic_vec::{VLByteSlice, VLBytes};
 
 #[cfg(feature = "derive")]
 pub use tls_codec_derive::{TlsDeserialize, TlsSerialize, TlsSize};

--- a/tls_codec/src/lib.rs
+++ b/tls_codec/src/lib.rs
@@ -34,6 +34,7 @@ use {
 
 mod arrays;
 mod primitives;
+#[cfg(feature = "std")]
 mod quic_vec;
 mod tls_vec;
 
@@ -43,6 +44,7 @@ pub use tls_vec::{
     TlsSliceU8, TlsVecU16, TlsVecU32, TlsVecU8,
 };
 
+#[cfg(feature = "std")]
 pub use quic_vec::{VLByteSlice, VLBytes};
 
 #[cfg(feature = "derive")]

--- a/tls_codec/src/primitives.rs
+++ b/tls_codec/src/primitives.rs
@@ -82,6 +82,7 @@ macro_rules! impl_unsigned {
             #[inline]
             fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
                 let written = writer.write(&self.to_be_bytes())?;
+                debug_assert_eq!(written, $bytes);
                 Ok(written)
             }
         }

--- a/tls_codec/src/quic_vec.rs
+++ b/tls_codec/src/quic_vec.rs
@@ -1,0 +1,339 @@
+//! # Variable length vectors
+//!
+//! While the TLS RFC 8446 only specifies vectors with fixed length length fields
+//! the QUIC RFC 9000 defines a variable length integer encoding.
+//!
+//! Note that we require, as the MLS specification does, that vectors have to
+//! use the minimum number of bytes necessary for the encoding.
+//! This ensures that encodings are unique.
+
+use alloc::vec::Vec;
+
+use crate::{Deserialize, Error, Serialize, Size};
+
+const MAX_LEN: u64 = 0x3fff_ffff_ffff_ffff; // <= (1<<62)-1
+
+/// Read the length of a variable-length vector.
+///
+/// This function assumes that the reader is at the start of a variable length
+/// vector and returns an error if there's not a single byte to read.
+///
+/// The length and number of bytes read are returned.
+#[inline]
+fn read_variable_length<R: std::io::Read>(bytes: &mut R) -> Result<(usize, usize), Error> {
+    // The length is encoded in the first two bits of the first byte.
+    let mut len_len_byte = [0u8; 1];
+    if bytes.read(&mut len_len_byte)? == 0 {
+        // Return in case there's nothing to read and this is just an
+        // empty vector.
+        return Ok((0, 0));
+    }
+
+    let mut length: usize = (len_len_byte[0] & 0x3F).into();
+    let len_len = (len_len_byte[0] >> 6).into();
+    debug_assert!(len_len <= 3);
+    if len_len > 3 {
+        return Err(Error::InvalidVectorLength);
+    }
+    for _ in 0..len_len {
+        let mut next = [0u8; 1];
+        bytes.read(&mut next)?;
+        length = (length << 8) + usize::from(next[0]);
+    }
+
+    Ok((length, len_len))
+}
+
+#[inline]
+fn length_encoding_bytes(length: u64) -> usize {
+    debug_assert!(length <= MAX_LEN);
+    if length < 0x40 {
+        1
+    } else if length < 0x3fff {
+        2
+    } else if length < 0x3fff_ffff {
+        4
+    } else {
+        8
+    }
+}
+
+// === (De)Serialize for `Vec<T>` and &[T].
+
+impl<T: Serialize + std::fmt::Debug> Serialize for Vec<T> {
+    #[cfg(feature = "std")]
+    #[inline(always)]
+    fn tls_serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, Error> {
+        self.as_slice().tls_serialize(writer)
+    }
+}
+
+impl<T: Size> Size for Vec<T> {
+    #[cfg(feature = "std")]
+    #[inline(always)]
+    fn tls_serialized_len(&self) -> usize {
+        self.as_slice().tls_serialized_len()
+    }
+}
+
+impl<T: Deserialize> Deserialize for Vec<T> {
+    #[cfg(feature = "std")]
+    #[inline(always)]
+    fn tls_deserialize<R: std::io::Read>(bytes: &mut R) -> Result<Self, Error> {
+        let (length, len_len) = read_variable_length(bytes)?;
+        if length == 0 {
+            // An empty vector.
+            return Ok(Vec::new());
+        }
+
+        let mut result = Vec::new();
+        let mut read = len_len;
+        while (read - len_len) < length as usize {
+            let element = T::tls_deserialize(bytes)?;
+            read += element.tls_serialized_len();
+            result.push(element);
+        }
+        Ok(result)
+    }
+}
+
+#[inline(always)]
+fn write_length<W: std::io::Write>(writer: &mut W, content_length: usize) -> Result<usize, Error> {
+    let len_len = length_encoding_bytes(content_length.try_into()?);
+    debug_assert!(len_len <= 8, "Invalid vector len_len {}", len_len);
+    if len_len > 8 {
+        return Err(Error::InvalidVectorLength);
+    }
+    let mut length_bytes = vec![0u8; len_len];
+    match len_len {
+        1 => length_bytes[0] = 0x00,
+        2 => length_bytes[0] = 0x40,
+        4 => length_bytes[0] = 0xc0,
+        8 => length_bytes[0] = 0x80,
+        _ => {
+            debug_assert!(false, "Invalid vector len_len {}", len_len);
+            return Err(Error::InvalidVectorLength);
+        }
+    }
+    let mut len = content_length;
+    for b in length_bytes.iter_mut().rev() {
+        *b |= (len & 0xFF) as u8;
+        len >>= 8;
+    }
+    writer.write_all(&mut length_bytes)?;
+    Ok(len_len)
+}
+
+impl<T: Serialize + std::fmt::Debug> Serialize for &[T] {
+    #[cfg(feature = "std")]
+    #[inline(always)]
+    fn tls_serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, Error> {
+        // We need to pre-compute the length of the content.
+        // This requires more computations but the other option would be to buffer
+        // the entire content, which can end up requiring a lot of memory.
+        let content_length = self.iter().fold(0, |acc, e| acc + e.tls_serialized_len());
+        let len_len = write_length(writer, content_length)?;
+
+        // Serialize the elements
+        #[cfg(debug_assertions)]
+        let mut written = 0;
+        for e in self.iter() {
+            #[cfg(debug_assertions)]
+            {
+                written += e.tls_serialize(writer)?;
+            }
+            // We don't care about the length here. We pre-computed it.
+            #[cfg(not(debug_assertions))]
+            e.tls_serialize(writer)?;
+        }
+        #[cfg(debug_assertions)]
+        debug_assert_eq!(written, content_length);
+
+        Ok(content_length + len_len)
+    }
+}
+
+impl<T: Size> Size for &[T] {
+    #[cfg(feature = "std")]
+    #[inline(always)]
+    fn tls_serialized_len(&self) -> usize {
+        let content_length = self.iter().fold(0, |acc, e| acc + e.tls_serialized_len());
+        let len_len = length_encoding_bytes(content_length as u64);
+        content_length + len_len
+    }
+}
+
+// === Vec<u8> and &[u8]
+
+/// Variable-length encoded byte vectors.
+/// Use this struct if bytes are encoded.
+/// This is faster than the generic version.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VLBytes {
+    vec: Vec<u8>,
+}
+
+impl VLBytes {
+    /// Generate a new variable-length byte vector.
+    pub fn new(vec: Vec<u8>) -> Self {
+        Self { vec }
+    }
+
+    /// Get a reference to the vlbytes's vec.
+    pub fn as_slice(&self) -> &[u8] {
+        self.vec.as_ref()
+    }
+}
+
+#[inline(always)]
+fn tls_serialize_bytes<W: std::io::Write>(writer: &mut W, bytes: &[u8]) -> Result<usize, Error> {
+    // Get the byte length of the content, make sure it's not too
+    // large and write it out.
+    let content_length = bytes.len();
+
+    debug_assert!(
+        content_length as u64 <= MAX_LEN,
+        "Vector can't be encoded. It's too large. {} >= {}",
+        content_length,
+        MAX_LEN
+    );
+    if content_length as u64 > MAX_LEN {
+        return Err(Error::InvalidVectorLength);
+    }
+
+    let len_len = write_length(writer, content_length)?;
+
+    // Now serialize the elements
+    let mut written = 0;
+    written += writer.write(bytes)?;
+
+    debug_assert_eq!(
+        written, content_length,
+        "{} bytes should have been serialized but {} were written",
+        content_length, written
+    );
+    if written != content_length {
+        return Err(Error::EncodingError(format!(
+            "{} bytes should have been serialized but {} were written",
+            content_length, written
+        )));
+    }
+    Ok(written + len_len)
+}
+
+#[inline(always)]
+fn tls_serialize_bytes_len(bytes: &[u8]) -> usize {
+    let content_length = bytes.len();
+    let len_len = length_encoding_bytes(content_length as u64);
+    content_length + len_len
+}
+
+impl Serialize for VLBytes {
+    #[cfg(feature = "std")]
+    #[inline(always)]
+    fn tls_serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, Error> {
+        tls_serialize_bytes(writer, self.as_slice())
+    }
+}
+
+impl Size for VLBytes {
+    #[cfg(feature = "std")]
+    #[inline(always)]
+    fn tls_serialized_len(&self) -> usize {
+        tls_serialize_bytes_len(self.as_slice())
+    }
+}
+
+impl Deserialize for VLBytes {
+    fn tls_deserialize<R: std::io::Read>(bytes: &mut R) -> Result<Self, Error> {
+        let (length, _) = read_variable_length(bytes)?;
+        if length == 0 {
+            return Ok(Self::new(vec![]));
+        }
+
+        debug_assert!(
+            length <= u16::MAX as usize,
+            "Trying to allocate {} bytes. Only {} allowed.",
+            length,
+            u16::MAX
+        );
+        if length > u16::MAX as usize {
+            return Err(Error::DecodingError(format!(
+                "Trying to allocate {} bytes. Only {} allowed.",
+                length,
+                u16::MAX
+            )));
+        }
+        let mut result = Self {
+            vec: vec![0u8; length],
+        };
+        let read = bytes.read(result.vec.as_mut_slice())?;
+        if read == length {
+            return Ok(result);
+        }
+
+        debug_assert_eq!(
+            read, length,
+            "Expected to read {} bytes but {} were read.",
+            length, read
+        );
+        Err(Error::DecodingError(format!(
+            "{} bytes were read but {} were expected",
+            read, length
+        )))
+    }
+}
+
+impl Serialize for &VLBytes {
+    #[cfg(feature = "std")]
+    #[inline(always)]
+    fn tls_serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, Error> {
+        (*self).tls_serialize(writer)
+    }
+}
+
+impl Size for &VLBytes {
+    #[cfg(feature = "std")]
+    #[inline(always)]
+    fn tls_serialized_len(&self) -> usize {
+        (*self).tls_serialized_len()
+    }
+}
+
+pub struct VLByteSlice<'a>(pub &'a [u8]);
+
+impl<'a> VLByteSlice<'a> {
+    /// Get the raw slice.
+    #[inline(always)]
+    pub fn as_slice(&self) -> &[u8] {
+        self.0
+    }
+}
+
+impl<'a> Serialize for &VLByteSlice<'a> {
+    #[cfg(feature = "std")]
+    fn tls_serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, Error> {
+        tls_serialize_bytes(writer, self.0)
+    }
+}
+
+impl<'a> Serialize for VLByteSlice<'a> {
+    #[cfg(feature = "std")]
+    fn tls_serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, Error> {
+        tls_serialize_bytes(writer, self.0)
+    }
+}
+
+impl<'a> Size for &VLByteSlice<'a> {
+    #[inline]
+    fn tls_serialized_len(&self) -> usize {
+        tls_serialize_bytes_len(self.0)
+    }
+}
+
+impl<'a> Size for VLByteSlice<'a> {
+    #[inline]
+    fn tls_serialized_len(&self) -> usize {
+        tls_serialize_bytes_len(self.0)
+    }
+}

--- a/tls_codec/src/tls_vec.rs
+++ b/tls_codec/src/tls_vec.rs
@@ -811,8 +811,6 @@ macro_rules! impl_tls_byte_vec {
     };
 }
 
-// TODO: #1 provide specialized TlsByteVec* versions holding u8 that are more efficient.
-
 impl_public_tls_vec!(u8, TlsVecU8, 1);
 impl_public_tls_vec!(u16, TlsVecU16, 2);
 impl_public_tls_vec!(u32, TlsVecU32, 4);

--- a/tls_codec/tests/decode.rs
+++ b/tls_codec/tests/decode.rs
@@ -140,7 +140,7 @@ fn deserialize_var_len_vec() {
 
 #[test]
 fn deserialize_tls_vl_bytes() {
-    let mut b = [4u8, 77, 88, 1, 99].as_slice();
+    let mut b = &[4u8, 77, 88, 1, 99] as &[u8];
 
     let v = VLBytes::tls_deserialize(&mut b).expect("Unable to tls_deserialize");
     assert_eq!(5, v.tls_serialized_len());

--- a/tls_codec/tests/decode.rs
+++ b/tls_codec/tests/decode.rs
@@ -2,7 +2,7 @@
 
 use tls_codec::{
     Deserialize, Serialize, Size, TlsByteSliceU16, TlsByteVecU16, TlsByteVecU8, TlsSliceU16,
-    TlsVecU16, TlsVecU32, TlsVecU8,
+    TlsVecU16, TlsVecU32, TlsVecU8, VLByteSlice, VLBytes,
 };
 
 #[test]
@@ -104,4 +104,60 @@ fn deserialize_tuples() {
     let deserialized = <(TlsVecU16<u8>, TlsVecU32<u16>)>::tls_deserialize(&mut bytes.as_slice())
         .expect("Error deserializing tuple.");
     assert_eq!(deserialized, t);
+}
+
+#[test]
+fn deserialize_var_len_vec() {
+    fn test_it<T: Serialize + Deserialize + std::fmt::Debug + PartialEq>(v: Vec<T>) {
+        let serialized = v.tls_serialize_detached().expect("Error encoding vector");
+        let deserialized: Vec<T> =
+            Vec::tls_deserialize(&mut serialized.as_slice()).expect("Error deserializing vector");
+        assert_eq!(deserialized, v);
+    }
+
+    let v = vec![9u8, 2, 98, 34, 55, 90, 54];
+    let serialized = v.tls_serialize_detached().expect("Error encoding vector");
+    assert_eq!(serialized, vec![0b00 << 6 | 7, 9, 2, 98, 34, 55, 90, 54]);
+    test_it(v);
+
+    let v  = b"Geilo is a centre in the municipality of Hol in Viken county, Norway. Geilo is primarily a ski resort town, with around 2,500 inhabitants. It is situated in the valley of Hallingdal, 250 km from Oslo and 260 km from Bergen. The Bergen Line facilitated Geilo's development as the first skiing resort in the country, and it is still one of the largest. It is also known for having some of the most luxurious and expensive holiday cabins in Norway. The center of the town lies at 800 meters above sea level, and its highest point is 1178 meters above sea level.".to_vec();
+    test_it(v);
+
+    let first = b"".to_vec();
+    let second = b"".to_vec();
+    let third = b"".to_vec();
+    let v = vec![first, second, third];
+    test_it(v);
+
+    let first =
+        b"The Three Pigs is a children's picture book written and illustrated by David Wiesner"
+            .to_vec();
+    let second = b"Published in 2001, the book is based on the traditional tale of the Three Little Pigs, though in this story they step out of their own tale and wander into others, depicted in different illustration styles.".to_vec();
+    let third = b"Wiesner won the 2002 Caldecott Medal for his illustrations, Wiesner's second of three such medals.".to_vec();
+    let v = vec![first, second, third];
+    test_it(v);
+}
+
+#[test]
+fn deserialize_tls_vl_bytes() {
+    let mut b = [4u8, 77, 88, 1, 99].as_slice();
+
+    let v = VLBytes::tls_deserialize(&mut b).expect("Unable to tls_deserialize");
+    assert_eq!(5, v.tls_serialized_len());
+    assert_eq!(&[77, 88, 1, 99], v.as_slice());
+
+    // It's empty now.
+    assert!(u8::tls_deserialize(&mut b).is_err());
+
+    let long_vector = vec![77u8; 65535];
+    let serialized_long_vec = VLByteSlice(&long_vector).tls_serialize_detached().unwrap();
+    std::println!("bytes: {:x?}", &serialized_long_vec[0..5]);
+    let deserialized_long_vec =
+        VLBytes::tls_deserialize(&mut serialized_long_vec.as_slice()).unwrap();
+    assert_eq!(
+        deserialized_long_vec.tls_serialized_len(),
+        long_vector.len() + 4
+    );
+    assert_eq!(long_vector.len(), deserialized_long_vec.as_slice().len());
+    assert_eq!(long_vector.as_slice(), deserialized_long_vec.as_slice());
 }


### PR DESCRIPTION
This implements the variable-length integer encoding from [RFC 9000] (quic) used to serialize variable-length vectors in quic and in [MLS].
It's opinionated because it doesn't allow anything longer than `u16::MAX` when deserialising (same as the other vectors), and it requires minimum lengths like MLS (unlike quic).

cc @kkohbrok @raphaelrobert if one of you wants to have a look at this.

[rfc 9000]: https://www.rfc-editor.org/rfc/rfc9000.html#name-variable-length-integer-enc
[mls]: https://messaginglayersecurity.rocks/mls-protocol/draft-ietf-mls-protocol.html#name-variable-size-vector-header