### PR TITLE
CI: add workspace-level `doc` tests

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -9,6 +9,11 @@ on:
     paths-ignore:
       - README.md
 
+env:
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: "-Dwarnings"
+  RUSTDOCFLAGS: "-Dwarnings"
+
 jobs:
   clippy:
     runs-on: ubuntu-latest
@@ -21,7 +26,19 @@ jobs:
           components: clippy
           override: true
           profile: minimal
-      - run: cargo clippy --all --all-features -- -D warnings
+      - run: cargo clippy --all-features
+
+  doc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: RustCrypto/actions/cargo-cache@master
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
+      - run: cargo doc --all-features
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/base64ct/src/decoder.rs
+++ b/base64ct/src/decoder.rs
@@ -16,7 +16,7 @@ use {alloc::vec::Vec, core::iter};
 #[cfg(feature = "std")]
 use std::io;
 
-#[cfg(docsrs)]
+#[cfg(doc)]
 use crate::{Base64, Base64Unpadded};
 
 /// Stateful Base64 decoder with support for buffered, incremental decoding.

--- a/base64ct/src/encoder.rs
+++ b/base64ct/src/encoder.rs
@@ -11,7 +11,7 @@ use core::{cmp, marker::PhantomData, str};
 #[cfg(feature = "std")]
 use std::io;
 
-#[cfg(docsrs)]
+#[cfg(doc)]
 use crate::{Base64, Base64Unpadded};
 
 /// Stateful Base64 encoder with support for buffered, incremental encoding.

--- a/der/src/asn1/utf8_string.rs
+++ b/der/src/asn1/utf8_string.rs
@@ -13,9 +13,9 @@ use alloc::{borrow::ToOwned, string::String};
 ///
 /// Supports the full UTF-8 encoding.
 ///
-/// Note that the [`Decode`][`crate::Decodable`] and
-/// [`Encode`][`crate::Encodable`] traits are impl'd for Rust's
-/// [`str`][`prim@str`] primitive, which decodes/encodes as a [`Utf8String`].
+/// Note that the [`Decode`][`crate::Decode`] and [`Encode`][`crate::Encode`]
+/// traits are impl'd for Rust's [`str`][`prim@str`] primitive, which
+/// decodes/encodes as a [`Utf8String`].
 ///
 /// You are free to use [`str`][`prim@str`] instead of this type, however it's
 /// still provided for explicitness in cases where it might be ambiguous with

--- a/der/src/decode.rs
+++ b/der/src/decode.rs
@@ -2,6 +2,9 @@
 
 use crate::{Decoder, FixedTag, Header, Result};
 
+#[cfg(doc)]
+use crate::{Length, Tag};
+
 /// Decoding trait.
 ///
 /// This trait provides the core abstraction upon which all decoding operations

--- a/der/src/encode.rs
+++ b/der/src/encode.rs
@@ -5,6 +5,9 @@ use crate::{Encoder, Header, Length, Result, Tagged};
 #[cfg(feature = "alloc")]
 use {crate::ErrorKind, alloc::vec::Vec, core::iter};
 
+#[cfg(doc)]
+use crate::Tag;
+
 /// Encoding trait.
 pub trait Encode {
     /// Compute the length of this value in bytes when encoded as ASN.1 DER.

--- a/pkcs1/src/traits.rs
+++ b/pkcs1/src/traits.rs
@@ -20,6 +20,9 @@ use der::Document;
 #[cfg(feature = "pem")]
 use zeroize::Zeroizing;
 
+#[cfg(doc)]
+use crate::{RsaPrivateKey, RsaPublicKey};
+
 /// Parse an [`RsaPrivateKey`] from a PKCS#1-encoded document.
 pub trait DecodeRsaPrivateKey: Sized {
     /// Deserialize PKCS#1 private key from ASN.1 DER-encoded data

--- a/pkcs5/src/lib.rs
+++ b/pkcs5/src/lib.rs
@@ -12,9 +12,8 @@
 //! # Usage
 //!
 //! The main API for this crate is the [`EncryptionScheme`] enum, which impls
-//! the [`Decode`][`der::Decodable`] and [`Encode`] traits from the
-//! [`der`] crate, and can be used for decoding/encoding PKCS#5
-//! [`AlgorithmIdentifier`] fields.
+//! the [`Decode`] and [`Encode`] traits from the [`der`] crate, and can be
+//! used for decoding/encoding PKCS#5 [`AlgorithmIdentifier`] fields.
 //!
 //! [RFC 8018]: https://tools.ietf.org/html/rfc8018
 

--- a/ssh-key/src/fingerprint.rs
+++ b/ssh-key/src/fingerprint.rs
@@ -84,7 +84,8 @@ pub struct Sha256Fingerprint([u8; SHA256_BASE64_LEN]);
 impl Sha256Fingerprint {
     /// Create a new SHA-256 fingerprint from the given binary digest.
     ///
-    /// Use [`FromStr`] to parse an existing Base64-encoded fingerprint.
+    /// Use [`FromStr`][`str::FromStr`] to parse an existing Base64-encoded
+    /// fingerprint.
     pub fn new(digest_bytes: &[u8; SHA256_BIN_LEN]) -> Self {
         let mut base64 = [0u8; SHA256_BASE64_LEN];
         Base64Unpadded::encode(digest_bytes, &mut base64).expect(ENCODING_ERR_MSG);


### PR DESCRIPTION
Ensures `cargo doc --all-features` runs successfully without warnings