### PR TITLE
ssh-key: SHA-256 fingerprint support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -976,6 +976,7 @@ dependencies = [
  "hex-literal",
  "pem-rfc7468",
  "sec1",
+ "sha2",
  "subtle",
  "tempfile",
  "zeroize",

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -22,6 +22,7 @@ zeroize = { version = "1", default-features = false }
 
 # optional dependencies
 sec1 = { version = "=0.3.0-pre.1", optional = true, default-features = false, path = "../sec1" }
+sha2 = { version = "0.10", optional = true, default-features = false }
 subtle = { version = "2", optional = true, default-features = false }
 
 [dev-dependencies]
@@ -29,9 +30,10 @@ hex-literal = "0.3"
 tempfile = "3"
 
 [features]
-default = ["ecdsa", "std"]
+default = ["ecdsa", "fingerprint", "std"]
 alloc = ["zeroize/alloc"]
 ecdsa = ["sec1"]
+fingerprint = ["sha2"]
 std = ["alloc", "base64ct/std"]
 
 [package.metadata.docs.rs]

--- a/ssh-key/src/fingerprint.rs
+++ b/ssh-key/src/fingerprint.rs
@@ -1,0 +1,153 @@
+//! SSH public key fingerprints.
+
+use crate::{encoder::Encode, Error, HashAlg, PublicKey, Result};
+use base64ct::{Base64Unpadded, Encoding};
+use core::{fmt, str};
+use sha2::{Digest, Sha256};
+
+/// Error message for malformed encoded strings which are expected to be
+/// well-formed according to type-level invariants.
+const ENCODING_ERR_MSG: &str = "Base64 encoding error";
+
+/// Size of a SHA-256 hash encoded as Base64.
+const SHA256_BASE64_LEN: usize = 43;
+
+/// Size of a SHA-256 hash serialized as binary.
+const SHA256_BIN_LEN: usize = 32;
+
+/// Prefix of SHA-256 fingerprints.
+const SHA256_PREFIX: &str = "SHA256:";
+
+/// SSH public key fingerprints.
+///
+/// Fingerprints have an associated key fingerprint algorithm, i.e. a hash
+/// function which is used to compute the fingerprint.
+#[cfg_attr(docsrs, doc(cfg(feature = "fingerprint")))]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub enum Fingerprint {
+    /// Fingerprints computed using SHA-256.
+    Sha256(Sha256Fingerprint),
+}
+
+impl Fingerprint {
+    /// Get the hash algorithm used for this fingerprint.
+    pub fn algorithm(self) -> HashAlg {
+        match self {
+            Self::Sha256(_) => HashAlg::Sha256,
+        }
+    }
+
+    /// Get the SHA-256 fingerprint, if this is one.
+    pub fn sha256(self) -> Option<Sha256Fingerprint> {
+        match self {
+            Self::Sha256(fingerprint) => Some(fingerprint),
+        }
+    }
+
+    /// Is this fingerprint SHA-256?
+    pub fn is_sha256(self) -> bool {
+        self.sha256().is_some()
+    }
+}
+
+impl From<Sha256Fingerprint> for Fingerprint {
+    fn from(fingerprint: Sha256Fingerprint) -> Fingerprint {
+        Fingerprint::Sha256(fingerprint)
+    }
+}
+
+impl str::FromStr for Fingerprint {
+    type Err = Error;
+
+    fn from_str(id: &str) -> Result<Self> {
+        if id.starts_with(SHA256_PREFIX) {
+            Sha256Fingerprint::from_str(id).map(Into::into)
+        } else {
+            Err(Error::Algorithm)
+        }
+    }
+}
+
+impl fmt::Display for Fingerprint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Sha256(fingerprint) => write!(f, "{}", fingerprint),
+        }
+    }
+}
+
+/// SSH key fingerprints calculated using the SHA-256 hash function.
+#[cfg_attr(docsrs, doc(cfg(feature = "fingerprint")))]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct Sha256Fingerprint([u8; SHA256_BASE64_LEN]);
+
+impl Sha256Fingerprint {
+    /// Create a new SHA-256 fingerprint from the given binary digest.
+    ///
+    /// Use [`FromStr`] to parse an existing Base64-encoded fingerprint.
+    pub fn new(digest_bytes: &[u8; SHA256_BIN_LEN]) -> Self {
+        let mut base64 = [0u8; SHA256_BASE64_LEN];
+        Base64Unpadded::encode(digest_bytes, &mut base64).expect(ENCODING_ERR_MSG);
+        Self(base64)
+    }
+
+    /// Borrow the Base64 encoding of the digest as a string.
+    ///
+    /// Does not include the `SHA256:` algorithm prefix.
+    pub fn as_base64(&self) -> &str {
+        str::from_utf8(&self.0).expect("invalid Base64 encoding")
+    }
+
+    /// Decode a Base64-encoded fingerprint to binary.
+    pub fn to_bytes(&self) -> [u8; SHA256_BIN_LEN] {
+        let mut decoded_bytes = [0u8; SHA256_BIN_LEN];
+        let decoded_len = Base64Unpadded::decode(&self.0, &mut decoded_bytes)
+            .expect(ENCODING_ERR_MSG)
+            .len();
+
+        assert_eq!(SHA256_BIN_LEN, decoded_len);
+        decoded_bytes
+    }
+}
+
+impl TryFrom<PublicKey> for Sha256Fingerprint {
+    type Error = Error;
+
+    fn try_from(public_key: PublicKey) -> Result<Sha256Fingerprint> {
+        Sha256Fingerprint::try_from(&public_key)
+    }
+}
+
+impl TryFrom<&PublicKey> for Sha256Fingerprint {
+    type Error = Error;
+
+    fn try_from(public_key: &PublicKey) -> Result<Sha256Fingerprint> {
+        let mut digest = Sha256::new();
+        public_key.key_data().encode(&mut digest)?;
+        Ok(Self::new(&digest.finalize().into()))
+    }
+}
+
+impl fmt::Display for Sha256Fingerprint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}{}", SHA256_PREFIX, self.as_base64())
+    }
+}
+
+impl str::FromStr for Sha256Fingerprint {
+    type Err = Error;
+
+    fn from_str(id: &str) -> Result<Self> {
+        let id = id.strip_prefix(SHA256_PREFIX).ok_or(Error::Algorithm)?;
+
+        let mut decoded_bytes = [0u8; SHA256_BIN_LEN];
+        match Base64Unpadded::decode(id, &mut decoded_bytes)?.len() {
+            SHA256_BIN_LEN => id
+                .as_bytes()
+                .try_into()
+                .map(Self)
+                .map_err(|_| Error::Length),
+            _ => Err(Error::Length),
+        }
+    }
+}

