### PR TITLE
ssh-key v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "ssh-key"
-version = "0.3.0-pre"
+version = "0.3.0"
 dependencies = [
  "base64ct",
  "hex-literal",

--- a/ssh-key/CHANGELOG.md
+++ b/ssh-key/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2022-03-16)
+### Added
+- `FromStr` impls for key types ([#368])
+- `PublicKey` encoder ([#369], [#371], [#372], [#373])
+- `AuthorizedKeys` parser ([#452])
+- `PrivateKey::public_key` and `From` conversions ([#485])
+- `PrivateKey` encoder ([#494])
+- Validate private key padding bytes ([#495])
+- File I/O methods for `PrivateKey` and `PublicKey` ([#494], [#503])
+- SHA-256 fingerprint support ([#513])
+
+### Changed
+- Use `pem-rfc7468` for private key PEM parser ([#407])
+- Make `PublicKey`/`PrivateKey` fields private ([#498])
+
+[#368]: https://github.com/RustCrypto/formats/pull/368
+[#369]: https://github.com/RustCrypto/formats/pull/369
+[#371]: https://github.com/RustCrypto/formats/pull/371
+[#372]: https://github.com/RustCrypto/formats/pull/372
+[#373]: https://github.com/RustCrypto/formats/pull/373
+[#407]: https://github.com/RustCrypto/formats/pull/407
+[#452]: https://github.com/RustCrypto/formats/pull/452
+[#485]: https://github.com/RustCrypto/formats/pull/485
+[#494]: https://github.com/RustCrypto/formats/pull/494
+[#495]: https://github.com/RustCrypto/formats/pull/495
+[#498]: https://github.com/RustCrypto/formats/pull/498
+[#503]: https://github.com/RustCrypto/formats/pull/503
+[#513]: https://github.com/RustCrypto/formats/pull/513
+
 ## 0.2.0 (2021-12-29)
 ### Added
 - OpenSSH private key decoder ([#297], [#301], [#307], [#311])

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssh-key"
-version = "0.3.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.3.0"
 description = """
 Pure Rust implementation of SSH key file format decoders/encoders as described
 in RFC4253 and RFC4716 as well as the OpenSSH key formats and `authorized_keys`.

--- a/ssh-key/src/lib.rs
+++ b/ssh-key/src/lib.rs
@@ -3,8 +3,7 @@
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/ssh-key/0.3.0-pre"
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Added
- `FromStr` impls for key types ([#368])
- `PublicKey` encoder ([#369], [#371], [#372], [#373])
- `AuthorizedKeys` parser ([#452])
- `PrivateKey::public_key` and `From` conversions ([#485])
- `PrivateKey` encoder ([#494])
- Validate private key padding bytes ([#495])
- File I/O methods for `PrivateKey` and `PublicKey` ([#494], [#503])
- SHA-256 fingerprint support ([#513])

### Changed
- Use `pem-rfc7468` for private key PEM parser ([#407])
- Make `PublicKey`/`PrivateKey` fields private ([#498])

[#368]: https://github.com/RustCrypto/formats/pull/368
[#369]: https://github.com/RustCrypto/formats/pull/369
[#371]: https://github.com/RustCrypto/formats/pull/371
[#372]: https://github.com/RustCrypto/formats/pull/372
[#373]: https://github.com/RustCrypto/formats/pull/373
[#407]: https://github.com/RustCrypto/formats/pull/407
[#452]: https://github.com/RustCrypto/formats/pull/452
[#485]: https://github.com/RustCrypto/formats/pull/485
[#494]: https://github.com/RustCrypto/formats/pull/494
[#495]: https://github.com/RustCrypto/formats/pull/495
[#498]: https://github.com/RustCrypto/formats/pull/498
[#503]: https://github.com/RustCrypto/formats/pull/503
[#513]: https://github.com/RustCrypto/formats/pull/513