### PR TITLE
ssh-key: add `Decoder::decode_length_prefixed`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,10 +459,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1076,7 +1074,6 @@ dependencies = [
  "base64ct",
  "bcrypt-pbkdf",
  "ctr",
- "getrandom",
  "hex-literal",
  "pem-rfc7468",
  "rand_core",

--- a/ssh-key/src/encoder.rs
+++ b/ssh-key/src/encoder.rs
@@ -33,7 +33,7 @@ pub(crate) trait Encode: Sized {
 }
 
 /// Encoder extension trait.
-pub(crate) trait Encoder {
+pub(crate) trait Encoder: Sized {
     /// Encode the given byte slice containing raw unstructured data.
     ///
     /// This is the base encoding method on which the rest of the trait is
@@ -59,6 +59,15 @@ pub(crate) trait Encoder {
     /// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
     fn encode_usize(&mut self, num: usize) -> Result<()> {
         self.encode_u32(u32::try_from(num)?)
+    }
+
+    /// Encodes length-prefixed nested data.
+    ///
+    /// Encodes a `uint32` which identifies the length of some encapsulated
+    /// data, then encodes the value.
+    fn encode_length_prefixed<T: Encode>(&mut self, value: &T) -> Result<()> {
+        self.encode_usize(value.encoded_len()?)?;
+        value.encode(self)
     }
 
     /// Encodes `[u8]` into `byte[n]` as described in [RFC4251 § 5]:

--- a/ssh-key/src/kdf.rs
+++ b/ssh-key/src/kdf.rs
@@ -138,13 +138,11 @@ impl Decode for Kdf {
                 return Err(Error::Algorithm);
 
                 #[cfg(feature = "alloc")]
-                {
-                    // TODO(tarcieri): validate length
-                    let _len = decoder.decode_usize()?;
+                decoder.decode_length_prefixed(|decoder, _len| {
                     let salt = decoder.decode_byte_vec()?;
                     let rounds = decoder.decode_u32()?;
                     Ok(Self::Bcrypt { salt, rounds })
-                }
+                })
             }
         }
     }

--- a/ssh-key/src/private/ecdsa.rs
+++ b/ssh-key/src/private/ecdsa.rs
@@ -33,19 +33,19 @@ impl<const SIZE: usize> EcdsaPrivateKey<SIZE> {
 
     /// Decode ECDSA private key using the provided Base64 decoder.
     fn decode(decoder: &mut impl Decoder) -> Result<Self> {
-        let len = decoder.decode_usize()?;
-
-        if len == SIZE + 1 {
-            // Strip leading zero
-            // TODO(tarcieri): make sure leading zero was necessary
-            if decoder.decode_u8()? != 0 {
-                return Err(Error::FormatEncoding);
+        decoder.decode_length_prefixed(|decoder, len| {
+            if len == SIZE + 1 {
+                // Strip leading zero
+                // TODO(tarcieri): make sure leading zero was necessary
+                if decoder.decode_u8()? != 0 {
+                    return Err(Error::FormatEncoding);
+                }
             }
-        }
 
-        let mut bytes = [0u8; SIZE];
-        decoder.decode_raw(&mut bytes)?;
-        Ok(Self { bytes })
+            let mut bytes = [0u8; SIZE];
+            decoder.decode_raw(&mut bytes)?;
+            Ok(Self { bytes })
+        })
     }
 
     /// Does this private key need to be prefixed with a leading zero?

--- a/ssh-key/src/public/ed25519.rs
+++ b/ssh-key/src/public/ed25519.rs
@@ -5,7 +5,7 @@
 use crate::{
     decoder::{Decode, Decoder},
     encoder::{Encode, Encoder},
-    Error, Result,
+    Result,
 };
 use core::fmt;
 
@@ -27,13 +27,8 @@ impl AsRef<[u8; Self::BYTE_SIZE]> for Ed25519PublicKey {
 
 impl Decode for Ed25519PublicKey {
     fn decode(decoder: &mut impl Decoder) -> Result<Self> {
-        // Validate length prefix
-        if decoder.decode_usize()? != Self::BYTE_SIZE {
-            return Err(Error::Length);
-        }
-
         let mut bytes = [0u8; Self::BYTE_SIZE];
-        decoder.decode_raw(&mut bytes)?;
+        decoder.decode_length_prefixed(|decoder, _len| decoder.decode_raw(&mut bytes))?;
         Ok(Self(bytes))
     }
 }


### PR DESCRIPTION
Adds a helper method for decoding length-prefixed data which calls a provided decoder function/closure and then afterward validates that the correct amount of data was read.

This could potentially be adapted to use a special decoder wrapper which enforces that data can't be read past the end of the buffer, but for now it uses a late check after the inner decoder function is finished.