### PR TITLE
ssh-key: factor out `DecoderExt`/`EncoderExt` traits

### DIFF
--- a/pem-rfc7468/src/decoder.rs
+++ b/pem-rfc7468/src/decoder.rs
@@ -119,11 +119,6 @@ impl<'i> Decoder<'i> {
     pub fn is_finished(&self) -> bool {
         self.base64.is_finished()
     }
-
-    /// Convert into the inner [`Base64Decoder`].
-    pub fn into_base64_decoder(self) -> Base64Decoder<'i> {
-        self.base64
-    }
 }
 
 impl<'i> From<Decoder<'i>> for Base64Decoder<'i> {

--- a/ssh-key/src/algorithm.rs
+++ b/ssh-key/src/algorithm.rs
@@ -1,7 +1,7 @@
 //! Algorithm support.
 
 use crate::{
-    base64::{self, Decode, Encode},
+    base64::{self, Decode, DecoderExt, Encode, EncoderExt},
     Error, Result,
 };
 use core::{fmt, str};

--- a/ssh-key/src/mpint.rs
+++ b/ssh-key/src/mpint.rs
@@ -1,7 +1,7 @@
 //! Multiple precision integer
 
 use crate::{
-    base64::{self, Decode, Encode},
+    base64::{self, Decode, DecoderExt, Encode, EncoderExt},
     Error, Result,
 };
 use alloc::vec::Vec;

--- a/ssh-key/src/private.rs
+++ b/ssh-key/src/private.rs
@@ -22,7 +22,7 @@ pub use self::{
 };
 
 use crate::{
-    base64::{self, Decode},
+    base64::{self, Decode, DecoderExt},
     public, Algorithm, CipherAlg, Error, KdfAlg, KdfOptions, Result,
 };
 use core::str::FromStr;
@@ -76,7 +76,7 @@ impl PrivateKey {
         let mut base64_decoder = base64::Decoder::from(pem_decoder);
 
         let mut auth_magic = [0u8; Self::AUTH_MAGIC.len()];
-        base64_decoder.decode_into(&mut auth_magic)?;
+        base64_decoder.decode(&mut auth_magic)?;
 
         if auth_magic != Self::AUTH_MAGIC {
             return Err(Error::FormatEncoding);

--- a/ssh-key/src/private/ecdsa.rs
+++ b/ssh-key/src/private/ecdsa.rs
@@ -1,7 +1,7 @@
 //! Elliptic Curve Digital Signature Algorithm (ECDSA) private keys.
 
 use crate::{
-    base64::{self, Decode},
+    base64::{self, Decode, DecoderExt},
     public::EcdsaPublicKey,
     Algorithm, EcdsaCurve, Error, Result,
 };
@@ -35,7 +35,7 @@ impl<const SIZE: usize> EcdsaPrivateKey<SIZE> {
         }
 
         let mut bytes = [0u8; SIZE];
-        decoder.decode_into(&mut bytes)?;
+        decoder.decode(&mut bytes)?;
         Ok(Self { bytes })
     }
 }

--- a/ssh-key/src/private/ed25519.rs
+++ b/ssh-key/src/private/ed25519.rs
@@ -3,7 +3,7 @@
 //! Edwards Digital Signature Algorithm (EdDSA) over Curve25519.
 
 use crate::{
-    base64::{self, Decode},
+    base64::{self, Decode, DecoderExt},
     public::Ed25519PublicKey,
     Error, Result,
 };
@@ -97,7 +97,7 @@ impl Decode for Ed25519Keypair {
         }
 
         let mut bytes = Zeroizing::new([0u8; Self::BYTE_SIZE]);
-        decoder.decode_into(&mut *bytes)?;
+        decoder.decode(&mut *bytes)?;
 
         let (priv_bytes, pub_bytes) = bytes.split_at(Ed25519PrivateKey::BYTE_SIZE);
         if pub_bytes != public.as_ref() {

--- a/ssh-key/src/public.rs
+++ b/ssh-key/src/public.rs
@@ -70,7 +70,7 @@ impl PublicKey {
         })
     }
 
-    /// Encode this public key as a OpenSSH-formatted public key.
+    /// Encode OpenSSH-formatted (PEM) public key.
     pub fn encode_openssh<'o>(&self, out: &'o mut [u8]) -> Result<&'o str> {
         #[cfg(not(feature = "alloc"))]
         let comment = "";

--- a/ssh-key/src/public/ecdsa.rs
+++ b/ssh-key/src/public/ecdsa.rs
@@ -1,7 +1,7 @@
 //! Elliptic Curve Digital Signature Algorithm (ECDSA) public keys.
 
 use crate::{
-    base64::{self, Decode, Encode},
+    base64::{self, Decode, DecoderExt, Encode, EncoderExt},
     Algorithm, EcdsaCurve, Error, Result,
 };
 use core::fmt;

--- a/ssh-key/src/public/ed25519.rs
+++ b/ssh-key/src/public/ed25519.rs
@@ -3,7 +3,7 @@
 //! Edwards Digital Signature Algorithm (EdDSA) over Curve25519.
 
 use crate::{
-    base64::{self, Decode, Encode},
+    base64::{self, Decode, DecoderExt, Encode, EncoderExt},
     Error, Result,
 };
 use core::fmt;
@@ -32,7 +32,7 @@ impl Decode for Ed25519PublicKey {
         }
 
         let mut bytes = [0u8; Self::BYTE_SIZE];
-        decoder.decode_into(&mut bytes)?;
+        decoder.decode(&mut bytes)?;
         Ok(Self(bytes))
     }
 }


### PR DESCRIPTION
Implements the SSH key wire format in terms of traits rather than newtypes.

Traits can be used with either the raw Base64 or PEM encoders.