### PR TITLE
pem-rfc7468: impl `io::Write` for `Encoder`

### DIFF
--- a/pem-rfc7468/src/decoder.rs
+++ b/pem-rfc7468/src/decoder.rs
@@ -61,19 +61,6 @@ pub fn decode_label(pem: &[u8]) -> Result<&str> {
     Ok(Encapsulation::try_from(pem)?.label())
 }
 
-/// Check for PEM headers in the input, as they are disallowed by RFC7468.
-///
-/// Returns `Error::HeaderDisallowed` if headers are encountered.
-fn check_for_headers(pem: &[u8], err: Error) -> Error {
-    if err == Error::Base64(base64ct::Error::InvalidEncoding)
-        && pem.iter().any(|&b| b == grammar::CHAR_COLON)
-    {
-        Error::HeaderDisallowed
-    } else {
-        err
-    }
-}
-
 /// Buffered PEM decoder.
 ///
 /// Stateful buffered decoder type which decodes an input PEM document according
@@ -251,6 +238,19 @@ impl<'a> TryFrom<&'a [u8]> for Encapsulation<'a> {
 
     fn try_from(bytes: &'a [u8]) -> Result<Self> {
         Self::parse(bytes)
+    }
+}
+
+/// Check for PEM headers in the input, as they are disallowed by RFC7468.
+///
+/// Returns `Error::HeaderDisallowed` if headers are encountered.
+fn check_for_headers(pem: &[u8], err: Error) -> Error {
+    if err == Error::Base64(base64ct::Error::InvalidEncoding)
+        && pem.iter().any(|&b| b == grammar::CHAR_COLON)
+    {
+        Error::HeaderDisallowed
+    } else {
+        err
     }
 }
 

--- a/pem-rfc7468/src/encoder.rs
+++ b/pem-rfc7468/src/encoder.rs
@@ -9,6 +9,9 @@ use base64ct::{Base64, Encoding};
 #[cfg(feature = "alloc")]
 use alloc::string::String;
 
+#[cfg(feature = "std")]
+use std::io;
+
 /// Encode a PEM document according to RFC 7468's "Strict" grammar.
 pub fn encode<'o>(
     type_label: &str,
@@ -152,6 +155,20 @@ impl<'l, 'o> Encoder<'l, 'o> {
             self.line_ending,
             base64.len() + self.line_ending.len(),
         ))
+    }
+}
+
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+impl<'l, 'o> io::Write for Encoder<'l, 'o> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.encode(buf)?;
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        // TODO(tarcieri): return an error if there's still data remaining in the buffer?
+        Ok(())
     }
 }
 

--- a/pem-rfc7468/src/error.rs
+++ b/pem-rfc7468/src/error.rs
@@ -71,3 +71,23 @@ impl From<base64ct::InvalidLengthError> for Error {
         Error::Length
     }
 }
+
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+impl From<Error> for std::io::Error {
+    fn from(err: Error) -> std::io::Error {
+        let kind = match err {
+            Error::Base64(err) => return err.into(), // Use existing conversion
+            Error::CharacterEncoding
+            | Error::EncapsulatedText
+            | Error::Label
+            | Error::Preamble
+            | Error::PreEncapsulationBoundary
+            | Error::PostEncapsulationBoundary => std::io::ErrorKind::InvalidData,
+            Error::Length => std::io::ErrorKind::UnexpectedEof,
+            _ => std::io::ErrorKind::Other,
+        };
+
+        std::io::Error::new(kind, err)
+    }
+}


### PR DESCRIPTION
Allows using the `std::io` API to encode data as PEM.