### PR TITLE
ssh-key: make `authorized_keys` types owned

### DIFF
--- a/ssh-key/src/algorithm.rs
+++ b/ssh-key/src/algorithm.rs
@@ -295,9 +295,9 @@ impl str::FromStr for KdfAlg {
 // TODO(tarcieri): stub!
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 #[non_exhaustive]
-pub struct KdfOptions {}
+pub struct KdfOpts {}
 
-impl KdfOptions {
+impl KdfOpts {
     /// Create new KDF options.
     pub(crate) fn new(kdfoptions: &str) -> Result<Self> {
         // TODO(tarcieri): support for KDF options
@@ -309,7 +309,7 @@ impl KdfOptions {
     }
 }
 
-impl Decode for KdfOptions {
+impl Decode for KdfOpts {
     fn decode(decoder: &mut impl DecoderExt) -> Result<Self> {
         // TODO(tarcieri): stub!
         let mut buf = [0u8; 0];
@@ -317,7 +317,7 @@ impl Decode for KdfOptions {
     }
 }
 
-impl Encode for KdfOptions {
+impl Encode for KdfOpts {
     fn encoded_len(&self) -> Result<usize> {
         Ok(4)
     }
@@ -328,14 +328,14 @@ impl Encode for KdfOptions {
     }
 }
 
-impl fmt::Display for KdfOptions {
+impl fmt::Display for KdfOpts {
     fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
         // TODO(tarcieri): stub!
         Ok(())
     }
 }
 
-impl str::FromStr for KdfOptions {
+impl str::FromStr for KdfOpts {
     type Err = Error;
 
     fn from_str(id: &str) -> Result<Self> {

--- a/ssh-key/src/lib.rs
+++ b/ssh-key/src/lib.rs
@@ -122,7 +122,7 @@ mod error;
 mod mpint;
 
 pub use crate::{
-    algorithm::{Algorithm, CipherAlg, EcdsaCurve, KdfAlg, KdfOptions},
+    algorithm::{Algorithm, CipherAlg, EcdsaCurve, KdfAlg, KdfOpts},
     authorized_keys::AuthorizedKeys,
     error::{Error, Result},
     private::PrivateKey,

--- a/ssh-key/src/private.rs
+++ b/ssh-key/src/private.rs
@@ -23,7 +23,7 @@ pub use self::{
 
 use crate::{
     base64::{Decode, DecoderExt, Encode, EncoderExt},
-    public, Algorithm, CipherAlg, Error, KdfAlg, KdfOptions, PublicKey, Result,
+    public, Algorithm, CipherAlg, Error, KdfAlg, KdfOpts, PublicKey, Result,
 };
 use core::str;
 use pem_rfc7468::{self as pem, LineEnding, PemLabel};
@@ -63,7 +63,7 @@ pub struct PrivateKey {
     kdf_alg: KdfAlg,
 
     /// KDF options.
-    kdf_options: KdfOptions,
+    kdf_opts: KdfOpts,
 
     /// Key data.
     key_data: KeypairData,
@@ -109,7 +109,7 @@ impl PrivateKey {
 
         let cipher_alg = CipherAlg::decode(&mut pem_decoder)?;
         let kdf_alg = KdfAlg::decode(&mut pem_decoder)?;
-        let kdf_options = KdfOptions::decode(&mut pem_decoder)?;
+        let kdf_opts = KdfOpts::decode(&mut pem_decoder)?;
         let nkeys = pem_decoder.decode_usize()?;
 
         // TODO(tarcieri): support more than one key?
@@ -153,7 +153,7 @@ impl PrivateKey {
         let private_key = Self {
             cipher_alg,
             kdf_alg,
-            kdf_options,
+            kdf_opts,
             key_data,
             #[cfg(feature = "alloc")]
             comment,
@@ -196,7 +196,7 @@ impl PrivateKey {
         // TODO(tarcieri): support for encrypted private keys
         self.cipher_alg.encode(&mut pem_encoder)?;
         self.kdf_alg.encode(&mut pem_encoder)?;
-        self.kdf_options.encode(&mut pem_encoder)?;
+        self.kdf_opts.encode(&mut pem_encoder)?;
 
         // TODO(tarcieri): support for encoding more than one private key
         let nkeys = 1;
@@ -291,8 +291,8 @@ impl PrivateKey {
     }
 
     /// KDF options.
-    pub fn kdf_options(&self) -> &KdfOptions {
-        &self.kdf_options
+    pub fn kdf_opts(&self) -> &KdfOpts {
+        &self.kdf_opts
     }
 
     /// Keypair data.
@@ -320,7 +320,7 @@ impl PrivateKey {
         let bytes_len = Self::AUTH_MAGIC.len()
             + self.cipher_alg.encoded_len()?
             + self.kdf_alg.encoded_len()?
-            + self.kdf_options.encoded_len()?
+            + self.kdf_opts.encoded_len()?
             + 4 // number of keys
             + 4 + public::KeyData::from(&self.key_data).encoded_len()?
             + 4 + private_key_len
@@ -351,7 +351,7 @@ impl From<KeypairData> for PrivateKey {
         PrivateKey {
             cipher_alg: CipherAlg::None,
             kdf_alg: KdfAlg::None,
-            kdf_options: KdfOptions::default(),
+            kdf_opts: KdfOpts::default(),
             key_data,
             #[cfg(feature = "alloc")]
             comment: String::new(),
@@ -393,7 +393,7 @@ impl ConstantTimeEq for PrivateKey {
             & Choice::from(
                 (self.cipher_alg == other.cipher_alg
                     && self.kdf_alg == other.kdf_alg
-                    && self.kdf_options == other.kdf_options) as u8,
+                    && self.kdf_opts == other.kdf_opts) as u8,
             )
     }
 }

--- a/ssh-key/tests/authorized_keys.rs
+++ b/ssh-key/tests/authorized_keys.rs
@@ -7,29 +7,43 @@ use ssh_key::AuthorizedKeys;
 // TODO(tarcieri): test file permissions
 #[test]
 fn read_example_file() {
-    AuthorizedKeys::read_file("./tests/examples/authorized_keys", |mut authorized_keys| {
-        let entry1 = authorized_keys.next().unwrap()?;
-        assert_eq!(entry1.options.to_string(), "");
-        assert_eq!(entry1.public_key.to_string(), "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILM+rvN+ot98qgEN796jTiQfZfG1KaT0PtFDJ/XFSqti user1@example.com");
-        assert_eq!(entry1.public_key.comment(), "user1@example.com");
+    let authorized_keys = AuthorizedKeys::read_file("./tests/examples/authorized_keys").unwrap();
+    assert_eq!(authorized_keys.len(), 4);
 
-        let entry2 = authorized_keys.next().unwrap()?;
-        assert_eq!(entry2.options.to_string(), "command=\"/usr/bin/date\"");
-        assert_eq!(entry2.public_key.to_string(), "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHwf2HMM5TRXvo2SQJjsNkiDD5KqiiNjrGVv3UUh+mMT5RHxiRtOnlqvjhQtBq0VpmpCV/PwUdhOig4vkbqAcEc= user2@example.com");
-        assert_eq!(entry2.public_key.comment(), "user2@example.com");
+    assert_eq!(authorized_keys[0].config_opts().to_string(), "");
+    assert_eq!(authorized_keys[0].public_key().to_string(), "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILM+rvN+ot98qgEN796jTiQfZfG1KaT0PtFDJ/XFSqti user1@example.com");
+    assert_eq!(
+        authorized_keys[0].public_key().comment(),
+        "user1@example.com"
+    );
 
-        let entry3 = authorized_keys.next().unwrap()?;
-        assert_eq!(entry3.options.to_string(), "environment=\"PATH=/bin:/usr/bin\"");
-        assert_eq!(entry3.public_key.to_string(), "ssh-dss AAAAB3NzaC1kc3MAAACBANw9iSUO2UYhFMssjUgW46URqv8bBrDgHeF8HLBOWBvKuXF2Rx2J/XyhgX48SOLMuv0hcPaejlyLarabnF9F2V4dkpPpZSJ+7luHmxEjNxwhsdtg8UteXAWkeCzrQ6MvRJZHcDBjYh56KGvslbFnJsGLXlI4PQCyl6awNImwYGilAAAAFQCJGBU3hZf+QtP9Jh/nbfNlhFu7hwAAAIBHObOQioQVRm3HsVb7mOy3FVKhcLoLO3qoG9gTkd4KeuehtFAC3+rckiX7xSCnE/5BBKdL7VP9WRXac2Nlr9Pwl3e7zPut96wrCHt/TZX6vkfXKkbpUIj5zSqfvyNrWKaYJkfzwAQwrXNS1Hol676Ud/DDEn2oatdEhkS3beWHXAAAAIBgQqaz/YYTRMshzMzYcZ4lqgvgmA55y6v0h39e8HH2A5dwNS6sPUw2jyna+le0dceNRJifFld1J+WYM0vmquSr11DDavgEidOSaXwfMvPPPJqLmbzdtT16N+Gij9U9STQTHPQcQ3xnNNHgQAStzZJbhLOVbDDDo5BO7LMUALDfSA== user3@example.com");
-        assert_eq!(entry3.public_key.comment(), "user3@example.com");
+    assert_eq!(
+        authorized_keys[1].config_opts().to_string(),
+        "command=\"/usr/bin/date\""
+    );
+    assert_eq!(authorized_keys[1].public_key().to_string(), "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHwf2HMM5TRXvo2SQJjsNkiDD5KqiiNjrGVv3UUh+mMT5RHxiRtOnlqvjhQtBq0VpmpCV/PwUdhOig4vkbqAcEc= user2@example.com");
+    assert_eq!(
+        authorized_keys[1].public_key().comment(),
+        "user2@example.com"
+    );
 
-        let entry4 = authorized_keys.next().unwrap()?;
-        assert_eq!(entry4.options.to_string(), "from=\"10.0.0.?,*.example.com\",no-X11-forwarding");
-        assert_eq!(entry4.public_key.to_string(), "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC0WRHtxuxefSJhpIxGq4ibGFgwYnESPm8C3JFM88A1JJLoprenklrd7VJ+VH3Ov/bQwZwLyRU5dRmfR/SWTtIPWs7tToJVayKKDB+/qoXmM5ui/0CU2U4rCdQ6PdaCJdC7yFgpPL8WexjWN06+eSIKYz1AAXbx9rRv1iasslK/KUqtsqzVliagI6jl7FPO2GhRZMcso6LsZGgSxuYf/Lp0D/FcBU8GkeOo1Sx5xEt8H8bJcErtCe4Blb8JxcW6EXO3sReb4z+zcR07gumPgFITZ6hDA8sSNuvo/AlWg0IKTeZSwHHVknWdQqDJ0uczE837caBxyTZllDNIGkBjCIIOFzuTT76HfYc/7CTTGk07uaNkUFXKN79xDiFOX8JQ1ZZMZvGOTwWjuT9CqgdTvQRORbRWwOYv3MH8re9ykw3Ip6lrPifY7s6hOaAKry/nkGPMt40m1TdiW98MTIpooE7W+WXu96ax2l2OJvxX8QR7l+LFlKnkIEEJd/ItF1G22UmOjkVwNASTwza/hlY+8DoVvEmwum/nMgH2TwQT3bTQzF9s9DOJkH4d8p4Mw4gEDjNx0EgUFA91ysCAeUMQQyIvuR8HXXa+VcvhOOO5mmBcVhxJ3qUOJTyDBsT0932Zb4mNtkxdigoVxu+iiwk0vwtvKwGVDYdyMP5EAQeEIP1t0w== user4@example.com");
-        assert_eq!(entry4.public_key.comment(), "user4@example.com");
+    assert_eq!(
+        authorized_keys[2].config_opts().to_string(),
+        "environment=\"PATH=/bin:/usr/bin\""
+    );
+    assert_eq!(authorized_keys[2].public_key().to_string(), "ssh-dss AAAAB3NzaC1kc3MAAACBANw9iSUO2UYhFMssjUgW46URqv8bBrDgHeF8HLBOWBvKuXF2Rx2J/XyhgX48SOLMuv0hcPaejlyLarabnF9F2V4dkpPpZSJ+7luHmxEjNxwhsdtg8UteXAWkeCzrQ6MvRJZHcDBjYh56KGvslbFnJsGLXlI4PQCyl6awNImwYGilAAAAFQCJGBU3hZf+QtP9Jh/nbfNlhFu7hwAAAIBHObOQioQVRm3HsVb7mOy3FVKhcLoLO3qoG9gTkd4KeuehtFAC3+rckiX7xSCnE/5BBKdL7VP9WRXac2Nlr9Pwl3e7zPut96wrCHt/TZX6vkfXKkbpUIj5zSqfvyNrWKaYJkfzwAQwrXNS1Hol676Ud/DDEn2oatdEhkS3beWHXAAAAIBgQqaz/YYTRMshzMzYcZ4lqgvgmA55y6v0h39e8HH2A5dwNS6sPUw2jyna+le0dceNRJifFld1J+WYM0vmquSr11DDavgEidOSaXwfMvPPPJqLmbzdtT16N+Gij9U9STQTHPQcQ3xnNNHgQAStzZJbhLOVbDDDo5BO7LMUALDfSA== user3@example.com");
+    assert_eq!(
+        authorized_keys[2].public_key().comment(),
+        "user3@example.com"
+    );
 
-        assert_eq!(authorized_keys.next(), None);
-        Ok(())
-    })
-    .unwrap();
+    assert_eq!(
+        authorized_keys[3].config_opts().to_string(),
+        "from=\"10.0.0.?,*.example.com\",no-X11-forwarding"
+    );
+    assert_eq!(authorized_keys[3].public_key().to_string(), "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC0WRHtxuxefSJhpIxGq4ibGFgwYnESPm8C3JFM88A1JJLoprenklrd7VJ+VH3Ov/bQwZwLyRU5dRmfR/SWTtIPWs7tToJVayKKDB+/qoXmM5ui/0CU2U4rCdQ6PdaCJdC7yFgpPL8WexjWN06+eSIKYz1AAXbx9rRv1iasslK/KUqtsqzVliagI6jl7FPO2GhRZMcso6LsZGgSxuYf/Lp0D/FcBU8GkeOo1Sx5xEt8H8bJcErtCe4Blb8JxcW6EXO3sReb4z+zcR07gumPgFITZ6hDA8sSNuvo/AlWg0IKTeZSwHHVknWdQqDJ0uczE837caBxyTZllDNIGkBjCIIOFzuTT76HfYc/7CTTGk07uaNkUFXKN79xDiFOX8JQ1ZZMZvGOTwWjuT9CqgdTvQRORbRWwOYv3MH8re9ykw3Ip6lrPifY7s6hOaAKry/nkGPMt40m1TdiW98MTIpooE7W+WXu96ax2l2OJvxX8QR7l+LFlKnkIEEJd/ItF1G22UmOjkVwNASTwza/hlY+8DoVvEmwum/nMgH2TwQT3bTQzF9s9DOJkH4d8p4Mw4gEDjNx0EgUFA91ysCAeUMQQyIvuR8HXXa+VcvhOOO5mmBcVhxJ3qUOJTyDBsT0932Zb4mNtkxdigoVxu+iiwk0vwtvKwGVDYdyMP5EAQeEIP1t0w== user4@example.com");
+    assert_eq!(
+        authorized_keys[3].public_key().comment(),
+        "user4@example.com"
+    );
 }


### PR DESCRIPTION
Owned types are easier to work with.

This commit retains the config options parser in a heapless mode but requires `alloc` to actually store them.

Since they were the only borrowed part of `authorized_key::Entry`, it can become owned as well.

This allows `AuthorizedKeys::read_file` to return a `Vec<Entry>` rather than taking a callback that borrows a string.