### PR TITLE
der: rename `Decodable`/`Encodable` => `Decode`/`Encode`

### DIFF
--- a/der/derive/src/choice.rs
+++ b/der/derive/src/choice.rs
@@ -1,4 +1,4 @@
-//! Support for deriving the `Decodable` and `Encodable` traits on enums for
+//! Support for deriving the `Decode` and `Encode` traits on enums for
 //! the purposes of decoding/encoding ASN.1 `CHOICE` types as mapped to
 //! enum variants.
 
@@ -94,7 +94,7 @@ impl DeriveChoice {
                 }
             }
 
-            impl<#lt_params> ::der::Decodable<#lifetime> for #ident<#lt_params> {
+            impl<#lt_params> ::der::Decode<#lifetime> for #ident<#lt_params> {
                 fn decode(decoder: &mut ::der::Decoder<#lifetime>) -> ::der::Result<Self> {
                     match decoder.peek_tag()? {
                         #(#decode_body)*

--- a/der/derive/src/enumerated.rs
+++ b/der/derive/src/enumerated.rs
@@ -1,4 +1,4 @@
-//! Support for deriving the `Decodable` and `Encodable` traits on enums for
+//! Support for deriving the `Decode` and `Encode` traits on enums for
 //! the purposes of decoding/encoding ASN.1 `ENUMERATED` types as mapped to
 //! enum variants.
 

--- a/der/derive/src/lib.rs
+++ b/der/derive/src/lib.rs
@@ -142,11 +142,11 @@ use syn::{parse_macro_input, DeriveInput};
 /// Derive the [`Choice`][1] trait on an `enum`.
 ///
 /// This custom derive macro can be used to automatically impl the
-/// [`Decodable`][2] and [`Encodable`][3] traits along with the
+/// [`Decode`][2] and [`Encode`][3] traits along with the
 /// [`Choice`][1] supertrait for any enum representing an ASN.1 `CHOICE`.
 ///
 /// The enum must consist entirely of 1-tuple variants wrapping inner
-/// types which must also impl the [`Decodable`][2] and [`Encodable`][3]
+/// types which must also impl the [`Decode`][2] and [`Encode`][3]
 /// traits. It will will also generate [`From`] impls for each of the
 /// inner types of the variants into the enum that wraps them.
 ///
@@ -173,8 +173,8 @@ use syn::{parse_macro_input, DeriveInput};
 /// information about the `#[asn1]` attribute.
 ///
 /// [1]: https://docs.rs/der/latest/der/trait.Choice.html
-/// [2]: https://docs.rs/der/latest/der/trait.Decodable.html
-/// [3]: https://docs.rs/der/latest/der/trait.Encodable.html
+/// [2]: https://docs.rs/der/latest/der/trait.Decode.html
+/// [3]: https://docs.rs/der/latest/der/trait.Encode.html
 /// [4]: https://docs.rs/der_derive/
 #[proc_macro_derive(Choice, attributes(asn1))]
 #[proc_macro_error]

--- a/der/derive/src/sequence.rs
+++ b/der/derive/src/sequence.rs
@@ -103,7 +103,7 @@ impl DeriveSequence {
             impl<#lt_params> ::der::Sequence<#lifetime> for #ident<#lt_params> {
                 fn fields<F, T>(&self, f: F) -> ::der::Result<T>
                 where
-                    F: FnOnce(&[&dyn der::Encodable]) -> ::der::Result<T>,
+                    F: FnOnce(&[&dyn der::Encode]) -> ::der::Result<T>,
                 {
                     f(&[
                         #(#encode_body),*

--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `ANY` type.
 
 use crate::{
-    asn1::*, ByteSlice, Choice, Decodable, DecodeValue, Decoder, DerOrd, EncodeValue, Encoder,
-    Error, ErrorKind, FixedTag, Header, Length, Result, Tag, Tagged, ValueOrd,
+    asn1::*, ByteSlice, Choice, Decode, DecodeValue, Decoder, DerOrd, EncodeValue, Encoder, Error,
+    ErrorKind, FixedTag, Header, Length, Result, Tag, Tagged, ValueOrd,
 };
 use core::cmp::Ordering;
 
@@ -79,7 +79,7 @@ impl<'a> Any<'a> {
     /// Attempt to decode an ASN.1 `CONTEXT-SPECIFIC` field.
     pub fn context_specific<T>(self) -> Result<ContextSpecific<T>>
     where
-        T: Decodable<'a>,
+        T: Decode<'a>,
     {
         self.try_into()
     }
@@ -152,7 +152,7 @@ impl<'a> Choice<'a> for Any<'a> {
     }
 }
 
-impl<'a> Decodable<'a> for Any<'a> {
+impl<'a> Decode<'a> for Any<'a> {
     fn decode(decoder: &mut Decoder<'a>) -> Result<Any<'a>> {
         let header = Header::decode(decoder)?;
         Ok(Self {

--- a/der/src/asn1/boolean.rs
+++ b/der/src/asn1/boolean.rs
@@ -65,7 +65,7 @@ impl TryFrom<Any<'_>> for bool {
 
 #[cfg(test)]
 mod tests {
-    use crate::{Decodable, Encodable};
+    use crate::{Decode, Encode};
 
     #[test]
     fn decode() {

--- a/der/src/asn1/choice.rs
+++ b/der/src/asn1/choice.rs
@@ -1,15 +1,15 @@
 //! ASN.1 `CHOICE` support.
 
-use crate::{Decodable, FixedTag, Tag, Tagged};
+use crate::{Decode, FixedTag, Tag, Tagged};
 
 /// ASN.1 `CHOICE` denotes a union of one or more possible alternatives.
 ///
 /// The types MUST have distinct tags.
 ///
 /// This crate models choice as a trait, with a blanket impl for all types
-/// which impl `Decodable + FixedTag` (i.e. they are modeled as a `CHOICE`
+/// which impl `Decode + FixedTag` (i.e. they are modeled as a `CHOICE`
 /// with only one possible variant)
-pub trait Choice<'a>: Decodable<'a> + Tagged {
+pub trait Choice<'a>: Decode<'a> + Tagged {
     /// Is the provided [`Tag`] decodable as a variant of this `CHOICE`?
     fn can_decode(tag: Tag) -> bool;
 }
@@ -18,7 +18,7 @@ pub trait Choice<'a>: Decodable<'a> + Tagged {
 /// with a single alternative.
 impl<'a, T> Choice<'a> for T
 where
-    T: Decodable<'a> + FixedTag,
+    T: Decode<'a> + FixedTag,
 {
     fn can_decode(tag: Tag) -> bool {
         T::TAG == tag

--- a/der/src/asn1/context_specific.rs
+++ b/der/src/asn1/context_specific.rs
@@ -1,8 +1,8 @@
 //! Context-specific field.
 
 use crate::{
-    asn1::Any, Choice, Decodable, DecodeValue, Decoder, DerOrd, Encodable, EncodeValue, Encoder,
-    Error, Header, Length, Result, Tag, TagMode, TagNumber, Tagged, ValueOrd,
+    asn1::Any, Choice, Decode, DecodeValue, Decoder, DerOrd, Encode, EncodeValue, Encoder, Error,
+    Header, Length, Result, Tag, TagMode, TagNumber, Tagged, ValueOrd,
 };
 use core::cmp::Ordering;
 
@@ -44,7 +44,7 @@ impl<T> ContextSpecific<T> {
         tag_number: TagNumber,
     ) -> Result<Option<Self>>
     where
-        T: Decodable<'a>,
+        T: Decode<'a>,
     {
         Self::decode_with(decoder, tag_number, |decoder| {
             let any = Any::decode(decoder)?;
@@ -123,16 +123,16 @@ impl<T> ContextSpecific<T> {
 
 impl<'a, T> Choice<'a> for ContextSpecific<T>
 where
-    T: Decodable<'a> + Tagged,
+    T: Decode<'a> + Tagged,
 {
     fn can_decode(tag: Tag) -> bool {
         tag.is_context_specific()
     }
 }
 
-impl<'a, T> Decodable<'a> for ContextSpecific<T>
+impl<'a, T> Decode<'a> for ContextSpecific<T>
 where
-    T: Decodable<'a>,
+    T: Decode<'a>,
 {
     fn decode(decoder: &mut Decoder<'a>) -> Result<Self> {
         Any::decode(decoder)?.try_into()
@@ -172,7 +172,7 @@ where
 
 impl<'a, T> TryFrom<Any<'a>> for ContextSpecific<T>
 where
-    T: Decodable<'a>,
+    T: Decode<'a>,
 {
     type Error = Error;
 
@@ -259,7 +259,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::ContextSpecific;
-    use crate::{asn1::BitString, Decodable, Decoder, Encodable, TagMode, TagNumber};
+    use crate::{asn1::BitString, Decode, Decoder, Encode, TagMode, TagNumber};
     use hex_literal::hex;
 
     // Public key data from `pkcs8` crate's `ed25519-pkcs8-v2.der`

--- a/der/src/asn1/generalized_time.rs
+++ b/der/src/asn1/generalized_time.rs
@@ -320,7 +320,7 @@ impl TryFrom<GeneralizedTime> for PrimitiveDateTime {
 #[cfg(test)]
 mod tests {
     use super::GeneralizedTime;
-    use crate::{Decodable, Encodable, Encoder};
+    use crate::{Decode, Encode, Encoder};
     use hex_literal::hex;
 
     #[test]

--- a/der/src/asn1/ia5_string.rs
+++ b/der/src/asn1/ia5_string.rs
@@ -136,7 +136,7 @@ impl<'a> fmt::Debug for Ia5String<'a> {
 #[cfg(test)]
 mod tests {
     use super::Ia5String;
-    use crate::Decodable;
+    use crate::Decode;
     use hex_literal::hex;
 
     #[test]

--- a/der/src/asn1/integer.rs
+++ b/der/src/asn1/integer.rs
@@ -152,7 +152,7 @@ where
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use crate::{Decodable, Encodable};
+    use crate::{Decode, Encode};
 
     // Vectors from Section 5.7 of:
     // https://luca.ntop.org/Teaching/Appunti/asn1.html

--- a/der/src/asn1/integer/bigint.rs
+++ b/der/src/asn1/integer/bigint.rs
@@ -97,7 +97,7 @@ mod tests {
     use super::UIntBytes;
     use crate::{
         asn1::{integer::tests::*, Any},
-        Decodable, Encodable, Encoder, ErrorKind, Tag,
+        Decode, Encode, Encoder, ErrorKind, Tag,
     };
 
     #[test]

--- a/der/src/asn1/null.rs
+++ b/der/src/asn1/null.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `NULL` support.
 
 use crate::{
-    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, Decoder, Encodable, EncodeValue,
-    Encoder, Error, ErrorKind, FixedTag, Header, Length, Result, Tag,
+    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, Decoder, Encode, EncodeValue, Encoder,
+    Error, ErrorKind, FixedTag, Header, Length, Result, Tag,
 };
 
 /// ASN.1 `NULL` type.
@@ -70,7 +70,7 @@ impl DecodeValue<'_> for () {
     }
 }
 
-impl Encodable for () {
+impl Encode for () {
     fn encoded_len(&self) -> Result<Length> {
         Null.encoded_len()
     }
@@ -87,7 +87,7 @@ impl FixedTag for () {
 #[cfg(test)]
 mod tests {
     use super::Null;
-    use crate::{Decodable, Encodable};
+    use crate::{Decode, Encode};
 
     #[test]
     fn decode() {

--- a/der/src/asn1/oid.rs
+++ b/der/src/asn1/oid.rs
@@ -56,7 +56,7 @@ impl TryFrom<Any<'_>> for ObjectIdentifier {
 #[cfg(test)]
 mod tests {
     use super::ObjectIdentifier;
-    use crate::{Decodable, Encodable, Length};
+    use crate::{Decode, Encode, Length};
 
     const EXAMPLE_OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549");
     const EXAMPLE_OID_BYTES: &[u8; 8] = &[0x06, 0x06, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d];

--- a/der/src/asn1/optional.rs
+++ b/der/src/asn1/optional.rs
@@ -1,11 +1,11 @@
 //! ASN.1 `OPTIONAL` as mapped to Rust's `Option` type
 
-use crate::{Choice, Decodable, Decoder, DerOrd, Encodable, Encoder, Length, Result, Tag};
+use crate::{Choice, Decode, Decoder, DerOrd, Encode, Encoder, Length, Result, Tag};
 use core::cmp::Ordering;
 
-impl<'a, T> Decodable<'a> for Option<T>
+impl<'a, T> Decode<'a> for Option<T>
 where
-    T: Choice<'a>, // NOTE: all `Decodable + Tagged` types receive a blanket `Choice` impl
+    T: Choice<'a>, // NOTE: all `Decode + Tagged` types receive a blanket `Choice` impl
 {
     fn decode(decoder: &mut Decoder<'a>) -> Result<Option<T>> {
         if let Some(byte) = decoder.peek_byte() {
@@ -18,9 +18,9 @@ where
     }
 }
 
-impl<T> Encodable for Option<T>
+impl<T> Encode for Option<T>
 where
-    T: Encodable,
+    T: Encode,
 {
     fn encoded_len(&self) -> Result<Length> {
         if let Some(encodable) = self {
@@ -59,9 +59,9 @@ where
 /// A reference to an ASN.1 `OPTIONAL` type, used for encoding only.
 pub struct OptionalRef<'a, T>(pub Option<&'a T>);
 
-impl<'a, T> Encodable for OptionalRef<'a, T>
+impl<'a, T> Encode for OptionalRef<'a, T>
 where
-    T: Encodable,
+    T: Encode,
 {
     fn encoded_len(&self) -> Result<Length> {
         if let Some(encodable) = self.0 {

--- a/der/src/asn1/printable_string.rs
+++ b/der/src/asn1/printable_string.rs
@@ -169,7 +169,7 @@ impl<'a> fmt::Debug for PrintableString<'a> {
 #[cfg(test)]
 mod tests {
     use super::PrintableString;
-    use crate::Decodable;
+    use crate::Decode;
 
     #[test]
     fn parse_bytes() {

--- a/der/src/asn1/sequence.rs
+++ b/der/src/asn1/sequence.rs
@@ -2,24 +2,24 @@
 //! `SEQUENCE`s to Rust structs.
 
 use crate::{
-    ByteSlice, Decodable, DecodeValue, Decoder, Encodable, EncodeValue, Encoder, FixedTag, Header,
+    ByteSlice, Decode, DecodeValue, Decoder, Encode, EncodeValue, Encoder, FixedTag, Header,
     Length, Result, Tag,
 };
 
 /// ASN.1 `SEQUENCE` trait.
 ///
-/// Types which impl this trait receive blanket impls for the [`Decodable`],
-/// [`Encodable`], and [`FixedTag`] traits.
-pub trait Sequence<'a>: Decodable<'a> {
-    /// Call the provided function with a slice of [`Encodable`] trait objects
+/// Types which impl this trait receive blanket impls for the [`Decode`],
+/// [`Encode`], and [`FixedTag`] traits.
+pub trait Sequence<'a>: Decode<'a> {
+    /// Call the provided function with a slice of [`Encode`] trait objects
     /// representing the fields of this `SEQUENCE`.
     ///
     /// This method uses a callback because structs with fields which aren't
-    /// directly [`Encodable`] may need to construct temporary values from
+    /// directly [`Encode`] may need to construct temporary values from
     /// their fields prior to encoding.
     fn fields<F, T>(&self, f: F) -> Result<T>
     where
-        F: FnOnce(&[&dyn Encodable]) -> Result<T>;
+        F: FnOnce(&[&dyn Encode]) -> Result<T>;
 }
 
 impl<'a, M> EncodeValue for M

--- a/der/src/asn1/sequence_of.rs
+++ b/der/src/asn1/sequence_of.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `SEQUENCE OF` support.
 
 use crate::{
-    arrayvec, ord::iter_cmp, ArrayVec, Decodable, DecodeValue, Decoder, DerOrd, Encodable,
-    EncodeValue, Encoder, ErrorKind, FixedTag, Header, Length, Result, Tag, ValueOrd,
+    arrayvec, ord::iter_cmp, ArrayVec, Decode, DecodeValue, Decoder, DerOrd, Encode, EncodeValue,
+    Encoder, ErrorKind, FixedTag, Header, Length, Result, Tag, ValueOrd,
 };
 use core::cmp::Ordering;
 
@@ -64,7 +64,7 @@ impl<T, const N: usize> Default for SequenceOf<T, N> {
 
 impl<'a, T, const N: usize> DecodeValue<'a> for SequenceOf<T, N>
 where
-    T: Decodable<'a>,
+    T: Decode<'a>,
 {
     fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> Result<Self> {
         let end_pos = (decoder.position() + header.length)?;
@@ -84,7 +84,7 @@ where
 
 impl<T, const N: usize> EncodeValue for SequenceOf<T, N>
 where
-    T: Encodable,
+    T: Encode,
 {
     fn value_len(&self) -> Result<Length> {
         self.iter()
@@ -132,7 +132,7 @@ impl<'a, T> ExactSizeIterator for SequenceOfIter<'a, T> {}
 
 impl<'a, T, const N: usize> DecodeValue<'a> for [T; N]
 where
-    T: Decodable<'a>,
+    T: Decode<'a>,
 {
     fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> Result<Self> {
         SequenceOf::decode_value(decoder, header)?
@@ -143,7 +143,7 @@ where
 
 impl<T, const N: usize> EncodeValue for [T; N]
 where
-    T: Encodable,
+    T: Encode,
 {
     fn value_len(&self) -> Result<Length> {
         self.iter()
@@ -176,7 +176,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<'a, T> DecodeValue<'a> for Vec<T>
 where
-    T: Decodable<'a>,
+    T: Decode<'a>,
 {
     fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> Result<Self> {
         let end_pos = (decoder.position() + header.length)?;
@@ -198,7 +198,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<T> EncodeValue for Vec<T>
 where
-    T: Encodable,
+    T: Encode,
 {
     fn value_len(&self) -> Result<Length> {
         self.iter()

--- a/der/src/asn1/set_of.rs
+++ b/der/src/asn1/set_of.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `SET OF` support.
 
 use crate::{
-    arrayvec, ord::iter_cmp, ArrayVec, Decodable, DecodeValue, Decoder, DerOrd, Encodable,
-    EncodeValue, Encoder, Error, ErrorKind, FixedTag, Header, Length, Result, Tag, ValueOrd,
+    arrayvec, ord::iter_cmp, ArrayVec, Decode, DecodeValue, Decoder, DerOrd, Encode, EncodeValue,
+    Encoder, Error, ErrorKind, FixedTag, Header, Length, Result, Tag, ValueOrd,
 };
 use core::cmp::Ordering;
 
@@ -83,7 +83,7 @@ where
 
 impl<'a, T, const N: usize> DecodeValue<'a> for SetOf<T, N>
 where
-    T: Decodable<'a> + DerOrd,
+    T: Decode<'a> + DerOrd,
 {
     fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> Result<Self> {
         let end_pos = (decoder.position() + header.length)?;
@@ -103,7 +103,7 @@ where
 
 impl<'a, T, const N: usize> EncodeValue for SetOf<T, N>
 where
-    T: 'a + Decodable<'a> + Encodable + DerOrd,
+    T: 'a + Decode<'a> + Encode + DerOrd,
 {
     fn value_len(&self) -> Result<Length> {
         self.iter()
@@ -121,7 +121,7 @@ where
 
 impl<'a, T, const N: usize> FixedTag for SetOf<T, N>
 where
-    T: Decodable<'a> + DerOrd,
+    T: Decode<'a> + DerOrd,
 {
     const TAG: Tag = Tag::Set;
 }
@@ -270,7 +270,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<'a, T> DecodeValue<'a> for SetOfVec<T>
 where
-    T: Decodable<'a> + DerOrd,
+    T: Decode<'a> + DerOrd,
 {
     fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> Result<Self> {
         let end_pos = (decoder.position() + header.length)?;
@@ -292,7 +292,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<'a, T> EncodeValue for SetOfVec<T>
 where
-    T: 'a + Decodable<'a> + Encodable + DerOrd,
+    T: 'a + Decode<'a> + Encode + DerOrd,
 {
     fn value_len(&self) -> Result<Length> {
         self.iter()

--- a/der/src/asn1/utc_time.rs
+++ b/der/src/asn1/utc_time.rs
@@ -188,7 +188,7 @@ impl TryFrom<Any<'_>> for UtcTime {
 #[cfg(test)]
 mod tests {
     use super::UtcTime;
-    use crate::{Decodable, Encodable, Encoder};
+    use crate::{Decode, Encode, Encoder};
     use hex_literal::hex;
 
     #[test]

--- a/der/src/asn1/utf8_string.rs
+++ b/der/src/asn1/utf8_string.rs
@@ -13,8 +13,8 @@ use alloc::{borrow::ToOwned, string::String};
 ///
 /// Supports the full UTF-8 encoding.
 ///
-/// Note that the [`Decodable`][`crate::Decodable`] and
-/// [`Encodable`][`crate::Encodable`] traits are impl'd for Rust's
+/// Note that the [`Decode`][`crate::Decodable`] and
+/// [`Encode`][`crate::Encodable`] traits are impl'd for Rust's
 /// [`str`][`prim@str`] primitive, which decodes/encodes as a [`Utf8String`].
 ///
 /// You are free to use [`str`][`prim@str`] instead of this type, however it's
@@ -196,7 +196,7 @@ impl OrdIsValueOrd for String {}
 #[cfg(test)]
 mod tests {
     use super::Utf8String;
-    use crate::Decodable;
+    use crate::Decode;
 
     #[test]
     fn parse_ascii_bytes() {

--- a/der/src/decodable.rs
+++ b/der/src/decodable.rs
@@ -1,4 +1,4 @@
-//! Trait definition for [`Decodable`].
+//! Trait definition for [`Decode`].
 
 use crate::{DecodeValue, Decoder, FixedTag, Header, Result};
 
@@ -12,7 +12,7 @@ use crate::{DecodeValue, Decoder, FixedTag, Header, Result};
 /// In almost all cases you do not need to impl this trait yourself, but rather
 /// can instead impl `TryFrom<Any<'a>, Error = Error>` and receive a blanket
 /// impl of this trait.
-pub trait Decodable<'a>: Sized {
+pub trait Decode<'a>: Sized {
     /// Attempt to decode this message using the provided decoder.
     fn decode(decoder: &mut Decoder<'a>) -> Result<Self>;
 
@@ -24,7 +24,7 @@ pub trait Decodable<'a>: Sized {
     }
 }
 
-impl<'a, T> Decodable<'a> for T
+impl<'a, T> Decode<'a> for T
 where
     T: DecodeValue<'a> + FixedTag,
 {

--- a/der/src/decoder.rs
+++ b/der/src/decoder.rs
@@ -1,8 +1,8 @@
 //! DER decoder.
 
 use crate::{
-    asn1::*, ByteSlice, Choice, Decodable, DecodeValue, Encodable, Error, ErrorKind, FixedTag,
-    Header, Length, Result, Tag, TagMode, TagNumber,
+    asn1::*, ByteSlice, Choice, Decode, DecodeValue, Encode, Error, ErrorKind, FixedTag, Header,
+    Length, Result, Tag, TagMode, TagNumber,
 };
 
 /// DER decoder.
@@ -45,8 +45,8 @@ impl<'a> Decoder<'a> {
         }
     }
 
-    /// Decode a value which impls the [`Decodable`] trait.
-    pub fn decode<T: Decodable<'a>>(&mut self) -> Result<T> {
+    /// Decode a value which impls the [`Decode`] trait.
+    pub fn decode<T: Decode<'a>>(&mut self) -> Result<T> {
         if self.is_failed() {
             return Err(self.error(ErrorKind::Failed));
         }
@@ -335,7 +335,7 @@ impl<'a> Decoder<'a> {
 #[cfg(test)]
 mod tests {
     use super::Decoder;
-    use crate::{Decodable, ErrorKind, Length, Tag};
+    use crate::{Decode, ErrorKind, Length, Tag};
     use hex_literal::hex;
 
     // INTEGER: 42

--- a/der/src/document.rs
+++ b/der/src/document.rs
@@ -1,6 +1,6 @@
 //! ASN.1 DER-encoded documents stored on the heap.
 
-use crate::{Decodable, Encodable, Error, Result};
+use crate::{Decode, Encode, Error, Result};
 use alloc::{boxed::Box, vec::Vec};
 
 #[cfg(feature = "pem")]
@@ -20,7 +20,7 @@ use std::{fs, path::Path};
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub trait Document<'a>: AsRef<[u8]> + Sized + TryFrom<Vec<u8>, Error = Error> {
     /// ASN.1 message type this document decodes to.
-    type Message: Decodable<'a> + Encodable + Sized;
+    type Message: Decode<'a> + Encode + Sized;
 
     /// Does this type contain potentially sensitive data?
     ///

--- a/der/src/encodable.rs
+++ b/der/src/encodable.rs
@@ -1,4 +1,4 @@
-//! Trait definition for [`Encodable`].
+//! Trait definition for [`Encode`].
 
 use crate::{EncodeValue, Encoder, Length, Result, Tagged};
 
@@ -6,7 +6,7 @@ use crate::{EncodeValue, Encoder, Length, Result, Tagged};
 use {crate::ErrorKind, alloc::vec::Vec, core::iter};
 
 /// Encoding trait.
-pub trait Encodable {
+pub trait Encode {
     /// Compute the length of this value in bytes when encoded as ASN.1 DER.
     fn encoded_len(&self) -> Result<Length>;
 
@@ -55,7 +55,7 @@ pub trait Encodable {
     }
 }
 
-impl<T> Encodable for T
+impl<T> Encode for T
 where
     T: EncodeValue + Tagged,
 {

--- a/der/src/encoder.rs
+++ b/der/src/encoder.rs
@@ -1,7 +1,7 @@
 //! DER encoder.
 
 use crate::{
-    asn1::*, Encodable, EncodeValue, Error, ErrorKind, Header, Length, Result, Tag, TagMode,
+    asn1::*, Encode, EncodeValue, Error, ErrorKind, Header, Length, Result, Tag, TagMode,
     TagNumber, Tagged,
 };
 
@@ -24,8 +24,8 @@ impl<'a> Encoder<'a> {
         }
     }
 
-    /// Encode a value which impls the [`Encodable`] trait.
-    pub fn encode<T: Encodable>(&mut self, encodable: &T) -> Result<()> {
+    /// Encode a value which impls the [`Encode`] trait.
+    pub fn encode<T: Encode>(&mut self, encodable: &T) -> Result<()> {
         if self.is_failed() {
             self.error(ErrorKind::Failed)?;
         }
@@ -249,7 +249,7 @@ impl<'a> Encoder<'a> {
 mod tests {
     use hex_literal::hex;
 
-    use crate::{asn1::BitString, Encodable, ErrorKind, Length, TagMode, TagNumber};
+    use crate::{asn1::BitString, Encode, ErrorKind, Length, TagMode, TagNumber};
 
     use super::Encoder;
 

--- a/der/src/header.rs
+++ b/der/src/header.rs
@@ -1,6 +1,6 @@
 //! ASN.1 DER headers.
 
-use crate::{Decodable, Decoder, DerOrd, Encodable, Encoder, ErrorKind, Length, Result, Tag};
+use crate::{Decode, Decoder, DerOrd, Encode, Encoder, ErrorKind, Length, Result, Tag};
 use core::cmp::Ordering;
 
 /// ASN.1 DER headers: tag + length component of TLV-encoded values
@@ -23,7 +23,7 @@ impl Header {
     }
 }
 
-impl Decodable<'_> for Header {
+impl Decode<'_> for Header {
     fn decode(decoder: &mut Decoder<'_>) -> Result<Header> {
         let tag = Tag::decode(decoder)?;
 
@@ -39,7 +39,7 @@ impl Decodable<'_> for Header {
     }
 }
 
-impl Encodable for Header {
+impl Encode for Header {
     fn encoded_len(&self) -> Result<Length> {
         self.tag.encoded_len()? + self.length.encoded_len()?
     }

--- a/der/src/length.rs
+++ b/der/src/length.rs
@@ -1,6 +1,6 @@
 //! Length calculations for encoded ASN.1 DER values
 
-use crate::{Decodable, Decoder, DerOrd, Encodable, Encoder, Error, ErrorKind, Result};
+use crate::{Decode, Decoder, DerOrd, Encode, Encoder, Error, ErrorKind, Result};
 use core::{
     cmp::Ordering,
     fmt,
@@ -191,7 +191,7 @@ impl TryFrom<Length> for usize {
     }
 }
 
-impl Decodable<'_> for Length {
+impl Decode<'_> for Length {
     fn decode(decoder: &mut Decoder<'_>) -> Result<Length> {
         match decoder.byte()? {
             // Note: per X.690 Section 8.1.3.6.1 the byte 0x80 encodes indefinite
@@ -225,7 +225,7 @@ impl Decodable<'_> for Length {
     }
 }
 
-impl Encodable for Length {
+impl Encode for Length {
     fn encoded_len(&self) -> Result<Length> {
         match self.0 {
             0..=0x7F => Ok(Length(1)),
@@ -278,7 +278,7 @@ impl fmt::Display for Length {
 #[cfg(test)]
 mod tests {
     use super::Length;
-    use crate::{Decodable, DerOrd, Encodable, ErrorKind};
+    use crate::{Decode, DerOrd, Encode, ErrorKind};
     use core::cmp::Ordering;
 
     #[test]

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -15,8 +15,8 @@
 )]
 
 //! # Usage
-//! ## [`Decodable`] and [`Encodable`] traits
-//! The [`Decodable`] and [`Encodable`] traits are the core abstractions on
+//! ## [`Decode`] and [`Encode`] traits
+//! The [`Decode`] and [`Encode`] traits are the core abstractions on
 //! which this crate is built and control what types can be (de)serialized
 //! as ASN.1 DER.
 //!
@@ -66,13 +66,13 @@
 //!
 //! Structured ASN.1 messages are typically encoded as a `SEQUENCE`, which
 //! this crate maps to a Rust struct using the [`Sequence`] trait. This
-//! trait is bounded on the [`Decodable`] trait and provides a blanket impl
-//! of the [`Encodable`] trait, so any type which impls [`Sequence`] can be
+//! trait is bounded on the [`Decode`] trait and provides a blanket impl
+//! of the [`Encode`] trait, so any type which impls [`Sequence`] can be
 //! used for both decoding and encoding.
 //!
 //! The [`Decoder`] and [`Encoder`] types provide the decoding/encoding API
 //! respectively, and are designed to work in conjunction with concrete ASN.1
-//! types which impl the [`Decodable`] and [`Encodable`] traits, including
+//! types which impl the [`Decode`] and [`Encode`] traits, including
 //! all types which impl the [`Sequence`] trait.
 //!
 //! The following code example shows how to define a struct which maps to the
@@ -86,7 +86,7 @@
 //! // "heapless" usage when the `alloc` feature is disabled.
 //! use der::{
 //!     asn1::{Any, ObjectIdentifier},
-//!     Decodable, Decoder, Encodable, Sequence
+//!     Decode, Decoder, Encode, Sequence
 //! };
 //!
 //! /// X.509 `AlgorithmIdentifier`.
@@ -100,14 +100,14 @@
 //!     pub parameters: Option<Any<'a>>
 //! }
 //!
-//! impl<'a> Decodable<'a> for AlgorithmIdentifier<'a> {
+//! impl<'a> Decode<'a> for AlgorithmIdentifier<'a> {
 //!     fn decode(decoder: &mut Decoder<'a>) -> der::Result<Self> {
 //!         // The `Decoder::sequence` method decodes an ASN.1 `SEQUENCE` tag
 //!         // and length then calls the provided `FnOnce` with a nested
 //!         // `der::Decoder` which can be used to decode it.
 //!         decoder.sequence(|decoder| {
 //!             // The `der::Decoder::Decode` method can be used to decode any
-//!             // type which impls the `Decodable` trait, which is impl'd for
+//!             // type which impls the `Decode` trait, which is impl'd for
 //!             // all of the ASN.1 built-in types in the `der` crate.
 //!             //
 //!             // Note that if your struct's fields don't contain an ASN.1
@@ -123,7 +123,7 @@
 //!
 //!             // This field contains an ASN.1 `OPTIONAL` type. The `der` crate
 //!             // maps this directly to Rust's `Option` type and provides
-//!             // impls of the `Decodable` and `Encodable` traits for `Option`.
+//!             // impls of the `Decode` and `Encode` traits for `Option`.
 //!             // To explicitly request an `OPTIONAL` type be decoded, use the
 //!             // `decoder.optional()` method.
 //!             let parameters = decoder.decode()?;
@@ -141,7 +141,7 @@
 //!     // The `Sequence::fields` method is used for encoding and functions as
 //!     // a visitor for all of the fields in a message.
 //!     //
-//!     // To implement it, you must define a slice containing `Encodable`
+//!     // To implement it, you must define a slice containing `Encode`
 //!     // trait objects, then pass it to the provided `field_encoder`
 //!     // function, which is implemented by the `der` crate and handles
 //!     // message serialization.
@@ -150,15 +150,15 @@
 //!     // heterogeneous field types, and a callback is used to allow for the
 //!     // construction of temporary field encoder types. The latter means
 //!     // that the fields of your Rust struct don't necessarily need to
-//!     // impl the `Encodable` trait, but if they don't you must construct
+//!     // impl the `Encode` trait, but if they don't you must construct
 //!     // a temporary wrapper value which does.
 //!     //
 //!     // Types which impl the `Sequence` trait receive blanket impls of both
-//!     // the `Encodable` and `Tagged` traits (where the latter is impl'd as
+//!     // the `Encode` and `Tagged` traits (where the latter is impl'd as
 //!     // `Tagged::TAG = der::Tag::Sequence`.
 //!     fn fields<F, T>(&self, field_encoder: F) -> der::Result<T>
 //!     where
-//!         F: FnOnce(&[&dyn Encodable]) -> der::Result<T>,
+//!         F: FnOnce(&[&dyn Encode]) -> der::Result<T>,
 //!     {
 //!         field_encoder(&[&self.algorithm, &self.parameters])
 //!     }
@@ -174,8 +174,8 @@
 //! // `Any` borrow a reference to it, so we have to serialize the OID.
 //! //
 //! // When the `alloc` feature of this crate is enabled, any type that impls
-//! // the `Encodable` trait including all ASN.1 built-in types and any type
-//! // which impls `Sequence` can be serialized by calling `Encodable::to_vec()`.
+//! // the `Encode` trait including all ASN.1 built-in types and any type
+//! // which impls `Sequence` can be serialized by calling `Encode::to_vec()`.
 //! //
 //! // If you would prefer to avoid allocations, you can create a byte array
 //! // as backing storage instead, pass that to `der::Encoder::new`, and then
@@ -202,7 +202,7 @@
 //! let der_encoded_algorithm_identifier = algorithm_identifier.to_vec().unwrap();
 //!
 //! // Deserialize the `AlgorithmIdentifier` we just serialized from ASN.1 DER
-//! // using `der::Decodable::from_bytes`.
+//! // using `der::Decode::from_bytes`.
 //! let decoded_algorithm_identifier = AlgorithmIdentifier::from_der(
 //!     &der_encoded_algorithm_identifier
 //! ).unwrap();
@@ -227,7 +227,7 @@
 //! ```
 //! # #[cfg(all(feature = "alloc", feature = "derive", feature = "oid"))]
 //! # {
-//! use der::{asn1::{Any, ObjectIdentifier}, Encodable, Decodable, Sequence};
+//! use der::{asn1::{Any, ObjectIdentifier}, Encode, Decode, Sequence};
 //!
 //! /// X.509 `AlgorithmIdentifier` (same as above)
 //! #[derive(Copy, Clone, Debug, Eq, PartialEq, Sequence)] // NOTE: added `Sequence`
@@ -264,7 +264,7 @@
 //! # }
 //! ```
 //!
-//! For fields which don't directly impl [`Decodable`] and [`Encodable`],
+//! For fields which don't directly impl [`Decode`] and [`Encode`],
 //! you can add annotations to convert to an intermediate ASN.1 type
 //! first, so long as that type impls `TryFrom` and `Into` for the
 //! ASN.1 type.
@@ -354,9 +354,9 @@ mod document;
 pub use crate::{
     asn1::{Any, Choice, Sequence},
     datetime::DateTime,
-    decodable::Decodable,
+    decodable::Decode,
     decoder::Decoder,
-    encodable::Encodable,
+    encodable::Encode,
     encoder::Encoder,
     error::{Error, ErrorKind, Result},
     header::Header,

--- a/der/src/tag.rs
+++ b/der/src/tag.rs
@@ -6,7 +6,7 @@ mod number;
 
 pub use self::{class::Class, mode::TagMode, number::TagNumber};
 
-use crate::{Decodable, Decoder, DerOrd, Encodable, Encoder, Error, ErrorKind, Length, Result};
+use crate::{Decode, Decoder, DerOrd, Encode, Encoder, Error, ErrorKind, Length, Result};
 use core::{cmp::Ordering, fmt};
 
 /// Indicator bit for constructed form encoding (i.e. vs primitive form)
@@ -297,13 +297,13 @@ impl From<&Tag> for u8 {
     }
 }
 
-impl Decodable<'_> for Tag {
+impl Decode<'_> for Tag {
     fn decode(decoder: &mut Decoder<'_>) -> Result<Self> {
         decoder.byte().and_then(Self::try_from)
     }
 }
 
-impl Encodable for Tag {
+impl Encode for Tag {
     fn encoded_len(&self) -> Result<Length> {
         Ok(Length::ONE)
     }

--- a/der/tests/datetime.rs
+++ b/der/tests/datetime.rs
@@ -1,6 +1,6 @@
 //! Tests for the [`DateTime`] type.
 
-use der::{asn1::UtcTime, DateTime, Decodable, Encodable};
+use der::{asn1::UtcTime, DateTime, Decode, Encode};
 use proptest::prelude::*;
 
 proptest! {

--- a/der/tests/derive.rs
+++ b/der/tests/derive.rs
@@ -15,7 +15,7 @@ mod choice {
     mod explicit {
         use der::{
             asn1::{GeneralizedTime, UtcTime},
-            Choice, Decodable, Encodable, Encoder,
+            Choice, Decode, Encode, Encoder,
         };
         use hex_literal::hex;
         use std::time::Duration;
@@ -82,7 +82,7 @@ mod choice {
     mod implicit {
         use der::{
             asn1::{BitString, GeneralizedTime},
-            Choice, Decodable, Encodable, Encoder,
+            Choice, Decode, Encode, Encoder,
         };
         use hex_literal::hex;
 
@@ -153,7 +153,7 @@ mod choice {
 
 /// Custom derive test cases for the `Enumerated` macro.
 mod enumerated {
-    use der::{Decodable, Encodable, Encoder, Enumerated};
+    use der::{Decode, Encode, Encoder, Enumerated};
     use hex_literal::hex;
 
     /// X.509 `CRLReason`.
@@ -203,7 +203,7 @@ mod enumerated {
 mod sequence {
     use der::{
         asn1::{Any, ObjectIdentifier, SetOf},
-        Decodable, Encodable, Sequence, ValueOrd,
+        Decode, Encode, Sequence, ValueOrd,
     };
     use hex_literal::hex;
 
@@ -459,7 +459,7 @@ mod sequence {
 }
 
 mod newtype {
-    use der::{asn1::BitString, Decodable, Encodable};
+    use der::{asn1::BitString, Decode, Encode};
     use der_derive::Newtype;
 
     #[derive(Newtype)]

--- a/der/tests/set_of.rs
+++ b/der/tests/set_of.rs
@@ -25,7 +25,7 @@ mod attr_regression {
     use core::cmp::Ordering;
     use der::{
         asn1::{Any, ObjectIdentifier, SetOf},
-        Decodable, Result, Sequence, ValueOrd,
+        Decode, Result, Sequence, ValueOrd,
     };
     use hex_literal::hex;
 

--- a/pkcs1/src/private_key.rs
+++ b/pkcs1/src/private_key.rs
@@ -7,7 +7,7 @@ pub(crate) mod other_prime_info;
 
 use crate::{Error, Result, RsaPublicKey, Version};
 use core::fmt;
-use der::{asn1::UIntBytes, Decodable, Decoder, Encodable, Sequence, Tag};
+use der::{asn1::UIntBytes, Decode, Decoder, Encode, Sequence, Tag};
 
 #[cfg(feature = "alloc")]
 use {self::other_prime_info::OtherPrimeInfo, crate::RsaPrivateKeyDocument, alloc::vec::Vec};
@@ -110,7 +110,7 @@ impl<'a> RsaPrivateKey<'a> {
     }
 }
 
-impl<'a> Decodable<'a> for RsaPrivateKey<'a> {
+impl<'a> Decode<'a> for RsaPrivateKey<'a> {
     fn decode(decoder: &mut Decoder<'a>) -> der::Result<Self> {
         decoder.sequence(|decoder| {
             let version = Version::decode(decoder)?;
@@ -140,7 +140,7 @@ impl<'a> Decodable<'a> for RsaPrivateKey<'a> {
 impl<'a> Sequence<'a> for RsaPrivateKey<'a> {
     fn fields<F, T>(&self, f: F) -> der::Result<T>
     where
-        F: FnOnce(&[&dyn Encodable]) -> der::Result<T>,
+        F: FnOnce(&[&dyn Encode]) -> der::Result<T>,
     {
         f(&[
             &self.version(),
@@ -197,7 +197,7 @@ pub struct OtherPrimeInfos<'a> {
 }
 
 #[cfg(not(feature = "alloc"))]
-impl<'a> Decodable<'a> for OtherPrimeInfos<'a> {
+impl<'a> Decode<'a> for OtherPrimeInfos<'a> {
     fn decode(decoder: &mut Decoder<'a>) -> der::Result<Self> {
         // Placeholder decoder that always returns an error.
         // Use `Tag::Integer` to signal an unsupported version.

--- a/pkcs1/src/private_key/document.rs
+++ b/pkcs1/src/private_key/document.rs
@@ -3,7 +3,7 @@
 use crate::{DecodeRsaPrivateKey, EncodeRsaPrivateKey, Error, Result, RsaPrivateKey};
 use alloc::vec::Vec;
 use core::fmt;
-use der::{Decodable, Document, Encodable};
+use der::{Decode, Document, Encode};
 use zeroize::{Zeroize, Zeroizing};
 
 #[cfg(feature = "pem")]

--- a/pkcs1/src/private_key/other_prime_info.rs
+++ b/pkcs1/src/private_key/other_prime_info.rs
@@ -1,6 +1,6 @@
 //! PKCS#1 OtherPrimeInfo support.
 
-use der::{asn1::UIntBytes, Decodable, Decoder, Encodable, Sequence};
+use der::{asn1::UIntBytes, Decode, Decoder, Encode, Sequence};
 
 /// PKCS#1 OtherPrimeInfo as defined in [RFC 8017 Appendix 1.2].
 ///
@@ -28,7 +28,7 @@ pub struct OtherPrimeInfo<'a> {
     pub coefficient: UIntBytes<'a>,
 }
 
-impl<'a> Decodable<'a> for OtherPrimeInfo<'a> {
+impl<'a> Decode<'a> for OtherPrimeInfo<'a> {
     fn decode(decoder: &mut Decoder<'a>) -> der::Result<Self> {
         decoder.sequence(|decoder| {
             Ok(Self {
@@ -43,7 +43,7 @@ impl<'a> Decodable<'a> for OtherPrimeInfo<'a> {
 impl<'a> Sequence<'a> for OtherPrimeInfo<'a> {
     fn fields<F, T>(&self, f: F) -> der::Result<T>
     where
-        F: FnOnce(&[&dyn Encodable]) -> der::Result<T>,
+        F: FnOnce(&[&dyn Encode]) -> der::Result<T>,
     {
         f(&[&self.prime, &self.exponent, &self.coefficient])
     }

--- a/pkcs1/src/public_key.rs
+++ b/pkcs1/src/public_key.rs
@@ -4,7 +4,7 @@
 pub(crate) mod document;
 
 use crate::{Error, Result};
-use der::{asn1::UIntBytes, Decodable, Decoder, Encodable, Sequence};
+use der::{asn1::UIntBytes, Decode, Decoder, Encode, Sequence};
 
 #[cfg(feature = "alloc")]
 use crate::RsaPublicKeyDocument;
@@ -50,7 +50,7 @@ impl<'a> RsaPublicKey<'a> {
     }
 }
 
-impl<'a> Decodable<'a> for RsaPublicKey<'a> {
+impl<'a> Decode<'a> for RsaPublicKey<'a> {
     fn decode(decoder: &mut Decoder<'a>) -> der::Result<Self> {
         decoder.sequence(|decoder| {
             Ok(Self {
@@ -64,7 +64,7 @@ impl<'a> Decodable<'a> for RsaPublicKey<'a> {
 impl<'a> Sequence<'a> for RsaPublicKey<'a> {
     fn fields<F, T>(&self, f: F) -> der::Result<T>
     where
-        F: FnOnce(&[&dyn Encodable]) -> der::Result<T>,
+        F: FnOnce(&[&dyn Encode]) -> der::Result<T>,
     {
         f(&[&self.modulus, &self.public_exponent])
     }

--- a/pkcs1/src/public_key/document.rs
+++ b/pkcs1/src/public_key/document.rs
@@ -3,7 +3,7 @@
 use crate::{DecodeRsaPublicKey, EncodeRsaPublicKey, Error, Result, RsaPublicKey};
 use alloc::vec::Vec;
 use core::fmt;
-use der::{Decodable, Document, Encodable};
+use der::{Decode, Document, Encode};
 
 #[cfg(feature = "pem")]
 use {

--- a/pkcs1/src/version.rs
+++ b/pkcs1/src/version.rs
@@ -1,7 +1,7 @@
 //! PKCS#1 version identifier.
 
 use crate::Error;
-use der::{Decodable, Decoder, Encodable, Encoder, FixedTag, Tag};
+use der::{Decode, Decoder, Encode, Encoder, FixedTag, Tag};
 
 /// Version identifier for PKCS#1 documents as defined in
 /// [RFC 8017 Appendix 1.2].
@@ -51,13 +51,13 @@ impl TryFrom<u8> for Version {
     }
 }
 
-impl Decodable<'_> for Version {
+impl Decode<'_> for Version {
     fn decode(decoder: &mut Decoder<'_>) -> der::Result<Self> {
         Version::try_from(u8::decode(decoder)?).map_err(|_| Self::TAG.value_error())
     }
 }
 
-impl Encodable for Version {
+impl Encode for Version {
     fn encoded_len(&self) -> der::Result<der::Length> {
         der::Length::ONE.for_tlv()
     }

--- a/pkcs5/src/lib.rs
+++ b/pkcs5/src/lib.rs
@@ -12,7 +12,7 @@
 //! # Usage
 //!
 //! The main API for this crate is the [`EncryptionScheme`] enum, which impls
-//! the [`Decodable`][`der::Decodable`] and [`Encodable`] traits from the
+//! the [`Decode`][`der::Decodable`] and [`Encode`] traits from the
 //! [`der`] crate, and can be used for decoding/encoding PKCS#5
 //! [`AlgorithmIdentifier`] fields.
 //!
@@ -30,7 +30,7 @@ pub use crate::error::{Error, Result};
 pub use der::{self, asn1::ObjectIdentifier};
 pub use spki::AlgorithmIdentifier;
 
-use der::{Decodable, Decoder, Encodable, Encoder, Length, Tag};
+use der::{Decode, Decoder, Encode, Encoder, Length, Tag};
 
 #[cfg(all(feature = "alloc", feature = "pbes2"))]
 use alloc::vec::Vec;
@@ -136,13 +136,13 @@ impl<'a> EncryptionScheme<'a> {
     }
 }
 
-impl<'a> Decodable<'a> for EncryptionScheme<'a> {
+impl<'a> Decode<'a> for EncryptionScheme<'a> {
     fn decode(decoder: &mut Decoder<'a>) -> der::Result<Self> {
         AlgorithmIdentifier::decode(decoder)?.try_into()
     }
 }
 
-impl<'a> Encodable for EncryptionScheme<'a> {
+impl<'a> Encode for EncryptionScheme<'a> {
     fn encoded_len(&self) -> der::Result<Length> {
         match self {
             Self::Pbes1(pbes1) => pbes1.encoded_len(),

--- a/pkcs5/src/pbes1.rs
+++ b/pkcs5/src/pbes1.rs
@@ -5,7 +5,7 @@
 use crate::AlgorithmIdentifier;
 use der::{
     asn1::{ObjectIdentifier, OctetString},
-    Decodable, Decoder, Encodable, Encoder, ErrorKind, FixedTag, Length, Tag,
+    Decode, Decoder, Encode, Encoder, ErrorKind, FixedTag, Length, Tag,
 };
 
 /// `pbeWithMD2AndDES-CBC` Object Identifier (OID).
@@ -80,13 +80,13 @@ impl Parameters {
     }
 }
 
-impl Decodable<'_> for Parameters {
+impl Decode<'_> for Parameters {
     fn decode(decoder: &mut Decoder<'_>) -> der::Result<Self> {
         AlgorithmIdentifier::decode(decoder)?.try_into()
     }
 }
 
-impl Encodable for Parameters {
+impl Encode for Parameters {
     fn encoded_len(&self) -> der::Result<Length> {
         self.inner_len()?.for_tlv()
     }
@@ -217,7 +217,7 @@ impl EncryptionScheme {
     }
 }
 
-impl Encodable for EncryptionScheme {
+impl Encode for EncryptionScheme {
     fn encoded_len(&self) -> der::Result<Length> {
         self.oid().encoded_len()
     }

--- a/pkcs5/src/pbes2.rs
+++ b/pkcs5/src/pbes2.rs
@@ -15,7 +15,7 @@ pub use self::kdf::{
 use crate::{AlgorithmIdentifier, Error, Result};
 use der::{
     asn1::{Any, ObjectIdentifier, OctetString},
-    Decodable, Decoder, Encodable, Encoder, ErrorKind, Length, Sequence, Tag,
+    Decode, Decoder, Encode, Encoder, ErrorKind, Length, Sequence, Tag,
 };
 
 #[cfg(all(feature = "alloc", feature = "pbes2"))]
@@ -200,7 +200,7 @@ impl<'a> Parameters<'a> {
     }
 }
 
-impl<'a> Decodable<'a> for Parameters<'a> {
+impl<'a> Decode<'a> for Parameters<'a> {
     fn decode(decoder: &mut Decoder<'a>) -> der::Result<Self> {
         decoder.any()?.try_into()
     }
@@ -209,7 +209,7 @@ impl<'a> Decodable<'a> for Parameters<'a> {
 impl<'a> Sequence<'a> for Parameters<'a> {
     fn fields<F, T>(&self, f: F) -> der::Result<T>
     where
-        F: FnOnce(&[&dyn Encodable]) -> der::Result<T>,
+        F: FnOnce(&[&dyn Encode]) -> der::Result<T>,
     {
         f(&[&self.kdf, &self.encryption])
     }
@@ -303,7 +303,7 @@ impl<'a> EncryptionScheme<'a> {
     }
 }
 
-impl<'a> Decodable<'a> for EncryptionScheme<'a> {
+impl<'a> Decode<'a> for EncryptionScheme<'a> {
     fn decode(decoder: &mut Decoder<'a>) -> der::Result<Self> {
         AlgorithmIdentifier::decode(decoder).and_then(TryInto::try_into)
     }
@@ -373,7 +373,7 @@ impl<'a> TryFrom<EncryptionScheme<'a>> for AlgorithmIdentifier<'a> {
     }
 }
 
-impl<'a> Encodable for EncryptionScheme<'a> {
+impl<'a> Encode for EncryptionScheme<'a> {
     fn encoded_len(&self) -> der::Result<Length> {
         AlgorithmIdentifier::try_from(*self)?.encoded_len()
     }

--- a/pkcs5/src/pbes2/kdf.rs
+++ b/pkcs5/src/pbes2/kdf.rs
@@ -3,7 +3,7 @@
 use crate::{AlgorithmIdentifier, Error, Result};
 use der::{
     asn1::{Any, ObjectIdentifier, OctetString},
-    Decodable, Decoder, Encodable, Encoder, ErrorKind, Length, Sequence, Tag, Tagged,
+    Decode, Decoder, Encode, Encoder, ErrorKind, Length, Sequence, Tag, Tagged,
 };
 
 /// Password-Based Key Derivation Function (PBKDF2) OID.
@@ -97,7 +97,7 @@ impl<'a> Kdf<'a> {
     }
 }
 
-impl<'a> Decodable<'a> for Kdf<'a> {
+impl<'a> Decode<'a> for Kdf<'a> {
     fn decode(decoder: &mut Decoder<'a>) -> der::Result<Self> {
         AlgorithmIdentifier::decode(decoder)?.try_into()
     }
@@ -106,7 +106,7 @@ impl<'a> Decodable<'a> for Kdf<'a> {
 impl<'a> Sequence<'a> for Kdf<'a> {
     fn fields<F, T>(&self, f: F) -> der::Result<T>
     where
-        F: FnOnce(&[&dyn Encodable]) -> der::Result<T>,
+        F: FnOnce(&[&dyn Encode]) -> der::Result<T>,
     {
         match self {
             Self::Pbkdf2(params) => f(&[&self.oid(), params]),
@@ -203,7 +203,7 @@ impl<'a> Pbkdf2Params<'a> {
     }
 }
 
-impl<'a> Decodable<'a> for Pbkdf2Params<'a> {
+impl<'a> Decode<'a> for Pbkdf2Params<'a> {
     fn decode(decoder: &mut Decoder<'a>) -> der::Result<Self> {
         decoder.any()?.try_into()
     }
@@ -212,7 +212,7 @@ impl<'a> Decodable<'a> for Pbkdf2Params<'a> {
 impl<'a> Sequence<'a> for Pbkdf2Params<'a> {
     fn fields<F, T>(&self, f: F) -> der::Result<T>
     where
-        F: FnOnce(&[&dyn Encodable]) -> der::Result<T>,
+        F: FnOnce(&[&dyn Encode]) -> der::Result<T>,
     {
         if self.prf == Pbkdf2Prf::default() {
             f(&[
@@ -336,7 +336,7 @@ impl<'a> From<Pbkdf2Prf> for AlgorithmIdentifier<'a> {
     }
 }
 
-impl Encodable for Pbkdf2Prf {
+impl Encode for Pbkdf2Prf {
     fn encoded_len(&self) -> der::Result<Length> {
         AlgorithmIdentifier::try_from(*self)?.encoded_len()
     }
@@ -396,7 +396,7 @@ impl<'a> ScryptParams<'a> {
     }
 }
 
-impl<'a> Decodable<'a> for ScryptParams<'a> {
+impl<'a> Decode<'a> for ScryptParams<'a> {
     fn decode(decoder: &mut Decoder<'a>) -> der::Result<Self> {
         decoder.any()?.try_into()
     }
@@ -405,7 +405,7 @@ impl<'a> Decodable<'a> for ScryptParams<'a> {
 impl<'a> Sequence<'a> for ScryptParams<'a> {
     fn fields<F, T>(&self, f: F) -> der::Result<T>
     where
-        F: FnOnce(&[&dyn Encodable]) -> der::Result<T>,
+        F: FnOnce(&[&dyn Encode]) -> der::Result<T>,
     {
         f(&[
             &OctetString::new(self.salt)?,

--- a/pkcs5/tests/pbes2.rs
+++ b/pkcs5/tests/pbes2.rs
@@ -1,6 +1,6 @@
 //! Password-Based Encryption Scheme 2 tests
 
-use der::Encodable;
+use der::Encode;
 use hex_literal::hex;
 use pkcs5::pbes2;
 

--- a/pkcs7/src/content_info.rs
+++ b/pkcs7/src/content_info.rs
@@ -2,7 +2,7 @@ use crate::{data_content::DataContent, encrypted_data_content::EncryptedDataCont
 
 use der::{
     asn1::{ContextSpecific, OctetString},
-    Decodable, Decoder, Encodable, Sequence, TagMode, TagNumber,
+    Decode, Decoder, Encode, Sequence, TagMode, TagNumber,
 };
 
 const CONTENT_TAG: TagNumber = TagNumber::new(0);
@@ -65,7 +65,7 @@ impl<'a> ContentInfo<'a> {
     }
 }
 
-impl<'a> Decodable<'a> for ContentInfo<'a> {
+impl<'a> Decode<'a> for ContentInfo<'a> {
     fn decode(decoder: &mut Decoder<'a>) -> der::Result<ContentInfo<'a>> {
         decoder.sequence(|decoder| {
             let content_type = decoder.decode()?;
@@ -89,7 +89,7 @@ impl<'a> Decodable<'a> for ContentInfo<'a> {
 impl<'a> Sequence<'a> for ContentInfo<'a> {
     fn fields<F, T>(&self, f: F) -> der::Result<T>
     where
-        F: FnOnce(&[&dyn Encodable]) -> der::Result<T>,
+        F: FnOnce(&[&dyn Encode]) -> der::Result<T>,
     {
         match self {
             Self::Data(data) => f(&[
@@ -124,7 +124,7 @@ impl<'a> Sequence<'a> for ContentInfo<'a> {
 mod tests {
     use super::{ContentInfo, DataContent};
     use core::convert::TryFrom;
-    use der::{asn1::OctetString, Decodable, Encodable, Encoder, Length, TagMode, TagNumber};
+    use der::{asn1::OctetString, Decode, Encode, Encoder, Length, TagMode, TagNumber};
 
     #[test]
     fn empty_data() -> der::Result<()> {

--- a/pkcs7/src/encrypted_data_content.rs
+++ b/pkcs7/src/encrypted_data_content.rs
@@ -2,8 +2,8 @@
 
 use crate::enveloped_data_content::EncryptedContentInfo;
 use der::{
-    Decodable, DecodeValue, Decoder, Encodable, EncodeValue, Encoder, FixedTag, Header, Length,
-    Sequence, Tag,
+    Decode, DecodeValue, Decoder, Encode, EncodeValue, Encoder, FixedTag, Header, Length, Sequence,
+    Tag,
 };
 
 /// Syntax version of the `encrypted-data` content type.
@@ -82,7 +82,7 @@ pub struct EncryptedDataContent<'a> {
     pub encrypted_content_info: EncryptedContentInfo<'a>,
 }
 
-impl<'a> Decodable<'a> for EncryptedDataContent<'a> {
+impl<'a> Decode<'a> for EncryptedDataContent<'a> {
     fn decode(decoder: &mut Decoder<'a>) -> der::Result<EncryptedDataContent<'a>> {
         decoder.sequence(|decoder| {
             Ok(EncryptedDataContent {
@@ -96,7 +96,7 @@ impl<'a> Decodable<'a> for EncryptedDataContent<'a> {
 impl<'a> Sequence<'a> for EncryptedDataContent<'a> {
     fn fields<F, T>(&self, f: F) -> der::Result<T>
     where
-        F: FnOnce(&[&dyn Encodable]) -> der::Result<T>,
+        F: FnOnce(&[&dyn Encode]) -> der::Result<T>,
     {
         f(&[&self.version, &self.encrypted_content_info])
     }

--- a/pkcs7/src/enveloped_data_content.rs
+++ b/pkcs7/src/enveloped_data_content.rs
@@ -4,7 +4,7 @@ use crate::ContentType;
 
 use der::{
     asn1::{ContextSpecific, OctetString},
-    Decodable, Decoder, Encodable, Sequence, TagMode, TagNumber,
+    Decode, Decoder, Encode, Sequence, TagMode, TagNumber,
 };
 use spki::AlgorithmIdentifier;
 
@@ -49,7 +49,7 @@ pub struct EncryptedContentInfo<'a> {
     pub encrypted_content: Option<&'a [u8]>,
 }
 
-impl<'a> Decodable<'a> for EncryptedContentInfo<'a> {
+impl<'a> Decode<'a> for EncryptedContentInfo<'a> {
     fn decode(decoder: &mut Decoder<'a>) -> der::Result<EncryptedContentInfo<'a>> {
         decoder.sequence(|decoder| {
             Ok(EncryptedContentInfo {
@@ -66,7 +66,7 @@ impl<'a> Decodable<'a> for EncryptedContentInfo<'a> {
 impl<'a> Sequence<'a> for EncryptedContentInfo<'a> {
     fn fields<F, T>(&self, f: F) -> der::Result<T>
     where
-        F: FnOnce(&[&dyn Encodable]) -> der::Result<T>,
+        F: FnOnce(&[&dyn Encode]) -> der::Result<T>,
     {
         let opt_octet = self.encrypted_content.map(OctetString::new).transpose()?;
         f(&[

--- a/pkcs7/tests/content_tests.rs
+++ b/pkcs7/tests/content_tests.rs
@@ -1,6 +1,6 @@
 //! PKCS#7 example tests
 
-use der::{asn1::ObjectIdentifier, Decodable, Encoder};
+use der::{asn1::ObjectIdentifier, Decode, Encoder};
 use hex_literal::hex;
 use pkcs7::{
     encrypted_data_content::EncryptedDataContent, enveloped_data_content::EncryptedContentInfo,

--- a/pkcs8/src/document/encrypted_private_key.rs
+++ b/pkcs8/src/document/encrypted_private_key.rs
@@ -3,7 +3,7 @@
 use crate::{EncryptedPrivateKeyInfo, Error, Result};
 use alloc::{borrow::ToOwned, vec::Vec};
 use core::fmt;
-use der::{Decodable, Document, Encodable};
+use der::{Decode, Document, Encode};
 use zeroize::{Zeroize, Zeroizing};
 
 #[cfg(feature = "encryption")]

--- a/pkcs8/src/document/private_key.rs
+++ b/pkcs8/src/document/private_key.rs
@@ -3,7 +3,7 @@
 use crate::{DecodePrivateKey, EncodePrivateKey, Error, PrivateKeyInfo, Result};
 use alloc::vec::Vec;
 use core::fmt;
-use der::{Decodable, Document};
+use der::{Decode, Document};
 use zeroize::{Zeroize, Zeroizing};
 
 #[cfg(feature = "encryption")]

--- a/pkcs8/src/encrypted_private_key_info.rs
+++ b/pkcs8/src/encrypted_private_key_info.rs
@@ -2,7 +2,7 @@
 
 use crate::{Error, Result};
 use core::fmt;
-use der::{asn1::OctetString, Decodable, Decoder, Encodable, Sequence};
+use der::{asn1::OctetString, Decode, Decoder, Encode, Sequence};
 use pkcs5::EncryptionScheme;
 
 #[cfg(feature = "alloc")]
@@ -71,7 +71,7 @@ impl<'a> EncryptedPrivateKeyInfo<'a> {
     }
 }
 
-impl<'a> Decodable<'a> for EncryptedPrivateKeyInfo<'a> {
+impl<'a> Decode<'a> for EncryptedPrivateKeyInfo<'a> {
     fn decode(decoder: &mut Decoder<'a>) -> der::Result<EncryptedPrivateKeyInfo<'a>> {
         decoder.sequence(|decoder| {
             Ok(Self {
@@ -85,7 +85,7 @@ impl<'a> Decodable<'a> for EncryptedPrivateKeyInfo<'a> {
 impl<'a> Sequence<'a> for EncryptedPrivateKeyInfo<'a> {
     fn fields<F, T>(&self, f: F) -> der::Result<T>
     where
-        F: FnOnce(&[&dyn Encodable]) -> der::Result<T>,
+        F: FnOnce(&[&dyn Encode]) -> der::Result<T>,
     {
         f(&[
             &self.encryption_algorithm,

--- a/pkcs8/src/private_key_info.rs
+++ b/pkcs8/src/private_key_info.rs
@@ -4,7 +4,7 @@ use crate::{AlgorithmIdentifier, Error, Result, Version};
 use core::fmt;
 use der::{
     asn1::{Any, BitString, ContextSpecific, OctetString},
-    Decodable, Decoder, Encodable, Sequence, TagMode, TagNumber,
+    Decode, Decoder, Encode, Sequence, TagMode, TagNumber,
 };
 
 #[cfg(feature = "alloc")]
@@ -156,7 +156,7 @@ impl<'a> PrivateKeyInfo<'a> {
     }
 }
 
-impl<'a> Decodable<'a> for PrivateKeyInfo<'a> {
+impl<'a> Decode<'a> for PrivateKeyInfo<'a> {
     fn decode(decoder: &mut Decoder<'a>) -> der::Result<PrivateKeyInfo<'a>> {
         decoder.sequence(|decoder| {
             // Parse and validate `version` INTEGER.
@@ -195,7 +195,7 @@ impl<'a> Decodable<'a> for PrivateKeyInfo<'a> {
 impl<'a> Sequence<'a> for PrivateKeyInfo<'a> {
     fn fields<F, T>(&self, f: F) -> der::Result<T>
     where
-        F: FnOnce(&[&dyn Encodable]) -> der::Result<T>,
+        F: FnOnce(&[&dyn Encode]) -> der::Result<T>,
     {
         f(&[
             &u8::from(self.version()),

--- a/pkcs8/src/version.rs
+++ b/pkcs8/src/version.rs
@@ -1,7 +1,7 @@
 //! PKCS#8 version identifier.
 
 use crate::Error;
-use der::{Decodable, Decoder, Encodable, Encoder, FixedTag, Tag};
+use der::{Decode, Decoder, Encode, Encoder, FixedTag, Tag};
 
 /// Version identifier for PKCS#8 documents.
 ///
@@ -25,13 +25,13 @@ impl Version {
     }
 }
 
-impl Decodable<'_> for Version {
+impl Decode<'_> for Version {
     fn decode(decoder: &mut Decoder<'_>) -> der::Result<Self> {
         Version::try_from(u8::decode(decoder)?).map_err(|_| Self::TAG.value_error())
     }
 }
 
-impl Encodable for Version {
+impl Encode for Version {
     fn encoded_len(&self) -> der::Result<der::Length> {
         der::Length::from(1u8).for_tlv()
     }

--- a/pkcs8/tests/public_key.rs
+++ b/pkcs8/tests/public_key.rs
@@ -4,7 +4,7 @@ use hex_literal::hex;
 use pkcs8::SubjectPublicKeyInfo;
 
 #[cfg(feature = "alloc")]
-use der::Encodable;
+use der::Encode;
 
 #[cfg(feature = "pem")]
 use pkcs8::{der::Document, EncodePublicKey};

--- a/sec1/src/private_key.rs
+++ b/sec1/src/private_key.rs
@@ -12,7 +12,7 @@ use crate::{EcParameters, Error};
 use core::fmt;
 use der::{
     asn1::{BitString, ContextSpecific, OctetString},
-    Decodable, Decoder, Encodable, Sequence, Tag, TagMode, TagNumber,
+    Decode, Decoder, Encode, Sequence, Tag, TagMode, TagNumber,
 };
 
 /// `ECPrivateKey` version.
@@ -67,7 +67,7 @@ pub struct EcPrivateKey<'a> {
     pub public_key: Option<&'a [u8]>,
 }
 
-impl<'a> Decodable<'a> for EcPrivateKey<'a> {
+impl<'a> Decode<'a> for EcPrivateKey<'a> {
     fn decode(decoder: &mut Decoder<'a>) -> der::Result<Self> {
         decoder.sequence(|decoder| {
             if decoder.uint8()? != VERSION {
@@ -93,7 +93,7 @@ impl<'a> Decodable<'a> for EcPrivateKey<'a> {
 impl<'a> Sequence<'a> for EcPrivateKey<'a> {
     fn fields<F, T>(&self, f: F) -> der::Result<T>
     where
-        F: FnOnce(&[&dyn Encodable]) -> der::Result<T>,
+        F: FnOnce(&[&dyn Encode]) -> der::Result<T>,
     {
         f(&[
             &VERSION,

--- a/sec1/src/private_key/document.rs
+++ b/sec1/src/private_key/document.rs
@@ -3,7 +3,7 @@
 use crate::{DecodeEcPrivateKey, EcPrivateKey, EncodeEcPrivateKey, Error, Result};
 use alloc::vec::Vec;
 use core::fmt;
-use der::{Decodable, Document, Encodable};
+use der::{Decode, Document, Encode};
 use zeroize::{Zeroize, Zeroizing};
 
 #[cfg(feature = "pem")]

--- a/sec1/src/traits.rs
+++ b/sec1/src/traits.rs
@@ -11,7 +11,7 @@ use {crate::LineEnding, alloc::string::String};
 #[cfg(feature = "pkcs8")]
 use {
     crate::{EcPrivateKey, ALGORITHM_OID},
-    der::Decodable,
+    der::Decode,
 };
 
 #[cfg(all(feature = "alloc", feature = "pkcs8"))]

--- a/spki/src/algorithm.rs
+++ b/spki/src/algorithm.rs
@@ -3,7 +3,7 @@
 use crate::{Error, Result};
 use core::cmp::Ordering;
 use der::asn1::{Any, ObjectIdentifier, SequenceRef};
-use der::{Decodable, DecodeValue, Decoder, DerOrd, Encodable, Header, Sequence, ValueOrd};
+use der::{Decode, DecodeValue, Decoder, DerOrd, Encode, Header, Sequence, ValueOrd};
 
 /// X.509 `AlgorithmIdentifier` as defined in [RFC 5280 Section 4.1.1.2].
 ///
@@ -107,7 +107,7 @@ impl<'a> DecodeValue<'a> for AlgorithmIdentifier<'a> {
 impl<'a> Sequence<'a> for AlgorithmIdentifier<'a> {
     fn fields<F, T>(&self, f: F) -> der::Result<T>
     where
-        F: FnOnce(&[&dyn Encodable]) -> der::Result<T>,
+        F: FnOnce(&[&dyn Encode]) -> der::Result<T>,
     {
         f(&[&self.oid, &self.parameters])
     }

--- a/spki/src/document.rs
+++ b/spki/src/document.rs
@@ -3,7 +3,7 @@
 use crate::{DecodePublicKey, EncodePublicKey, Error, Result, SubjectPublicKeyInfo};
 use alloc::vec::Vec;
 use core::fmt;
-use der::{Decodable, Document};
+use der::{Decode, Document};
 
 #[cfg(feature = "std")]
 use std::path::Path;

--- a/spki/src/spki.rs
+++ b/spki/src/spki.rs
@@ -2,7 +2,7 @@
 
 use crate::{AlgorithmIdentifier, Error, Result};
 use core::cmp::Ordering;
-use der::{asn1::BitString, Decodable, Decoder, DerOrd, Encodable, Sequence, ValueOrd};
+use der::{asn1::BitString, Decode, Decoder, DerOrd, Encode, Sequence, ValueOrd};
 
 #[cfg(feature = "fingerprint")]
 use sha2::{digest, Digest, Sha256};
@@ -57,7 +57,7 @@ impl<'a> SubjectPublicKeyInfo<'a> {
     }
 }
 
-impl<'a> Decodable<'a> for SubjectPublicKeyInfo<'a> {
+impl<'a> Decode<'a> for SubjectPublicKeyInfo<'a> {
     fn decode(decoder: &mut Decoder<'a>) -> der::Result<Self> {
         decoder.sequence(|decoder| {
             let algorithm = decoder.decode()?;
@@ -77,7 +77,7 @@ impl<'a> Decodable<'a> for SubjectPublicKeyInfo<'a> {
 impl<'a> Sequence<'a> for SubjectPublicKeyInfo<'a> {
     fn fields<F, T>(&self, f: F) -> der::Result<T>
     where
-        F: FnOnce(&[&dyn Encodable]) -> der::Result<T>,
+        F: FnOnce(&[&dyn Encode]) -> der::Result<T>,
     {
         f(&[&self.algorithm, &self.subject_public_key_bitstring()?])
     }

--- a/spki/tests/spki.rs
+++ b/spki/tests/spki.rs
@@ -1,7 +1,7 @@
 //! `SubjectPublicKeyInfo` tests.
 
 #[cfg(all(feature = "alloc", feature = "fingerprint"))]
-use spki::der::Encodable;
+use spki::der::Encode;
 
 #[cfg(feature = "fingerprint")]
 use {hex_literal::hex, spki::SubjectPublicKeyInfo};

--- a/x509/src/attr.rs
+++ b/x509/src/attr.rs
@@ -5,7 +5,7 @@ use core::fmt::{self, Write};
 
 use const_oid::db::DB;
 use der::asn1::{Any, ObjectIdentifier, SetOfVec};
-use der::{Decodable, Encodable, Error, ErrorKind, Sequence, Tag, Tagged, ValueOrd};
+use der::{Decode, Encode, Error, ErrorKind, Sequence, Tag, Tagged, ValueOrd};
 
 /// X.501 `AttributeType` as defined in [RFC 5280 Appendix A.1].
 ///

--- a/x509/src/certificate.rs
+++ b/x509/src/certificate.rs
@@ -6,7 +6,7 @@ use alloc::vec::Vec;
 
 use const_oid::AssociatedOid;
 use der::asn1::{BitString, UIntBytes};
-use der::{Decodable, Enumerated, Error, ErrorKind, Newtype, Sequence};
+use der::{Decode, Enumerated, Error, ErrorKind, Newtype, Sequence};
 use spki::{AlgorithmIdentifier, SubjectPublicKeyInfo};
 
 pub mod document;
@@ -98,7 +98,7 @@ impl<'a> TbsCertificate<'a> {
     /// Returns an error if multiple of these extensions is present. Returns
     /// `Ok(None)` if the extension is not present. Returns a decoding error
     /// if decoding failed. Otherwise returns the extension.
-    pub fn get<'b: 'a, T: Decodable<'a> + AssociatedOid>(
+    pub fn get<'b: 'a, T: Decode<'a> + AssociatedOid>(
         &'b self,
     ) -> Result<Option<(bool, T)>, Error> {
         let mut iter = self.filter::<T>().peekable();
@@ -114,7 +114,7 @@ impl<'a> TbsCertificate<'a> {
     /// Filters extensions by an associated OID
     ///
     /// Returns a filtered iterator over all the extensions with the OID.
-    pub fn filter<'b: 'a, T: Decodable<'a> + AssociatedOid>(
+    pub fn filter<'b: 'a, T: Decode<'a> + AssociatedOid>(
         &'b self,
     ) -> impl 'b + Iterator<Item = Result<(bool, T), Error>> {
         self.extensions

--- a/x509/src/certificate/document.rs
+++ b/x509/src/certificate/document.rs
@@ -5,7 +5,7 @@ use der::{Error, Result};
 
 use alloc::vec::Vec;
 use core::fmt;
-use der::{Decodable, Document};
+use der::{Decode, Document};
 
 #[cfg(feature = "pem")]
 use {core::str::FromStr, der::pem};

--- a/x509/src/ext/pkix/name/ediparty.rs
+++ b/x509/src/ext/pkix/name/ediparty.rs
@@ -1,4 +1,4 @@
-use der::{Decodable, Sequence};
+use der::{Decode, Sequence};
 
 use super::DirectoryString;
 

--- a/x509/src/ext/pkix/name/other.rs
+++ b/x509/src/ext/pkix/name/other.rs
@@ -1,4 +1,4 @@
-use der::{asn1::ObjectIdentifier, Any, Decodable, Sequence};
+use der::{asn1::ObjectIdentifier, Any, Decode, Sequence};
 
 /// OtherName as defined in [RFC 5280 Section 4.2.1.6].
 ///
@@ -23,7 +23,7 @@ pub struct OtherName<'a> {
 #[cfg(test)]
 fn test() {
     use alloc::string::ToString;
-    use der::{Decodable, Encodable};
+    use der::{Decode, Encode};
     use hex_literal::hex;
 
     let input = hex!("3021060A2B060104018237140203A0130C1155706E5F323134393530313330406D696C");

--- a/x509/src/name.rs
+++ b/x509/src/name.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 
 use crate::attr::AttributeTypeAndValue;
 
-use der::{asn1::SetOfVec, Decodable, Encodable, Newtype};
+use der::{asn1::SetOfVec, Decode, Encode, Newtype};
 
 /// X.501 Name as defined in [RFC 5280 Section 4.1.2.4]. X.501 Name is used to represent distinguished names.
 ///

--- a/x509/src/request.rs
+++ b/x509/src/request.rs
@@ -8,7 +8,7 @@ use alloc::vec::Vec;
 use const_oid::db::rfc5912::ID_EXTENSION_REQ;
 use const_oid::{AssociatedOid, ObjectIdentifier};
 use der::asn1::BitString;
-use der::{Decodable, Enumerated, Newtype, Sequence};
+use der::{Decode, Enumerated, Newtype, Sequence};
 use spki::{AlgorithmIdentifier, SubjectPublicKeyInfo};
 
 /// Version identifier for certification request information.

--- a/x509/src/time.rs
+++ b/x509/src/time.rs
@@ -3,7 +3,7 @@
 use core::fmt;
 use core::time::Duration;
 use der::asn1::{GeneralizedTime, UtcTime};
-use der::{Choice, DateTime, Decodable, Error, Result, Sequence};
+use der::{Choice, DateTime, Decode, Error, Result, Sequence};
 
 #[cfg(feature = "std")]
 use std::time::SystemTime;

--- a/x509/tests/certificate.rs
+++ b/x509/tests/certificate.rs
@@ -1,6 +1,6 @@
 //! Certificate tests
 use der::asn1::{BitString, ObjectIdentifier, UIntBytes};
-use der::{Decodable, Decoder, Encodable, Tag, Tagged};
+use der::{Decode, Decoder, Encode, Tag, Tagged};
 use hex_literal::hex;
 use spki::AlgorithmIdentifier;
 use x509_cert::Certificate;
@@ -30,7 +30,7 @@ pub struct DeferDecodeCertificate<'a> {
     pub signature: &'a [u8],
 }
 
-impl<'a> Decodable<'a> for DeferDecodeCertificate<'a> {
+impl<'a> Decode<'a> for DeferDecodeCertificate<'a> {
     fn decode(decoder: &mut Decoder<'a>) -> der::Result<DeferDecodeCertificate<'a>> {
         decoder.sequence(|decoder| {
             let tbs_certificate = decoder.tlv_bytes()?;
@@ -69,7 +69,7 @@ pub struct DeferDecodeTBSCertificate<'a> {
     pub extensions: &'a [u8],
 }
 
-impl<'a> Decodable<'a> for DeferDecodeTBSCertificate<'a> {
+impl<'a> Decode<'a> for DeferDecodeTBSCertificate<'a> {
     fn decode(decoder: &mut Decoder<'a>) -> der::Result<DeferDecodeTBSCertificate<'a>> {
         decoder.sequence(|decoder| {
             let version =

--- a/x509/tests/certreq.rs
+++ b/x509/tests/certreq.rs
@@ -1,6 +1,6 @@
 //! Certification request (`CertReq`) tests
 
-use der::{Encodable, Tag, Tagged};
+use der::{Encode, Tag, Tagged};
 use hex_literal::hex;
 use x509_cert::request::{CertReq, Version};
 

--- a/x509/tests/crl.rs
+++ b/x509/tests/crl.rs
@@ -1,4 +1,4 @@
-use der::Decodable;
+use der::Decode;
 use x509_cert::crl::CertificateList;
 
 #[test]

--- a/x509/tests/document.rs
+++ b/x509/tests/document.rs
@@ -3,7 +3,7 @@ use der::Document;
 use x509_cert::certificate::document::CertificateDocument;
 
 #[cfg(all(feature = "pem", any(feature = "alloc", feature = "std")))]
-use der::Encodable;
+use der::Encode;
 
 use x509_cert::*;
 

--- a/x509/tests/general_name.rs
+++ b/x509/tests/general_name.rs
@@ -1,6 +1,6 @@
 use x509_cert::ext::pkix::name::{GeneralName, GeneralNames};
 
-use der::{Decodable, Encodable};
+use der::{Decode, Encode};
 use hex_literal::hex;
 use rstest::rstest;
 

--- a/x509/tests/name.rs
+++ b/x509/tests/name.rs
@@ -2,7 +2,7 @@
 
 use const_oid::ObjectIdentifier;
 use der::asn1::{OctetString, SetOfVec, Utf8String};
-use der::{Any, Decodable, Encodable, Tag, Tagged};
+use der::{Any, Decode, Encode, Tag, Tagged};
 use hex_literal::hex;
 use x509_cert::attr::AttributeTypeAndValue;
 use x509_cert::name::{Name, RdnSequence, RelativeDistinguishedName};

--- a/x509/tests/pkix_extensions.rs
+++ b/x509/tests/pkix_extensions.rs
@@ -1,7 +1,7 @@
 //! Certificate tests
 use const_oid::AssociatedOid;
 use der::asn1::UIntBytes;
-use der::{Decodable, Encodable, ErrorKind, Length, Tag, Tagged};
+use der::{Decode, Encode, ErrorKind, Length, Tag, Tagged};
 use hex_literal::hex;
 use x509_cert::ext::pkix::crl::dp::{DistributionPoint, ReasonFlags, Reasons};
 use x509_cert::ext::pkix::name::{DistributionPointName, GeneralName, GeneralNames};

--- a/x509/tests/trust_anchor_format.rs
+++ b/x509/tests/trust_anchor_format.rs
@@ -1,4 +1,4 @@
-use der::{Decodable, Decoder, Encodable};
+use der::{Decode, Decoder, Encode};
 use hex_literal::hex;
 use x509_cert::anchor::{CertPolicies, TrustAnchorChoice};
 use x509_cert::ext::pkix::name::GeneralName;

--- a/x509/tests/validity.rs
+++ b/x509/tests/validity.rs
@@ -1,6 +1,6 @@
 //! Validity tests
 
-use der::Encodable;
+use der::Encode;
 use hex_literal::hex;
 use x509_cert::time::Validity;
 


### PR DESCRIPTION
As proposed in #420.

This better aligns with the naming of `DecodeValue`/`EncodeValue`.