### PR TITLE
crypto-serde: `alloc` feature

### DIFF
--- a/crypto-serde/Cargo.toml
+++ b/crypto-serde/Cargo.toml
@@ -12,11 +12,11 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-base16ct = { version = "0.1.1", default-features = false, features = ["alloc"] }
-serde = { version = "1", default-features = false, features = ["alloc"] }
+serde = { version = "1", default-features = false }
 
 # optional features
-zeroize = { version = "1", optional = true, default-features = false, features = ["alloc"] }
+base16ct = { version = "0.1.1", optional = true, default-features = false }
+zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
 bincode = "1"
@@ -26,3 +26,7 @@ proptest = "1"
 serde = { version = "1.0.100", default-features = false, features = ["derive"] }
 serde_json = "1"
 toml = "0.5"
+
+[features]
+default = ["alloc"]
+alloc = ["base16ct/alloc", "serde/alloc"]

--- a/crypto-serde/src/lib.rs
+++ b/crypto-serde/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
@@ -11,14 +12,17 @@
     unused_qualifications
 )]
 
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 pub use serde;
 
-use alloc::vec::Vec;
-use serde::{
-    de::{self, Error},
-    ser, Deserialize, Serialize,
+use serde::{ser, Serialize};
+
+#[cfg(feature = "alloc")]
+use {
+    alloc::vec::Vec,
+    serde::de::{self, Deserialize, Error},
 };
 
 #[cfg(feature = "zeroize")]
@@ -31,11 +35,12 @@ where
     S: ser::Serializer,
     T: AsRef<[u8]>,
 {
+    #[cfg(feature = "alloc")]
     if serializer.is_human_readable() {
-        base16ct::lower::encode_string(value.as_ref()).serialize(serializer)
-    } else {
-        value.as_ref().serialize(serializer)
+        return base16ct::lower::encode_string(value.as_ref()).serialize(serializer);
     }
+
+    value.as_ref().serialize(serializer)
 }
 
 /// Serialize the given type as upper case hex when using human-readable
@@ -45,47 +50,65 @@ where
     S: ser::Serializer,
     T: AsRef<[u8]>,
 {
+    #[cfg(feature = "alloc")]
     if serializer.is_human_readable() {
-        base16ct::upper::encode_string(value.as_ref()).serialize(serializer)
-    } else {
-        value.as_ref().serialize(serializer)
+        return base16ct::upper::encode_string(value.as_ref()).serialize(serializer);
     }
+
+    value.as_ref().serialize(serializer)
 }
 
 /// [`HexOrBin`] serializer which uses lower case.
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub type HexLowerOrBin = HexOrBin<false>;
 
 /// [`HexOrBin`] serializer which uses upper case.
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub type HexUpperOrBin = HexOrBin<true>;
 
-/// Serializer/deserializer newtype which encodes as binary when using
-/// binary-oriented formats or hexadecimal when using human-readable formats.
+/// Serializer/deserializer newtype which encodes bytes as either binary or hex.
+///
+/// Use hexadecimal with human-readable formats, or raw binary with binary formats.
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub struct HexOrBin<const UPPERCASE: bool>(pub Vec<u8>);
 
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<const UPPERCASE: bool> AsRef<[u8]> for HexOrBin<UPPERCASE> {
     fn as_ref(&self) -> &[u8] {
         self.0.as_ref()
     }
 }
 
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<const UPPERCASE: bool> From<&[u8]> for HexOrBin<UPPERCASE> {
     fn from(bytes: &[u8]) -> HexOrBin<UPPERCASE> {
         Self(bytes.into())
     }
 }
 
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<const UPPERCASE: bool> From<Vec<u8>> for HexOrBin<UPPERCASE> {
     fn from(vec: Vec<u8>) -> HexOrBin<UPPERCASE> {
         Self(vec)
     }
 }
 
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<const UPPERCASE: bool> From<HexOrBin<UPPERCASE>> for Vec<u8> {
     fn from(vec: HexOrBin<UPPERCASE>) -> Vec<u8> {
         vec.0
     }
 }
 
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<const UPPERCASE: bool> Serialize for HexOrBin<UPPERCASE> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -99,6 +122,8 @@ impl<const UPPERCASE: bool> Serialize for HexOrBin<UPPERCASE> {
     }
 }
 
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<'de, const UPPERCASE: bool> Deserialize<'de> for HexOrBin<UPPERCASE> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -114,9 +139,10 @@ impl<'de, const UPPERCASE: bool> Deserialize<'de> for HexOrBin<UPPERCASE> {
     }
 }
 
-#[cfg(feature = "zeroize")]
+#[cfg(all(feature = "alloc", feature = "zeroize"))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "alloc", feature = "zeroize"))))]
 impl<const UPPERCASE: bool> Zeroize for HexOrBin<UPPERCASE> {
     fn zeroize(&mut self) {
-        self.0.zeroize();
+        self.0.as_mut_slice().zeroize();
     }
 }

--- a/crypto-serde/tests/bincode.rs
+++ b/crypto-serde/tests/bincode.rs
@@ -1,5 +1,7 @@
 //! bincode-specific tests.
 
+#![cfg(feature = "alloc")]
+
 use crypto_serde::HexUpperOrBin;
 use hex_literal::hex;
 use proptest::{prelude::*, string::*};

--- a/crypto-serde/tests/cbor.rs
+++ b/crypto-serde/tests/cbor.rs
@@ -1,5 +1,7 @@
 //! CBOR-specific tests.
 
+#![cfg(feature = "alloc")]
+
 use ciborium::{de, ser};
 use crypto_serde::HexUpperOrBin;
 use hex_literal::hex;

--- a/crypto-serde/tests/json.rs
+++ b/crypto-serde/tests/json.rs
@@ -1,5 +1,7 @@
 //! JSON-specific tests.
 
+#![cfg(feature = "alloc")]
+
 use crypto_serde::{HexLowerOrBin, HexUpperOrBin};
 use hex_literal::hex;
 use proptest::{prelude::*, string::*};

--- a/crypto-serde/tests/toml.rs
+++ b/crypto-serde/tests/toml.rs
@@ -1,5 +1,7 @@
 //! TOML-specific tests.
 
+#![cfg(feature = "alloc")]
+
 use crypto_serde::{HexLowerOrBin, HexUpperOrBin};
 use hex_literal::hex;
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
Adds a baseline heapless `no_std` profile which is capable of serializing binary data without `alloc`.