### PR TITLE
ssh-key: `authorized_keys::Options` type

### DIFF
--- a/ssh-key/src/authorized_keys.rs
+++ b/ssh-key/src/authorized_keys.rs
@@ -1,6 +1,7 @@
 //! Parser for `AuthorizedKeysFile`-formatted data.
 
 use crate::{Error, PublicKey, Result};
+use core::fmt;
 
 #[cfg(feature = "std")]
 use std::{fs, path::Path};
@@ -52,94 +53,206 @@ impl<'a> AuthorizedKeys<'a> {
         let input = fs::read_to_string(path)?;
         f(AuthorizedKeys::new(&input))
     }
+
+    /// Get the next line, trimming any comments and trailing whitespace.
+    ///
+    /// Ignores empty lines.
+    fn next_line_trimmed(&mut self) -> Option<&'a str> {
+        loop {
+            let mut line = self.lines.next()?;
+
+            // Strip comment, if present
+            if let Some((l, _)) = line.split_once(COMMENT_DELIMITER) {
+                line = l;
+            }
+
+            // Trim trailing whitespace
+            line = line.trim_end();
+
+            if !line.is_empty() {
+                return Some(line);
+            }
+        }
+    }
 }
 
 impl<'a> Iterator for AuthorizedKeys<'a> {
     type Item = Result<Entry<'a>>;
 
     fn next(&mut self) -> Option<Result<Entry<'a>>> {
-        loop {
-            let result = LineParser::new(self.lines.next()?);
-
-            match result {
-                Ok(LineParser {
-                    options_str: None,
-                    public_key_str: None,
-                }) => (),
-                Ok(line) => return Some(line.try_into()),
-                Err(err) => return Some(Err(err)),
-            }
-        }
+        self.next_line_trimmed().map(TryInto::try_into)
     }
 }
 
 /// Individual entry in an `authorized_keys` file containing a single public key.
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Entry<'a> {
     /// Options field, if present.
-    pub options: Option<&'a str>,
+    pub options: Options<'a>,
 
     /// Public key
     pub public_key: PublicKey,
 }
 
-impl<'a> TryFrom<LineParser<'a>> for Entry<'a> {
+impl<'a> TryFrom<&'a str> for Entry<'a> {
     type Error = Error;
 
-    fn try_from(line: LineParser<'a>) -> Result<Entry<'a>> {
-        let public_key = line
-            .public_key_str
-            .ok_or(Error::FormatEncoding)?
-            .parse::<PublicKey>()?;
-
-        Ok(Self {
-            options: line.options_str,
-            public_key,
-        })
+    fn try_from(line: &'a str) -> Result<Self> {
+        // TODO(tarcieri): more liberal whitespace handling?
+        match line.matches(' ').count() {
+            1..=2 => Ok(Self {
+                options: Default::default(),
+                public_key: line.parse()?,
+            }),
+            3 => line
+                .split_once(' ')
+                .map(|(options_str, public_key_str)| {
+                    Ok(Self {
+                        options: options_str.try_into()?,
+                        public_key: public_key_str.parse()?,
+                    })
+                })
+                .ok_or(Error::FormatEncoding)?,
+            _ => Err(Error::FormatEncoding),
+        }
     }
 }
 
-/// Parser for an individual line in an `authorized_keys` file.
-#[derive(Debug)]
-struct LineParser<'a> {
-    /// Options field, if present.
-    options_str: Option<&'a str>,
+/// Configuration options associated with a particular public key.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct Options<'a>(&'a str);
 
-    /// Public key data, if present.
-    public_key_str: Option<&'a str>,
+impl<'a> Options<'a> {
+    /// Parse an options string.
+    pub fn new(string: &'a str) -> Result<Self> {
+        // Ensure options can be iterated over successfully
+        let mut opts = Self(string);
+        while opts.try_next()?.is_some() {}
+        Ok(Self(string))
+    }
+
+    /// Attempt to parse the next comma-delimited option string.
+    fn try_next(&mut self) -> Result<Option<&'a str>> {
+        if self.0.is_empty() {
+            return Ok(None);
+        }
+
+        let mut quoted = false;
+        let mut index = 0;
+
+        while let Some(byte) = self.0.as_bytes().get(index).cloned() {
+            match byte {
+                b',' => {
+                    // Commas inside quoted text are ignored
+                    if !quoted {
+                        let (next, rest) = self.0.split_at(index);
+                        self.0 = &rest[1..]; // Strip comma
+                        return Ok(Some(next));
+                    }
+                }
+                // TODO(tarcieri): stricter handling of quotes
+                b'"' => {
+                    // Toggle quoted mode on-off
+                    quoted = !quoted;
+                }
+                // Valid characters
+                b'A'..=b'Z'
+                | b'a'..=b'z'
+                | b'0'..=b'9'
+                | b'!'..=b'/'
+                | b':'..=b'@'
+                | b'['..=b'_'
+                | b'{'
+                | b'}'
+                | b'|'
+                | b'~' => (),
+                _ => return Err(Error::CharacterEncoding),
+            }
+
+            index += 1;
+        }
+
+        let remaining = self.0;
+        self.0 = "";
+        Ok(Some(remaining))
+    }
 }
 
