### PR TITLE
ssh-key: make `PublicKey`/`PrivateKey` fields private

### DIFF
--- a/ssh-key/README.md
+++ b/ssh-key/README.md
@@ -17,9 +17,9 @@ and `authorized_keys` files.
 
 ## Features
 
-- [x] Constant-time Base64 decoding using the `base64ct` crate
+- [x] Constant-time Base64 decoding/encoding using the `base64ct` crate
 - [x] `no_std` support including support for "heapless" (no-`alloc`) targets
-- [x] Parsing OpenSSH-formatted public and private keys with the following algorithms:
+- [x] Decoding/encoding OpenSSH-formatted public & private keys:
   - [x] DSA (`no_std` + `alloc`)
   - [x] ECDSA (`no_std` "heapless")
   - [x] Ed25519 (`no_std` "heapless")
@@ -29,7 +29,6 @@ and `authorized_keys` files.
 
 #### TODO:
 
-- [ ] Encoder support (currently decode-only)
 - [ ] Encrypted private key support
 - [ ] Legacy SSH key (pre-OpenSSH) format support
 - [ ] Integrations with other RustCrypto crates (e.g. `ecdsa`, `ed25519`, `rsa`)

--- a/ssh-key/src/base64.rs
+++ b/ssh-key/src/base64.rs
@@ -178,6 +178,21 @@ pub(crate) trait DecoderExt {
     fn decode_string(&mut self) -> Result<String> {
         String::from_utf8(self.decode_byte_vec()?).map_err(|_| Error::CharacterEncoding)
     }
+
+    /// Drain the given number of bytes from the decoder, discarding them.
+    fn drain(&mut self, n_bytes: usize) -> Result<()> {
+        let mut byte = [0];
+        for _ in 0..n_bytes {
+            self.decode_base64(&mut byte)?;
+        }
+        Ok(())
+    }
+
+    /// Decode a `u32` length prefix, and then drain the length of the body.
+    fn drain_prefixed(&mut self) -> Result<()> {
+        let n_bytes = self.decode_usize()?;
+        self.drain(n_bytes)
+    }
 }
 
 impl DecoderExt for Decoder<'_> {

--- a/ssh-key/src/lib.rs
+++ b/ssh-key/src/lib.rs
@@ -21,10 +21,9 @@
 //!
 //! #### Example
 //!
-//! ```
+#![cfg_attr(feature = "std", doc = "```")]
+#![cfg_attr(not(feature = "std"), doc = "```ignore")]
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! # #[cfg(feature = "std")]
-//! # {
 //! use ssh_key::PublicKey;
 //!
 //! let encoded_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILM+rvN+ot98qgEN796jTiQfZfG1KaT0PtFDJ/XFSqti user@example.com";
@@ -32,10 +31,10 @@
 //!
 //! // Key attributes
 //! assert_eq!(public_key.algorithm(), ssh_key::Algorithm::Ed25519);
-//! assert_eq!(public_key.comment, "user@example.com");
+//! assert_eq!(public_key.comment(), "user@example.com");
 //!
 //! // Key data: in this example an Ed25519 key
-//! if let Some(ed25519_public_key) = public_key.key_data.ed25519() {
+//! if let Some(ed25519_public_key) = public_key.key_data().ed25519() {
 //!     assert_eq!(
 //!         ed25519_public_key.as_ref(),
 //!         [
@@ -45,7 +44,6 @@
 //!         ].as_ref()
 //!     );
 //! }
-//! # }
 //! # Ok(())
 //! # }
 //! ```
@@ -60,10 +58,9 @@
 //!
 //! #### Example
 //!
-//! ```
+#![cfg_attr(feature = "std", doc = " ```")]
+#![cfg_attr(not(feature = "std"), doc = " ```ignore")]
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! # #[cfg(feature = "std")]
-//! # {
 //! use ssh_key::PrivateKey;
 //!
 //! // WARNING: don't actually hardcode private keys in source code!!!
@@ -81,10 +78,10 @@
 //!
 //! // Key attributes
 //! assert_eq!(private_key.algorithm(), ssh_key::Algorithm::Ed25519);
