### PR TITLE
ssh-key: private key decryption support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bcrypt-pbkdf"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3806a8db60cf56efee531616a34a6aaa9a114d6da2add861b0fa4a188881b2c7"
+dependencies = [
+ "blowfish",
+ "pbkdf2",
+ "sha2",
+]
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,6 +111,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5808df4b2412175c4db3afb115c83d8d0cd26ca4f30a042026cddef8580e526a"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blowfish"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
+dependencies = [
+ "byteorder",
+ "cipher",
 ]
 
 [[package]]
@@ -339,6 +360,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d14f329cfbaf5d0e06b5e87fff7e265d2673c5ea7d2c27691a2c107db1442a0"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1029,7 +1059,10 @@ dependencies = [
 name = "ssh-key"
 version = "0.4.0-pre"
 dependencies = [
+ "aes",
  "base64ct",
+ "bcrypt-pbkdf",
+ "ctr",
  "hex-literal",
  "pem-rfc7468",
  "sec1",

--- a/pkcs5/src/pbes2.rs
+++ b/pkcs5/src/pbes2.rs
@@ -269,7 +269,7 @@ pub enum EncryptionScheme<'a> {
 }
 
 impl<'a> EncryptionScheme<'a> {
-    /// Get the size of a key used by this algorithm.
+    /// Get the size of a key used by this algorithm in bytes.
     pub fn key_size(&self) -> usize {
         match self {
             Self::Aes128Cbc { .. } => 16,

--- a/pkcs5/src/pbes2/kdf.rs
+++ b/pkcs5/src/pbes2/kdf.rs
@@ -48,7 +48,8 @@ pub enum Kdf<'a> {
 }
 
 impl<'a> Kdf<'a> {
-    /// Get derived key length, if defined
+    /// Get derived key length in bytes, if defined.
+    // TODO(tarcieri): rename to `key_size` to match `EncryptionScheme::key_size`?
     pub fn key_length(&self) -> Option<u16> {
         match self {
             Self::Pbkdf2(params) => params.key_length,

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -21,6 +21,9 @@ pem-rfc7468 = { version = "0.4", path = "../pem-rfc7468" }
 zeroize = { version = "1", default-features = false }
 
 # optional dependencies
+aes = { version = "0.8", optional = true, default-features = false }
+ctr = { version = "0.9", optional = true, default-features = false }
+bcrypt-pbkdf = { version = "0.9", optional = true, default-features = false }
 sec1 = { version = "=0.3.0-pre.1", optional = true, default-features = false, features = ["point"], path = "../sec1" }
 sha2 = { version = "0.10", optional = true, default-features = false }
 subtle = { version = "2", optional = true, default-features = false }
@@ -33,6 +36,7 @@ tempfile = "3"
 default = ["ecdsa", "fingerprint", "std"]
 alloc = ["zeroize/alloc"]
 ecdsa = ["sec1"]
+encryption = ["aes", "alloc", "bcrypt-pbkdf", "ctr"]
 fingerprint = ["sha2"]
 std = ["alloc", "base64ct/std"]
 

--- a/ssh-key/src/algorithm.rs
+++ b/ssh-key/src/algorithm.rs
@@ -207,6 +207,30 @@ impl CipherAlg {
     pub fn is_none(self) -> bool {
         self == Self::None
     }
+
+    /// Get the key size for this cipher in bytes.
+    pub fn key_size(self) -> Option<usize> {
+        match self {
+            Self::None => None,
+            Self::Aes256Ctr => Some(32),
+        }
+    }
+
+    /// Get the initialization vector size for this cipher in bytes.
+    pub fn iv_size(self) -> Option<usize> {
+        match self {
+            Self::None => None,
+            Self::Aes256Ctr => Some(16),
+        }
+    }
+
+    /// Get the block size for this cipher in bytes.
+    pub fn block_size(self) -> Option<usize> {
+        match self {
+            Self::None => None,
+            Self::Aes256Ctr => Some(16),
+        }
+    }
 }
 
 impl AsRef<str> for CipherAlg {

--- a/ssh-key/src/error.rs
+++ b/ssh-key/src/error.rs
@@ -19,6 +19,12 @@ pub enum Error {
     /// Character encoding-related errors.
     CharacterEncoding,
 
+    /// Cryptographic errors.
+    Crypto,
+
+    /// Cannot perform operation on decrypted private key.
+    Decrypted,
+
     /// ECDSA key encoding errors.
     #[cfg(feature = "ecdsa")]
     #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
@@ -54,6 +60,8 @@ impl fmt::Display for Error {
             Error::Algorithm => f.write_str("unknown or unsupported algorithm"),
             Error::Base64(err) => write!(f, "Base64 encoding error: {}", err),
             Error::CharacterEncoding => f.write_str("character encoding invalid"),
+            Error::Crypto => f.write_str("cryptographic error"),
+            Error::Decrypted => f.write_str("private key is already decrypted"),
             #[cfg(feature = "ecdsa")]
             Error::Ecdsa(err) => write!(f, "ECDSA encoding error: {}", err),
             Error::Encrypted => f.write_str("private key is encrypted"),

--- a/ssh-key/src/public.rs
+++ b/ssh-key/src/public.rs
@@ -164,6 +164,22 @@ impl PublicKey {
         }
         .expect("error calculating fingerprint")
     }
+
+    /// Decode comment (e.g. email address).
+    ///
+    /// This is a stub implementation that ignores the comment.
+    #[cfg(not(feature = "alloc"))]
+    pub(crate) fn decode_comment(&mut self, decoder: &mut impl Decoder) -> Result<()> {
+        decoder.drain_prefixed()?;
+        Ok(())
+    }
+
+    /// Decode comment (e.g. email address)
+    #[cfg(feature = "alloc")]
+    pub(crate) fn decode_comment(&mut self, decoder: &mut impl Decoder) -> Result<()> {
+        self.comment = decoder.decode_string()?;
+        Ok(())
+    }
 }
 
 impl From<KeyData> for PublicKey {

--- a/ssh-key/tests/encrypted_private_key.rs
+++ b/ssh-key/tests/encrypted_private_key.rs
@@ -5,8 +5,18 @@
 use hex_literal::hex;
 use ssh_key::{Algorithm, KdfAlg, KdfOpts, PrivateKey};
 
+/// Unencrypted Ed25519 OpenSSH-formatted private key.
+#[cfg(all(feature = "encryption", feature = "subtle"))]
+const OSSH_ED25519_EXAMPLE: &str = include_str!("examples/id_ed25519");
+
 /// Encrypted Ed25519 OpenSSH-formatted private key.
+///
+/// This is the encrypted form of `OSSH_ED25519_EXAMPLE`.
 const OSSH_ED25519_ENC_EXAMPLE: &str = include_str!("examples/id_ed25519.enc");
+
+/// Bad password; don't actually use outside tests!
+#[cfg(all(feature = "encryption", feature = "subtle"))]
+const PASSWORD: &[u8] = b"hunter42";
 
 #[test]
 fn decode_ed25519_enc_openssh() {
@@ -25,6 +35,17 @@ fn decode_ed25519_enc_openssh() {
     assert_eq!(
         &hex!("b33eaef37ea2df7caa010defdea34e241f65f1b529a4f43ed14327f5c54aab62"),
         ossh_key.public_key().key_data().ed25519().unwrap().as_ref(),
+    );
+}
+
+#[cfg(all(feature = "encryption", feature = "subtle"))]
+#[test]
+fn decrypt_ed25519_enc_openssh() {
+    let ossh_key_enc = PrivateKey::from_openssh(OSSH_ED25519_ENC_EXAMPLE).unwrap();
+    let ossh_key_dec = ossh_key_enc.decrypt(PASSWORD).unwrap();
+    assert_eq!(
+        PrivateKey::from_openssh(OSSH_ED25519_EXAMPLE).unwrap(),
+        ossh_key_dec
     );
 }
 


### PR DESCRIPTION
Preliminary support for decrypting encrypted OpenSSH private keys, with support for `bcrypt-pbkdf` as the KDF and `aes256-ctr` as the encryption cipher.

Tested against an example encrypted private key (`id_ed25519.enc`) produced using the `ssh-keygen` utility:

    $ ssh-keygen -p -f id_ed25519