### PR TITLE
base64ct v1.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,7 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "base64ct"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "base64",
  "proptest",

--- a/base64ct/CHANGELOG.md
+++ b/base64ct/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.4.0 (2022-03-10)
+## 1.4.1 (2022-03-11)
+### Changed
+- Rename `Decoder::decoded_len` => `::remaining_len` ([#500])
+
+[#500]: https://github.com/RustCrypto/formats/pull/500
+
+## 1.4.0 (2022-03-10) [YANKED]
 ### Added
 - Buffered `Encoder` type ([#366], [#455], [#457])
 - `Decoder::decoded_len` method ([#403])

--- a/base64ct/Cargo.toml
+++ b/base64ct/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base64ct"
-version = "1.4.0" # Also update html_root_url in lib.rs when bumping this
+version = "1.4.1" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Base64 (RFC 4648) which avoids any usages of
 data-dependent branches/LUTs and thereby provides portable "best effort"

--- a/base64ct/src/lib.rs
+++ b/base64ct/src/lib.rs
@@ -3,7 +3,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/base64ct/1.4.0"
+    html_root_url = "https://docs.rs/base64ct/1.4.1"
 )]
 #![doc = include_str!("../README.md")]
 #![warn(


### PR DESCRIPTION
### Changed
- Rename `Decoder::decoded_len` => `::remaining_len` ([#500])

[#500]: https://github.com/RustCrypto/formats/pull/500