### PR TITLE
ssh-key: various naming fixups

### DIFF
--- a/ssh-key/src/private.rs
+++ b/ssh-key/src/private.rs
@@ -24,7 +24,7 @@ pub use self::{
 use crate::{
     decoder::{Decode, Decoder},
     encoder::{Encode, Encoder},
-    public, Algorithm, CipherAlg, Error, Kdf, KdfAlg, PublicKey, Result,
+    public, Algorithm, CipherAlg, Error, Kdf, PublicKey, Result,
 };
 use core::str;
 use pem_rfc7468::{self as pem, LineEnding, PemLabel};
@@ -41,6 +41,9 @@ use aes::{
     cipher::{InnerIvInit, KeyInit, StreamCipherCore},
     Aes256,
 };
+
+#[cfg(feature = "fingerprint")]
+use crate::{Fingerprint, HashAlg};
 
 #[cfg(feature = "std")]
 use std::{fs, io::Write, path::Path};
@@ -316,14 +319,18 @@ impl PrivateKey {
         self.cipher_alg
     }
 
+    /// Compute key fingerprint.
+    ///
+    /// Use [`Default::default()`] to use the default hash function (SHA-256).
+    #[cfg(feature = "fingerprint")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "fingerprint")))]
+    pub fn fingerprint(&self, hash_alg: HashAlg) -> Fingerprint {
+        self.public_key.fingerprint(hash_alg)
+    }
+
     /// Is this key encrypted?
     pub fn is_encrypted(&self) -> bool {
         self.key_data.is_encrypted()
-    }
-
-    /// KDF algorithm.
-    pub fn kdf_alg(&self) -> KdfAlg {
-        self.kdf.algorithm()
     }
 
     /// KDF options.

--- a/ssh-key/tests/encrypted_private_key.rs
+++ b/ssh-key/tests/encrypted_private_key.rs
@@ -7,12 +7,12 @@ use ssh_key::{Algorithm, Kdf, KdfAlg, PrivateKey};
 
 /// Unencrypted Ed25519 OpenSSH-formatted private key.
 #[cfg(all(feature = "encryption", feature = "subtle"))]
-const OSSH_ED25519_EXAMPLE: &str = include_str!("examples/id_ed25519");
+const OPENSSH_ED25519_EXAMPLE: &str = include_str!("examples/id_ed25519");
 
 /// Encrypted Ed25519 OpenSSH-formatted private key.
 ///
-/// This is the encrypted form of `OSSH_ED25519_EXAMPLE`.
-const OSSH_ED25519_ENC_EXAMPLE: &str = include_str!("examples/id_ed25519.enc");
+/// This is the encrypted form of `OPENSSH_ED25519_EXAMPLE`.
+const OPENSSH_ED25519_ENC_EXAMPLE: &str = include_str!("examples/id_ed25519.enc");
 
 /// Bad password; don't actually use outside tests!
 #[cfg(all(feature = "encryption", feature = "subtle"))]
@@ -20,11 +20,11 @@ const PASSWORD: &[u8] = b"hunter42";
 
 #[test]
 fn decode_ed25519_enc_openssh() {
-    let ossh_key = PrivateKey::from_openssh(OSSH_ED25519_ENC_EXAMPLE).unwrap();
-    assert_eq!(Algorithm::Ed25519, ossh_key.algorithm());
-    assert_eq!(KdfAlg::Bcrypt, ossh_key.kdf_alg());
+    let key = PrivateKey::from_openssh(OPENSSH_ED25519_ENC_EXAMPLE).unwrap();
+    assert_eq!(Algorithm::Ed25519, key.algorithm());
+    assert_eq!(KdfAlg::Bcrypt, key.kdf().algorithm());
 
-    match ossh_key.kdf() {
+    match key.kdf() {
         Kdf::Bcrypt { salt, rounds } => {
             assert_eq!(salt, &hex!("4a1fdeae8d6ba607afd69d334f8d379a"));
             assert_eq!(*rounds, 16);
@@ -34,26 +34,26 @@ fn decode_ed25519_enc_openssh() {
 
     assert_eq!(
         &hex!("b33eaef37ea2df7caa010defdea34e241f65f1b529a4f43ed14327f5c54aab62"),
-        ossh_key.public_key().key_data().ed25519().unwrap().as_ref(),
+        key.public_key().key_data().ed25519().unwrap().as_ref(),
     );
 }
 
 #[cfg(all(feature = "encryption", feature = "subtle"))]
 #[test]
 fn decrypt_ed25519_enc_openssh() {
-    let ossh_key_enc = PrivateKey::from_openssh(OSSH_ED25519_ENC_EXAMPLE).unwrap();
-    let ossh_key_dec = ossh_key_enc.decrypt(PASSWORD).unwrap();
+    let key_enc = PrivateKey::from_openssh(OPENSSH_ED25519_ENC_EXAMPLE).unwrap();
+    let key_dec = key_enc.decrypt(PASSWORD).unwrap();
     assert_eq!(
-        PrivateKey::from_openssh(OSSH_ED25519_EXAMPLE).unwrap(),
-        ossh_key_dec
+        PrivateKey::from_openssh(OPENSSH_ED25519_EXAMPLE).unwrap(),
+        key_dec
     );
 }
 
 #[test]
 fn encode_ed25519_enc_openssh() {
-    let ossh_key = PrivateKey::from_openssh(OSSH_ED25519_ENC_EXAMPLE).unwrap();
+    let key = PrivateKey::from_openssh(OPENSSH_ED25519_ENC_EXAMPLE).unwrap();
     assert_eq!(
-        OSSH_ED25519_ENC_EXAMPLE.trim_end(),
-        ossh_key.to_openssh(Default::default()).unwrap().trim_end()
+        OPENSSH_ED25519_ENC_EXAMPLE.trim_end(),
+        key.to_openssh(Default::default()).unwrap().trim_end()
     );
 }

--- a/ssh-key/tests/private_key.rs
+++ b/ssh-key/tests/private_key.rs
@@ -17,41 +17,41 @@ use {
 
 /// DSA OpenSSH-formatted public key
 #[cfg(feature = "alloc")]
-const OSSH_DSA_EXAMPLE: &str = include_str!("examples/id_dsa_1024");
+const OPENSSH_DSA_EXAMPLE: &str = include_str!("examples/id_dsa_1024");
 
 /// Ed25519 OpenSSH-formatted private key
-const OSSH_ED25519_EXAMPLE: &str = include_str!("examples/id_ed25519");
+const OPENSSH_ED25519_EXAMPLE: &str = include_str!("examples/id_ed25519");
 
 /// ECDSA/P-256 OpenSSH-formatted public key
 #[cfg(feature = "ecdsa")]
-const OSSH_ECDSA_P256_EXAMPLE: &str = include_str!("examples/id_ecdsa_p256");
+const OPENSSH_ECDSA_P256_EXAMPLE: &str = include_str!("examples/id_ecdsa_p256");
 
 /// ECDSA/P-384 OpenSSH-formatted public key
 #[cfg(feature = "ecdsa")]
-const OSSH_ECDSA_P384_EXAMPLE: &str = include_str!("examples/id_ecdsa_p384");
+const OPENSSH_ECDSA_P384_EXAMPLE: &str = include_str!("examples/id_ecdsa_p384");
 
 /// ECDSA/P-521 OpenSSH-formatted public key
 #[cfg(feature = "ecdsa")]
-const OSSH_ECDSA_P521_EXAMPLE: &str = include_str!("examples/id_ecdsa_p521");
+const OPENSSH_ECDSA_P521_EXAMPLE: &str = include_str!("examples/id_ecdsa_p521");
 
 /// RSA (3072-bit) OpenSSH-formatted public key
 #[cfg(feature = "alloc")]
-const OSSH_RSA_3072_EXAMPLE: &str = include_str!("examples/id_rsa_3072");
+const OPENSSH_RSA_3072_EXAMPLE: &str = include_str!("examples/id_rsa_3072");
 
 /// RSA (4096-bit) OpenSSH-formatted public key
 #[cfg(feature = "alloc")]
-const OSSH_RSA_4096_EXAMPLE: &str = include_str!("examples/id_rsa_4096");
+const OPENSSH_RSA_4096_EXAMPLE: &str = include_str!("examples/id_rsa_4096");
 
 #[cfg(feature = "alloc")]
 #[test]
 fn decode_dsa_openssh() {
-    let ossh_key = PrivateKey::from_openssh(OSSH_DSA_EXAMPLE).unwrap();
-    assert_eq!(Algorithm::Dsa, ossh_key.algorithm());
-    assert_eq!(CipherAlg::None, ossh_key.cipher_alg());
-    assert_eq!(KdfAlg::None, ossh_key.kdf_alg());
-    assert!(ossh_key.kdf().is_none());
+    let key = PrivateKey::from_openssh(OPENSSH_DSA_EXAMPLE).unwrap();
+    assert_eq!(Algorithm::Dsa, key.algorithm());
+    assert_eq!(CipherAlg::None, key.cipher_alg());
+    assert_eq!(KdfAlg::None, key.kdf().algorithm());
+    assert!(key.kdf().is_none());
 
-    let dsa_keypair = ossh_key.key_data().dsa().unwrap();
+    let dsa_keypair = key.key_data().dsa().unwrap();
     assert_eq!(
         &hex!(
             "00dc3d89250ed9462114cb2c8d4816e3a511aaff1b06b0e01de17c1cb04e581bcab97176471d89fd7ca1817
@@ -84,19 +84,19 @@ fn decode_dsa_openssh() {
         &hex!("0c377ac449e770d89a3557743cbd050396114b62"),
         dsa_keypair.private.as_bytes()
     );
-    assert_eq!("user@example.com", ossh_key.comment());
+    assert_eq!("user@example.com", key.comment());
 }
 
 #[cfg(feature = "ecdsa")]
 #[test]
 fn decode_ecdsa_p256_openssh() {
-    let ossh_key = PrivateKey::from_openssh(OSSH_ECDSA_P256_EXAMPLE).unwrap();
-    assert_eq!(Algorithm::Ecdsa(EcdsaCurve::NistP256), ossh_key.algorithm(),);
-    assert_eq!(CipherAlg::None, ossh_key.cipher_alg());
-    assert_eq!(KdfAlg::None, ossh_key.kdf_alg());
-    assert!(ossh_key.kdf().is_none());
+    let key = PrivateKey::from_openssh(OPENSSH_ECDSA_P256_EXAMPLE).unwrap();
+    assert_eq!(Algorithm::Ecdsa(EcdsaCurve::NistP256), key.algorithm(),);
+    assert_eq!(CipherAlg::None, key.cipher_alg());
+    assert_eq!(KdfAlg::None, key.kdf().algorithm());
+    assert!(key.kdf().is_none());
 
-    let ecdsa_keypair = ossh_key.key_data().ecdsa().unwrap();
+    let ecdsa_keypair = key.key_data().ecdsa().unwrap();
     assert_eq!(EcdsaCurve::NistP256, ecdsa_keypair.curve());
     assert_eq!(
         &hex!(
@@ -111,19 +111,19 @@ fn decode_ecdsa_p256_openssh() {
     );
 
     #[cfg(feature = "alloc")]
-    assert_eq!("user@example.com", ossh_key.comment());
+    assert_eq!("user@example.com", key.comment());
 }
 
 #[cfg(feature = "ecdsa")]
 #[test]
 fn decode_ecdsa_p384_openssh() {
-    let ossh_key = PrivateKey::from_openssh(OSSH_ECDSA_P384_EXAMPLE).unwrap();
-    assert_eq!(Algorithm::Ecdsa(EcdsaCurve::NistP384), ossh_key.algorithm(),);
-    assert_eq!(CipherAlg::None, ossh_key.cipher_alg());
-    assert_eq!(KdfAlg::None, ossh_key.kdf_alg());
-    assert!(ossh_key.kdf().is_none());
+    let key = PrivateKey::from_openssh(OPENSSH_ECDSA_P384_EXAMPLE).unwrap();
+    assert_eq!(Algorithm::Ecdsa(EcdsaCurve::NistP384), key.algorithm(),);
+    assert_eq!(CipherAlg::None, key.cipher_alg());
+    assert_eq!(KdfAlg::None, key.kdf().algorithm());
+    assert!(key.kdf().is_none());
 
-    let ecdsa_keypair = ossh_key.key_data().ecdsa().unwrap();
+    let ecdsa_keypair = key.key_data().ecdsa().unwrap();
     assert_eq!(EcdsaCurve::NistP384, ecdsa_keypair.curve());
     assert_eq!(
         &hex!(
@@ -142,19 +142,19 @@ fn decode_ecdsa_p384_openssh() {
     );
 
     #[cfg(feature = "alloc")]
-    assert_eq!("user@example.com", ossh_key.comment());
+    assert_eq!("user@example.com", key.comment());
 }
 
 #[cfg(feature = "ecdsa")]
 #[test]
 fn decode_ecdsa_p521_openssh() {
-    let ossh_key = PrivateKey::from_openssh(OSSH_ECDSA_P521_EXAMPLE).unwrap();
-    assert_eq!(Algorithm::Ecdsa(EcdsaCurve::NistP521), ossh_key.algorithm(),);
-    assert_eq!(CipherAlg::None, ossh_key.cipher_alg());
-    assert_eq!(KdfAlg::None, ossh_key.kdf_alg());
-    assert!(ossh_key.kdf().is_none());
+    let key = PrivateKey::from_openssh(OPENSSH_ECDSA_P521_EXAMPLE).unwrap();
+    assert_eq!(Algorithm::Ecdsa(EcdsaCurve::NistP521), key.algorithm(),);
+    assert_eq!(CipherAlg::None, key.cipher_alg());
+    assert_eq!(KdfAlg::None, key.kdf().algorithm());
+    assert!(key.kdf().is_none());
 
-    let ecdsa_keypair = ossh_key.key_data().ecdsa().unwrap();
+    let ecdsa_keypair = key.key_data().ecdsa().unwrap();
     assert_eq!(EcdsaCurve::NistP521, ecdsa_keypair.curve());
     assert_eq!(
         &hex!(
@@ -174,18 +174,18 @@ fn decode_ecdsa_p521_openssh() {
     );
 
     #[cfg(feature = "alloc")]
-    assert_eq!("user@example.com", ossh_key.comment());
+    assert_eq!("user@example.com", key.comment());
 }
 
 #[test]
 fn decode_ed25519_openssh() {
-    let ossh_key = PrivateKey::from_openssh(OSSH_ED25519_EXAMPLE).unwrap();
-    assert_eq!(Algorithm::Ed25519, ossh_key.algorithm());
-    assert_eq!(CipherAlg::None, ossh_key.cipher_alg());
-    assert_eq!(KdfAlg::None, ossh_key.kdf_alg());
-    assert!(ossh_key.kdf().is_none());
+    let key = PrivateKey::from_openssh(OPENSSH_ED25519_EXAMPLE).unwrap();
+    assert_eq!(Algorithm::Ed25519, key.algorithm());
+    assert_eq!(CipherAlg::None, key.cipher_alg());
+    assert_eq!(KdfAlg::None, key.kdf().algorithm());
+    assert!(key.kdf().is_none());
 
-    let ed25519_keypair = ossh_key.key_data().ed25519().unwrap();
+    let ed25519_keypair = key.key_data().ed25519().unwrap();
     assert_eq!(
         &hex!("b33eaef37ea2df7caa010defdea34e241f65f1b529a4f43ed14327f5c54aab62"),
         ed25519_keypair.public.as_ref(),
@@ -196,19 +196,19 @@ fn decode_ed25519_openssh() {
     );
 
     #[cfg(feature = "alloc")]
-    assert_eq!(ossh_key.comment(), "user@example.com");
+    assert_eq!(key.comment(), "user@example.com");
 }
 
 #[cfg(feature = "alloc")]
 #[test]
 fn decode_rsa_3072_openssh() {
-    let ossh_key = PrivateKey::from_openssh(OSSH_RSA_3072_EXAMPLE).unwrap();
-    assert_eq!(Algorithm::Rsa, ossh_key.algorithm());
-    assert_eq!(CipherAlg::None, ossh_key.cipher_alg());
-    assert_eq!(KdfAlg::None, ossh_key.kdf_alg());
-    assert!(ossh_key.kdf().is_none());
+    let key = PrivateKey::from_openssh(OPENSSH_RSA_3072_EXAMPLE).unwrap();
+    assert_eq!(Algorithm::Rsa, key.algorithm());
+    assert_eq!(CipherAlg::None, key.cipher_alg());
+    assert_eq!(KdfAlg::None, key.kdf().algorithm());
+    assert!(key.kdf().is_none());
 
-    let rsa_keypair = ossh_key.key_data().rsa().unwrap();
+    let rsa_keypair = key.key_data().rsa().unwrap();
     assert_eq!(&hex!("010001"), rsa_keypair.public.e.as_bytes());
     assert_eq!(
         &hex!(
@@ -268,19 +268,19 @@ fn decode_rsa_3072_openssh() {
         ),
         rsa_keypair.private.q.as_bytes()
     );
-    assert_eq!("user@example.com", ossh_key.comment());
+    assert_eq!("user@example.com", key.comment());
 }
 
 #[cfg(feature = "alloc")]
 #[test]
 fn decode_rsa_4096_openssh() {
-    let ossh_key = PrivateKey::from_openssh(OSSH_RSA_4096_EXAMPLE).unwrap();
-    assert_eq!(Algorithm::Rsa, ossh_key.algorithm());
-    assert_eq!(CipherAlg::None, ossh_key.cipher_alg());
-    assert_eq!(KdfAlg::None, ossh_key.kdf_alg());
-    assert!(ossh_key.kdf().is_none());
+    let key = PrivateKey::from_openssh(OPENSSH_RSA_4096_EXAMPLE).unwrap();
+    assert_eq!(Algorithm::Rsa, key.algorithm());
+    assert_eq!(CipherAlg::None, key.cipher_alg());
+    assert_eq!(KdfAlg::None, key.kdf().algorithm());
+    assert!(key.kdf().is_none());
 
-    let rsa_keypair = ossh_key.key_data().rsa().unwrap();
+    let rsa_keypair = key.key_data().rsa().unwrap();
     assert_eq!(&hex!("010001"), rsa_keypair.public.e.as_bytes());
     assert_eq!(
         &hex!(
@@ -349,63 +349,63 @@ fn decode_rsa_4096_openssh() {
         ),
         rsa_keypair.private.q.as_bytes()
     );
-    assert_eq!("user@example.com", ossh_key.comment());
+    assert_eq!("user@example.com", key.comment());
 }
 
 #[cfg(all(feature = "alloc", feature = "subtle"))]
 #[test]
 fn encode_dsa_openssh() {
-    encoding_test(OSSH_DSA_EXAMPLE)
+    encoding_test(OPENSSH_DSA_EXAMPLE)
 }
 
 #[cfg(all(feature = "alloc", feature = "ecdsa", feature = "subtle"))]
 #[test]
 fn encode_ecdsa_p256_openssh() {
-    encoding_test(OSSH_ECDSA_P256_EXAMPLE)
+    encoding_test(OPENSSH_ECDSA_P256_EXAMPLE)
 }
 
 #[cfg(all(feature = "alloc", feature = "ecdsa", feature = "subtle"))]
 #[test]
 fn encode_ecdsa_p384_openssh() {
-    encoding_test(OSSH_ECDSA_P384_EXAMPLE)
+    encoding_test(OPENSSH_ECDSA_P384_EXAMPLE)
 }
 
 #[cfg(all(feature = "alloc", feature = "ecdsa", feature = "subtle"))]
 #[test]
 fn encode_ecdsa_p521_openssh() {
-    encoding_test(OSSH_ECDSA_P521_EXAMPLE)
+    encoding_test(OPENSSH_ECDSA_P521_EXAMPLE)
 }
 
 #[cfg(all(feature = "alloc", feature = "subtle"))]
 #[test]
 fn encode_ed25519_openssh() {
-    encoding_test(OSSH_ED25519_EXAMPLE)
+    encoding_test(OPENSSH_ED25519_EXAMPLE)
 }
 
 #[cfg(all(feature = "alloc", feature = "subtle"))]
 #[test]
 fn encode_rsa_3072_openssh() {
-    encoding_test(OSSH_RSA_3072_EXAMPLE)
+    encoding_test(OPENSSH_RSA_3072_EXAMPLE)
 }
 
 #[cfg(all(feature = "alloc", feature = "subtle"))]
 #[test]
 fn encode_rsa_4096_openssh() {
-    encoding_test(OSSH_RSA_4096_EXAMPLE)
+    encoding_test(OPENSSH_RSA_4096_EXAMPLE)
 }
 
 /// Common behavior of all encoding tests
 #[cfg(all(feature = "alloc", feature = "subtle"))]
 fn encoding_test(private_key: &str) {
-    let ossh_key = PrivateKey::from_openssh(private_key).unwrap();
+    let key = PrivateKey::from_openssh(private_key).unwrap();
 
     // Ensure key round-trips
-    let ossh_pem = ossh_key.to_openssh(LineEnding::LF).unwrap();
-    let ossh_key2 = PrivateKey::from_openssh(&*ossh_pem).unwrap();
-    assert_eq!(ossh_key, ossh_key2);
+    let ossh_pem = key.to_openssh(LineEnding::LF).unwrap();
+    let key2 = PrivateKey::from_openssh(&*ossh_pem).unwrap();
+    assert_eq!(key, key2);
 
     #[cfg(feature = "std")]
-    encoding_integration_test(ossh_key)
+    encoding_integration_test(key)
 }
 
 /// Parse PEM encoded using `PrivateKey::to_openssh` using the `ssh-keygen` utility.

--- a/ssh-key/tests/public_key.rs
+++ b/ssh-key/tests/public_key.rs
@@ -8,38 +8,38 @@ use ssh_key::EcdsaCurve;
 
 /// DSA OpenSSH-formatted public key
 #[cfg(feature = "alloc")]
-const OSSH_DSA_EXAMPLE: &str = include_str!("examples/id_dsa_1024.pub");
+const OPENSSH_DSA_EXAMPLE: &str = include_str!("examples/id_dsa_1024.pub");
 
 /// ECDSA/P-256 OpenSSH-formatted public key
 #[cfg(feature = "ecdsa")]
-const OSSH_ECDSA_P256_EXAMPLE: &str = include_str!("examples/id_ecdsa_p256.pub");
+const OPENSSH_ECDSA_P256_EXAMPLE: &str = include_str!("examples/id_ecdsa_p256.pub");
 
 /// ECDSA/P-384 OpenSSH-formatted public key
 #[cfg(feature = "ecdsa")]
-const OSSH_ECDSA_P384_EXAMPLE: &str = include_str!("examples/id_ecdsa_p384.pub");
+const OPENSSH_ECDSA_P384_EXAMPLE: &str = include_str!("examples/id_ecdsa_p384.pub");
 
 /// ECDSA/P-521 OpenSSH-formatted public key
 #[cfg(feature = "ecdsa")]
-const OSSH_ECDSA_P521_EXAMPLE: &str = include_str!("examples/id_ecdsa_p521.pub");
+const OPENSSH_ECDSA_P521_EXAMPLE: &str = include_str!("examples/id_ecdsa_p521.pub");
 
 /// Ed25519 OpenSSH-formatted public key
-const OSSH_ED25519_EXAMPLE: &str = include_str!("examples/id_ed25519.pub");
+const OPENSSH_ED25519_EXAMPLE: &str = include_str!("examples/id_ed25519.pub");
 
 /// RSA (3072-bit) OpenSSH-formatted public key
 #[cfg(feature = "alloc")]
-const OSSH_RSA_3072_EXAMPLE: &str = include_str!("examples/id_rsa_3072.pub");
+const OPENSSH_RSA_3072_EXAMPLE: &str = include_str!("examples/id_rsa_3072.pub");
 
 /// RSA (4096-bit) OpenSSH-formatted public key
 #[cfg(feature = "alloc")]
-const OSSH_RSA_4096_EXAMPLE: &str = include_str!("examples/id_rsa_4096.pub");
+const OPENSSH_RSA_4096_EXAMPLE: &str = include_str!("examples/id_rsa_4096.pub");
 
 #[cfg(feature = "alloc")]
 #[test]
 fn decode_dsa_openssh() {
-    let ossh_key = PublicKey::from_openssh(OSSH_DSA_EXAMPLE).unwrap();
-    assert_eq!(Algorithm::Dsa, ossh_key.key_data().algorithm());
+    let key = PublicKey::from_openssh(OPENSSH_DSA_EXAMPLE).unwrap();
+    assert_eq!(Algorithm::Dsa, key.key_data().algorithm());
 
-    let dsa_key = ossh_key.key_data().dsa().unwrap();
+    let dsa_key = key.key_data().dsa().unwrap();
     assert_eq!(
         &hex!(
             "00dc3d89250ed9462114cb2c8d4816e3a511aaff1b06b0e01de17c1cb04e581bcab97176471d89fd7ca1817
@@ -69,11 +69,11 @@ fn decode_dsa_openssh() {
         dsa_key.y.as_bytes(),
     );
 
-    assert_eq!("user@example.com", ossh_key.comment());
+    assert_eq!("user@example.com", key.comment());
 
     #[cfg(feature = "fingerprint")]
     assert_eq!(
-        &ossh_key.fingerprint(Default::default()).to_string(),
+        &key.fingerprint(Default::default()).to_string(),
         "SHA256:Nh0Me49Zh9fDw/VYUfq43IJmI1T+XrjiYONPND8GzaM"
     );
 }
@@ -81,13 +81,13 @@ fn decode_dsa_openssh() {
 #[cfg(feature = "ecdsa")]
 #[test]
 fn decode_ecdsa_p256_openssh() {
-    let ossh_key = PublicKey::from_openssh(OSSH_ECDSA_P256_EXAMPLE).unwrap();
+    let key = PublicKey::from_openssh(OPENSSH_ECDSA_P256_EXAMPLE).unwrap();
     assert_eq!(
         Algorithm::Ecdsa(EcdsaCurve::NistP256),
-        ossh_key.key_data().algorithm(),
+        key.key_data().algorithm(),
     );
 
-    let ecdsa_key = ossh_key.key_data().ecdsa().unwrap();
+    let ecdsa_key = key.key_data().ecdsa().unwrap();
     assert_eq!(EcdsaCurve::NistP256, ecdsa_key.curve());
     assert_eq!(
         &hex!(
@@ -98,11 +98,11 @@ fn decode_ecdsa_p256_openssh() {
     );
 
     #[cfg(feature = "alloc")]
-    assert_eq!("user@example.com", ossh_key.comment());
+    assert_eq!("user@example.com", key.comment());
 
     #[cfg(feature = "fingerprint")]
     assert_eq!(
-        &ossh_key.fingerprint(Default::default()).to_string(),
+        &key.fingerprint(Default::default()).to_string(),
         "SHA256:JQ6FV0rf7qqJHZqIj4zNH8eV0oB8KLKh9Pph3FTD98g"
     );
 }
@@ -110,13 +110,13 @@ fn decode_ecdsa_p256_openssh() {
 #[cfg(feature = "ecdsa")]
 #[test]
 fn decode_ecdsa_p384_openssh() {
-    let ossh_key = PublicKey::from_openssh(OSSH_ECDSA_P384_EXAMPLE).unwrap();
+    let key = PublicKey::from_openssh(OPENSSH_ECDSA_P384_EXAMPLE).unwrap();
     assert_eq!(
         Algorithm::Ecdsa(EcdsaCurve::NistP384),
-        ossh_key.key_data().algorithm(),
+        key.key_data().algorithm(),
     );
 
-    let ecdsa_key = ossh_key.key_data().ecdsa().unwrap();
+    let ecdsa_key = key.key_data().ecdsa().unwrap();
     assert_eq!(EcdsaCurve::NistP384, ecdsa_key.curve());
     assert_eq!(
         &hex!(
@@ -128,11 +128,11 @@ fn decode_ecdsa_p384_openssh() {
     );
 
     #[cfg(feature = "alloc")]
-    assert_eq!("user@example.com", ossh_key.comment());
+    assert_eq!("user@example.com", key.comment());
 
     #[cfg(feature = "fingerprint")]
     assert_eq!(
-        &ossh_key.fingerprint(Default::default()).to_string(),
+        &key.fingerprint(Default::default()).to_string(),
         "SHA256:nkGE8oV7pHvOiPKHtQRs67WUPiVLRxbNu//gV/k4Vjw"
     );
 }
@@ -140,13 +140,13 @@ fn decode_ecdsa_p384_openssh() {
 #[cfg(feature = "ecdsa")]
 #[test]
 fn decode_ecdsa_p521_openssh() {
-    let ossh_key = PublicKey::from_openssh(OSSH_ECDSA_P521_EXAMPLE).unwrap();
+    let key = PublicKey::from_openssh(OPENSSH_ECDSA_P521_EXAMPLE).unwrap();
     assert_eq!(
         Algorithm::Ecdsa(EcdsaCurve::NistP521),
-        ossh_key.key_data().algorithm(),
+        key.key_data().algorithm(),
     );
 
-    let ecdsa_key = ossh_key.key_data().ecdsa().unwrap();
+    let ecdsa_key = key.key_data().ecdsa().unwrap();
     assert_eq!(ecdsa_key.curve(), EcdsaCurve::NistP521);
     assert_eq!(
         &hex!(
@@ -159,31 +159,31 @@ fn decode_ecdsa_p521_openssh() {
     );
 
     #[cfg(feature = "alloc")]
-    assert_eq!("user@example.com", ossh_key.comment());
+    assert_eq!("user@example.com", key.comment());
 
     #[cfg(feature = "fingerprint")]
     assert_eq!(
-        &ossh_key.fingerprint(Default::default()).to_string(),
+        &key.fingerprint(Default::default()).to_string(),
         "SHA256:l3AUUMK6Q2BbuiqvMx2fs97f8LUYq7sWCAx7q5m3S6M"
     );
 }
 
 #[test]
 fn decode_ed25519_openssh() {
-    let ossh_key = PublicKey::from_openssh(OSSH_ED25519_EXAMPLE).unwrap();
+    let key = PublicKey::from_openssh(OPENSSH_ED25519_EXAMPLE).unwrap();
 
-    assert_eq!(Algorithm::Ed25519, ossh_key.key_data().algorithm());
+    assert_eq!(Algorithm::Ed25519, key.key_data().algorithm());
     assert_eq!(
         &hex!("b33eaef37ea2df7caa010defdea34e241f65f1b529a4f43ed14327f5c54aab62"),
-        ossh_key.key_data().ed25519().unwrap().as_ref(),
+        key.key_data().ed25519().unwrap().as_ref(),
     );
 
     #[cfg(feature = "alloc")]
-    assert_eq!("user@example.com", ossh_key.comment());
+    assert_eq!("user@example.com", key.comment());
 
     #[cfg(feature = "fingerprint")]
     assert_eq!(
-        &ossh_key.fingerprint(Default::default()).to_string(),
+        &key.fingerprint(Default::default()).to_string(),
         "SHA256:UCUiLr7Pjs9wFFJMDByLgc3NrtdU344OgUM45wZPcIQ"
     );
 }
@@ -191,10 +191,10 @@ fn decode_ed25519_openssh() {
 #[cfg(feature = "alloc")]
 #[test]
 fn decode_rsa_3072_openssh() {
-    let ossh_key = PublicKey::from_openssh(OSSH_RSA_3072_EXAMPLE).unwrap();
-    assert_eq!(Algorithm::Rsa, ossh_key.key_data().algorithm());
+    let key = PublicKey::from_openssh(OPENSSH_RSA_3072_EXAMPLE).unwrap();
+    assert_eq!(Algorithm::Rsa, key.key_data().algorithm());
 
-    let rsa_key = ossh_key.key_data().rsa().unwrap();
+    let rsa_key = key.key_data().rsa().unwrap();
     assert_eq!(&hex!("010001"), rsa_key.e.as_bytes());
     assert_eq!(
         &hex!(
@@ -211,11 +211,11 @@ fn decode_rsa_3072_openssh() {
         rsa_key.n.as_bytes(),
     );
 
-    assert_eq!("user@example.com", ossh_key.comment());
+    assert_eq!("user@example.com", key.comment());
 
     #[cfg(feature = "fingerprint")]
     assert_eq!(
-        &ossh_key.fingerprint(Default::default()).to_string(),
+        &key.fingerprint(Default::default()).to_string(),
         "SHA256:Fmxts/GcV77PakFnf1Ueki5mpU4ZjUQWGRjZGAo3n/I"
     );
 }
@@ -223,10 +223,10 @@ fn decode_rsa_3072_openssh() {
 #[cfg(feature = "alloc")]
 #[test]
 fn decode_rsa_4096_openssh() {
-    let ossh_key = PublicKey::from_openssh(OSSH_RSA_4096_EXAMPLE).unwrap();
-    assert_eq!(Algorithm::Rsa, ossh_key.key_data().algorithm());
+    let key = PublicKey::from_openssh(OPENSSH_RSA_4096_EXAMPLE).unwrap();
+    assert_eq!(Algorithm::Rsa, key.key_data().algorithm());
 
-    let rsa_key = ossh_key.key_data().rsa().unwrap();
+    let rsa_key = key.key_data().rsa().unwrap();
     assert_eq!(&hex!("010001"), rsa_key.e.as_bytes());
     assert_eq!(
         &hex!(
@@ -246,11 +246,11 @@ fn decode_rsa_4096_openssh() {
         rsa_key.n.as_bytes(),
     );
 
-    assert_eq!("user@example.com", ossh_key.comment());
+    assert_eq!("user@example.com", key.comment());
 
     #[cfg(feature = "fingerprint")]
     assert_eq!(
-        &ossh_key.fingerprint(Default::default()).to_string(),
+        &key.fingerprint(Default::default()).to_string(),
         "SHA256:FKAyeywtQNZLl1YTzIzCV/ThadBlnWMaD7jHQYDseEY"
     );
 }
@@ -258,48 +258,48 @@ fn decode_rsa_4096_openssh() {
 #[cfg(feature = "alloc")]
 #[test]
 fn encode_dsa_openssh() {
-    let ossh_key = PublicKey::from_openssh(OSSH_DSA_EXAMPLE).unwrap();
-    assert_eq!(OSSH_DSA_EXAMPLE.trim_end(), &ossh_key.to_string());
+    let key = PublicKey::from_openssh(OPENSSH_DSA_EXAMPLE).unwrap();
+    assert_eq!(OPENSSH_DSA_EXAMPLE.trim_end(), &key.to_string());
 }
 
 #[cfg(all(feature = "alloc", feature = "ecdsa"))]
 #[test]
 fn encode_ecdsa_p256_openssh() {
-    let ossh_key = PublicKey::from_openssh(OSSH_ECDSA_P256_EXAMPLE).unwrap();
-    assert_eq!(OSSH_ECDSA_P256_EXAMPLE.trim_end(), &ossh_key.to_string());
+    let key = PublicKey::from_openssh(OPENSSH_ECDSA_P256_EXAMPLE).unwrap();
+    assert_eq!(OPENSSH_ECDSA_P256_EXAMPLE.trim_end(), &key.to_string());
 }
 
 #[cfg(all(feature = "alloc", feature = "ecdsa"))]
 #[test]
 fn encode_ecdsa_p384_openssh() {
-    let ossh_key = PublicKey::from_openssh(OSSH_ECDSA_P384_EXAMPLE).unwrap();
-    assert_eq!(OSSH_ECDSA_P384_EXAMPLE.trim_end(), &ossh_key.to_string());
+    let key = PublicKey::from_openssh(OPENSSH_ECDSA_P384_EXAMPLE).unwrap();
+    assert_eq!(OPENSSH_ECDSA_P384_EXAMPLE.trim_end(), &key.to_string());
 }
 
 #[cfg(all(feature = "alloc", feature = "ecdsa"))]
 #[test]
 fn encode_ecdsa_p521_openssh() {
-    let ossh_key = PublicKey::from_openssh(OSSH_ECDSA_P521_EXAMPLE).unwrap();
-    assert_eq!(OSSH_ECDSA_P521_EXAMPLE.trim_end(), &ossh_key.to_string());
+    let key = PublicKey::from_openssh(OPENSSH_ECDSA_P521_EXAMPLE).unwrap();
+    assert_eq!(OPENSSH_ECDSA_P521_EXAMPLE.trim_end(), &key.to_string());
 }
 
 #[cfg(feature = "alloc")]
 #[test]
 fn encode_ed25519_openssh() {
-    let ossh_key = PublicKey::from_openssh(OSSH_ED25519_EXAMPLE).unwrap();
-    assert_eq!(OSSH_ED25519_EXAMPLE.trim_end(), &ossh_key.to_string());
+    let key = PublicKey::from_openssh(OPENSSH_ED25519_EXAMPLE).unwrap();
+    assert_eq!(OPENSSH_ED25519_EXAMPLE.trim_end(), &key.to_string());
 }
 
 #[cfg(feature = "alloc")]
 #[test]
 fn encode_rsa_3072_openssh() {
-    let ossh_key = PublicKey::from_openssh(OSSH_RSA_3072_EXAMPLE).unwrap();
-    assert_eq!(OSSH_RSA_3072_EXAMPLE.trim_end(), &ossh_key.to_string());
+    let key = PublicKey::from_openssh(OPENSSH_RSA_3072_EXAMPLE).unwrap();
+    assert_eq!(OPENSSH_RSA_3072_EXAMPLE.trim_end(), &key.to_string());
 }
 
 #[cfg(feature = "alloc")]
 #[test]
 fn encode_rsa_4096_openssh() {
-    let ossh_key = PublicKey::from_openssh(OSSH_RSA_4096_EXAMPLE).unwrap();
-    assert_eq!(OSSH_RSA_4096_EXAMPLE.trim_end(), &ossh_key.to_string());
+    let key = PublicKey::from_openssh(OPENSSH_RSA_4096_EXAMPLE).unwrap();
+    assert_eq!(OPENSSH_RSA_4096_EXAMPLE.trim_end(), &key.to_string());
 }


### PR DESCRIPTION
- Removes `PrivateKey::kdf_alg` in favor of `.kdf().algorithm()`
- Removes "ossh_"/"OSSH_" prefixes from test fixtures