### PR TITLE
ssh-key: rename `CipherAlg` => `Cipher`; refactoring

### DIFF
--- a/ssh-key/src/cipher.rs
+++ b/ssh-key/src/cipher.rs
@@ -1,0 +1,114 @@
+//! Symmetric encryption ciphers.
+//!
+//! These are used for encrypting private keys.
+
+use crate::{algorithm::AlgString, Error, Result};
+use core::{fmt, str};
+
+#[cfg(feature = "encryption")]
+use aes::{
+    cipher::{InnerIvInit, KeyInit, StreamCipherCore},
+    Aes256,
+};
+
+/// AES-256 in counter (CTR) mode
+const AES256_CTR: &str = "aes256-ctr";
+
+/// Counter mode with a 32-bit big endian counter.
+#[cfg(feature = "encryption")]
+type Ctr128BE<Cipher> = ctr::CtrCore<Cipher, ctr::flavors::Ctr128BE>;
+
+/// Cipher algorithms.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[non_exhaustive]
+pub enum Cipher {
+    /// AES-256 in counter (CTR) mode.
+    Aes256Ctr,
+}
+
+impl Cipher {
+    /// Maximum length of an algorithm string: `aes256-ctr` (10 chars)
+    const MAX_SIZE: usize = 10;
+
+    /// Decode cipher algorithm from the given `ciphername`.
+    ///
+    /// # Supported cipher names
+    /// - `aes256-ctr`
+    pub fn new(ciphername: &str) -> Result<Self> {
+        match ciphername {
+            AES256_CTR => Ok(Self::Aes256Ctr),
+            _ => Err(Error::Algorithm),
+        }
+    }
+
+    /// Get the string identifier which corresponds to this algorithm.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Aes256Ctr => AES256_CTR,
+        }
+    }
+
+    /// Get the key size for this cipher in bytes.
+    pub fn key_size(self) -> usize {
+        match self {
+            Self::Aes256Ctr => 32,
+        }
+    }
+
+    /// Get the initialization vector size for this cipher in bytes.
+    pub fn iv_size(self) -> usize {
+        match self {
+            Self::Aes256Ctr => 16,
+        }
+    }
+
+    /// Get the block size for this cipher in bytes.
+    pub fn block_size(self) -> usize {
+        match self {
+            Self::Aes256Ctr => 16,
+        }
+    }
+
+    /// Decrypt the ciphertext in the `buffer` in-place using this cipher.
+    #[cfg(feature = "encryption")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "encryption")))]
+    pub fn decrypt(self, key: &[u8], iv: &[u8], buffer: &mut [u8]) -> Result<()> {
+        match self {
+            Self::Aes256Ctr => {
+                let cipher = Aes256::new_from_slice(key)
+                    .and_then(|aes| Ctr128BE::inner_iv_slice_init(aes, iv))
+                    .map_err(|_| Error::Crypto)?;
+
+                cipher
+                    .try_apply_keystream_partial(buffer.into())
+                    .map_err(|_| Error::Crypto)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl AsRef<str> for Cipher {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl AlgString for Cipher {
+    type DecodeBuf = [u8; Self::MAX_SIZE];
+}
+
+impl fmt::Display for Cipher {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl str::FromStr for Cipher {
+    type Err = Error;
+
+    fn from_str(id: &str) -> Result<Self> {
+        Self::new(id)
+    }
+}

--- a/ssh-key/src/lib.rs
+++ b/ssh-key/src/lib.rs
@@ -114,6 +114,7 @@ pub mod private;
 pub mod public;
 
 mod algorithm;
+mod cipher;
 mod decoder;
 mod encoder;
 mod error;
@@ -125,8 +126,9 @@ mod fingerprint;
 mod mpint;
 
 pub use crate::{
-    algorithm::{Algorithm, CipherAlg, EcdsaCurve, HashAlg, KdfAlg},
+    algorithm::{Algorithm, EcdsaCurve, HashAlg, KdfAlg},
     authorized_keys::AuthorizedKeys,
+    cipher::Cipher,
     error::{Error, Result},
     kdf::Kdf,
     private::PrivateKey,

--- a/ssh-key/tests/encrypted_private_key.rs
+++ b/ssh-key/tests/encrypted_private_key.rs
@@ -3,7 +3,7 @@
 #![cfg(feature = "alloc")]
 
 use hex_literal::hex;
-use ssh_key::{Algorithm, Kdf, KdfAlg, PrivateKey};
+use ssh_key::{Algorithm, Cipher, Kdf, KdfAlg, PrivateKey};
 
 /// Unencrypted Ed25519 OpenSSH-formatted private key.
 #[cfg(all(feature = "encryption", feature = "subtle"))]
@@ -22,6 +22,7 @@ const PASSWORD: &[u8] = b"hunter42";
 fn decode_ed25519_enc_openssh() {
     let key = PrivateKey::from_openssh(OPENSSH_ED25519_ENC_EXAMPLE).unwrap();
     assert_eq!(Algorithm::Ed25519, key.algorithm());
+    assert_eq!(Cipher::Aes256Ctr, key.cipher().unwrap());
     assert_eq!(KdfAlg::Bcrypt, key.kdf().algorithm());
 
     match key.kdf() {

--- a/ssh-key/tests/private_key.rs
+++ b/ssh-key/tests/private_key.rs
@@ -1,7 +1,7 @@
 //! SSH private key tests.
 
 use hex_literal::hex;
-use ssh_key::{Algorithm, CipherAlg, KdfAlg, PrivateKey};
+use ssh_key::{Algorithm, KdfAlg, PrivateKey};
 
 #[cfg(feature = "ecdsa")]
 use ssh_key::EcdsaCurve;
@@ -47,7 +47,7 @@ const OPENSSH_RSA_4096_EXAMPLE: &str = include_str!("examples/id_rsa_4096");
 fn decode_dsa_openssh() {
     let key = PrivateKey::from_openssh(OPENSSH_DSA_EXAMPLE).unwrap();
     assert_eq!(Algorithm::Dsa, key.algorithm());
-    assert_eq!(CipherAlg::None, key.cipher_alg());
+    assert_eq!(None, key.cipher());
     assert_eq!(KdfAlg::None, key.kdf().algorithm());
     assert!(key.kdf().is_none());
 
@@ -92,7 +92,7 @@ fn decode_dsa_openssh() {
 fn decode_ecdsa_p256_openssh() {
     let key = PrivateKey::from_openssh(OPENSSH_ECDSA_P256_EXAMPLE).unwrap();
     assert_eq!(Algorithm::Ecdsa(EcdsaCurve::NistP256), key.algorithm(),);
-    assert_eq!(CipherAlg::None, key.cipher_alg());
+    assert_eq!(None, key.cipher());
     assert_eq!(KdfAlg::None, key.kdf().algorithm());
     assert!(key.kdf().is_none());
 
@@ -119,7 +119,7 @@ fn decode_ecdsa_p256_openssh() {
 fn decode_ecdsa_p384_openssh() {
     let key = PrivateKey::from_openssh(OPENSSH_ECDSA_P384_EXAMPLE).unwrap();
     assert_eq!(Algorithm::Ecdsa(EcdsaCurve::NistP384), key.algorithm(),);
-    assert_eq!(CipherAlg::None, key.cipher_alg());
+    assert_eq!(None, key.cipher());
     assert_eq!(KdfAlg::None, key.kdf().algorithm());
     assert!(key.kdf().is_none());
 
@@ -150,7 +150,7 @@ fn decode_ecdsa_p384_openssh() {
 fn decode_ecdsa_p521_openssh() {
     let key = PrivateKey::from_openssh(OPENSSH_ECDSA_P521_EXAMPLE).unwrap();
     assert_eq!(Algorithm::Ecdsa(EcdsaCurve::NistP521), key.algorithm(),);
-    assert_eq!(CipherAlg::None, key.cipher_alg());
+    assert_eq!(None, key.cipher());
     assert_eq!(KdfAlg::None, key.kdf().algorithm());
     assert!(key.kdf().is_none());
 
@@ -181,7 +181,7 @@ fn decode_ecdsa_p521_openssh() {
 fn decode_ed25519_openssh() {
     let key = PrivateKey::from_openssh(OPENSSH_ED25519_EXAMPLE).unwrap();
     assert_eq!(Algorithm::Ed25519, key.algorithm());
-    assert_eq!(CipherAlg::None, key.cipher_alg());
+    assert_eq!(None, key.cipher());
     assert_eq!(KdfAlg::None, key.kdf().algorithm());
     assert!(key.kdf().is_none());
 
@@ -204,7 +204,7 @@ fn decode_ed25519_openssh() {
 fn decode_rsa_3072_openssh() {
     let key = PrivateKey::from_openssh(OPENSSH_RSA_3072_EXAMPLE).unwrap();
     assert_eq!(Algorithm::Rsa, key.algorithm());
-    assert_eq!(CipherAlg::None, key.cipher_alg());
+    assert_eq!(None, key.cipher());
     assert_eq!(KdfAlg::None, key.kdf().algorithm());
     assert!(key.kdf().is_none());
 
@@ -276,7 +276,7 @@ fn decode_rsa_3072_openssh() {
 fn decode_rsa_4096_openssh() {
     let key = PrivateKey::from_openssh(OPENSSH_RSA_4096_EXAMPLE).unwrap();
     assert_eq!(Algorithm::Rsa, key.algorithm());
-    assert_eq!(CipherAlg::None, key.cipher_alg());
+    assert_eq!(None, key.cipher());
     assert_eq!(KdfAlg::None, key.kdf().algorithm());
     assert!(key.kdf().is_none());
 


### PR DESCRIPTION
- Renames the type to `Cipher`
- Models the property of `PrivateKey` as `Option<Cipher>`. This eliminates the need to return `Option` from every method as the type always represents a valid cipher.
- Extracts `Cipher` into a `cipher` module
- Move decryption-related functionality into `Cipher::decrypt`