### PR TITLE
base64ct: rename `Decoder::decoded_len` => `::remaining_len`

### DIFF
--- a/base64ct/tests/proptests.rs
+++ b/base64ct/tests/proptests.rs
@@ -33,7 +33,7 @@ proptest! {
 
         let mut buffer = [0u8; 384];
         let mut decoder = Decoder::new(encoded.as_bytes()).unwrap();
-        let mut remaining_len = decoder.decoded_len();
+        let mut remaining_len = decoder.remaining_len();
 
         for chunk in bytes.chunks(chunk_size) {
             prop_assert!(!decoder.is_finished());
@@ -42,11 +42,11 @@ proptest! {
             prop_assert_eq!(Ok(chunk), decoded);
 
             remaining_len -= decoded.unwrap().len();
-            prop_assert_eq!(remaining_len, decoder.decoded_len());
+            prop_assert_eq!(remaining_len, decoder.remaining_len());
         }
 
         prop_assert!(decoder.is_finished());
-        prop_assert_eq!(decoder.decoded_len(), 0);
+        prop_assert_eq!(decoder.remaining_len(), 0);
     }
 
     #[test]
@@ -81,7 +81,7 @@ proptest! {
 
             let mut buffer = [0u8; 384];
             let mut decoder = Decoder::new_wrapped(&encoded_wrapped, line_width).unwrap();
-            let mut remaining_len = decoder.decoded_len();
+            let mut remaining_len = decoder.remaining_len();
 
             for chunk in bytes.chunks(chunk_size) {
                 prop_assert!(!decoder.is_finished());
@@ -90,11 +90,11 @@ proptest! {
                 prop_assert_eq!(Ok(chunk), decoded);
 
                 remaining_len -= decoded.unwrap().len();
-                prop_assert_eq!(remaining_len, decoder.decoded_len());
+                prop_assert_eq!(remaining_len, decoder.remaining_len());
             }
 
             prop_assert!(decoder.is_finished());
-            prop_assert_eq!(decoder.decoded_len(), 0);
+            prop_assert_eq!(decoder.remaining_len(), 0);
         }
     }
 

--- a/pem-rfc7468/src/decoder.rs
+++ b/pem-rfc7468/src/decoder.rs
@@ -30,7 +30,9 @@ use std::io;
 pub fn decode<'i, 'o>(pem: &'i [u8], buf: &'o mut [u8]) -> Result<(&'i str, &'o [u8])> {
     let mut decoder = Decoder::new(pem).map_err(|e| check_for_headers(pem, e))?;
     let type_label = decoder.type_label();
-    let buf = buf.get_mut(..decoder.decoded_len()).ok_or(Error::Length)?;
+    let buf = buf
+        .get_mut(..decoder.remaining_len())
+        .ok_or(Error::Length)?;
     let decoded = decoder.decode(buf).map_err(|e| check_for_headers(pem, e))?;
 
     if decoder.base64.is_finished() {
@@ -111,8 +113,8 @@ impl<'i> Decoder<'i> {
     }
 
     /// Get the decoded length of the remaining PEM data after Base64 decoding.
-    pub fn decoded_len(&self) -> usize {
-        self.base64.decoded_len()
+    pub fn remaining_len(&self) -> usize {
+        self.base64.remaining_len()
     }
 
     /// Are we finished decoding the PEM input?

--- a/ssh-key/src/base64.rs
+++ b/ssh-key/src/base64.rs
@@ -201,7 +201,7 @@ impl DecoderExt for Decoder<'_> {
     }
 
     fn decoded_len(&self) -> usize {
-        self.decoded_len()
+        self.remaining_len()
     }
 
     fn is_finished(&self) -> bool {
@@ -215,7 +215,7 @@ impl DecoderExt for pem::Decoder<'_> {
     }
 
     fn decoded_len(&self) -> usize {
-        self.decoded_len()
+        self.remaining_len()
     }
 
     fn is_finished(&self) -> bool {

--- a/ssh-key/src/private.rs
+++ b/ssh-key/src/private.rs
@@ -130,7 +130,7 @@ impl PrivateKey {
         // TODO(tarcieri): support for encrypted private keys
         let block_size = UNENCRYPTED_BLOCK_SIZE;
 
-        if (private_key_len % block_size != 0) || (private_key_len != pem_decoder.decoded_len()) {
+        if (private_key_len % block_size != 0) || (private_key_len != pem_decoder.remaining_len()) {
             return Err(Error::Length);
         }
 
@@ -159,7 +159,7 @@ impl PrivateKey {
             comment,
         };
 
-        let padding_len = pem_decoder.decoded_len();
+        let padding_len = pem_decoder.remaining_len();
 
         if padding_len >= block_size {
             return Err(Error::Length);


### PR DESCRIPTION
This is technically a breaking change, but this method was only just introduced in the v1.4.0 release which occurred less than 24h ago, so changing things now, yanking that release, and cutting a replacement v1.4.1 release should hopefully not cause any real-world breakages.

In using this method it felt confusingly named: it returns the number of bytes of as-yet-to-be-decoded data, but the "decoded" name implies past tense, which feels more like it's returning the number of bytes which have been decoded so far.

It *would* be useful to have such a method as well which tracks the current cursor/position within the decoded output, but adding one would be rather confusing as `decoded_len` would be a good candidate for *that* name.