### PR TITLE
ssh-key: refactor encoding

### DIFF
--- a/ssh-key/src/decoder.rs
+++ b/ssh-key/src/decoder.rs
@@ -1,7 +1,6 @@
-//! Base64 support.
+//! Decoder support.
 //!
-//! Provides helper types which use the `base64ct` crate's constant-time Base64
-//! implementation for decoding.
+//! Support for decoding SSH keys from the OpenSSH wire format.
 
 use crate::{Error, Result};
 use core::str;
@@ -13,65 +12,17 @@ use alloc::{string::String, vec::Vec};
 /// Maximum size of a `usize` this library will accept.
 const MAX_SIZE: usize = 0xFFFFF;
 
-/// Get the estimated length of data when encoded as Base64.
-///
-/// This is an upper bound where the actual length might be slightly shorter.
-#[cfg(feature = "alloc")]
-pub(crate) fn encoded_len(input_len: usize) -> usize {
-    (((input_len * 4) / 3) + 3) & !3
-}
+/// Stateful Base64 decoder.
+pub(crate) type Base64Decoder<'i> = base64ct::Decoder<'i, base64ct::Base64>;
 
 /// Decoder trait.
 pub(crate) trait Decode: Sized {
     /// Attempt to decode a value of this type using the provided [`Decoder`].
-    fn decode(decoder: &mut impl DecoderExt) -> Result<Self>;
+    fn decode(decoder: &mut impl Decoder) -> Result<Self>;
 }
-
-/// Encoder trait.
-pub(crate) trait Encode: Sized {
-    /// Get the length of this type encoded in bytes, prior to Base64 encoding.
-    fn encoded_len(&self) -> Result<usize>;
-
-    /// Attempt to encode a value of this type using the provided [`Encoder`].
-    fn encode(&self, encoder: &mut impl EncoderExt) -> Result<()>;
-}
-
-/// String-like fields.
-///
-/// These fields receive a blanket impl of [`Decode`] and [`Encode`].
-pub(crate) trait StrField: AsRef<str> + str::FromStr<Err = Error> {
-    /// Decoding buffer type.
-    ///
-    /// This needs to be a byte array large enough to fit the largest
-    /// possible value of this type.
-    type DecodeBuf: AsMut<[u8]> + Default;
-}
-
-impl<T: StrField> Decode for T {
-    fn decode(decoder: &mut impl DecoderExt) -> Result<Self> {
-        let mut buf = T::DecodeBuf::default();
-        decoder.decode_str(buf.as_mut())?.parse()
-    }
-}
-
-impl<T: StrField> Encode for T {
-    fn encoded_len(&self) -> Result<usize> {
-        Ok(4 + self.as_ref().len())
-    }
-
-    fn encode(&self, encoder: &mut impl EncoderExt) -> Result<()> {
-        encoder.encode_str(self.as_ref())
-    }
-}
-
-/// Stateful Base64 decoder.
-pub(crate) type Decoder<'i> = base64ct::Decoder<'i, base64ct::Base64>;
-
-/// Stateful Base64 encoder.
-pub(crate) type Encoder<'o> = base64ct::Encoder<'o, base64ct::Base64>;
 
 /// Decoder extension trait.
-pub(crate) trait DecoderExt {
+pub(crate) trait Decoder {
     /// Decode as much Base64 as is needed to exactly fill `out`.
     ///
     /// This is the base decoding method on which the rest of the trait is
@@ -195,7 +146,7 @@ pub(crate) trait DecoderExt {
     }
 }
 
-impl DecoderExt for Decoder<'_> {
+impl Decoder for Base64Decoder<'_> {
     fn decode_base64<'o>(&mut self, out: &'o mut [u8]) -> Result<&'o [u8]> {
         Ok(self.decode(out)?)
     }
@@ -209,7 +160,7 @@ impl DecoderExt for Decoder<'_> {
     }
 }
 
