### PR TITLE
base64ct v1.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,7 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "base64ct"
-version = "1.4.0-pre.0"
+version = "1.4.0"
 dependencies = [
  "base64",
  "proptest",

--- a/base64ct/CHANGELOG.md
+++ b/base64ct/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.4.0 (2022-03-10)
+### Added
+- Buffered `Encoder` type ([#366], [#455], [#457])
+- `Decoder::decoded_len` method ([#403])
+- Impl `std::io::Read` for `Decoder` ([#404])
+- Bounds for `Encoding`/`Variant` ZSTs ([#405], [#408])
+
+[#366]: https://github.com/RustCrypto/formats/pull/366
+[#403]: https://github.com/RustCrypto/formats/pull/403
+[#404]: https://github.com/RustCrypto/formats/pull/404
+[#405]: https://github.com/RustCrypto/formats/pull/405
+[#408]: https://github.com/RustCrypto/formats/pull/408
+[#455]: https://github.com/RustCrypto/formats/pull/455
+[#457]: https://github.com/RustCrypto/formats/pull/457
+
 ## 1.3.3 (2021-12-28)
 ### Fixed
 - Potential infinite loop in `Decoder::decode` ([#305])

--- a/base64ct/Cargo.toml
+++ b/base64ct/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base64ct"
-version = "1.4.0-pre.0" # Also update html_root_url in lib.rs when bumping this
+version = "1.4.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Base64 (RFC 4648) which avoids any usages of
 data-dependent branches/LUTs and thereby provides portable "best effort"

--- a/base64ct/src/lib.rs
+++ b/base64ct/src/lib.rs
@@ -3,7 +3,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/base64ct/1.4.0-pre.0"
+    html_root_url = "https://docs.rs/base64ct/1.4.0"
 )]
 #![doc = include_str!("../README.md")]
 #![warn(

--- a/pem-rfc7468/Cargo.toml
+++ b/pem-rfc7468/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-base64ct = { version = "=1.4.0-pre.0", path = "../base64ct" }
+base64ct = { version = "1.4", path = "../base64ct" }
 
 [features]
 alloc = ["base64ct/alloc"]

--- a/spki/Cargo.toml
+++ b/spki/Cargo.toml
@@ -19,7 +19,7 @@ der = { version = "=0.6.0-pre.1", features = ["oid"], path = "../der" }
 
 # Optional dependencies
 sha2 = { version = "0.10", optional = true, default-features = false }
-base64ct = { version = "=1.4.0-pre.0", path = "../base64ct", optional = true, default-features = false }
+base64ct = { version = "1", path = "../base64ct", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-base64ct = { version = "=1.4.0-pre.0", path = "../base64ct" }
+base64ct = { version = "1.4", path = "../base64ct" }
 pem-rfc7468 = { version = "=0.4.0-pre.0", path = "../pem-rfc7468" }
 zeroize = { version = "1", default-features = false }
 


### PR DESCRIPTION
### Added
- Buffered `Encoder` type ([#366], [#455], [#457])
- `Decoder::decoded_len` method ([#403])
- Impl `std::io::Read` for `Decoder` ([#404])
- Bounds for `Encoding`/`Variant` ZSTs ([#405], [#408])

[#366]: https://github.com/RustCrypto/formats/pull/366
[#403]: https://github.com/RustCrypto/formats/pull/403
[#404]: https://github.com/RustCrypto/formats/pull/404
[#405]: https://github.com/RustCrypto/formats/pull/405
[#408]: https://github.com/RustCrypto/formats/pull/408
[#455]: https://github.com/RustCrypto/formats/pull/455
[#457]: https://github.com/RustCrypto/formats/pull/457