### PR TITLE
Bump prerelease versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.6.0-pre.2"
+version = "0.6.0-pre.3"
 dependencies = [
  "const-oid",
  "der_derive",
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "der_derive"
-version = "0.6.0-pre.2"
+version = "0.6.0-pre.3"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -552,7 +552,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs5"
-version = "0.5.0-pre"
+version = "0.5.0-pre.1"
 dependencies = [
  "aes",
  "cbc",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.9.0-pre"
+version = "0.9.0-pre.1"
 dependencies = [
  "der",
  "hex-literal",
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.3.0-pre"
+version = "0.3.0-pre.1"
 dependencies = [
  "der",
  "generic-array",
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.6.0-pre.1"
+version = "0.6.0-pre.2"
 dependencies = [
  "base64ct",
  "der",

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der"
-version = "0.6.0-pre.2" # Also update html_root_url in lib.rs when bumping this
+version = "0.6.0-pre.3" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust embedded-friendly implementation of the Distinguished Encoding Rules
 (DER) for Abstract Syntax Notation One (ASN.1) as described in ITU X.690 with
@@ -17,7 +17,7 @@ rust-version = "1.57"
 
 [dependencies]
 const-oid = { version = "0.9", optional = true, path = "../const-oid" }
-der_derive = { version = "=0.6.0-pre.2", optional = true, path = "derive" }
+der_derive = { version = "=0.6.0-pre.3", optional = true, path = "derive" }
 flagset = { version = "0.4.3", optional = true }
 pem-rfc7468 = { version = "0.4", optional = true, path = "../pem-rfc7468" }
 time = { version = "0.3.4", optional = true, default-features = false }

--- a/der/derive/Cargo.toml
+++ b/der/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der_derive"
-version = "0.6.0-pre.2" # Also update html_root_url in lib.rs when bumping this
+version = "0.6.0-pre.3" # Also update html_root_url in lib.rs when bumping this
 description = "Custom derive support for the `der` crate's `Choice` and `Sequence` traits"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"

--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -15,10 +15,10 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-der = { version = "=0.6.0-pre.2", features = ["oid"], path = "../der" }
+der = { version = "=0.6.0-pre.3", features = ["oid"], path = "../der" }
 
 # optional dependencies
-pkcs8 = { version = "=0.9.0-pre", optional = true, default-features = false, path = "../pkcs8" }
+pkcs8 = { version = "=0.9.0-pre.1", optional = true, default-features = false, path = "../pkcs8" }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs5"
-version = "0.5.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.5.0-pre.1" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #5:
 Password-Based Cryptography Specification Version 2.1 (RFC 8018)
@@ -15,8 +15,8 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-der = { version = "=0.6.0-pre.2", features = ["oid"], path = "../der" }
-spki = { version = "=0.6.0-pre.1", path = "../spki" }
+der = { version = "=0.6.0-pre.3", features = ["oid"], path = "../der" }
+spki = { version = "=0.6.0-pre.2", path = "../spki" }
 
 # optional dependencies
 cbc = { version = "0.1.1", optional = true }

--- a/pkcs7/Cargo.toml
+++ b/pkcs7/Cargo.toml
@@ -15,8 +15,8 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-der = { version = "=0.6.0-pre.2", features = ["oid"], path = "../der" }
-spki = { version = "=0.6.0-pre.1", path = "../spki" }
+der = { version = "=0.6.0-pre.3", features = ["oid"], path = "../der" }
+spki = { version = "=0.6.0-pre.2", path = "../spki" }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs8"
-version = "0.9.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.9.0-pre.1" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #8:
 Private-Key Information Syntax Specification (RFC 5208), with additional
@@ -16,12 +16,12 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-der = { version = "=0.6.0-pre.2", features = ["oid"], path = "../der" }
-spki = { version = "=0.6.0-pre.1", path = "../spki" }
+der = { version = "=0.6.0-pre.3", features = ["oid"], path = "../der" }
+spki = { version = "=0.6.0-pre.2", path = "../spki" }
 
 # optional dependencies
 rand_core = { version = "0.6", optional = true, default-features = false }
-pkcs5 = { version = "=0.5.0-pre", optional = true, path = "../pkcs5" }
+pkcs5 = { version = "=0.5.0-pre.1", optional = true, path = "../pkcs5" }
 subtle = { version = "2", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false, features = ["alloc"] }
 

--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sec1"
-version = "0.3.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.3.0-pre.1" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of SEC1: Elliptic Curve Cryptography encoding formats
 including ASN.1 DER-serialized private keys as well as the
@@ -19,8 +19,8 @@ rust-version = "1.57"
 generic-array = { version = "0.14.4", default-features = false }
 
 # optional dependencies
-der = { version = "=0.6.0-pre.2", optional = true, features = ["oid"], path = "../der" }
-pkcs8 = { version = "=0.9.0-pre", optional = true, default-features = false, path = "../pkcs8" }
+der = { version = "=0.6.0-pre.3", optional = true, features = ["oid"], path = "../der" }
+pkcs8 = { version = "=0.9.0-pre.1", optional = true, default-features = false, path = "../pkcs8" }
 serde = { version = "1.0.16", optional = true, default-features = false }
 subtle = { version = "2", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }

--- a/spki/Cargo.toml
+++ b/spki/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spki"
-version = "0.6.0-pre.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.6.0-pre.2" # Also update html_root_url in lib.rs when bumping this
 description = """
 X.509 Subject Public Key Info (RFC5280) describing public keys as well as their
 associated AlgorithmIdentifiers (i.e. OIDs)
@@ -15,7 +15,7 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-der = { version = "=0.6.0-pre.2", features = ["oid"], path = "../der" }
+der = { version = "=0.6.0-pre.3", features = ["oid"], path = "../der" }
 
 # Optional dependencies
 sha2 = { version = "0.10", optional = true, default-features = false }

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -21,7 +21,7 @@ pem-rfc7468 = { version = "0.4", path = "../pem-rfc7468" }
 zeroize = { version = "1", default-features = false }
 
 # optional dependencies
-sec1 = { version = "=0.3.0-pre", optional = true, default-features = false, path = "../sec1" }
+sec1 = { version = "=0.3.0-pre.1", optional = true, default-features = false, path = "../sec1" }
 subtle = { version = "2", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/x509/Cargo.toml
+++ b/x509/Cargo.toml
@@ -16,9 +16,9 @@ rust-version = "1.56"
 
 [dependencies]
 const-oid = { version = "0.9", features = ["db"], path = "../const-oid" }
-der = { version = "=0.6.0-pre.2", features = ["derive", "alloc", "flagset"], path = "../der" }
+der = { version = "=0.6.0-pre.3", features = ["derive", "alloc", "flagset"], path = "../der" }
 flagset = { version = "0.4.3" }
-spki = { version = "=0.6.0-pre.1", path = "../spki" }
+spki = { version = "=0.6.0-pre.2", path = "../spki" }
 
 [dev-dependencies]
 hex-literal = "0.3"


### PR DESCRIPTION
Cuts releases of the following crates (mainly to pick up the `pem-rfc7468` v0.4.0 release):

- `der` v0.6.0-pre.3
- `der_derive` v0.6.0-pre.3
- `pkcs5` v0.5.0-pre.1
- `pkcs8` v0.9.0-pre.1
- `sec1` v0.3.0-pre.1
- `spki` v0.6.0-pre.2