### PR TITLE
ssh-key: add `PrivateKey::public_key` and `From` conversions

### DIFF
--- a/ssh-key/src/private/dsa.rs
+++ b/ssh-key/src/private/dsa.rs
@@ -71,6 +71,18 @@ impl Decode for DsaKeypair {
     }
 }
 
+impl From<DsaKeypair> for DsaPublicKey {
+    fn from(keypair: DsaKeypair) -> DsaPublicKey {
+        keypair.public
+    }
+}
+
+impl From<&DsaKeypair> for DsaPublicKey {
+    fn from(keypair: &DsaKeypair) -> DsaPublicKey {
+        keypair.public.clone()
+    }
+}
+
 impl fmt::Debug for DsaKeypair {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("DsaKeypair")

--- a/ssh-key/src/private/ed25519.rs
+++ b/ssh-key/src/private/ed25519.rs
@@ -109,6 +109,18 @@ impl Decode for Ed25519Keypair {
     }
 }
 
+impl From<Ed25519Keypair> for Ed25519PublicKey {
+    fn from(keypair: Ed25519Keypair) -> Ed25519PublicKey {
+        keypair.public
+    }
+}
+
+impl From<&Ed25519Keypair> for Ed25519PublicKey {
+    fn from(keypair: &Ed25519Keypair) -> Ed25519PublicKey {
+        keypair.public
+    }
+}
+
 impl fmt::Debug for Ed25519Keypair {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Ed25519Keypair")

--- a/ssh-key/src/private/rsa.rs
+++ b/ssh-key/src/private/rsa.rs
@@ -64,6 +64,18 @@ impl Decode for RsaKeypair {
     }
 }
 
+impl From<RsaKeypair> for RsaPublicKey {
+    fn from(keypair: RsaKeypair) -> RsaPublicKey {
+        keypair.public
+    }
+}
+
+impl From<&RsaKeypair> for RsaPublicKey {
+    fn from(keypair: &RsaKeypair) -> RsaPublicKey {
+        keypair.public.clone()
+    }
+}
+
 impl fmt::Debug for RsaKeypair {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RsaKeypair")


### PR DESCRIPTION
Support for getting the `PublicKey` associated with a `PrivateKey`, along with `From` conversions between them and the various intermediate types.