### PR TITLE
const-oid: test improvements

### DIFF
--- a/const-oid/src/lib.rs
+++ b/const-oid/src/lib.rs
@@ -119,10 +119,11 @@ impl ObjectIdentifier {
     pub fn from_bytes(ber_bytes: &[u8]) -> Result<Self> {
         let len = ber_bytes.len();
 
-        if !(2..=Self::MAX_SIZE).contains(&len) {
-            return Err(Error::Length);
+        match len {
+            0 => return Err(Error::Empty),
+            3..=Self::MAX_SIZE => (),
+            _ => return Err(Error::NotEnoughArcs),
         }
-
         let mut bytes = [0u8; Self::MAX_SIZE];
         bytes[..len].copy_from_slice(ber_bytes);
 

--- a/const-oid/tests/lib.rs
+++ b/const-oid/tests/lib.rs
@@ -56,11 +56,17 @@ fn from_bytes() {
     assert_eq!(oid3, EXAMPLE_OID_LARGE_ARC);
 
     // Empty
-    assert!(ObjectIdentifier::from_bytes(&[]).is_err());
+    assert_eq!(ObjectIdentifier::from_bytes(&[]), Err(Error::Empty));
 
     // Truncated
-    assert!(ObjectIdentifier::from_bytes(&[42]).is_err());
-    assert!(ObjectIdentifier::from_bytes(&[42, 134]).is_err());
+    assert_eq!(
+        ObjectIdentifier::from_bytes(&[42]),
+        Err(Error::NotEnoughArcs)
+    );
+    assert_eq!(
+        ObjectIdentifier::from_bytes(&[42, 134]),
+        Err(Error::NotEnoughArcs)
+    );
 }
 
 #[test]
@@ -93,16 +99,25 @@ fn from_str() {
     assert_eq!(oid3, EXAMPLE_OID_LARGE_ARC);
 
     // Too short
-    assert!("1.2".parse::<ObjectIdentifier>().is_err());
+    assert_eq!("1.2".parse::<ObjectIdentifier>(), Err(Error::NotEnoughArcs));
 
     // Truncated
-    assert!("1.2.840.10045.2.".parse::<ObjectIdentifier>().is_err());
+    assert_eq!(
+        "1.2.840.10045.2.".parse::<ObjectIdentifier>(),
+        Err(Error::TrailingDot)
+    );
 
     // Invalid first arc
-    assert!("3.2.840.10045.2.1".parse::<ObjectIdentifier>().is_err());
+    assert_eq!(
+        "3.2.840.10045.2.1".parse::<ObjectIdentifier>(),
+        Err(Error::ArcInvalid { arc: 3 })
+    );
 
     // Invalid second arc
-    assert!("1.40.840.10045.2.1".parse::<ObjectIdentifier>().is_err());
+    assert_eq!(
+        "1.40.840.10045.2.1".parse::<ObjectIdentifier>(),
+        Err(Error::ArcInvalid { arc: 40 })
+    );
 }
 
 #[test]
@@ -126,13 +141,22 @@ fn try_from_u32_slice() {
     assert_eq!(EXAMPLE_OID_2, oid2);
 
     // Too short
-    assert!(ObjectIdentifier::from_arcs([1, 2]).is_err());
+    assert_eq!(
+        ObjectIdentifier::from_arcs([1, 2]),
+        Err(Error::NotEnoughArcs)
+    );
 
     // Invalid first arc
-    assert!(ObjectIdentifier::from_arcs([3, 2, 840, 10045, 3, 1, 7]).is_err());
+    assert_eq!(
+        ObjectIdentifier::from_arcs([3, 2, 840, 10045, 3, 1, 7]),
+        Err(Error::ArcInvalid { arc: 3 })
+    );
 
     // Invalid second arc
-    assert!(ObjectIdentifier::from_arcs([1, 40, 840, 10045, 3, 1, 7]).is_err());
+    assert_eq!(
+        ObjectIdentifier::from_arcs([1, 40, 840, 10045, 3, 1, 7]),
+        Err(Error::ArcInvalid { arc: 40 })
+    );
 }
 
 #[test]


### PR DESCRIPTION
Test specific error return values as opposed to just checking `is_err`