### PR TITLE
chore: bump crate prerelease versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.6.0-pre.1"
+version = "0.6.0-pre.2"
 dependencies = [
  "const-oid",
  "der_derive",
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "der_derive"
-version = "0.6.0-pre.1"
+version = "0.6.0-pre.2"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.4.0-pre.0"
+version = "0.4.0-pre.1"
 dependencies = [
  "base64ct",
 ]
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.6.0-pre.0"
+version = "0.6.0-pre.1"
 dependencies = [
  "base64ct",
  "der",

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der"
-version = "0.6.0-pre.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.6.0-pre.2" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust embedded-friendly implementation of the Distinguished Encoding Rules
 (DER) for Abstract Syntax Notation One (ASN.1) as described in ITU X.690 with
@@ -17,9 +17,9 @@ rust-version = "1.57"
 
 [dependencies]
 const-oid = { version = "0.9", optional = true, path = "../const-oid" }
-der_derive = { version = "=0.6.0-pre.1", optional = true, path = "derive" }
+der_derive = { version = "=0.6.0-pre.2", optional = true, path = "derive" }
 flagset = { version = "0.4.3", optional = true }
-pem-rfc7468 = { version = "=0.4.0-pre.0", optional = true, path = "../pem-rfc7468" }
+pem-rfc7468 = { version = "=0.4.0-pre.1", optional = true, path = "../pem-rfc7468" }
 time = { version = "0.3.4", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/der/derive/Cargo.toml
+++ b/der/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der_derive"
-version = "0.6.0-pre.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.6.0-pre.2" # Also update html_root_url in lib.rs when bumping this
 description = "Custom derive support for the `der` crate's `Choice` and `Sequence` traits"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -4,7 +4,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/der/0.6.0-pre.1"
+    html_root_url = "https://docs.rs/der/0.6.0-pre.2"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(

--- a/pem-rfc7468/Cargo.toml
+++ b/pem-rfc7468/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pem-rfc7468"
-version = "0.4.0-pre.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.4.0-pre.1" # Also update html_root_url in lib.rs when bumping this
 description = """
 PEM Encoding (RFC 7468) for PKIX, PKCS, and CMS Structures, implementing a
 strict subset of the original Privacy-Enhanced Mail encoding intended

--- a/pem-rfc7468/src/lib.rs
+++ b/pem-rfc7468/src/lib.rs
@@ -3,7 +3,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/pem-rfc7468/0.4.0-pre.0"
+    html_root_url = "https://docs.rs/pem-rfc7468/0.4.0-pre.1"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]

--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-der = { version = "=0.6.0-pre.1", features = ["oid"], path = "../der" }
+der = { version = "=0.6.0-pre.2", features = ["oid"], path = "../der" }
 
 # optional dependencies
 pkcs8 = { version = "=0.9.0-pre", optional = true, default-features = false, path = "../pkcs8" }

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -15,8 +15,8 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-der = { version = "=0.6.0-pre.1", features = ["oid"], path = "../der" }
-spki = { version = "=0.6.0-pre.0", path = "../spki" }
+der = { version = "=0.6.0-pre.2", features = ["oid"], path = "../der" }
+spki = { version = "=0.6.0-pre.1", path = "../spki" }
 
 # optional dependencies
 cbc = { version = "0.1.1", optional = true }

--- a/pkcs7/Cargo.toml
+++ b/pkcs7/Cargo.toml
@@ -15,8 +15,8 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-der = { version = "=0.6.0-pre.1", features = ["oid"], path = "../der" }
-spki = { version = "=0.6.0-pre.0", path = "../spki" }
+der = { version = "=0.6.0-pre.2", features = ["oid"], path = "../der" }
+spki = { version = "=0.6.0-pre.1", path = "../spki" }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -16,8 +16,8 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-der = { version = "=0.6.0-pre.1", features = ["oid"], path = "../der" }
-spki = { version = "=0.6.0-pre.0", path = "../spki" }
+der = { version = "=0.6.0-pre.2", features = ["oid"], path = "../der" }
+spki = { version = "=0.6.0-pre.1", path = "../spki" }
 
 # optional dependencies
 rand_core = { version = "0.6", optional = true, default-features = false }

--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.57"
 generic-array = { version = "0.14.4", default-features = false }
 
 # optional dependencies
-der = { version = "=0.6.0-pre.1", optional = true, features = ["oid"], path = "../der" }
+der = { version = "=0.6.0-pre.2", optional = true, features = ["oid"], path = "../der" }
 pkcs8 = { version = "=0.9.0-pre", optional = true, default-features = false, path = "../pkcs8" }
 serde = { version = "1.0.16", optional = true, default-features = false }
 subtle = { version = "2", optional = true, default-features = false }

--- a/spki/Cargo.toml
+++ b/spki/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spki"
-version = "0.6.0-pre.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.6.0-pre.1" # Also update html_root_url in lib.rs when bumping this
 description = """
 X.509 Subject Public Key Info (RFC5280) describing public keys as well as their
 associated AlgorithmIdentifiers (i.e. OIDs)
@@ -15,7 +15,7 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-der = { version = "=0.6.0-pre.1", features = ["oid"], path = "../der" }
+der = { version = "=0.6.0-pre.2", features = ["oid"], path = "../der" }
 
 # Optional dependencies
 sha2 = { version = "0.10", optional = true, default-features = false }

--- a/spki/src/lib.rs
+++ b/spki/src/lib.rs
@@ -4,7 +4,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/spki/0.6.0-pre.0"
+    html_root_url = "https://docs.rs/spki/0.6.0-pre.1"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.57"
 
 [dependencies]
 base64ct = { version = "1.4", path = "../base64ct" }
-pem-rfc7468 = { version = "=0.4.0-pre.0", path = "../pem-rfc7468" }
+pem-rfc7468 = { version = "=0.4.0-pre.1", path = "../pem-rfc7468" }
 zeroize = { version = "1", default-features = false }
 
 # optional dependencies

--- a/x509/Cargo.toml
+++ b/x509/Cargo.toml
@@ -15,10 +15,10 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-der = { version = "=0.6.0-pre.1", features = ["derive", "alloc", "flagset"], path = "../der" }
 const-oid = { version = "0.9", features = ["db"], path = "../const-oid" }
+der = { version = "=0.6.0-pre.2", features = ["derive", "alloc", "flagset"], path = "../der" }
 flagset = { version = "0.4.3" }
-spki = { version = "=0.6.0-pre.0", path = "../spki" }
+spki = { version = "=0.6.0-pre.1", path = "../spki" }
 
 [dev-dependencies]
 hex-literal = "0.3"


### PR DESCRIPTION
This bumps the prerelease versions for the following crates:

der
der_derive
pem-rfc7468
spki