-impl DecoderExt for pem::Decoder<'_> {
+impl Decoder for pem::Decoder<'_> {
     fn decode_base64<'o>(&mut self, out: &'o mut [u8]) -> Result<&'o [u8]> {
         Ok(self.decode(out)?)
     }
@@ -220,80 +171,5 @@ impl DecoderExt for pem::Decoder<'_> {
 
     fn is_finished(&self) -> bool {
         self.is_finished()
-    }
-}
-
-/// Encoder extension trait.
-pub(crate) trait EncoderExt {
-    /// Encode the given byte slice as Base64.
-    ///
-    /// This is the base encoding method on which the rest of the trait is
-    /// implemented in terms of.
-    fn encode_base64(&mut self, bytes: &[u8]) -> Result<()>;
-
-    /// Encode a `uint32` as described in [RFC4251 § 5]:
-    ///
-    /// > Represents a 32-bit unsigned integer.  Stored as four bytes in the
-    /// > order of decreasing significance (network byte order).
-    /// > For example: the value 699921578 (0x29b7f4aa) is stored as 29 b7 f4 aa.
-    ///
-    /// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
-    fn encode_u32(&mut self, num: u32) -> Result<()> {
-        self.encode_base64(&num.to_be_bytes())
-    }
-
-    /// Encode a `usize` as a `uint32` as described in [RFC4251 § 5].
-    ///
-    /// Uses [`Encoder::encode_u32`] after converting from a `usize`, handling
-    /// potential overflow if `usize` is bigger than `u32`.
-    ///
-    /// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
-    fn encode_usize(&mut self, num: usize) -> Result<()> {
-        self.encode_u32(u32::try_from(num)?)
-    }
-
-    /// Encodes `[u8]` into `byte[n]` as described in [RFC4251 § 5]:
-    ///
-    /// > A byte represents an arbitrary 8-bit value (octet).  Fixed length
-    /// > data is sometimes represented as an array of bytes, written
-    /// > byte[n], where n is the number of bytes in the array.
-    ///
-    /// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
-    fn encode_byte_slice(&mut self, bytes: &[u8]) -> Result<()> {
-        self.encode_usize(bytes.len())?;
-        self.encode_base64(bytes)
-    }
-
-    /// Encode a `string` as described in [RFC4251 § 5]:
-    ///
-    /// > Arbitrary length binary string.  Strings are allowed to contain
-    /// > arbitrary binary data, including null characters and 8-bit
-    /// > characters.  They are stored as a uint32 containing its length
-    /// > (number of bytes that follow) and zero (= empty string) or more
-    /// > bytes that are the value of the string.  Terminating null
-    /// > characters are not used.
-    /// >
-    /// > Strings are also used to store text.  In that case, US-ASCII is
-    /// > used for internal names, and ISO-10646 UTF-8 for text that might
-    /// > be displayed to the user.  The terminating null character SHOULD
-    /// > NOT normally be stored in the string.  For example: the US-ASCII
-    /// > string "testing" is represented as 00 00 00 07 t e s t i n g.  The
-    /// > UTF-8 mapping does not alter the encoding of US-ASCII characters.
-    ///
-    /// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
-    fn encode_str(&mut self, s: &str) -> Result<()> {
-        self.encode_byte_slice(s.as_bytes())
-    }
-}
-
-impl EncoderExt for Encoder<'_> {
-    fn encode_base64(&mut self, bytes: &[u8]) -> Result<()> {
-        Ok(self.encode(bytes)?)
-    }
-}
-
-impl EncoderExt for pem::Encoder<'_, '_> {
-    fn encode_base64(&mut self, bytes: &[u8]) -> Result<()> {
-        Ok(self.encode(bytes)?)
     }
 }