-impl<'a> LineParser<'a> {
-    /// Parse the given line.
-    pub fn new(mut line: &'a str) -> Result<Self> {
-        // Strip comment, if present
-        if let Some((l, _)) = line.split_once(COMMENT_DELIMITER) {
-            line = l;
-        }
+impl<'a> Iterator for Options<'a> {
+    type Item = &'a str;
 
-        // Trim trailing whitespace
-        line = line.trim_end();
+    fn next(&mut self) -> Option<&'a str> {
+        // Ensured valid by constructor
+        self.try_next().expect("malformed options string")
+    }
+}
 
-        if line.is_empty() {
-            return Ok(Self {
-                options_str: None,
-                public_key_str: None,
-            });
-        }
+impl<'a> TryFrom<&'a str> for Options<'a> {
+    type Error = Error;
 
-        match line.matches(' ').count() {
-            1..=2 => Ok(Self {
-                options_str: None,
-                public_key_str: Some(line),
-            }),
-            3 => match line.split_once(' ') {
-                Some((options_str, public_key_str)) => Ok(Self {
-                    options_str: Some(options_str),
-                    public_key_str: Some(public_key_str),
-                }),
-                _ => Err(Error::FormatEncoding),
-            },
-            _ => Err(Error::FormatEncoding),
-        }
+    fn try_from(s: &'a str) -> Result<Self> {
+        Options::new(s)
+    }
+}
+
+impl fmt::Display for Options<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Options;
+    use crate::Error;
+
+    #[test]
+    fn options_empty() {
+        assert_eq!(Options("").try_next(), Ok(None));
+    }
+
+    #[test]
+    fn options_no_comma() {
+        let mut opts = Options("foo");
+        assert_eq!(opts.try_next(), Ok(Some("foo")));
+        assert_eq!(opts.try_next(), Ok(None));
+    }
+
+    #[test]
+    fn options_no_comma_quoted() {
+        let mut opts = Options("foo=\"bar\"");
+        assert_eq!(opts.try_next(), Ok(Some("foo=\"bar\"")));
+        assert_eq!(opts.try_next(), Ok(None));
+
+        // Comma inside quoted section
+        let mut opts = Options("foo=\"bar,baz\"");
+        assert_eq!(opts.try_next(), Ok(Some("foo=\"bar,baz\"")));
+        assert_eq!(opts.try_next(), Ok(None));
+    }
+
+    #[test]
+    fn options_comma_delimited() {
+        let mut opts = Options("foo,bar");
+        assert_eq!(opts.try_next(), Ok(Some("foo")));
+        assert_eq!(opts.try_next(), Ok(Some("bar")));
+        assert_eq!(opts.try_next(), Ok(None));
+    }
+
+    #[test]
+    fn options_comma_delimited_quoted() {
+        let mut opts = Options("foo=\"bar\",baz");
+        assert_eq!(opts.try_next(), Ok(Some("foo=\"bar\"")));
+        assert_eq!(opts.try_next(), Ok(Some("baz")));
+        assert_eq!(opts.try_next(), Ok(None));
+    }
+
+    #[test]
+    fn options_invalid_character() {
+        let mut opts = Options("❌");
+        assert_eq!(opts.try_next(), Err(Error::CharacterEncoding));
+
+        let mut opts = Options("x,❌");
+        assert_eq!(opts.try_next(), Ok(Some("x")));
+        assert_eq!(opts.try_next(), Err(Error::CharacterEncoding));
     }
 }

