### PR TITLE
sec1: make DER feature optional

### DIFF
--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -16,10 +16,10 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-der = { version = "=0.6.0-pre.1", features = ["oid"], path = "../der" }
 generic-array = { version = "0.14.4", default-features = false }
 
 # optional dependencies
+der = { version = "=0.6.0-pre.1", optional = true, features = ["oid"], path = "../der" }
 pkcs8 = { version = "=0.9.0-pre", optional = true, default-features = false, path = "../pkcs8" }
 serde = { version = "1.0.16", optional = true, default-features = false }
 subtle = { version = "2", optional = true, default-features = false }
@@ -29,6 +29,7 @@ zeroize = { version = "1", optional = true, default-features = false }
 hex-literal = "0.3"
 
 [features]
+default = ["der"]
 alloc = ["der/alloc", "pkcs8/alloc", "zeroize/alloc"]
 pem = ["alloc", "der/pem", "pkcs8/pem"]
 std = ["der/std", "alloc"]

--- a/sec1/src/error.rs
+++ b/sec1/src/error.rs
@@ -10,6 +10,8 @@ pub type Result<T> = core::result::Result<T, Error>;
 #[non_exhaustive]
 pub enum Error {
     /// ASN.1 DER-related errors.
+    #[cfg(feature = "der")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "der")))]
     Asn1(der::Error),
 
     /// Cryptographic errors.
@@ -35,6 +37,7 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            #[cfg(feature = "der")]
             Error::Asn1(err) => write!(f, "SEC1 ASN.1 error: {}", err),
             Error::Crypto => f.write_str("SEC1 cryptographic error"),
             #[cfg(feature = "pkcs8")]
@@ -45,6 +48,8 @@ impl fmt::Display for Error {
     }
 }
 
+#[cfg(feature = "der")]
+#[cfg_attr(docsrs, doc(cfg(feature = "der")))]
 impl From<der::Error> for Error {
     fn from(err: der::Error) -> Error {
         Error::Asn1(err)

--- a/sec1/src/lib.rs
+++ b/sec1/src/lib.rs
@@ -26,19 +26,23 @@ extern crate std;
 pub mod point;
 
 mod error;
+#[cfg(feature = "der")]
 mod parameters;
+#[cfg(feature = "der")]
 mod private_key;
+#[cfg(feature = "der")]
 mod traits;
 
+#[cfg(feature = "der")]
 pub use der;
 
-pub use self::{
+pub use crate::{
     error::{Error, Result},
-    parameters::EcParameters,
     point::EncodedPoint,
-    private_key::EcPrivateKey,
-    traits::DecodeEcPrivateKey,
 };
+
+#[cfg(feature = "der")]
+pub use crate::{parameters::EcParameters, private_key::EcPrivateKey, traits::DecodeEcPrivateKey};
 
 pub use generic_array::typenum::consts;
 

--- a/sec1/src/parameters.rs
+++ b/sec1/src/parameters.rs
@@ -18,6 +18,7 @@ use der::{
 ///   -- with ANSI X9.
 /// ```
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(docsrs, doc(cfg(feature = "der")))]
 pub enum EcParameters {
     /// Elliptic curve named by a particular OID.
     ///

--- a/sec1/src/private_key.rs
+++ b/sec1/src/private_key.rs
@@ -55,6 +55,7 @@ const PUBLIC_KEY_TAG: TagNumber = TagNumber::new(1);
 /// [SEC1: Elliptic Curve Cryptography (Version 2.0)]: https://www.secg.org/sec1-v2.pdf
 /// [RFC5915 Section 3]: https://datatracker.ietf.org/doc/html/rfc5915#section-3
 #[derive(Clone)]
+#[cfg_attr(docsrs, doc(cfg(feature = "der")))]
 pub struct EcPrivateKey<'a> {
     /// Private key data.
     pub private_key: &'a [u8],

--- a/sec1/src/traits.rs
+++ b/sec1/src/traits.rs
@@ -24,6 +24,7 @@ use std::path::Path;
 use zeroize::Zeroizing;
 
 /// Parse an [`EcPrivateKey`] from a SEC1-encoded document.
+#[cfg_attr(docsrs, doc(cfg(feature = "der")))]
 pub trait DecodeEcPrivateKey: Sized {
     /// Deserialize SEC1 private key from ASN.1 DER-encoded data
     /// (binary format).
@@ -63,7 +64,7 @@ pub trait DecodeEcPrivateKey: Sized {
 
 /// Serialize a [`EcPrivateKey`] to a SEC1 encoded document.
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "alloc", feature = "der"))))]
 pub trait EncodeEcPrivateKey {
     /// Serialize a [`EcPrivateKeyDocument`] containing a SEC1-encoded private key.
     fn to_sec1_der(&self) -> Result<EcPrivateKeyDocument>;

--- a/sec1/tests/private_key.rs
+++ b/sec1/tests/private_key.rs
@@ -1,5 +1,7 @@
 //! SEC1 private key tests
 
+#![cfg(feature = "der")]
+
 use der::asn1::ObjectIdentifier;
 use hex_literal::hex;
 use sec1::{EcParameters, EcPrivateKey};


### PR DESCRIPTION
This allows the SEC1 encoded point types to be used without pulling in the `der` crate and its associated dependencies