### PR TITLE
crypto-serde: proptests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,6 +312,7 @@ dependencies = [
  "bincode",
  "ciborium",
  "hex-literal",
+ "proptest",
  "serde",
  "serde_json",
  "toml",

--- a/crypto-serde/Cargo.toml
+++ b/crypto-serde/Cargo.toml
@@ -22,6 +22,7 @@ zeroize = { version = "1", optional = true, default-features = false, features =
 bincode = "1"
 ciborium = "0.2"
 hex-literal = "0.3"
+proptest = "1"
 serde = { version = "1.0.100", default-features = false, features = ["derive"] }
 serde_json = "1"
 toml = "0.5"

--- a/crypto-serde/tests/bincode.rs
+++ b/crypto-serde/tests/bincode.rs
@@ -2,6 +2,7 @@
 
 use crypto_serde::HexUpperOrBin;
 use hex_literal::hex;
+use proptest::{prelude::*, string::*};
 
 /// Example input to be serialized.
 const EXAMPLE_BYTES: &[u8] = &hex!("000102030405060708090A0B0C0D0E0F");
@@ -19,4 +20,13 @@ fn deserialize() {
 fn serialize() {
     let serialized = bincode::serialize(&HexUpperOrBin::from(EXAMPLE_BYTES)).unwrap();
     assert_eq!(&serialized, BINCODE_BYTES);
+}
+
+proptest! {
+    #[test]
+    fn round_trip(bytes in bytes_regex(".{0,256}").unwrap()) {
+        let serialized = bincode::serialize(&HexUpperOrBin::from(bytes.as_ref())).unwrap();
+        let deserialized = bincode::deserialize::<HexUpperOrBin>(&serialized).unwrap();
+        prop_assert_eq!(bytes, deserialized.0);
+    }
 }

--- a/crypto-serde/tests/cbor.rs
+++ b/crypto-serde/tests/cbor.rs
@@ -3,6 +3,7 @@
 use ciborium::{de, ser};
 use crypto_serde::HexUpperOrBin;
 use hex_literal::hex;
+use proptest::{prelude::*, string::*};
 
 /// Example input to be serialized.
 const EXAMPLE_BYTES: &[u8] = &hex!("000102030405060708090A0B0C0D0E0F");
@@ -21,4 +22,15 @@ fn serialize() {
     let mut serialized = Vec::new();
     ser::into_writer(&HexUpperOrBin::from(EXAMPLE_BYTES), &mut serialized).unwrap();
     assert_eq!(&serialized, CBOR_BYTES);
+}
+
+proptest! {
+    #[test]
+    fn round_trip(bytes in bytes_regex(".{0,256}").unwrap()) {
+        let mut serialized = Vec::new();
+        ser::into_writer(&HexUpperOrBin::from(bytes.as_ref()), &mut serialized).unwrap();
+
+        let deserialized = de::from_reader::<HexUpperOrBin, _>(serialized.as_slice()).unwrap();
+        prop_assert_eq!(bytes, deserialized.0);
+    }
 }

--- a/crypto-serde/tests/json.rs
+++ b/crypto-serde/tests/json.rs
@@ -2,6 +2,7 @@
 
 use crypto_serde::{HexLowerOrBin, HexUpperOrBin};
 use hex_literal::hex;
+use proptest::{prelude::*, string::*};
 use serde_json as json;
 
 /// Example input to be serialized.
@@ -29,4 +30,20 @@ fn hex_upper() {
 
     let deserialized = json::from_str::<HexUpperOrBin>(&serialized).unwrap();
     assert_eq!(deserialized.as_ref(), EXAMPLE_BYTES);
+}
+
+proptest! {
+    #[test]
+    fn round_trip_lower(bytes in bytes_regex(".{0,256}").unwrap()) {
+        let serialized = json::to_string(&HexLowerOrBin::from(bytes.as_ref())).unwrap();
+        let deserialized = json::from_str::<HexLowerOrBin>(&serialized).unwrap();
+        prop_assert_eq!(bytes, deserialized.0);
+    }
+
+    #[test]
+    fn round_trip_upper(bytes in bytes_regex(".{0,256}").unwrap()) {
+        let serialized = json::to_string(&HexUpperOrBin::from(bytes.as_ref())).unwrap();
+        let deserialized = json::from_str::<HexUpperOrBin>(&serialized).unwrap();
+        prop_assert_eq!(bytes, deserialized.0);
+    }
 }


### PR DESCRIPTION
Adds initial proptests which ensure that randomly generated inputs round trip back to their original values