-//! assert_eq!(private_key.comment, "user@example.com");
+//! assert_eq!(private_key.comment(), "user@example.com");
 //!
 //! // Key data: in this example an Ed25519 key
-//! if let Some(ed25519_keypair) = private_key.key_data.ed25519() {
+//! if let Some(ed25519_keypair) = private_key.key_data().ed25519() {
 //!     assert_eq!(
 //!         ed25519_keypair.public.as_ref(),
 //!         [
@@ -103,7 +100,6 @@
 //!         ].as_ref()
 //!     )
 //! }
-//! # }
 //! # Ok(())
 //! # }
 //! ```

--- a/ssh-key/tests/authorized_keys.rs
+++ b/ssh-key/tests/authorized_keys.rs
@@ -11,22 +11,22 @@ fn read_example_file() {
         let entry1 = authorized_keys.next().unwrap()?;
         assert_eq!(entry1.options.to_string(), "");
         assert_eq!(entry1.public_key.to_string(), "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILM+rvN+ot98qgEN796jTiQfZfG1KaT0PtFDJ/XFSqti user1@example.com");
-        assert_eq!(entry1.public_key.comment, "user1@example.com");
+        assert_eq!(entry1.public_key.comment(), "user1@example.com");
 
         let entry2 = authorized_keys.next().unwrap()?;
         assert_eq!(entry2.options.to_string(), "command=\"/usr/bin/date\"");
         assert_eq!(entry2.public_key.to_string(), "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHwf2HMM5TRXvo2SQJjsNkiDD5KqiiNjrGVv3UUh+mMT5RHxiRtOnlqvjhQtBq0VpmpCV/PwUdhOig4vkbqAcEc= user2@example.com");
-        assert_eq!(entry2.public_key.comment, "user2@example.com");
+        assert_eq!(entry2.public_key.comment(), "user2@example.com");
 
         let entry3 = authorized_keys.next().unwrap()?;
         assert_eq!(entry3.options.to_string(), "environment=\"PATH=/bin:/usr/bin\"");
         assert_eq!(entry3.public_key.to_string(), "ssh-dss AAAAB3NzaC1kc3MAAACBANw9iSUO2UYhFMssjUgW46URqv8bBrDgHeF8HLBOWBvKuXF2Rx2J/XyhgX48SOLMuv0hcPaejlyLarabnF9F2V4dkpPpZSJ+7luHmxEjNxwhsdtg8UteXAWkeCzrQ6MvRJZHcDBjYh56KGvslbFnJsGLXlI4PQCyl6awNImwYGilAAAAFQCJGBU3hZf+QtP9Jh/nbfNlhFu7hwAAAIBHObOQioQVRm3HsVb7mOy3FVKhcLoLO3qoG9gTkd4KeuehtFAC3+rckiX7xSCnE/5BBKdL7VP9WRXac2Nlr9Pwl3e7zPut96wrCHt/TZX6vkfXKkbpUIj5zSqfvyNrWKaYJkfzwAQwrXNS1Hol676Ud/DDEn2oatdEhkS3beWHXAAAAIBgQqaz/YYTRMshzMzYcZ4lqgvgmA55y6v0h39e8HH2A5dwNS6sPUw2jyna+le0dceNRJifFld1J+WYM0vmquSr11DDavgEidOSaXwfMvPPPJqLmbzdtT16N+Gij9U9STQTHPQcQ3xnNNHgQAStzZJbhLOVbDDDo5BO7LMUALDfSA== user3@example.com");
-        assert_eq!(entry3.public_key.comment, "user3@example.com");
+        assert_eq!(entry3.public_key.comment(), "user3@example.com");
 
         let entry4 = authorized_keys.next().unwrap()?;
         assert_eq!(entry4.options.to_string(), "from=\"10.0.0.?,*.example.com\",no-X11-forwarding");
         assert_eq!(entry4.public_key.to_string(), "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC0WRHtxuxefSJhpIxGq4ibGFgwYnESPm8C3JFM88A1JJLoprenklrd7VJ+VH3Ov/bQwZwLyRU5dRmfR/SWTtIPWs7tToJVayKKDB+/qoXmM5ui/0CU2U4rCdQ6PdaCJdC7yFgpPL8WexjWN06+eSIKYz1AAXbx9rRv1iasslK/KUqtsqzVliagI6jl7FPO2GhRZMcso6LsZGgSxuYf/Lp0D/FcBU8GkeOo1Sx5xEt8H8bJcErtCe4Blb8JxcW6EXO3sReb4z+zcR07gumPgFITZ6hDA8sSNuvo/AlWg0IKTeZSwHHVknWdQqDJ0uczE837caBxyTZllDNIGkBjCIIOFzuTT76HfYc/7CTTGk07uaNkUFXKN79xDiFOX8JQ1ZZMZvGOTwWjuT9CqgdTvQRORbRWwOYv3MH8re9ykw3Ip6lrPifY7s6hOaAKry/nkGPMt40m1TdiW98MTIpooE7W+WXu96ax2l2OJvxX8QR7l+LFlKnkIEEJd/ItF1G22UmOjkVwNASTwza/hlY+8DoVvEmwum/nMgH2TwQT3bTQzF9s9DOJkH4d8p4Mw4gEDjNx0EgUFA91ysCAeUMQQyIvuR8HXXa+VcvhOOO5mmBcVhxJ3qUOJTyDBsT0932Zb4mNtkxdigoVxu+iiwk0vwtvKwGVDYdyMP5EAQeEIP1t0w== user4@example.com");
-        assert_eq!(entry4.public_key.comment, "user4@example.com");
+        assert_eq!(entry4.public_key.comment(), "user4@example.com");
 
         assert_eq!(authorized_keys.next(), None);
         Ok(())

--- a/ssh-key/tests/private_key.rs
+++ b/ssh-key/tests/private_key.rs
@@ -46,9 +46,9 @@ const OSSH_RSA_4096_EXAMPLE: &str = include_str!("examples/id_rsa_4096");
 #[test]
 fn decode_dsa_openssh() {
     let ossh_key = PrivateKey::from_openssh(OSSH_DSA_EXAMPLE).unwrap();
-    assert_eq!(Algorithm::Dsa, ossh_key.key_data.algorithm());
+    assert_eq!(Algorithm::Dsa, ossh_key.key_data().algorithm());
 
-    let dsa_keypair = ossh_key.key_data.dsa().unwrap();
+    let dsa_keypair = ossh_key.key_data().dsa().unwrap();
     assert_eq!(
         &hex!(
             "00dc3d89250ed9462114cb2c8d4816e3a511aaff1b06b0e01de17c1cb04e581bcab97176471d89fd7ca1817
@@ -81,7 +81,7 @@ fn decode_dsa_openssh() {
         &hex!("0c377ac449e770d89a3557743cbd050396114b62"),
         dsa_keypair.private.as_bytes()
     );
-    assert_eq!("user@example.com", ossh_key.comment);
+    assert_eq!("user@example.com", ossh_key.comment());
 }
 
 #[cfg(feature = "ecdsa")]
@@ -90,10 +90,10 @@ fn decode_ecdsa_p256_openssh() {
     let ossh_key = PrivateKey::from_openssh(OSSH_ECDSA_P256_EXAMPLE).unwrap();
     assert_eq!(
         Algorithm::Ecdsa(EcdsaCurve::NistP256),
-        ossh_key.key_data.algorithm(),
+        ossh_key.key_data().algorithm(),
     );
 
-    let ecdsa_keypair = ossh_key.key_data.ecdsa().unwrap();
+    let ecdsa_keypair = ossh_key.key_data().ecdsa().unwrap();
     assert_eq!(EcdsaCurve::NistP256, ecdsa_keypair.curve());
     assert_eq!(
         &hex!(
@@ -108,7 +108,7 @@ fn decode_ecdsa_p256_openssh() {
     );
 
     #[cfg(feature = "alloc")]
-    assert_eq!("user@example.com", ossh_key.comment);
+    assert_eq!("user@example.com", ossh_key.comment());
 }
 
 #[cfg(feature = "ecdsa")]
@@ -117,10 +117,10 @@ fn decode_ecdsa_p384_openssh() {
     let ossh_key = PrivateKey::from_openssh(OSSH_ECDSA_P384_EXAMPLE).unwrap();
     assert_eq!(
         Algorithm::Ecdsa(EcdsaCurve::NistP384),
-        ossh_key.key_data.algorithm(),
+        ossh_key.key_data().algorithm(),
     );
 
-    let ecdsa_keypair = ossh_key.key_data.ecdsa().unwrap();
+    let ecdsa_keypair = ossh_key.key_data().ecdsa().unwrap();
     assert_eq!(EcdsaCurve::NistP384, ecdsa_keypair.curve());
     assert_eq!(
         &hex!(
@@ -139,7 +139,7 @@ fn decode_ecdsa_p384_openssh() {
     );
 
     #[cfg(feature = "alloc")]
-    assert_eq!("user@example.com", ossh_key.comment);
+    assert_eq!("user@example.com", ossh_key.comment());
 }
 
 #[cfg(feature = "ecdsa")]
@@ -148,10 +148,10 @@ fn decode_ecdsa_p521_openssh() {
     let ossh_key = PrivateKey::from_openssh(OSSH_ECDSA_P521_EXAMPLE).unwrap();
     assert_eq!(
         Algorithm::Ecdsa(EcdsaCurve::NistP521),
-        ossh_key.key_data.algorithm(),
+        ossh_key.key_data().algorithm(),
     );
 
-    let ecdsa_keypair = ossh_key.key_data.ecdsa().unwrap();
+    let ecdsa_keypair = ossh_key.key_data().ecdsa().unwrap();
     assert_eq!(EcdsaCurve::NistP521, ecdsa_keypair.curve());
     assert_eq!(
         &hex!(
@@ -171,15 +171,15 @@ fn decode_ecdsa_p521_openssh() {
     );
 
     #[cfg(feature = "alloc")]
-    assert_eq!("user@example.com", ossh_key.comment);
+    assert_eq!("user@example.com", ossh_key.comment());
 }
 
 #[test]
 fn decode_ed25519_openssh() {
     let ossh_key = PrivateKey::from_openssh(OSSH_ED25519_EXAMPLE).unwrap();
-    assert_eq!(Algorithm::Ed25519, ossh_key.key_data.algorithm());
+    assert_eq!(Algorithm::Ed25519, ossh_key.key_data().algorithm());
 
-    let ed25519_keypair = ossh_key.key_data.ed25519().unwrap();
+    let ed25519_keypair = ossh_key.key_data().ed25519().unwrap();
     assert_eq!(
         &hex!("b33eaef37ea2df7caa010defdea34e241f65f1b529a4f43ed14327f5c54aab62"),
         ed25519_keypair.public.as_ref(),
@@ -190,16 +190,16 @@ fn decode_ed25519_openssh() {
     );
 
     #[cfg(feature = "alloc")]
-    assert_eq!(ossh_key.comment, "user@example.com");
+    assert_eq!(ossh_key.comment(), "user@example.com");
 }
 
 #[cfg(feature = "alloc")]
 #[test]
 fn decode_rsa_3072_openssh() {
     let ossh_key = PrivateKey::from_openssh(OSSH_RSA_3072_EXAMPLE).unwrap();
-    assert_eq!(Algorithm::Rsa, ossh_key.key_data.algorithm());
+    assert_eq!(Algorithm::Rsa, ossh_key.key_data().algorithm());
 
-    let rsa_keypair = ossh_key.key_data.rsa().unwrap();
+    let rsa_keypair = ossh_key.key_data().rsa().unwrap();
     assert_eq!(&hex!("010001"), rsa_keypair.public.e.as_bytes());
     assert_eq!(
         &hex!(
@@ -259,16 +259,16 @@ fn decode_rsa_3072_openssh() {
         ),
         rsa_keypair.private.q.as_bytes()
     );
-    assert_eq!("user@example.com", ossh_key.comment);
+    assert_eq!("user@example.com", ossh_key.comment());
 }
 
 #[cfg(feature = "alloc")]
 #[test]
 fn decode_rsa_4096_openssh() {
     let ossh_key = PrivateKey::from_openssh(OSSH_RSA_4096_EXAMPLE).unwrap();
-    assert_eq!(Algorithm::Rsa, ossh_key.key_data.algorithm());
+    assert_eq!(Algorithm::Rsa, ossh_key.key_data().algorithm());
 
-    let rsa_keypair = ossh_key.key_data.rsa().unwrap();
+    let rsa_keypair = ossh_key.key_data().rsa().unwrap();
     assert_eq!(&hex!("010001"), rsa_keypair.public.e.as_bytes());
     assert_eq!(
         &hex!(
@@ -337,7 +337,7 @@ fn decode_rsa_4096_openssh() {
         ),
         rsa_keypair.private.q.as_bytes()
     );
-    assert_eq!("user@example.com", ossh_key.comment);
+    assert_eq!("user@example.com", ossh_key.comment());
 }
 
 #[cfg(all(feature = "alloc", feature = "subtle"))]

--- a/ssh-key/tests/public_key.rs
+++ b/ssh-key/tests/public_key.rs
@@ -37,9 +37,9 @@ const OSSH_RSA_4096_EXAMPLE: &str = include_str!("examples/id_rsa_4096.pub");
 #[test]
 fn decode_dsa_openssh() {
     let ossh_key = PublicKey::from_openssh(OSSH_DSA_EXAMPLE).unwrap();
-    assert_eq!(Algorithm::Dsa, ossh_key.key_data.algorithm());
+    assert_eq!(Algorithm::Dsa, ossh_key.key_data().algorithm());
 
-    let dsa_key = ossh_key.key_data.dsa().unwrap();
+    let dsa_key = ossh_key.key_data().dsa().unwrap();
     assert_eq!(
         &hex!(
             "00dc3d89250ed9462114cb2c8d4816e3a511aaff1b06b0e01de17c1cb04e581bcab97176471d89fd7ca1817
@@ -69,7 +69,7 @@ fn decode_dsa_openssh() {
         dsa_key.y.as_bytes(),
     );
 
-    assert_eq!("user@example.com", ossh_key.comment);
+    assert_eq!("user@example.com", ossh_key.comment());
 }
 
 #[cfg(feature = "ecdsa")]
@@ -78,10 +78,10 @@ fn decode_ecdsa_p256_openssh() {
     let ossh_key = PublicKey::from_openssh(OSSH_ECDSA_P256_EXAMPLE).unwrap();
     assert_eq!(
         Algorithm::Ecdsa(EcdsaCurve::NistP256),
-        ossh_key.key_data.algorithm(),
+        ossh_key.key_data().algorithm(),
     );
 
-    let ecdsa_key = ossh_key.key_data.ecdsa().unwrap();
+    let ecdsa_key = ossh_key.key_data().ecdsa().unwrap();
     assert_eq!(EcdsaCurve::NistP256, ecdsa_key.curve());
     assert_eq!(
         &hex!(
@@ -92,7 +92,7 @@ fn decode_ecdsa_p256_openssh() {
     );
 
     #[cfg(feature = "alloc")]
-    assert_eq!("user@example.com", ossh_key.comment);
+    assert_eq!("user@example.com", ossh_key.comment());
 }
 
 #[cfg(feature = "ecdsa")]
@@ -101,10 +101,10 @@ fn decode_ecdsa_p384_openssh() {
     let ossh_key = PublicKey::from_openssh(OSSH_ECDSA_P384_EXAMPLE).unwrap();
     assert_eq!(
         Algorithm::Ecdsa(EcdsaCurve::NistP384),
-        ossh_key.key_data.algorithm(),
+        ossh_key.key_data().algorithm(),
     );
 
-    let ecdsa_key = ossh_key.key_data.ecdsa().unwrap();
+    let ecdsa_key = ossh_key.key_data().ecdsa().unwrap();
     assert_eq!(EcdsaCurve::NistP384, ecdsa_key.curve());
     assert_eq!(
         &hex!(
@@ -116,7 +116,7 @@ fn decode_ecdsa_p384_openssh() {
     );
 
     #[cfg(feature = "alloc")]
-    assert_eq!("user@example.com", ossh_key.comment);
+    assert_eq!("user@example.com", ossh_key.comment());
 }
 
 #[cfg(feature = "ecdsa")]
@@ -125,10 +125,10 @@ fn decode_ecdsa_p521_openssh() {
     let ossh_key = PublicKey::from_openssh(OSSH_ECDSA_P521_EXAMPLE).unwrap();
     assert_eq!(
         Algorithm::Ecdsa(EcdsaCurve::NistP521),
-        ossh_key.key_data.algorithm(),
+        ossh_key.key_data().algorithm(),
     );
 
-    let ecdsa_key = ossh_key.key_data.ecdsa().unwrap();
+    let ecdsa_key = ossh_key.key_data().ecdsa().unwrap();
     assert_eq!(ecdsa_key.curve(), EcdsaCurve::NistP521);
     assert_eq!(
         &hex!(
@@ -141,30 +141,30 @@ fn decode_ecdsa_p521_openssh() {
     );
 
     #[cfg(feature = "alloc")]
-    assert_eq!("user@example.com", ossh_key.comment);
+    assert_eq!("user@example.com", ossh_key.comment());
 }
 
 #[test]
 fn decode_ed25519_openssh() {
     let ossh_key = PublicKey::from_openssh(OSSH_ED25519_EXAMPLE).unwrap();
 
-    assert_eq!(Algorithm::Ed25519, ossh_key.key_data.algorithm());
+    assert_eq!(Algorithm::Ed25519, ossh_key.key_data().algorithm());
     assert_eq!(
         &hex!("b33eaef37ea2df7caa010defdea34e241f65f1b529a4f43ed14327f5c54aab62"),
-        ossh_key.key_data.ed25519().unwrap().as_ref(),
+        ossh_key.key_data().ed25519().unwrap().as_ref(),
     );
 
     #[cfg(feature = "alloc")]
-    assert_eq!("user@example.com", ossh_key.comment);
+    assert_eq!("user@example.com", ossh_key.comment());
 }
 
 #[cfg(feature = "alloc")]
 #[test]
 fn decode_rsa_3072_openssh() {
     let ossh_key = PublicKey::from_openssh(OSSH_RSA_3072_EXAMPLE).unwrap();
-    assert_eq!(Algorithm::Rsa, ossh_key.key_data.algorithm());
+    assert_eq!(Algorithm::Rsa, ossh_key.key_data().algorithm());
 
-    let rsa_key = ossh_key.key_data.rsa().unwrap();
+    let rsa_key = ossh_key.key_data().rsa().unwrap();
     assert_eq!(&hex!("010001"), rsa_key.e.as_bytes());
     assert_eq!(
         &hex!(
@@ -181,16 +181,16 @@ fn decode_rsa_3072_openssh() {
         rsa_key.n.as_bytes(),
     );
 
-    assert_eq!("user@example.com", ossh_key.comment);
+    assert_eq!("user@example.com", ossh_key.comment());
 }
 
 #[cfg(feature = "alloc")]
 #[test]
 fn decode_rsa_4096_openssh() {
     let ossh_key = PublicKey::from_openssh(OSSH_RSA_4096_EXAMPLE).unwrap();
-    assert_eq!(Algorithm::Rsa, ossh_key.key_data.algorithm());
+    assert_eq!(Algorithm::Rsa, ossh_key.key_data().algorithm());
 
-    let rsa_key = ossh_key.key_data.rsa().unwrap();
+    let rsa_key = ossh_key.key_data().rsa().unwrap();
     assert_eq!(&hex!("010001"), rsa_key.e.as_bytes());
     assert_eq!(
         &hex!(
@@ -210,7 +210,7 @@ fn decode_rsa_4096_openssh() {
         rsa_key.n.as_bytes(),
     );
 
-    assert_eq!("user@example.com", ossh_key.comment);
+    assert_eq!("user@example.com", ossh_key.comment());
 }
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
Replaces direct field access with accessor methods.

This helps smooth out the absence of heap-allocated comments when the `alloc` feature isn't enabled.