### PR TITLE
pem-rfc7468: return `str` from `encode`

### DIFF
--- a/pem-rfc7468/src/error.rs
+++ b/pem-rfc7468/src/error.rs
@@ -72,6 +72,12 @@ impl From<base64ct::InvalidLengthError> for Error {
     }
 }
 
+impl From<core::str::Utf8Error> for Error {
+    fn from(_: core::str::Utf8Error) -> Error {
+        Error::CharacterEncoding
+    }
+}
+
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl From<Error> for std::io::Error {


### PR DESCRIPTION
Changes the return type of `encode` from `[u8]` to `str`.

It's easy to go the other direction with `.as_bytes()`.