### PR TITLE
chore(x509): enable unused_lifetimes and unused_qualifications lints

### DIFF
--- a/x509/src/anchor.rs
+++ b/x509/src/anchor.rs
@@ -84,7 +84,7 @@ pub struct CertPathControls<'a> {
     pub policy_set: Option<CertificatePolicies<'a>>,
 
     #[asn1(context_specific = "2", tag_mode = "IMPLICIT", optional = "true")]
-    pub policy_flags: Option<CertPolicyFlags<'a>>,
+    pub policy_flags: Option<CertPolicyFlags>,
 
     #[asn1(context_specific = "3", tag_mode = "IMPLICIT", optional = "true")]
     pub name_constr: Option<NameConstraints<'a>>,
@@ -116,7 +116,7 @@ flags! {
 /// Certificate policy flags as defined in [RFC 5280 Section 4.2.1.13].
 ///
 /// [RFC 5280 Section 4.2.1.13]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.13
-pub type CertPolicyFlags<'a> = FlagSet<CertPolicies>;
+pub type CertPolicyFlags = FlagSet<CertPolicies>;
 
 /// ```text
 /// TrustAnchorChoice ::= CHOICE {

--- a/x509/src/lib.rs
+++ b/x509/src/lib.rs
@@ -7,7 +7,12 @@
     html_root_url = "https://docs.rs/x509/0.0.1"
 )]
 #![forbid(unsafe_code)]
-#![warn(missing_docs, rust_2018_idioms)]
+#![warn(
+    missing_docs,
+    rust_2018_idioms,
+    unused_lifetimes,
+    unused_qualifications
+)]
 
 extern crate alloc;
 

--- a/x509/src/time.rs
+++ b/x509/src/time.rs
@@ -97,9 +97,9 @@ impl From<&Time> for SystemTime {
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl TryFrom<SystemTime> for Time {
-    type Error = der::Error;
+    type Error = Error;
 
-    fn try_from(time: SystemTime) -> der::Result<Time> {
+    fn try_from(time: SystemTime) -> Result<Time> {
         Ok(GeneralizedTime::try_from(time)?.into())
     }
 }


### PR DESCRIPTION
Also, clean up the types they warn about.

Signed-off-by: Nathaniel McCallum <nathaniel@profian.com>