### PR TITLE
const-oid v0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "hex-literal",
 ]

--- a/const-oid/CHANGELOG.md
+++ b/const-oid/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.0 (2022-03-11)
+### Added
+- Fallible `const fn` parser + `::new_unwrap` ([#458], [#459])
+- OID database gated under the `db` feature ([#451], [#453], [#456], [#488])
+- `AssociatedOid` trait ([#479])
+- `ObjectIdentifier::push_arc` ([#504])
+- `ObjectIdentifier::parent` ([#505])
+
+### Changed
+- `ObjectIdentifier::new` now returns a `Result` ([#458])
+
+[#451]: https://github.com/RustCrypto/formats/pull/451
+[#453]: https://github.com/RustCrypto/formats/pull/453
+[#456]: https://github.com/RustCrypto/formats/pull/456
+[#458]: https://github.com/RustCrypto/formats/pull/458
+[#459]: https://github.com/RustCrypto/formats/pull/459
+[#479]: https://github.com/RustCrypto/formats/pull/479
+[#488]: https://github.com/RustCrypto/formats/pull/488
+[#504]: https://github.com/RustCrypto/formats/pull/504
+[#505]: https://github.com/RustCrypto/formats/pull/505
+
 ## 0.8.0 (2022-01-17)
 ### Changed
 - Leverage `const_panic`; MSRV 1.57 ([#341])

--- a/const-oid/Cargo.toml
+++ b/const-oid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "const-oid"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """

--- a/const-oid/src/lib.rs
+++ b/const-oid/src/lib.rs
@@ -4,7 +4,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/const-oid/0.8.0"
+    html_root_url = "https://docs.rs/const-oid/0.9.0"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms)]

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-const-oid = { version = "0.8", optional = true, path = "../const-oid" }
+const-oid = { version = "0.9", optional = true, path = "../const-oid" }
 der_derive = { version = "=0.6.0-pre.1", optional = true, path = "derive" }
 flagset = { version = "0.4.3", optional = true }
 pem-rfc7468 = { version = "=0.4.0-pre.0", optional = true, path = "../pem-rfc7468" }

--- a/x509/Cargo.toml
+++ b/x509/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.56"
 
 [dependencies]
 der = { version = "=0.6.0-pre.1", features = ["derive", "alloc", "flagset"], path = "../der" }
-const-oid = { version = "0.8", features = ["db"], path = "../const-oid" }
+const-oid = { version = "0.9", features = ["db"], path = "../const-oid" }
 flagset = { version = "0.4.3" }
 spki = { version = "=0.6.0-pre.0", path = "../spki" }
 


### PR DESCRIPTION
### Added
- Fallible `const fn` parser + `::new_unwrap` ([#458], [#459])
- OID database gated under the `db` feature ([#451], [#453], [#456], [#488])
- `AssociatedOid` trait ([#479])
- `ObjectIdentifier::push_arc` ([#504])
- `ObjectIdentifier::parent` ([#505])

### Changed
- `ObjectIdentifier::new` now returns a `Result` ([#458])

[#451]: https://github.com/RustCrypto/formats/pull/451
[#453]: https://github.com/RustCrypto/formats/pull/453
[#456]: https://github.com/RustCrypto/formats/pull/456
[#458]: https://github.com/RustCrypto/formats/pull/458
[#459]: https://github.com/RustCrypto/formats/pull/459
[#479]: https://github.com/RustCrypto/formats/pull/479
[#488]: https://github.com/RustCrypto/formats/pull/488
[#504]: https://github.com/RustCrypto/formats/pull/504
[#505]: https://github.com/RustCrypto/formats/pull/505