--- a/ssh-key/src/encoder.rs
+++ b/ssh-key/src/encoder.rs
@@ -1,0 +1,102 @@
+//! Encoder support.
+//!
+//! Support for encoding SSH keys to the OpenSSH wire format.
+
+use crate::Result;
+use core::str;
+use pem_rfc7468 as pem;
+
+/// Get the estimated length of data when encoded as Base64.
+///
+/// This is an upper bound where the actual length might be slightly shorter.
+#[cfg(feature = "alloc")]
+pub(crate) fn encoded_len(input_len: usize) -> usize {
+    (((input_len * 4) / 3) + 3) & !3
+}
+
+/// Stateful Base64 encoder.
+pub(crate) type Base64Encoder<'o> = base64ct::Encoder<'o, base64ct::Base64>;
+
+/// Encoder trait.
+pub(crate) trait Encode: Sized {
+    /// Get the length of this type encoded in bytes, prior to Base64 encoding.
+    fn encoded_len(&self) -> Result<usize>;
+
+    /// Attempt to encode a value of this type using the provided [`Encoder`].
+    fn encode(&self, encoder: &mut impl Encoder) -> Result<()>;
+}
+
+/// Encoder extension trait.
+pub(crate) trait Encoder {
+    /// Encode the given byte slice as Base64.
+    ///
+    /// This is the base encoding method on which the rest of the trait is
+    /// implemented in terms of.
+    fn encode_base64(&mut self, bytes: &[u8]) -> Result<()>;
+
+    /// Encode a `uint32` as described in [RFC4251 § 5]:
+    ///
+    /// > Represents a 32-bit unsigned integer.  Stored as four bytes in the
+    /// > order of decreasing significance (network byte order).
+    /// > For example: the value 699921578 (0x29b7f4aa) is stored as 29 b7 f4 aa.
+    ///
+    /// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
+    fn encode_u32(&mut self, num: u32) -> Result<()> {
+        self.encode_base64(&num.to_be_bytes())
+    }
+
+    /// Encode a `usize` as a `uint32` as described in [RFC4251 § 5].
+    ///
+    /// Uses [`Encoder::encode_u32`] after converting from a `usize`, handling
+    /// potential overflow if `usize` is bigger than `u32`.
+    ///
+    /// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
+    fn encode_usize(&mut self, num: usize) -> Result<()> {
+        self.encode_u32(u32::try_from(num)?)
+    }
+
+    /// Encodes `[u8]` into `byte[n]` as described in [RFC4251 § 5]:
+    ///
+    /// > A byte represents an arbitrary 8-bit value (octet).  Fixed length
+    /// > data is sometimes represented as an array of bytes, written
+    /// > byte[n], where n is the number of bytes in the array.
+    ///
+    /// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
+    fn encode_byte_slice(&mut self, bytes: &[u8]) -> Result<()> {
+        self.encode_usize(bytes.len())?;
+        self.encode_base64(bytes)
+    }
+
+    /// Encode a `string` as described in [RFC4251 § 5]:
+    ///
+    /// > Arbitrary length binary string.  Strings are allowed to contain
+    /// > arbitrary binary data, including null characters and 8-bit
+    /// > characters.  They are stored as a uint32 containing its length
+    /// > (number of bytes that follow) and zero (= empty string) or more
+    /// > bytes that are the value of the string.  Terminating null
+    /// > characters are not used.
+    /// >
+    /// > Strings are also used to store text.  In that case, US-ASCII is
+    /// > used for internal names, and ISO-10646 UTF-8 for text that might
+    /// > be displayed to the user.  The terminating null character SHOULD
+    /// > NOT normally be stored in the string.  For example: the US-ASCII
+    /// > string "testing" is represented as 00 00 00 07 t e s t i n g.  The
+    /// > UTF-8 mapping does not alter the encoding of US-ASCII characters.
+    ///
+    /// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
+    fn encode_str(&mut self, s: &str) -> Result<()> {
+        self.encode_byte_slice(s.as_bytes())
+    }
+}
+
+impl Encoder for Base64Encoder<'_> {
+    fn encode_base64(&mut self, bytes: &[u8]) -> Result<()> {
+        Ok(self.encode(bytes)?)
+    }
+}
+
+impl Encoder for pem::Encoder<'_, '_> {
+    fn encode_base64(&mut self, bytes: &[u8]) -> Result<()> {
+        Ok(self.encode(bytes)?)
+    }
+}