--- a/ssh-key/src/lib.rs
+++ b/ssh-key/src/lib.rs
@@ -119,11 +119,13 @@ mod decoder;
 mod encoder;
 mod error;
 
+#[cfg(feature = "fingerprint")]
+mod fingerprint;
 #[cfg(feature = "alloc")]
 mod mpint;
 
 pub use crate::{
-    algorithm::{Algorithm, CipherAlg, EcdsaCurve, KdfAlg, KdfOpts},
+    algorithm::{Algorithm, CipherAlg, EcdsaCurve, HashAlg, KdfAlg, KdfOpts},
     authorized_keys::AuthorizedKeys,
     error::{Error, Result},
     private::PrivateKey,
@@ -137,3 +139,6 @@ pub use crate::mpint::MPInt;
 #[cfg(feature = "ecdsa")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
 pub use sec1;
+
+#[cfg(feature = "fingerprint")]
+pub use crate::fingerprint::{Fingerprint, Sha256Fingerprint};

--- a/ssh-key/src/private.rs
+++ b/ssh-key/src/private.rs
@@ -217,7 +217,7 @@ impl PrivateKey {
         pem_encoder.encode_u32(checkint)?;
         self.key_data.encode(&mut pem_encoder)?;
         pem_encoder.encode_str(self.comment())?;
-        pem_encoder.encode_base64(&PADDING_BYTES[..padding_len])?;
+        pem_encoder.encode_raw(&PADDING_BYTES[..padding_len])?;
 
         let encoded_len = pem_encoder.finish()?;
         Ok(str::from_utf8(&out[..encoded_len])?)

--- a/ssh-key/src/private/ecdsa.rs
+++ b/ssh-key/src/private/ecdsa.rs
@@ -44,7 +44,7 @@ impl<const SIZE: usize> EcdsaPrivateKey<SIZE> {
         }
 
         let mut bytes = [0u8; SIZE];
-        decoder.decode_base64(&mut bytes)?;
+        decoder.decode_raw(&mut bytes)?;
         Ok(Self { bytes })
     }
 
@@ -63,10 +63,10 @@ impl<const SIZE: usize> Encode for EcdsaPrivateKey<SIZE> {
         encoder.encode_usize(usize::from(self.needs_leading_zero()) + SIZE)?;
 
         if self.needs_leading_zero() {
-            encoder.encode_base64(&[0])?;
+            encoder.encode_raw(&[0])?;
         }
 
-        encoder.encode_base64(&self.bytes)
+        encoder.encode_raw(&self.bytes)
     }
 }
 

--- a/ssh-key/src/private/ed25519.rs
+++ b/ssh-key/src/private/ed25519.rs
@@ -121,7 +121,7 @@ impl Decode for Ed25519Keypair {
         }
 
         let mut bytes = Zeroizing::new([0u8; Self::BYTE_SIZE]);
-        decoder.decode_base64(&mut *bytes)?;
+        decoder.decode_raw(&mut *bytes)?;
 
         let (priv_bytes, pub_bytes) = bytes.split_at(Ed25519PrivateKey::BYTE_SIZE);
 

--- a/ssh-key/src/public.rs
+++ b/ssh-key/src/public.rs
@@ -33,6 +33,9 @@ use {
     },
 };
 
+#[cfg(feature = "fingerprint")]
+use crate::{Fingerprint, HashAlg, Sha256Fingerprint};
+
 #[cfg(feature = "std")]
 use std::{fs, path::Path};
 
