### PR TITLE
der: add `DecodeOwned` marker trait

### DIFF
--- a/der/src/decode.rs
+++ b/der/src/decode.rs
@@ -35,6 +35,18 @@ where
     }
 }
 
+/// Marker trait for data structures that can be decoded from DER without
+/// borrowing any data from the decoder.
+///
+/// This is primarily useful for trait bounds on functions which require that
+/// no data is borrowed from the decoder, for example a PEM decoder which needs
+/// to first decode data from Base64.
+///
+/// This trait is inspired by the [`DeserializeOwned` trait from `serde`](https://docs.rs/serde/latest/serde/de/trait.DeserializeOwned.html).
+pub trait DecodeOwned: for<'a> Decode<'a> {}
+
+impl<T> DecodeOwned for T where T: for<'a> Decode<'a> {}
+
 /// Decode the value part of a Tag-Length-Value encoded field, sans the [`Tag`]
 /// and [`Length`].
 pub trait DecodeValue<'a>: Sized {

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -353,7 +353,7 @@ mod document;
 pub use crate::{
     asn1::{Any, Choice, Sequence},
     datetime::DateTime,
-    decode::{Decode, DecodeValue},
+    decode::{Decode, DecodeOwned, DecodeValue},
     decoder::Decoder,
     encode::{Encode, EncodeValue},
     encoder::Encoder,


### PR DESCRIPTION
Adds a marker trait for types which can be `der::Decode`d without borrowing any data from the input.

It's useful for cases where borrowing from the input isn't possible. For example, if we were to add on-the-fly PEM decoding as proposed in #525.

Inspired by the [`DeserializeOwned`](https://docs.rs/serde/latest/serde/de/trait.DeserializeOwned.html) trait from `serde`.