### PR TITLE
pem-rfc7468 v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.4.0-pre.1"
+version = "0.4.0"
 dependencies = [
  "base64ct",
 ]

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.57"
 const-oid = { version = "0.9", optional = true, path = "../const-oid" }
 der_derive = { version = "=0.6.0-pre.2", optional = true, path = "derive" }
 flagset = { version = "0.4.3", optional = true }
-pem-rfc7468 = { version = "=0.4.0-pre.1", optional = true, path = "../pem-rfc7468" }
+pem-rfc7468 = { version = "0.4", optional = true, path = "../pem-rfc7468" }
 time = { version = "0.3.4", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/pem-rfc7468/CHANGELOG.md
+++ b/pem-rfc7468/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2022-03-12)
+### Added
+- Buffered `Decoder` type ([#406])
+- Buffered `Encoder` type ([#463], [#474])
+
+### Changed
+- Return `str` from `encode` ([#482])
+
+[#406]: https://github.com/RustCrypto/formats/pull/406
+[#463]: https://github.com/RustCrypto/formats/pull/463
+[#474]: https://github.com/RustCrypto/formats/pull/474
+[#482]: https://github.com/RustCrypto/formats/pull/482
+
 ## 0.3.1 (2021-11-17)
 ### Changed
 - Relax `base64ct` version requirement to `^1` ([#239])

--- a/pem-rfc7468/Cargo.toml
+++ b/pem-rfc7468/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pem-rfc7468"
-version = "0.4.0-pre.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.4.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 PEM Encoding (RFC 7468) for PKIX, PKCS, and CMS Structures, implementing a
 strict subset of the original Privacy-Enhanced Mail encoding intended

--- a/pem-rfc7468/src/lib.rs
+++ b/pem-rfc7468/src/lib.rs
@@ -3,7 +3,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/pem-rfc7468/0.4.0-pre.1"
+    html_root_url = "https://docs.rs/pem-rfc7468/0.4.0"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.57"
 
 [dependencies]
 base64ct = { version = "1.4", path = "../base64ct" }
-pem-rfc7468 = { version = "=0.4.0-pre.1", path = "../pem-rfc7468" }
+pem-rfc7468 = { version = "0.4", path = "../pem-rfc7468" }
 zeroize = { version = "1", default-features = false }
 
 # optional dependencies


### PR DESCRIPTION
### Added
- Buffered `Decoder` type ([#406])
- Buffered `Encoder` type ([#463], [#474])

### Changed
- Return `str` from `encode` ([#482])

[#406]: https://github.com/RustCrypto/formats/pull/406
[#463]: https://github.com/RustCrypto/formats/pull/463
[#474]: https://github.com/RustCrypto/formats/pull/474
[#482]: https://github.com/RustCrypto/formats/pull/482