### PR TITLE
ssh-key: trait-based decoder/encoder

### DIFF
--- a/ssh-key/src/algorithm.rs
+++ b/ssh-key/src/algorithm.rs
@@ -1,7 +1,7 @@
 //! Algorithm support.
 
 use crate::{
-    base64::{self, Decode, DecoderExt, Encode, EncoderExt},
+    base64::{Decode, DecoderExt, Encode, EncoderExt},
     Error, Result,
 };
 use core::{fmt, str};
@@ -103,7 +103,7 @@ impl Algorithm {
 }
 
 impl Decode for Algorithm {
-    fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+    fn decode(decoder: &mut impl DecoderExt) -> Result<Self> {
         let mut buf = [0u8; Self::MAX_SIZE];
         Self::new(decoder.decode_str(&mut buf)?)
     }
@@ -114,7 +114,7 @@ impl Encode for Algorithm {
         Ok(4 + self.as_str().len())
     }
 
-    fn encode(&self, encoder: &mut base64::Encoder<'_>) -> Result<()> {
+    fn encode(&self, encoder: &mut impl EncoderExt) -> Result<()> {
         encoder.encode_str(self.as_str())
     }
 }
@@ -165,7 +165,7 @@ impl CipherAlg {
 }
 
 impl Decode for CipherAlg {
-    fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+    fn decode(decoder: &mut impl DecoderExt) -> Result<Self> {
         let mut buf = [0u8; Self::MAX_SIZE];
         Self::new(decoder.decode_str(&mut buf)?)
     }
@@ -229,7 +229,7 @@ impl EcdsaCurve {
 }
 
 impl Decode for EcdsaCurve {
-    fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+    fn decode(decoder: &mut impl DecoderExt) -> Result<Self> {
         let mut buf = [0u8; Self::MAX_SIZE];
         Self::new(decoder.decode_str(&mut buf)?)
     }
@@ -240,7 +240,7 @@ impl Encode for EcdsaCurve {
         Ok(4 + self.as_str().len())
     }
 
-    fn encode(&self, encoder: &mut base64::Encoder<'_>) -> Result<()> {
+    fn encode(&self, encoder: &mut impl EncoderExt) -> Result<()> {
         encoder.encode_str(self.as_str())
     }
 }
@@ -291,7 +291,7 @@ impl KdfAlg {
 }
 
 impl Decode for KdfAlg {
-    fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+    fn decode(decoder: &mut impl DecoderExt) -> Result<Self> {
         let mut buf = [0u8; Self::MAX_SIZE];
         Self::new(decoder.decode_str(&mut buf)?)
     }
@@ -330,7 +330,7 @@ impl KdfOptions {
 }
 
 impl Decode for KdfOptions {
-    fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+    fn decode(decoder: &mut impl DecoderExt) -> Result<Self> {
         let mut buf = [0u8; 0];
         Self::new(decoder.decode_str(&mut buf)?)
     }

--- a/ssh-key/src/mpint.rs
+++ b/ssh-key/src/mpint.rs
@@ -1,7 +1,7 @@
 //! Multiple precision integer
 
 use crate::{
-    base64::{self, Decode, DecoderExt, Encode, EncoderExt},
+    base64::{Decode, DecoderExt, Encode, EncoderExt},
     Error, Result,
 };
 use alloc::vec::Vec;
@@ -84,7 +84,7 @@ impl AsRef<[u8]> for MPInt {
 }
 
 impl Decode for MPInt {
-    fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+    fn decode(decoder: &mut impl DecoderExt) -> Result<Self> {
         decoder.decode_byte_vec()?.try_into()
     }
 }
@@ -94,7 +94,7 @@ impl Encode for MPInt {
         Ok(4 + self.as_bytes().len())
     }
 
-    fn encode(&self, encoder: &mut base64::Encoder<'_>) -> Result<()> {
+    fn encode(&self, encoder: &mut impl EncoderExt) -> Result<()> {
         encoder.encode_byte_slice(self.as_bytes())
     }
 }

--- a/ssh-key/src/private/dsa.rs
+++ b/ssh-key/src/private/dsa.rs
@@ -1,7 +1,7 @@
 //! Digital Signature Algorithm (DSA) private keys.
 
 use crate::{
-    base64::{self, Decode},
+    base64::{Decode, DecoderExt},
     public::DsaPublicKey,
     MPInt, Result,
 };
@@ -40,7 +40,7 @@ impl AsRef<[u8]> for DsaPrivateKey {
 }
 
 impl Decode for DsaPrivateKey {
-    fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+    fn decode(decoder: &mut impl DecoderExt) -> Result<Self> {
         Ok(Self {
             inner: MPInt::decode(decoder)?,
         })
@@ -64,7 +64,7 @@ pub struct DsaKeypair {
 }
 
 impl Decode for DsaKeypair {
-    fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+    fn decode(decoder: &mut impl DecoderExt) -> Result<Self> {
         let public = DsaPublicKey::decode(decoder)?;
         let private = DsaPrivateKey::decode(decoder)?;
         Ok(DsaKeypair { public, private })

--- a/ssh-key/src/private/ecdsa.rs
+++ b/ssh-key/src/private/ecdsa.rs
@@ -1,7 +1,7 @@
 //! Elliptic Curve Digital Signature Algorithm (ECDSA) private keys.
 
 use crate::{
-    base64::{self, Decode, DecoderExt},
+    base64::{Decode, DecoderExt},
     public::EcdsaPublicKey,
     Algorithm, EcdsaCurve, Error, Result,
 };
@@ -23,7 +23,7 @@ impl<const SIZE: usize> EcdsaPrivateKey<SIZE> {
     }
 
     /// Decode ECDSA private key using the provided Base64 decoder.
-    fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+    fn decode(decoder: &mut impl DecoderExt) -> Result<Self> {
         let len = decoder.decode_usize()?;
 
         if len == SIZE + 1 {
@@ -35,7 +35,7 @@ impl<const SIZE: usize> EcdsaPrivateKey<SIZE> {
         }
 
         let mut bytes = [0u8; SIZE];
-        decoder.decode(&mut bytes)?;
+        decoder.decode_base64(&mut bytes)?;
         Ok(Self { bytes })
     }
 }
@@ -142,7 +142,7 @@ impl EcdsaKeypair {
 }
 
 impl Decode for EcdsaKeypair {
-    fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+    fn decode(decoder: &mut impl DecoderExt) -> Result<Self> {
         match EcdsaPublicKey::decode(decoder)? {
             EcdsaPublicKey::NistP256(public) => {
                 let private = EcdsaPrivateKey::<32>::decode(decoder)?;

--- a/ssh-key/src/private/ed25519.rs
+++ b/ssh-key/src/private/ed25519.rs
@@ -3,7 +3,7 @@
 //! Edwards Digital Signature Algorithm (EdDSA) over Curve25519.
 
 use crate::{
-    base64::{self, Decode, DecoderExt},
+    base64::{Decode, DecoderExt},
     public::Ed25519PublicKey,
     Error, Result,
 };
@@ -85,7 +85,7 @@ impl Ed25519Keypair {
 }
 
 impl Decode for Ed25519Keypair {
-    fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+    fn decode(decoder: &mut impl DecoderExt) -> Result<Self> {
         // Decode private key
         let public = Ed25519PublicKey::decode(decoder)?;
 
@@ -97,7 +97,7 @@ impl Decode for Ed25519Keypair {
         }
 
         let mut bytes = Zeroizing::new([0u8; Self::BYTE_SIZE]);
-        decoder.decode(&mut *bytes)?;
+        decoder.decode_base64(&mut *bytes)?;
 
         let (priv_bytes, pub_bytes) = bytes.split_at(Ed25519PrivateKey::BYTE_SIZE);
         if pub_bytes != public.as_ref() {

--- a/ssh-key/src/private/rsa.rs
+++ b/ssh-key/src/private/rsa.rs
@@ -1,7 +1,7 @@
 //! Rivest–Shamir–Adleman (RSA) private keys.
 
 use crate::{
-    base64::{self, Decode},
+    base64::{Decode, DecoderExt},
     public::RsaPublicKey,
     MPInt, Result,
 };
@@ -26,7 +26,7 @@ pub struct RsaPrivateKey {
 }
 
 impl Decode for RsaPrivateKey {
-    fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+    fn decode(decoder: &mut impl DecoderExt) -> Result<Self> {
         let d = MPInt::decode(decoder)?;
         let iqmp = MPInt::decode(decoder)?;
         let p = MPInt::decode(decoder)?;
@@ -55,7 +55,7 @@ pub struct RsaKeypair {
 }
 
 impl Decode for RsaKeypair {
-    fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+    fn decode(decoder: &mut impl DecoderExt) -> Result<Self> {
         let n = MPInt::decode(decoder)?;
         let e = MPInt::decode(decoder)?;
         let public = RsaPublicKey { n, e };

--- a/ssh-key/src/public.rs
+++ b/ssh-key/src/public.rs
@@ -18,7 +18,7 @@ pub use self::ed25519::Ed25519PublicKey;
 pub use self::{dsa::DsaPublicKey, rsa::RsaPublicKey};
 
 use crate::{
-    base64::{self, Decode, Encode},
+    base64::{self, Decode, DecoderExt, Encode, EncoderExt},
     Algorithm, Error, Result,
 };
 use core::str::FromStr;
@@ -222,7 +222,7 @@ impl KeyData {
 }
 
 impl Decode for KeyData {
-    fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+    fn decode(decoder: &mut impl DecoderExt) -> Result<Self> {
         match Algorithm::decode(decoder)? {
             #[cfg(feature = "alloc")]
             Algorithm::Dsa => DsaPublicKey::decode(decoder).map(Self::Dsa),
@@ -256,7 +256,7 @@ impl Encode for KeyData {
         Ok(alg_len + key_len)
     }
 
-    fn encode(&self, encoder: &mut base64::Encoder<'_>) -> Result<()> {
+    fn encode(&self, encoder: &mut impl EncoderExt) -> Result<()> {
         self.algorithm().encode(encoder)?;
         match self {
             #[cfg(feature = "alloc")]

--- a/ssh-key/src/public/dsa.rs
+++ b/ssh-key/src/public/dsa.rs
@@ -1,7 +1,7 @@
 //! Digital Signature Algorithm (DSA) public keys.
 
 use crate::{
-    base64::{self, Decode, Encode},
+    base64::{Decode, DecoderExt, Encode, EncoderExt},
     MPInt, Result,
 };
 
@@ -26,7 +26,7 @@ pub struct DsaPublicKey {
 }
 
 impl Decode for DsaPublicKey {
-    fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+    fn decode(decoder: &mut impl DecoderExt) -> Result<Self> {
         let p = MPInt::decode(decoder)?;
         let q = MPInt::decode(decoder)?;
         let g = MPInt::decode(decoder)?;
@@ -43,7 +43,7 @@ impl Encode for DsaPublicKey {
             + self.y.encoded_len()?)
     }
 
-    fn encode(&self, encoder: &mut base64::Encoder<'_>) -> Result<()> {
+    fn encode(&self, encoder: &mut impl EncoderExt) -> Result<()> {
         self.p.encode(encoder)?;
         self.q.encode(encoder)?;
         self.g.encode(encoder)?;

--- a/ssh-key/src/public/ecdsa.rs
+++ b/ssh-key/src/public/ecdsa.rs
@@ -1,7 +1,7 @@
 //! Elliptic Curve Digital Signature Algorithm (ECDSA) public keys.
 
 use crate::{
-    base64::{self, Decode, DecoderExt, Encode, EncoderExt},
+    base64::{Decode, DecoderExt, Encode, EncoderExt},
     Algorithm, EcdsaCurve, Error, Result,
 };
 use core::fmt;
@@ -90,7 +90,7 @@ impl AsRef<[u8]> for EcdsaPublicKey {
 }
 
 impl Decode for EcdsaPublicKey {
-    fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+    fn decode(decoder: &mut impl DecoderExt) -> Result<Self> {
         let curve = EcdsaCurve::decode(decoder)?;
 
         let mut buf = [0u8; Self::MAX_SIZE];
@@ -109,7 +109,7 @@ impl Encode for EcdsaPublicKey {
         Ok(4 + self.curve().encoded_len()? + self.as_ref().len())
     }
 
-    fn encode(&self, encoder: &mut base64::Encoder<'_>) -> Result<()> {
+    fn encode(&self, encoder: &mut impl EncoderExt) -> Result<()> {
         self.curve().encode(encoder)?;
         encoder.encode_byte_slice(self.as_ref())
     }

--- a/ssh-key/src/public/ed25519.rs
+++ b/ssh-key/src/public/ed25519.rs
@@ -3,7 +3,7 @@
 //! Edwards Digital Signature Algorithm (EdDSA) over Curve25519.
 
 use crate::{
-    base64::{self, Decode, DecoderExt, Encode, EncoderExt},
+    base64::{Decode, DecoderExt, Encode, EncoderExt},
     Error, Result,
 };
 use core::fmt;
@@ -25,14 +25,14 @@ impl AsRef<[u8; Self::BYTE_SIZE]> for Ed25519PublicKey {
 }
 
 impl Decode for Ed25519PublicKey {
-    fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+    fn decode(decoder: &mut impl DecoderExt) -> Result<Self> {
         // Validate length prefix
         if decoder.decode_usize()? != Self::BYTE_SIZE {
             return Err(Error::Length);
         }
 
         let mut bytes = [0u8; Self::BYTE_SIZE];
-        decoder.decode(&mut bytes)?;
+        decoder.decode_base64(&mut bytes)?;
         Ok(Self(bytes))
     }
 }
@@ -42,7 +42,7 @@ impl Encode for Ed25519PublicKey {
         Ok(4 + Self::BYTE_SIZE)
     }
 
-    fn encode(&self, encoder: &mut base64::Encoder<'_>) -> Result<()> {
+    fn encode(&self, encoder: &mut impl EncoderExt) -> Result<()> {
         encoder.encode_byte_slice(self.as_ref())
     }
 }

--- a/ssh-key/src/public/openssh.rs
+++ b/ssh-key/src/public/openssh.rs
@@ -12,7 +12,10 @@
 //! ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILM+rvN+ot98qgEN796jTiQfZfG1KaT0PtFDJ/XFSqti user@example.com
 //! ```
 
-use crate::{base64, Error, Result};
+use crate::{
+    base64::{self},
+    Error, Result,
+};
 use core::str;
 
 /// OpenSSH public key encapsulation parser.

--- a/ssh-key/src/public/rsa.rs
+++ b/ssh-key/src/public/rsa.rs
@@ -1,7 +1,7 @@
 //! Rivest–Shamir–Adleman (RSA) public keys.
 
 use crate::{
-    base64::{self, Decode, Encode},
+    base64::{Decode, DecoderExt, Encode, EncoderExt},
     MPInt, Result,
 };
 
@@ -19,7 +19,7 @@ pub struct RsaPublicKey {
 }
 
 impl Decode for RsaPublicKey {
-    fn decode(decoder: &mut base64::Decoder<'_>) -> Result<Self> {
+    fn decode(decoder: &mut impl DecoderExt) -> Result<Self> {
         let e = MPInt::decode(decoder)?;
         let n = MPInt::decode(decoder)?;
         Ok(Self { e, n })
@@ -31,7 +31,7 @@ impl Encode for RsaPublicKey {
         Ok(self.e.encoded_len()? + self.n.encoded_len()?)
     }
 
-    fn encode(&self, encoder: &mut base64::Encoder<'_>) -> Result<()> {
+    fn encode(&self, encoder: &mut impl EncoderExt) -> Result<()> {
         self.e.encode(encoder)?;
         self.n.encode(encoder)
     }


### PR DESCRIPTION
Changes the `Decode` and `Encode` traits to accept `impl DecoderExt`/`impl EncoderExt` (respectively) as parameters.

This abstracts over the decoder/encoder type, which may be raw Base64 (as used by public keys) or PEM (as used by private keys).