### PR TITLE
ssh-key: consolidate `KdfAlg` and `KdfOpts` into `Kdf`

### DIFF
--- a/ssh-key/src/lib.rs
+++ b/ssh-key/src/lib.rs
@@ -128,7 +128,7 @@ pub use crate::{
     algorithm::{Algorithm, CipherAlg, EcdsaCurve, HashAlg, KdfAlg},
     authorized_keys::AuthorizedKeys,
     error::{Error, Result},
-    kdf::KdfOpts,
+    kdf::Kdf,
     private::PrivateKey,
     public::PublicKey,
 };

--- a/ssh-key/tests/encrypted_private_key.rs
+++ b/ssh-key/tests/encrypted_private_key.rs
@@ -3,7 +3,7 @@
 #![cfg(feature = "alloc")]
 
 use hex_literal::hex;
-use ssh_key::{Algorithm, KdfAlg, KdfOpts, PrivateKey};
+use ssh_key::{Algorithm, Kdf, KdfAlg, PrivateKey};
 
 /// Unencrypted Ed25519 OpenSSH-formatted private key.
 #[cfg(all(feature = "encryption", feature = "subtle"))]
@@ -24,8 +24,8 @@ fn decode_ed25519_enc_openssh() {
     assert_eq!(Algorithm::Ed25519, ossh_key.algorithm());
     assert_eq!(KdfAlg::Bcrypt, ossh_key.kdf_alg());
 
-    match ossh_key.kdf_opts() {
-        KdfOpts::Bcrypt { salt, rounds } => {
+    match ossh_key.kdf() {
+        Kdf::Bcrypt { salt, rounds } => {
             assert_eq!(salt, &hex!("4a1fdeae8d6ba607afd69d334f8d379a"));
             assert_eq!(*rounds, 16);
         }

--- a/ssh-key/tests/private_key.rs
+++ b/ssh-key/tests/private_key.rs
@@ -49,7 +49,7 @@ fn decode_dsa_openssh() {
     assert_eq!(Algorithm::Dsa, ossh_key.algorithm());
     assert_eq!(CipherAlg::None, ossh_key.cipher_alg());
     assert_eq!(KdfAlg::None, ossh_key.kdf_alg());
-    assert!(ossh_key.kdf_opts().is_empty());
+    assert!(ossh_key.kdf().is_none());
 
     let dsa_keypair = ossh_key.key_data().dsa().unwrap();
     assert_eq!(
@@ -94,7 +94,7 @@ fn decode_ecdsa_p256_openssh() {
     assert_eq!(Algorithm::Ecdsa(EcdsaCurve::NistP256), ossh_key.algorithm(),);
     assert_eq!(CipherAlg::None, ossh_key.cipher_alg());
     assert_eq!(KdfAlg::None, ossh_key.kdf_alg());
-    assert!(ossh_key.kdf_opts().is_empty());
+    assert!(ossh_key.kdf().is_none());
 
     let ecdsa_keypair = ossh_key.key_data().ecdsa().unwrap();
     assert_eq!(EcdsaCurve::NistP256, ecdsa_keypair.curve());
@@ -121,7 +121,7 @@ fn decode_ecdsa_p384_openssh() {
     assert_eq!(Algorithm::Ecdsa(EcdsaCurve::NistP384), ossh_key.algorithm(),);
     assert_eq!(CipherAlg::None, ossh_key.cipher_alg());
     assert_eq!(KdfAlg::None, ossh_key.kdf_alg());
-    assert!(ossh_key.kdf_opts().is_empty());
+    assert!(ossh_key.kdf().is_none());
 
     let ecdsa_keypair = ossh_key.key_data().ecdsa().unwrap();
     assert_eq!(EcdsaCurve::NistP384, ecdsa_keypair.curve());
@@ -152,7 +152,7 @@ fn decode_ecdsa_p521_openssh() {
     assert_eq!(Algorithm::Ecdsa(EcdsaCurve::NistP521), ossh_key.algorithm(),);
     assert_eq!(CipherAlg::None, ossh_key.cipher_alg());
     assert_eq!(KdfAlg::None, ossh_key.kdf_alg());
-    assert!(ossh_key.kdf_opts().is_empty());
+    assert!(ossh_key.kdf().is_none());
 
     let ecdsa_keypair = ossh_key.key_data().ecdsa().unwrap();
     assert_eq!(EcdsaCurve::NistP521, ecdsa_keypair.curve());
@@ -183,7 +183,7 @@ fn decode_ed25519_openssh() {
     assert_eq!(Algorithm::Ed25519, ossh_key.algorithm());
     assert_eq!(CipherAlg::None, ossh_key.cipher_alg());
     assert_eq!(KdfAlg::None, ossh_key.kdf_alg());
-    assert!(ossh_key.kdf_opts().is_empty());
+    assert!(ossh_key.kdf().is_none());
 
     let ed25519_keypair = ossh_key.key_data().ed25519().unwrap();
     assert_eq!(
@@ -206,7 +206,7 @@ fn decode_rsa_3072_openssh() {
     assert_eq!(Algorithm::Rsa, ossh_key.algorithm());
     assert_eq!(CipherAlg::None, ossh_key.cipher_alg());
     assert_eq!(KdfAlg::None, ossh_key.kdf_alg());
-    assert!(ossh_key.kdf_opts().is_empty());
+    assert!(ossh_key.kdf().is_none());
 
     let rsa_keypair = ossh_key.key_data().rsa().unwrap();
     assert_eq!(&hex!("010001"), rsa_keypair.public.e.as_bytes());
@@ -278,7 +278,7 @@ fn decode_rsa_4096_openssh() {
     assert_eq!(Algorithm::Rsa, ossh_key.algorithm());
     assert_eq!(CipherAlg::None, ossh_key.cipher_alg());
     assert_eq!(KdfAlg::None, ossh_key.kdf_alg());
-    assert!(ossh_key.kdf_opts().is_empty());
+    assert!(ossh_key.kdf().is_none());
 
     let rsa_keypair = ossh_key.key_data().rsa().unwrap();
     assert_eq!(&hex!("010001"), rsa_keypair.public.e.as_bytes());


### PR DESCRIPTION
Since the KDF algorithm and options are located side-by-side in private keys, and this crate models them as effectively a single `enum`, this commit makes that a first-class arrangement, combining the two into a unified `pub enum Kdf`.

This allows the enum to impl the `Decode` trait proper.

Internally it still decodes/encodes a `KdfAlg`, however it only uses it to select the enum variant and inform the KDF options decoding.