### PR TITLE
ssh-key: private key encryption support

### DIFF
--- a/.github/workflows/ssh-key.yml
+++ b/.github/workflows/ssh-key.yml
@@ -39,7 +39,7 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - uses: RustCrypto/actions/cargo-hack-install@master
-      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features default,std
+      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features default,getrandom,std
 
   minimal-versions:
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,8 +459,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1074,8 +1076,10 @@ dependencies = [
  "base64ct",
  "bcrypt-pbkdf",
  "ctr",
+ "getrandom",
  "hex-literal",
  "pem-rfc7468",
+ "rand_core",
  "sec1",
  "sha2",
  "subtle",

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -25,6 +25,7 @@ aes = { version = "0.8", optional = true, default-features = false }
 ctr = { version = "0.9", optional = true, default-features = false }
 bcrypt-pbkdf = { version = "0.9", optional = true, default-features = false }
 sec1 = { version = "=0.3.0-pre.1", optional = true, default-features = false, features = ["point"], path = "../sec1" }
+rand_core = { version = "0.6", optional = true, default-features = false }
 sha2 = { version = "0.10", optional = true, default-features = false }
 subtle = { version = "2", optional = true, default-features = false }
 
@@ -33,11 +34,12 @@ hex-literal = "0.3"
 tempfile = "3"
 
 [features]
-default = ["ecdsa", "fingerprint", "std"]
+default = ["ecdsa", "encryption", "fingerprint", "std"]
 alloc = ["zeroize/alloc"]
 ecdsa = ["sec1"]
-encryption = ["aes", "alloc", "bcrypt-pbkdf", "ctr"]
+encryption = ["aes", "alloc", "bcrypt-pbkdf", "ctr", "rand_core"]
 fingerprint = ["sha2"]
+getrandom = ["rand_core/getrandom"]
 std = ["alloc", "base64ct/std"]
 
 [package.metadata.docs.rs]

--- a/ssh-key/README.md
+++ b/ssh-key/README.md
@@ -12,25 +12,25 @@
 ## About
 
 Pure Rust implementation of SSH key file format decoders/encoders as described
-in [RFC4253] and [RFC4716] as well as OpenSSH's [PROTOCOL.key] format specification
-and `authorized_keys` files.
+in [RFC4253] and [RFC4716] as well as OpenSSH's [PROTOCOL.key] format
+specification  and `authorized_keys` files.
 
 ## Features
 
-- [x] Constant-time Base64 decoding/encoding using the `base64ct` crate
+- [x] Constant-time Base64 decoding/encoding using `base64ct`/`pem-rfc7468` crates
 - [x] `no_std` support including support for "heapless" (no-`alloc`) targets
 - [x] Decoding/encoding OpenSSH-formatted public & private keys:
   - [x] DSA (`no_std` + `alloc`)
   - [x] ECDSA (`no_std` "heapless")
   - [x] Ed25519 (`no_std` "heapless")
   - [x] RSA (`no_std` + `alloc`)
+- [x] Encrypted private key support
 - [x] Fingerprint support (SHA-256 only)
 - [x] Parsing `authorized_keys` files
 - [x] Built-in zeroize support for private keys
 
 #### TODO
 
-- [ ] Encrypted private key support
 - [ ] SSH certificate support
 - [ ] Legacy SSH key (pre-OpenSSH) format support
 - [ ] Integrations with other RustCrypto crates (e.g. `ecdsa`, `ed25519`, `rsa`)

--- a/ssh-key/src/algorithm.rs
+++ b/ssh-key/src/algorithm.rs
@@ -363,6 +363,12 @@ impl AlgString for KdfAlg {
     type DecodeBuf = [u8; Self::MAX_SIZE];
 }
 
+impl Default for KdfAlg {
+    fn default() -> KdfAlg {
+        KdfAlg::Bcrypt
+    }
+}
+
 impl fmt::Display for KdfAlg {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())

--- a/ssh-key/src/cipher.rs
+++ b/ssh-key/src/cipher.rs
@@ -74,6 +74,18 @@ impl Cipher {
     #[cfg_attr(docsrs, doc(cfg(feature = "encryption")))]
     pub fn decrypt(self, key: &[u8], iv: &[u8], buffer: &mut [u8]) -> Result<()> {
         match self {
+            // Counter mode encryption and decryption are the same operation
+            Self::Aes256Ctr => self.encrypt(key, iv, buffer)?,
+        }
+
+        Ok(())
+    }
+
+    /// Encrypt the ciphertext in the `buffer` in-place using this cipher.
+    #[cfg(feature = "encryption")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "encryption")))]
+    pub fn encrypt(self, key: &[u8], iv: &[u8], buffer: &mut [u8]) -> Result<()> {
+        match self {
             Self::Aes256Ctr => {
                 let cipher = Aes256::new_from_slice(key)
                     .and_then(|aes| Ctr128BE::inner_iv_slice_init(aes, iv))
@@ -97,6 +109,12 @@ impl AsRef<str> for Cipher {
 
 impl AlgString for Cipher {
     type DecodeBuf = [u8; Self::MAX_SIZE];
+}
+
+impl Default for Cipher {
+    fn default() -> Cipher {
+        Cipher::Aes256Ctr
+    }
 }
 
 impl fmt::Display for Cipher {

--- a/ssh-key/src/encoder.rs
+++ b/ssh-key/src/encoder.rs
@@ -6,6 +6,9 @@ use crate::Result;
 use core::str;
 use pem_rfc7468 as pem;
 
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
 #[cfg(feature = "fingerprint")]
 use sha2::{Digest, Sha256};
 
@@ -101,6 +104,15 @@ impl Encoder for Base64Encoder<'_> {
 impl Encoder for pem::Encoder<'_, '_> {
     fn encode_raw(&mut self, bytes: &[u8]) -> Result<()> {
         Ok(self.encode(bytes)?)
+    }
+}
+
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+impl Encoder for Vec<u8> {
+    fn encode_raw(&mut self, bytes: &[u8]) -> Result<()> {
+        self.extend_from_slice(bytes);
+        Ok(())
     }
 }
 

--- a/ssh-key/src/lib.rs
+++ b/ssh-key/src/lib.rs
@@ -140,8 +140,10 @@ pub use base64ct::LineEnding;
 pub use crate::mpint::MPInt;
 
 #[cfg(feature = "ecdsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
 pub use sec1;
 
 #[cfg(feature = "fingerprint")]
 pub use crate::fingerprint::{Fingerprint, Sha256Fingerprint};
+
+#[cfg(feature = "rand_core")]
+pub use rand_core;

--- a/ssh-key/tests/encrypted_private_key.rs
+++ b/ssh-key/tests/encrypted_private_key.rs
@@ -58,3 +58,21 @@ fn encode_ed25519_enc_openssh() {
         key.to_openssh(Default::default()).unwrap().trim_end()
     );
 }
+
+#[cfg(all(feature = "encryption", feature = "getrandom", feature = "subtle"))]
+#[test]
+fn encrypt_ed25519_openssh() {
+    use rand_core::OsRng;
+
+    let key_dec = PrivateKey::from_openssh(OPENSSH_ED25519_EXAMPLE).unwrap();
+    let key_enc = key_dec.encrypt(&mut OsRng, PASSWORD).unwrap();
+
+    // Ensure encrypted key round trips through encoder/decoder
+    let key_enc_str = key_enc.to_openssh(Default::default()).unwrap();
+    let key_enc2 = PrivateKey::from_openssh(&*key_enc_str).unwrap();
+    assert_eq!(key_enc, key_enc2);
+
+    // Ensure decrypted key matches the original
+    let key_dec2 = key_enc.decrypt(PASSWORD).unwrap();
+    assert_eq!(key_dec, key_dec2);
+}


### PR DESCRIPTION
Support for encrypting an unencrypted SSH private key using the default recommended algorithms:

- Cipher: `aes256-ctr`
- KDF: `bcrypt` (i.e. bcrypt-pbkdf)