@@ -148,6 +151,17 @@ impl PublicKey {
     /// Private key data.
     pub fn key_data(&self) -> &KeyData {
         &self.key_data
+    }
+
+    /// Compute key fingerprint.
+    ///
+    /// Use [`Default::default()`] to use the default hash function (SHA-256).
+    #[cfg(feature = "fingerprint")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "fingerprint")))]
+    pub fn fingerprint(&self, hash_alg: HashAlg) -> Result<Fingerprint> {
+        match hash_alg {
+            HashAlg::Sha256 => Sha256Fingerprint::try_from(self).map(Into::into),
+        }
     }
 }
 

--- a/ssh-key/src/public/ed25519.rs
+++ b/ssh-key/src/public/ed25519.rs
@@ -33,7 +33,7 @@ impl Decode for Ed25519PublicKey {
         }
 
         let mut bytes = [0u8; Self::BYTE_SIZE];
-        decoder.decode_base64(&mut bytes)?;
+        decoder.decode_raw(&mut bytes)?;
         Ok(Self(bytes))
     }
 }

--- a/ssh-key/tests/public_key.rs
+++ b/ssh-key/tests/public_key.rs
@@ -70,6 +70,15 @@ fn decode_dsa_openssh() {
     );
 
     assert_eq!("user@example.com", ossh_key.comment());
+
+    #[cfg(feature = "fingerprint")]
+    assert_eq!(
+        &ossh_key
+            .fingerprint(Default::default())
+            .unwrap()
+            .to_string(),
+        "SHA256:Nh0Me49Zh9fDw/VYUfq43IJmI1T+XrjiYONPND8GzaM"
+    );
 }
 
 #[cfg(feature = "ecdsa")]
@@ -93,6 +102,15 @@ fn decode_ecdsa_p256_openssh() {
 
     #[cfg(feature = "alloc")]
     assert_eq!("user@example.com", ossh_key.comment());
+
+    #[cfg(feature = "fingerprint")]
+    assert_eq!(
+        &ossh_key
+            .fingerprint(Default::default())
+            .unwrap()
+            .to_string(),
+        "SHA256:JQ6FV0rf7qqJHZqIj4zNH8eV0oB8KLKh9Pph3FTD98g"
+    );
 }
 
 #[cfg(feature = "ecdsa")]
@@ -117,6 +135,15 @@ fn decode_ecdsa_p384_openssh() {
 
     #[cfg(feature = "alloc")]
     assert_eq!("user@example.com", ossh_key.comment());
+
+    #[cfg(feature = "fingerprint")]
+    assert_eq!(
+        &ossh_key
+            .fingerprint(Default::default())
+            .unwrap()
+            .to_string(),
+        "SHA256:nkGE8oV7pHvOiPKHtQRs67WUPiVLRxbNu//gV/k4Vjw"
+    );
 }
 
 #[cfg(feature = "ecdsa")]
@@ -142,6 +169,15 @@ fn decode_ecdsa_p521_openssh() {
 
     #[cfg(feature = "alloc")]
     assert_eq!("user@example.com", ossh_key.comment());
+
+    #[cfg(feature = "fingerprint")]
+    assert_eq!(
+        &ossh_key
+            .fingerprint(Default::default())
+            .unwrap()
+            .to_string(),
+        "SHA256:l3AUUMK6Q2BbuiqvMx2fs97f8LUYq7sWCAx7q5m3S6M"
+    );
 }
 
 #[test]
@@ -156,6 +192,15 @@ fn decode_ed25519_openssh() {
 
     #[cfg(feature = "alloc")]
     assert_eq!("user@example.com", ossh_key.comment());
+
+    #[cfg(feature = "fingerprint")]
+    assert_eq!(
+        &ossh_key
+            .fingerprint(Default::default())
+            .unwrap()
+            .to_string(),
+        "SHA256:UCUiLr7Pjs9wFFJMDByLgc3NrtdU344OgUM45wZPcIQ"
+    );
 }
 
 #[cfg(feature = "alloc")]
@@ -182,6 +227,15 @@ fn decode_rsa_3072_openssh() {
     );
 
     assert_eq!("user@example.com", ossh_key.comment());
+
+    #[cfg(feature = "fingerprint")]
+    assert_eq!(
+        &ossh_key
+            .fingerprint(Default::default())
+            .unwrap()
+            .to_string(),
+        "SHA256:Fmxts/GcV77PakFnf1Ueki5mpU4ZjUQWGRjZGAo3n/I"
+    );
 }
 
 #[cfg(feature = "alloc")]
@@ -211,6 +265,15 @@ fn decode_rsa_4096_openssh() {
     );
 
     assert_eq!("user@example.com", ossh_key.comment());
+
+    #[cfg(feature = "fingerprint")]
+    assert_eq!(
+        &ossh_key
+            .fingerprint(Default::default())
+            .unwrap()
+            .to_string(),
+        "SHA256:FKAyeywtQNZLl1YTzIzCV/ThadBlnWMaD7jHQYDseEY"
+    );
 }
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
Optional support for computing SHA-256 fingerprints of keys.

Uses the `Encoder` trait to write data to `Sha256`, allowing OTF computation of key fingerprints.