### PR TITLE
feat(sec1): add default cargo feature for disabling point module

### DIFF
--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -16,10 +16,9 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-generic-array = { version = "0.14.4", default-features = false }
-
 # optional dependencies
 der = { version = "=0.6.0-pre.3", optional = true, features = ["oid"], path = "../der" }
+generic-array = { version = "0.14.4", optional = true, default-features = false }
 pkcs8 = { version = "=0.9.0-pre.1", optional = true, default-features = false, path = "../pkcs8" }
 serde = { version = "1.0.16", optional = true, default-features = false }
 subtle = { version = "2", optional = true, default-features = false }
@@ -29,9 +28,10 @@ zeroize = { version = "1", optional = true, default-features = false }
 hex-literal = "0.3"
 
 [features]
-default = ["der"]
+default = ["der", "point"]
 alloc = ["der/alloc", "pkcs8/alloc", "zeroize/alloc"]
 pem = ["alloc", "der/pem", "pkcs8/pem"]
+point = ["generic-array"]
 std = ["der/std", "alloc"]
 
 [package.metadata.docs.rs]

--- a/sec1/src/lib.rs
+++ b/sec1/src/lib.rs
@@ -23,6 +23,7 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
+#[cfg(feature = "point")]
 pub mod point;
 
 mod error;
@@ -36,15 +37,16 @@ mod traits;
 #[cfg(feature = "der")]
 pub use der;
 
-pub use crate::{
-    error::{Error, Result},
-    point::EncodedPoint,
-};
+pub use crate::error::{Error, Result};
+
+#[cfg(feature = "point")]
+pub use crate::point::EncodedPoint;
+
+#[cfg(feature = "point")]
+pub use generic_array::typenum::consts;
 
 #[cfg(feature = "der")]
 pub use crate::{parameters::EcParameters, private_key::EcPrivateKey, traits::DecodeEcPrivateKey};
-
-pub use generic_array::typenum::consts;
 
 #[cfg(feature = "alloc")]
 pub use crate::{private_key::document::EcPrivateKeyDocument, traits::EncodeEcPrivateKey};

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -21,7 +21,7 @@ pem-rfc7468 = { version = "0.4", path = "../pem-rfc7468" }
 zeroize = { version = "1", default-features = false }
 
 # optional dependencies
-sec1 = { version = "=0.3.0-pre.1", optional = true, default-features = false, path = "../sec1" }
+sec1 = { version = "=0.3.0-pre.1", optional = true, default-features = false, features = ["point"], path = "../sec1" }
 sha2 = { version = "0.10", optional = true, default-features = false }
 subtle = { version = "2", optional = true, default-features = false }
 


### PR DESCRIPTION
This allows users who aren't using EncodedPoint to omit dependencies on generic-array, typenum, and version_check.