### PR TITLE
ssh-key: bcrypt-pbkdf KDF options decoder/encoder

### DIFF
--- a/ssh-key/src/algorithm.rs
+++ b/ssh-key/src/algorithm.rs
@@ -7,13 +7,10 @@ use crate::{
 };
 use core::{fmt, str};
 
-#[cfg(feature = "alloc")]
-use alloc::vec::Vec;
-
 /// AES-256 in counter (CTR) mode
 const AES256_CTR: &str = "aes256-ctr";
 
-/// bcrypt-pbkdf2
+/// bcrypt-pbkdf
 const BCRYPT: &str = "bcrypt";
 
 /// ECDSA with SHA-256 + NIST P-256
@@ -364,7 +361,7 @@ pub enum KdfAlg {
     /// None.
     None,
 
-    /// bcrypt-pbkdf2.
+    /// bcrypt-pbkdf.
     Bcrypt,
 }
 
@@ -419,61 +416,5 @@ impl str::FromStr for KdfAlg {
 
     fn from_str(id: &str) -> Result<Self> {
         Self::new(id)
-    }
-}
-
-/// Key Derivation Function (KDF) options.
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
-#[non_exhaustive]
-pub struct KdfOpts {
-    /// Encoded KDF options.
-    #[cfg(feature = "alloc")]
-    bytes: Vec<u8>,
-}
-
-impl KdfOpts {
-    /// Are the KDF options empty?
-    pub fn is_empty(&self) -> bool {
-        self.as_ref().is_empty()
-    }
-}
-
-impl AsRef<[u8]> for KdfOpts {
-    #[cfg(not(feature = "alloc"))]
-    fn as_ref(&self) -> &[u8] {
-        &[]
-    }
-
-    #[cfg(feature = "alloc")]
-    fn as_ref(&self) -> &[u8] {
-        self.bytes.as_ref()
-    }
-}
-
-impl Decode for KdfOpts {
-    #[cfg(not(feature = "alloc"))]
-    fn decode(decoder: &mut impl Decoder) -> Result<Self> {
-        if decoder.decode_usize()? == 0 {
-            Ok(Self::default())
-        } else {
-            Err(Error::Algorithm)
-        }
-    }
-
-    #[cfg(feature = "alloc")]
-    fn decode(decoder: &mut impl Decoder) -> Result<Self> {
-        Ok(Self {
-            bytes: decoder.decode_byte_vec()?,
-        })
-    }
-}
-
-impl Encode for KdfOpts {
-    fn encoded_len(&self) -> Result<usize> {
-        Ok(4 + self.as_ref().len())
-    }
-
-    fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {
-        encoder.encode_byte_slice(self.as_ref())
     }
 }

