### PR TITLE
ssh-key: add back `Cipher::None` variant

### DIFF
--- a/ssh-key/src/algorithm.rs
+++ b/ssh-key/src/algorithm.rs
@@ -55,23 +55,6 @@ impl<T: AlgString> Decode for T {
     }
 }
 
-impl<T: AlgString> Decode for Option<T> {
-    fn decode(decoder: &mut impl Decoder) -> Result<Self> {
-        let mut buf = T::DecodeBuf::default();
-        debug_assert!(buf.as_mut().len() >= NONE.len());
-
-        let name = decoder
-            .decode_str(buf.as_mut())
-            .map_err(|_| Error::Algorithm)?;
-
-        if name == NONE {
-            Ok(None)
-        } else {
-            name.parse().map(Some)
-        }
-    }
-}
-
 impl<T: AlgString> Encode for T {
     fn encoded_len(&self) -> Result<usize> {
         Ok(4 + self.as_ref().len())
@@ -79,16 +62,6 @@ impl<T: AlgString> Encode for T {
 
     fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {
         encoder.encode_str(self.as_ref())
-    }
-}
-
-impl<T: AlgString> Encode for Option<T> {
-    fn encoded_len(&self) -> Result<usize> {
-        Ok(4 + self.as_ref().map(AsRef::as_ref).unwrap_or(NONE).len())
-    }
-
-    fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {
-        encoder.encode_str(self.as_ref().map(AsRef::as_ref).unwrap_or(NONE))
     }
 }
 

--- a/ssh-key/src/encoder.rs
+++ b/ssh-key/src/encoder.rs
@@ -16,7 +16,7 @@ use sha2::{Digest, Sha256};
 ///
 /// This is an upper bound where the actual length might be slightly shorter.
 #[cfg(feature = "alloc")]
-pub(crate) fn encoded_len(input_len: usize) -> usize {
+pub(crate) fn base64_encoded_len(input_len: usize) -> usize {
     (((input_len * 4) / 3) + 3) & !3
 }
 

--- a/ssh-key/src/private/rsa.rs
+++ b/ssh-key/src/private/rsa.rs
@@ -4,7 +4,7 @@ use crate::{
     decoder::{Decode, Decoder},
     encoder::{Encode, Encoder},
     public::RsaPublicKey,
-    MPInt, Result,
+    Error, MPInt, Result,
 };
 use core::fmt;
 use zeroize::Zeroize;
@@ -43,7 +43,8 @@ impl Encode for RsaPrivateKey {
     fn encoded_len(&self) -> Result<usize> {
         [&self.d, &self.iqmp, &self.p, &self.q]
             .iter()
-            .fold(Ok(0), |acc, n| Ok(acc? + n.encoded_len()?))
+            .try_fold(0usize, |acc, n| acc.checked_add(n.encoded_len().ok()?))
+            .ok_or(Error::Length)
     }
 
     fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {

--- a/ssh-key/tests/encrypted_private_key.rs
+++ b/ssh-key/tests/encrypted_private_key.rs
@@ -22,7 +22,7 @@ const PASSWORD: &[u8] = b"hunter42";
 fn decode_ed25519_enc_openssh() {
     let key = PrivateKey::from_openssh(OPENSSH_ED25519_ENC_EXAMPLE).unwrap();
     assert_eq!(Algorithm::Ed25519, key.algorithm());
-    assert_eq!(Cipher::Aes256Ctr, key.cipher().unwrap());
+    assert_eq!(Cipher::Aes256Ctr, key.cipher());
     assert_eq!(KdfAlg::Bcrypt, key.kdf().algorithm());
 
     match key.kdf() {

--- a/ssh-key/tests/private_key.rs
+++ b/ssh-key/tests/private_key.rs
@@ -1,7 +1,7 @@
 //! SSH private key tests.
 
 use hex_literal::hex;
-use ssh_key::{Algorithm, KdfAlg, PrivateKey};
+use ssh_key::{Algorithm, Cipher, KdfAlg, PrivateKey};
 
 #[cfg(feature = "ecdsa")]
 use ssh_key::EcdsaCurve;
@@ -47,7 +47,7 @@ const OPENSSH_RSA_4096_EXAMPLE: &str = include_str!("examples/id_rsa_4096");
 fn decode_dsa_openssh() {
     let key = PrivateKey::from_openssh(OPENSSH_DSA_EXAMPLE).unwrap();
     assert_eq!(Algorithm::Dsa, key.algorithm());
-    assert_eq!(None, key.cipher());
+    assert_eq!(Cipher::None, key.cipher());
     assert_eq!(KdfAlg::None, key.kdf().algorithm());
     assert!(key.kdf().is_none());
 
@@ -92,7 +92,7 @@ fn decode_dsa_openssh() {
 fn decode_ecdsa_p256_openssh() {
     let key = PrivateKey::from_openssh(OPENSSH_ECDSA_P256_EXAMPLE).unwrap();
     assert_eq!(Algorithm::Ecdsa(EcdsaCurve::NistP256), key.algorithm(),);
-    assert_eq!(None, key.cipher());
+    assert_eq!(Cipher::None, key.cipher());
     assert_eq!(KdfAlg::None, key.kdf().algorithm());
     assert!(key.kdf().is_none());
 
@@ -119,7 +119,7 @@ fn decode_ecdsa_p256_openssh() {
 fn decode_ecdsa_p384_openssh() {
     let key = PrivateKey::from_openssh(OPENSSH_ECDSA_P384_EXAMPLE).unwrap();
     assert_eq!(Algorithm::Ecdsa(EcdsaCurve::NistP384), key.algorithm(),);
-    assert_eq!(None, key.cipher());
+    assert_eq!(Cipher::None, key.cipher());
     assert_eq!(KdfAlg::None, key.kdf().algorithm());
     assert!(key.kdf().is_none());
 
@@ -150,7 +150,7 @@ fn decode_ecdsa_p384_openssh() {
 fn decode_ecdsa_p521_openssh() {
     let key = PrivateKey::from_openssh(OPENSSH_ECDSA_P521_EXAMPLE).unwrap();
     assert_eq!(Algorithm::Ecdsa(EcdsaCurve::NistP521), key.algorithm(),);
-    assert_eq!(None, key.cipher());
+    assert_eq!(Cipher::None, key.cipher());
     assert_eq!(KdfAlg::None, key.kdf().algorithm());
     assert!(key.kdf().is_none());
 
@@ -181,7 +181,7 @@ fn decode_ecdsa_p521_openssh() {
 fn decode_ed25519_openssh() {
     let key = PrivateKey::from_openssh(OPENSSH_ED25519_EXAMPLE).unwrap();
     assert_eq!(Algorithm::Ed25519, key.algorithm());
-    assert_eq!(None, key.cipher());
+    assert_eq!(Cipher::None, key.cipher());
     assert_eq!(KdfAlg::None, key.kdf().algorithm());
     assert!(key.kdf().is_none());
 
@@ -204,7 +204,7 @@ fn decode_ed25519_openssh() {
 fn decode_rsa_3072_openssh() {
     let key = PrivateKey::from_openssh(OPENSSH_RSA_3072_EXAMPLE).unwrap();
     assert_eq!(Algorithm::Rsa, key.algorithm());
-    assert_eq!(None, key.cipher());
+    assert_eq!(Cipher::None, key.cipher());
     assert_eq!(KdfAlg::None, key.kdf().algorithm());
     assert!(key.kdf().is_none());
 
@@ -276,7 +276,7 @@ fn decode_rsa_3072_openssh() {
 fn decode_rsa_4096_openssh() {
     let key = PrivateKey::from_openssh(OPENSSH_RSA_4096_EXAMPLE).unwrap();
     assert_eq!(Algorithm::Rsa, key.algorithm());
-    assert_eq!(None, key.cipher());
+    assert_eq!(Cipher::None, key.cipher());
     assert_eq!(KdfAlg::None, key.kdf().algorithm());
     assert!(key.kdf().is_none());
 


### PR DESCRIPTION
It was originally removed in #544, replacing it with `Option<Cipher>`, however there are various properties it'd be nice to attach to `Cipher` which can't be modeled with an `Option`, namely the block size.