--- a/ssh-key/src/lib.rs
+++ b/ssh-key/src/lib.rs
@@ -115,7 +115,8 @@ pub mod private;
 pub mod public;
 
 mod algorithm;
-mod base64;
+mod decoder;
+mod encoder;
 mod error;
 
 #[cfg(feature = "alloc")]

--- a/ssh-key/src/mpint.rs
+++ b/ssh-key/src/mpint.rs
@@ -1,7 +1,8 @@
 //! Multiple precision integer
 
 use crate::{
-    base64::{Decode, DecoderExt, Encode, EncoderExt},
+    decoder::{Decode, Decoder},
+    encoder::{Encode, Encoder},
     Error, Result,
 };
 use alloc::vec::Vec;
@@ -87,7 +88,7 @@ impl AsRef<[u8]> for MPInt {
 }
 
 impl Decode for MPInt {
-    fn decode(decoder: &mut impl DecoderExt) -> Result<Self> {
+    fn decode(decoder: &mut impl Decoder) -> Result<Self> {
         decoder.decode_byte_vec()?.try_into()
     }
 }
@@ -97,7 +98,7 @@ impl Encode for MPInt {
         Ok(4 + self.as_bytes().len())
     }
 
-    fn encode(&self, encoder: &mut impl EncoderExt) -> Result<()> {
+    fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {
         encoder.encode_byte_slice(self.as_bytes())
     }
 }

--- a/ssh-key/src/private/dsa.rs
+++ b/ssh-key/src/private/dsa.rs
@@ -1,7 +1,8 @@
 //! Digital Signature Algorithm (DSA) private keys.
 
 use crate::{
-    base64::{Decode, DecoderExt, Encode, EncoderExt},
+    decoder::{Decode, Decoder},
+    encoder::{Encode, Encoder},
     public::DsaPublicKey,
     MPInt, Result,
 };
@@ -43,7 +44,7 @@ impl AsRef<[u8]> for DsaPrivateKey {
 }
 
 impl Decode for DsaPrivateKey {
-    fn decode(decoder: &mut impl DecoderExt) -> Result<Self> {
+    fn decode(decoder: &mut impl Decoder) -> Result<Self> {
         Ok(Self {
             inner: MPInt::decode(decoder)?,
         })
@@ -61,7 +62,7 @@ impl Encode for DsaPrivateKey {
         self.inner.encoded_len()
     }
 
-    fn encode(&self, encoder: &mut impl EncoderExt) -> Result<()> {
+    fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {
         self.inner.encode(encoder)
     }
 }
@@ -103,7 +104,7 @@ pub struct DsaKeypair {
 }
 
 impl Decode for DsaKeypair {
-    fn decode(decoder: &mut impl DecoderExt) -> Result<Self> {
+    fn decode(decoder: &mut impl Decoder) -> Result<Self> {
         let public = DsaPublicKey::decode(decoder)?;
         let private = DsaPrivateKey::decode(decoder)?;
         Ok(DsaKeypair { public, private })
@@ -115,7 +116,7 @@ impl Encode for DsaKeypair {
         Ok(self.public.encoded_len()? + self.private.encoded_len()?)
     }
 
-    fn encode(&self, encoder: &mut impl EncoderExt) -> Result<()> {
+    fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {
         self.public.encode(encoder)?;
         self.private.encode(encoder)
     }

--- a/ssh-key/src/private/ecdsa.rs
+++ b/ssh-key/src/private/ecdsa.rs
@@ -1,7 +1,8 @@
 //! Elliptic Curve Digital Signature Algorithm (ECDSA) private keys.
 
 use crate::{
-    base64::{Decode, DecoderExt, Encode, EncoderExt},
+    decoder::{Decode, Decoder},
+    encoder::{Encode, Encoder},
     public::EcdsaPublicKey,
     Algorithm, EcdsaCurve, Error, Result,
 };
@@ -31,7 +32,7 @@ impl<const SIZE: usize> EcdsaPrivateKey<SIZE> {
     }
 
     /// Decode ECDSA private key using the provided Base64 decoder.
-    fn decode(decoder: &mut impl DecoderExt) -> Result<Self> {
+    fn decode(decoder: &mut impl Decoder) -> Result<Self> {
         let len = decoder.decode_usize()?;
 
         if len == SIZE + 1 {
@@ -58,7 +59,7 @@ impl<const SIZE: usize> Encode for EcdsaPrivateKey<SIZE> {
         Ok(4usize + usize::from(self.needs_leading_zero()) + SIZE)
     }
 
-    fn encode(&self, encoder: &mut impl EncoderExt) -> Result<()> {
+    fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {
         encoder.encode_usize(usize::from(self.needs_leading_zero()) + SIZE)?;
 
         if self.needs_leading_zero() {
@@ -191,7 +192,7 @@ impl EcdsaKeypair {
 }
 
 impl Decode for EcdsaKeypair {
-    fn decode(decoder: &mut impl DecoderExt) -> Result<Self> {
+    fn decode(decoder: &mut impl Decoder) -> Result<Self> {
         match EcdsaPublicKey::decode(decoder)? {
             EcdsaPublicKey::NistP256(public) => {
                 let private = EcdsaPrivateKey::<32>::decode(decoder)?;
@@ -222,7 +223,7 @@ impl Encode for EcdsaKeypair {
         Ok(public_len + private_len)
     }
 
-    fn encode(&self, encoder: &mut impl EncoderExt) -> Result<()> {
+    fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {
         EcdsaPublicKey::from(self).encode(encoder)?;
 
         match self {

--- a/ssh-key/src/private/ed25519.rs
+++ b/ssh-key/src/private/ed25519.rs
@@ -3,7 +3,8 @@
 //! Edwards Digital Signature Algorithm (EdDSA) over Curve25519.
 
 use crate::{
-    base64::{Decode, DecoderExt, Encode, EncoderExt},
+    decoder::{Decode, Decoder},
+    encoder::{Encode, Encoder},
     public::Ed25519PublicKey,
     Error, Result,
 };
@@ -108,7 +109,7 @@ impl Ed25519Keypair {
 }
 
 impl Decode for Ed25519Keypair {
-    fn decode(decoder: &mut impl DecoderExt) -> Result<Self> {
+    fn decode(decoder: &mut impl Decoder) -> Result<Self> {
         // Decode private key
         let public = Ed25519PublicKey::decode(decoder)?;
 
@@ -139,7 +140,7 @@ impl Encode for Ed25519Keypair {
         Ok(self.public.encoded_len()? + 4 + Self::BYTE_SIZE)
     }
 
-    fn encode(&self, encoder: &mut impl EncoderExt) -> Result<()> {
+    fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {
         self.public.encode(encoder)?;
         encoder.encode_byte_slice(&*Zeroizing::new(self.to_bytes()))
     }

--- a/ssh-key/src/private/rsa.rs
+++ b/ssh-key/src/private/rsa.rs
@@ -1,7 +1,8 @@
 //! Rivest–Shamir–Adleman (RSA) private keys.
 
 use crate::{
-    base64::{Decode, DecoderExt, Encode, EncoderExt},
+    decoder::{Decode, Decoder},
+    encoder::{Encode, Encoder},
     public::RsaPublicKey,
     MPInt, Result,
 };
@@ -29,7 +30,7 @@ pub struct RsaPrivateKey {
 }
 
 impl Decode for RsaPrivateKey {
-    fn decode(decoder: &mut impl DecoderExt) -> Result<Self> {
+    fn decode(decoder: &mut impl Decoder) -> Result<Self> {
         let d = MPInt::decode(decoder)?;
         let iqmp = MPInt::decode(decoder)?;
         let p = MPInt::decode(decoder)?;
@@ -45,7 +46,7 @@ impl Encode for RsaPrivateKey {
             .fold(Ok(0), |acc, n| Ok(acc? + n.encoded_len()?))
     }
 
-    fn encode(&self, encoder: &mut impl EncoderExt) -> Result<()> {
+    fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {
         self.d.encode(encoder)?;
         self.iqmp.encode(encoder)?;
         self.p.encode(encoder)?;
@@ -96,7 +97,7 @@ pub struct RsaKeypair {
 }
 
 impl Decode for RsaKeypair {
-    fn decode(decoder: &mut impl DecoderExt) -> Result<Self> {
+    fn decode(decoder: &mut impl Decoder) -> Result<Self> {
         let n = MPInt::decode(decoder)?;
         let e = MPInt::decode(decoder)?;
         let public = RsaPublicKey { n, e };
@@ -112,7 +113,7 @@ impl Encode for RsaKeypair {
             + self.private.encoded_len()?)
     }
 
-    fn encode(&self, encoder: &mut impl EncoderExt) -> Result<()> {
+    fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {
         self.public.n.encode(encoder)?;
         self.public.e.encode(encoder)?;
         self.private.encode(encoder)

--- a/ssh-key/src/public/dsa.rs
+++ b/ssh-key/src/public/dsa.rs
@@ -1,7 +1,8 @@
 //! Digital Signature Algorithm (DSA) public keys.
 
 use crate::{
-    base64::{Decode, DecoderExt, Encode, EncoderExt},
+    decoder::{Decode, Decoder},
+    encoder::{Encode, Encoder},
     MPInt, Result,
 };
 
@@ -35,7 +36,7 @@ impl DsaPublicKey {
 }
 
 impl Decode for DsaPublicKey {
-    fn decode(decoder: &mut impl DecoderExt) -> Result<Self> {
+    fn decode(decoder: &mut impl Decoder) -> Result<Self> {
         let p = MPInt::decode(decoder)?;
         let q = MPInt::decode(decoder)?;
         let g = MPInt::decode(decoder)?;
@@ -52,7 +53,7 @@ impl Encode for DsaPublicKey {
             + self.y.encoded_len()?)
     }
 
-    fn encode(&self, encoder: &mut impl EncoderExt) -> Result<()> {
+    fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {
         self.p.encode(encoder)?;
         self.q.encode(encoder)?;
         self.g.encode(encoder)?;

--- a/ssh-key/src/public/ecdsa.rs
+++ b/ssh-key/src/public/ecdsa.rs
@@ -1,7 +1,8 @@
 //! Elliptic Curve Digital Signature Algorithm (ECDSA) public keys.
 
 use crate::{
-    base64::{Decode, DecoderExt, Encode, EncoderExt},
+    decoder::{Decode, Decoder},
+    encoder::{Encode, Encoder},
     Algorithm, EcdsaCurve, Error, Result,
 };
 use core::fmt;
@@ -90,7 +91,7 @@ impl AsRef<[u8]> for EcdsaPublicKey {
 }
 
 impl Decode for EcdsaPublicKey {
-    fn decode(decoder: &mut impl DecoderExt) -> Result<Self> {
+    fn decode(decoder: &mut impl Decoder) -> Result<Self> {
         let curve = EcdsaCurve::decode(decoder)?;
 
         let mut buf = [0u8; Self::MAX_SIZE];
@@ -109,7 +110,7 @@ impl Encode for EcdsaPublicKey {
         Ok(4 + self.curve().encoded_len()? + self.as_ref().len())
     }
 
-    fn encode(&self, encoder: &mut impl EncoderExt) -> Result<()> {
+    fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {
         self.curve().encode(encoder)?;
         encoder.encode_byte_slice(self.as_ref())
     }

--- a/ssh-key/src/public/ed25519.rs
+++ b/ssh-key/src/public/ed25519.rs
@@ -3,7 +3,8 @@
 //! Edwards Digital Signature Algorithm (EdDSA) over Curve25519.
 
 use crate::{
-    base64::{Decode, DecoderExt, Encode, EncoderExt},
+    decoder::{Decode, Decoder},
+    encoder::{Encode, Encoder},
     Error, Result,
 };
 use core::fmt;
@@ -25,7 +26,7 @@ impl AsRef<[u8; Self::BYTE_SIZE]> for Ed25519PublicKey {
 }
 
 impl Decode for Ed25519PublicKey {
-    fn decode(decoder: &mut impl DecoderExt) -> Result<Self> {
+    fn decode(decoder: &mut impl Decoder) -> Result<Self> {
         // Validate length prefix
         if decoder.decode_usize()? != Self::BYTE_SIZE {
             return Err(Error::Length);
@@ -42,7 +43,7 @@ impl Encode for Ed25519PublicKey {
         Ok(4 + Self::BYTE_SIZE)
     }
 
-    fn encode(&self, encoder: &mut impl EncoderExt) -> Result<()> {
+    fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {
         encoder.encode_byte_slice(self.as_ref())
     }
 }

--- a/ssh-key/src/public/openssh.rs
+++ b/ssh-key/src/public/openssh.rs
@@ -12,10 +12,7 @@
 //! ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILM+rvN+ot98qgEN796jTiQfZfG1KaT0PtFDJ/XFSqti user@example.com
 //! ```
 
-use crate::{
-    base64::{self},
-    Error, Result,
-};
+use crate::{encoder::Base64Encoder, Error, Result};
 use core::str;
 
 /// OpenSSH public key encapsulation parser.
@@ -60,13 +57,13 @@ impl<'a> Encapsulation<'a> {
         f: F,
     ) -> Result<&'o str>
     where
-        F: FnOnce(&mut base64::Encoder<'_>) -> Result<()>,
+        F: FnOnce(&mut Base64Encoder<'_>) -> Result<()>,
     {
         let mut offset = 0;
         encode_str(out, &mut offset, algorithm_id)?;
         encode_str(out, &mut offset, " ")?;
 
-        let mut encoder = base64::Encoder::new(&mut out[offset..])?;
+        let mut encoder = Base64Encoder::new(&mut out[offset..])?;
         f(&mut encoder)?;
         let base64_len = encoder.finish()?.len();
 

--- a/ssh-key/src/public/rsa.rs
+++ b/ssh-key/src/public/rsa.rs
@@ -1,7 +1,8 @@
 //! Rivest–Shamir–Adleman (RSA) public keys.
 
 use crate::{
-    base64::{Decode, DecoderExt, Encode, EncoderExt},
+    decoder::{Decode, Decoder},
+    encoder::{Encode, Encoder},
     MPInt, Result,
 };
 
@@ -28,7 +29,7 @@ impl RsaPublicKey {
 }
 
 impl Decode for RsaPublicKey {
-    fn decode(decoder: &mut impl DecoderExt) -> Result<Self> {
+    fn decode(decoder: &mut impl Decoder) -> Result<Self> {
         let e = MPInt::decode(decoder)?;
         let n = MPInt::decode(decoder)?;
         Ok(Self { e, n })
@@ -40,7 +41,7 @@ impl Encode for RsaPublicKey {
         Ok(self.e.encoded_len()? + self.n.encoded_len()?)
     }
 
-    fn encode(&self, encoder: &mut impl EncoderExt) -> Result<()> {
+    fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {
         self.e.encode(encoder)?;
         self.n.encode(encoder)
     }


### PR DESCRIPTION
Factors encoding support into separate `decoder` and `encoder` modules