--- a/ssh-key/src/kdf.rs
+++ b/ssh-key/src/kdf.rs
@@ -1,0 +1,101 @@
+//! Key Derivation Functions.
+//!
+//! These are used for deriving an encryption key from a password.
+
+use crate::{
+    decoder::Decoder,
+    encoder::{Encode, Encoder},
+    Error, KdfAlg, Result,
+};
+
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
+/// Key Derivation Function (KDF) options.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum KdfOpts {
+    /// No KDF options.
+    Empty,
+
+    /// bcrypt-pbkdf options.
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    Bcrypt {
+        /// Salt
+        salt: Vec<u8>,
+
+        /// Rounds
+        rounds: u32,
+    },
+}
+
+impl KdfOpts {
+    /// Decode KDF options for the given algorithm.
+    pub(crate) fn decode(alg: KdfAlg, decoder: &mut impl Decoder) -> Result<Self> {
+        match alg {
+            KdfAlg::None => {
+                if decoder.decode_usize()? == 0 {
+                    Ok(Self::Empty)
+                } else {
+                    Err(Error::Algorithm)
+                }
+            }
+            KdfAlg::Bcrypt => {
+                #[cfg(not(feature = "alloc"))]
+                return Err(Error::Algorithm);
+
+                #[cfg(feature = "alloc")]
+                {
+                    // TODO(tarcieri): validate length
+                    let _len = decoder.decode_usize()?;
+                    let salt = decoder.decode_byte_vec()?;
+                    let rounds = decoder.decode_u32()?;
+                    Ok(Self::Bcrypt { salt, rounds })
+                }
+            }
+        }
+    }
+
+    /// Get the KDF algorithm.
+    pub fn algorithm(&self) -> KdfAlg {
+        match self {
+            Self::Empty => KdfAlg::None,
+            #[cfg(feature = "alloc")]
+            Self::Bcrypt { .. } => KdfAlg::Bcrypt,
+        }
+    }
+
+    /// Are the KDF options empty?
+    pub fn is_empty(&self) -> bool {
+        self == &Self::Empty
+    }
+}
+
+impl Default for KdfOpts {
+    fn default() -> Self {
+        Self::Empty
+    }
+}
+
+impl Encode for KdfOpts {
+    fn encoded_len(&self) -> Result<usize> {
+        match self {
+            Self::Empty => Ok(4),
+            #[cfg(feature = "alloc")]
+            Self::Bcrypt { salt, .. } => Ok(4 + 4 + salt.len() + 4),
+        }
+    }
+
+    fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {
+        match self {
+            Self::Empty => encoder.encode_usize(0),
+            #[cfg(feature = "alloc")]
+            Self::Bcrypt { salt, rounds } => {
+                encoder.encode_usize(4 + salt.len() + 4)?;
+                encoder.encode_byte_slice(salt)?;
+                encoder.encode_u32(*rounds)
+            }
+        }
+    }
+}

--- a/ssh-key/src/lib.rs
+++ b/ssh-key/src/lib.rs
@@ -117,6 +117,7 @@ mod algorithm;
 mod decoder;
 mod encoder;
 mod error;
+mod kdf;
 
 #[cfg(feature = "fingerprint")]
 mod fingerprint;
@@ -124,9 +125,10 @@ mod fingerprint;
 mod mpint;
 
 pub use crate::{
-    algorithm::{Algorithm, CipherAlg, EcdsaCurve, HashAlg, KdfAlg, KdfOpts},
+    algorithm::{Algorithm, CipherAlg, EcdsaCurve, HashAlg, KdfAlg},
     authorized_keys::AuthorizedKeys,
     error::{Error, Result},
+    kdf::KdfOpts,
     private::PrivateKey,
     public::PublicKey,
 };

--- a/ssh-key/tests/encrypted_private_key.rs
+++ b/ssh-key/tests/encrypted_private_key.rs
@@ -3,7 +3,7 @@
 #![cfg(feature = "alloc")]
 
 use hex_literal::hex;
-use ssh_key::{Algorithm, PrivateKey};
+use ssh_key::{Algorithm, KdfAlg, KdfOpts, PrivateKey};
 
 /// Encrypted Ed25519 OpenSSH-formatted private key.
 const OSSH_ED25519_ENC_EXAMPLE: &str = include_str!("examples/id_ed25519.enc");
@@ -12,6 +12,16 @@ const OSSH_ED25519_ENC_EXAMPLE: &str = include_str!("examples/id_ed25519.enc");
 fn decode_ed25519_enc_openssh() {
     let ossh_key = PrivateKey::from_openssh(OSSH_ED25519_ENC_EXAMPLE).unwrap();
     assert_eq!(Algorithm::Ed25519, ossh_key.algorithm());
+    assert_eq!(KdfAlg::Bcrypt, ossh_key.kdf_alg());
+
+    match ossh_key.kdf_opts() {
+        KdfOpts::Bcrypt { salt, rounds } => {
+            assert_eq!(salt, &hex!("4a1fdeae8d6ba607afd69d334f8d379a"));
+            assert_eq!(*rounds, 16);
+        }
+        other => panic!("unexpected KDF algorithm: {:?}", other),
+    }
+
     assert_eq!(
         &hex!("b33eaef37ea2df7caa010defdea34e241f65f1b529a4f43ed14327f5c54aab62"),
         ossh_key.public_key().key_data().ed25519().unwrap().as_ref(),


### PR DESCRIPTION
Support for parsing bcrypt-pbkdf's KDF options into `KdfOpts::Bcrypt` and encoding them into an output private key document