--- a/ssh-key/tests/authorized_keys.rs
+++ b/ssh-key/tests/authorized_keys.rs
@@ -9,22 +9,22 @@ use ssh_key::AuthorizedKeys;
 fn read_example_file() {
     AuthorizedKeys::read_file("./tests/examples/authorized_keys", |mut authorized_keys| {
         let entry1 = authorized_keys.next().unwrap()?;
-        assert_eq!(entry1.options, None);
+        assert_eq!(entry1.options.to_string(), "");
         assert_eq!(entry1.public_key.to_string(), "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILM+rvN+ot98qgEN796jTiQfZfG1KaT0PtFDJ/XFSqti user1@example.com");
         assert_eq!(entry1.public_key.comment, "user1@example.com");
 
         let entry2 = authorized_keys.next().unwrap()?;
-        assert_eq!(entry2.options, Some("command=\"/usr/bin/date\""));
+        assert_eq!(entry2.options.to_string(), "command=\"/usr/bin/date\"");
         assert_eq!(entry2.public_key.to_string(), "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHwf2HMM5TRXvo2SQJjsNkiDD5KqiiNjrGVv3UUh+mMT5RHxiRtOnlqvjhQtBq0VpmpCV/PwUdhOig4vkbqAcEc= user2@example.com");
         assert_eq!(entry2.public_key.comment, "user2@example.com");
 
         let entry3 = authorized_keys.next().unwrap()?;
-        assert_eq!(entry3.options, Some("environment=\"PATH=/bin:/usr/bin\""));
+        assert_eq!(entry3.options.to_string(), "environment=\"PATH=/bin:/usr/bin\"");
         assert_eq!(entry3.public_key.to_string(), "ssh-dss AAAAB3NzaC1kc3MAAACBANw9iSUO2UYhFMssjUgW46URqv8bBrDgHeF8HLBOWBvKuXF2Rx2J/XyhgX48SOLMuv0hcPaejlyLarabnF9F2V4dkpPpZSJ+7luHmxEjNxwhsdtg8UteXAWkeCzrQ6MvRJZHcDBjYh56KGvslbFnJsGLXlI4PQCyl6awNImwYGilAAAAFQCJGBU3hZf+QtP9Jh/nbfNlhFu7hwAAAIBHObOQioQVRm3HsVb7mOy3FVKhcLoLO3qoG9gTkd4KeuehtFAC3+rckiX7xSCnE/5BBKdL7VP9WRXac2Nlr9Pwl3e7zPut96wrCHt/TZX6vkfXKkbpUIj5zSqfvyNrWKaYJkfzwAQwrXNS1Hol676Ud/DDEn2oatdEhkS3beWHXAAAAIBgQqaz/YYTRMshzMzYcZ4lqgvgmA55y6v0h39e8HH2A5dwNS6sPUw2jyna+le0dceNRJifFld1J+WYM0vmquSr11DDavgEidOSaXwfMvPPPJqLmbzdtT16N+Gij9U9STQTHPQcQ3xnNNHgQAStzZJbhLOVbDDDo5BO7LMUALDfSA== user3@example.com");
         assert_eq!(entry3.public_key.comment, "user3@example.com");
 
         let entry4 = authorized_keys.next().unwrap()?;
-        assert_eq!(entry4.options, Some("from=\"10.0.0.?,*.example.com\",no-X11-forwarding"));
+        assert_eq!(entry4.options.to_string(), "from=\"10.0.0.?,*.example.com\",no-X11-forwarding");
         assert_eq!(entry4.public_key.to_string(), "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC0WRHtxuxefSJhpIxGq4ibGFgwYnESPm8C3JFM88A1JJLoprenklrd7VJ+VH3Ov/bQwZwLyRU5dRmfR/SWTtIPWs7tToJVayKKDB+/qoXmM5ui/0CU2U4rCdQ6PdaCJdC7yFgpPL8WexjWN06+eSIKYz1AAXbx9rRv1iasslK/KUqtsqzVliagI6jl7FPO2GhRZMcso6LsZGgSxuYf/Lp0D/FcBU8GkeOo1Sx5xEt8H8bJcErtCe4Blb8JxcW6EXO3sReb4z+zcR07gumPgFITZ6hDA8sSNuvo/AlWg0IKTeZSwHHVknWdQqDJ0uczE837caBxyTZllDNIGkBjCIIOFzuTT76HfYc/7CTTGk07uaNkUFXKN79xDiFOX8JQ1ZZMZvGOTwWjuT9CqgdTvQRORbRWwOYv3MH8re9ykw3Ip6lrPifY7s6hOaAKry/nkGPMt40m1TdiW98MTIpooE7W+WXu96ax2l2OJvxX8QR7l+LFlKnkIEEJd/ItF1G22UmOjkVwNASTwza/hlY+8DoVvEmwum/nMgH2TwQT3bTQzF9s9DOJkH4d8p4Mw4gEDjNx0EgUFA91ysCAeUMQQyIvuR8HXXa+VcvhOOO5mmBcVhxJ3qUOJTyDBsT0932Zb4mNtkxdigoVxu+iiwk0vwtvKwGVDYdyMP5EAQeEIP1t0w== user4@example.com");
         assert_eq!(entry4.public_key.comment, "user4@example.com");
 


### PR DESCRIPTION
Adds a type for modeling the "options" field of the `authorized_keys` file, which parses comma-delimited strings while incorporating basic quoting logic.

The `Options` type is an iterator over comma-separated `str` and performs an eager first-pass iteration to ensure the contents are valid and can be iterated over infallibly.