### PR TITLE
ssh-key: enforce checked arithmetic

### DIFF
--- a/ssh-key/src/algorithm.rs
+++ b/ssh-key/src/algorithm.rs
@@ -57,7 +57,7 @@ impl<T: AlgString> Decode for T {
 
 impl<T: AlgString> Encode for T {
     fn encoded_len(&self) -> Result<usize> {
-        Ok(4 + self.as_ref().len())
+        4usize.checked_add(self.as_ref().len()).ok_or(Error::Length)
     }
 
     fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {

--- a/ssh-key/src/authorized_keys.rs
+++ b/ssh-key/src/authorized_keys.rs
@@ -296,7 +296,7 @@ impl<'a> ConfigOptsIter<'a> {
                 _ => return Err(Error::CharacterEncoding),
             }
 
-            index += 1;
+            index = index.checked_add(1).ok_or(Error::Length)?;
         }
 
         let remaining = self.0;

--- a/ssh-key/src/cipher.rs
+++ b/ssh-key/src/cipher.rs
@@ -71,6 +71,7 @@ impl Cipher {
 
     /// Compute the length of padding necessary to pad the given input to
     /// the block size.
+    #[allow(clippy::integer_arithmetic)]
     pub fn padding_len(self, input_size: usize) -> usize {
         match input_size % self.block_size() {
             0 => 0,

--- a/ssh-key/src/encoder.rs
+++ b/ssh-key/src/encoder.rs
@@ -16,7 +16,9 @@ use sha2::{Digest, Sha256};
 ///
 /// This is an upper bound where the actual length might be slightly shorter.
 #[cfg(feature = "alloc")]
+#[allow(clippy::integer_arithmetic)]
 pub(crate) fn base64_encoded_len(input_len: usize) -> usize {
+    // TODO(tarcieri): checked arithmetic
     (((input_len * 4) / 3) + 3) & !3
 }
 

--- a/ssh-key/src/kdf.rs
+++ b/ssh-key/src/kdf.rs
@@ -99,7 +99,9 @@ impl Kdf {
         password: impl AsRef<[u8]>,
     ) -> Result<(Zeroizing<Vec<u8>>, Vec<u8>)> {
         let (key_size, iv_size) = cipher.key_and_iv_size().ok_or(Error::Decrypted)?;
-        let mut okm = Zeroizing::new(vec![0u8; key_size + iv_size]);
+        let okm_size = key_size.checked_add(iv_size).ok_or(Error::Length)?;
+
+        let mut okm = Zeroizing::new(vec![0u8; okm_size]);
         self.derive(password, &mut okm)?;
         let iv = okm.split_off(key_size);
         Ok((okm, iv))

--- a/ssh-key/src/lib.rs
+++ b/ssh-key/src/lib.rs
@@ -6,7 +6,13 @@
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
-#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+#![warn(
+    missing_docs,
+    rust_2018_idioms,
+    unused_lifetimes,
+    unused_qualifications,
+    clippy::integer_arithmetic
+)]
 
 //! ## Usage
 //!

--- a/ssh-key/src/mpint.rs
+++ b/ssh-key/src/mpint.rs
@@ -95,7 +95,9 @@ impl Decode for MPInt {
 
 impl Encode for MPInt {
     fn encoded_len(&self) -> Result<usize> {
-        Ok(4 + self.as_bytes().len())
+        4usize
+            .checked_add(self.as_bytes().len())
+            .ok_or(Error::Length)
     }
 
     fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {

--- a/ssh-key/src/private/dsa.rs
+++ b/ssh-key/src/private/dsa.rs
@@ -4,7 +4,7 @@ use crate::{
     decoder::{Decode, Decoder},
     encoder::{Encode, Encoder},
     public::DsaPublicKey,
-    MPInt, Result,
+    Error, MPInt, Result,
 };
 use core::fmt;
 use zeroize::Zeroize;
@@ -113,7 +113,10 @@ impl Decode for DsaKeypair {
 
 impl Encode for DsaKeypair {
     fn encoded_len(&self) -> Result<usize> {
-        Ok(self.public.encoded_len()? + self.private.encoded_len()?)
+        self.public
+            .encoded_len()?
+            .checked_add(self.private.encoded_len()?)
+            .ok_or(Error::Length)
     }
 
     fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {

--- a/ssh-key/src/private/ed25519.rs
+++ b/ssh-key/src/private/ed25519.rs
@@ -133,7 +133,11 @@ impl Decode for Ed25519Keypair {
 
 impl Encode for Ed25519Keypair {
     fn encoded_len(&self) -> Result<usize> {
-        Ok(self.public.encoded_len()? + 4 + Self::BYTE_SIZE)
+        self.public
+            .encoded_len()?
+            .checked_add(4)
+            .and_then(|len| len.checked_add(Self::BYTE_SIZE))
+            .ok_or(Error::Length)
     }
 
     fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {

--- a/ssh-key/src/private/rsa.rs
+++ b/ssh-key/src/private/rsa.rs
@@ -109,9 +109,14 @@ impl Decode for RsaKeypair {
 
 impl Encode for RsaKeypair {
     fn encoded_len(&self) -> Result<usize> {
-        Ok(self.public.n.encoded_len()?
-            + self.public.e.encoded_len()?
-            + self.private.encoded_len()?)
+        [
+            self.public.n.encoded_len()?,
+            self.public.e.encoded_len()?,
+            self.private.encoded_len()?,
+        ]
+        .iter()
+        .try_fold(0usize, |acc, &len| acc.checked_add(len))
+        .ok_or(Error::Length)
     }
 
     fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {

--- a/ssh-key/src/public/dsa.rs
+++ b/ssh-key/src/public/dsa.rs
@@ -3,7 +3,7 @@
 use crate::{
     decoder::{Decode, Decoder},
     encoder::{Encode, Encoder},
-    MPInt, Result,
+    Error, MPInt, Result,
 };
 
 /// Digital Signature Algorithm (DSA) public key.
@@ -47,10 +47,10 @@ impl Decode for DsaPublicKey {
 
 impl Encode for DsaPublicKey {
     fn encoded_len(&self) -> Result<usize> {
-        Ok(self.p.encoded_len()?
-            + self.q.encoded_len()?
-            + self.g.encoded_len()?
-            + self.y.encoded_len()?)
+        [&self.p, &self.q, &self.g, &self.y]
+            .iter()
+            .try_fold(0usize, |acc, n| acc.checked_add(n.encoded_len().ok()?))
+            .ok_or(Error::Length)
     }
 
     fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {

--- a/ssh-key/src/public/ecdsa.rs
+++ b/ssh-key/src/public/ecdsa.rs
@@ -107,7 +107,10 @@ impl Decode for EcdsaPublicKey {
 
 impl Encode for EcdsaPublicKey {
     fn encoded_len(&self) -> Result<usize> {
-        Ok(4 + self.curve().encoded_len()? + self.as_ref().len())
+        4usize
+            .checked_add(self.curve().encoded_len()?)
+            .and_then(|len| len.checked_add(self.as_ref().len()))
+            .ok_or(Error::Length)
     }
 
     fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {

--- a/ssh-key/src/public/ed25519.rs
+++ b/ssh-key/src/public/ed25519.rs
@@ -5,7 +5,7 @@
 use crate::{
     decoder::{Decode, Decoder},
     encoder::{Encode, Encoder},
-    Result,
+    Error, Result,
 };
 use core::fmt;
 
@@ -35,7 +35,7 @@ impl Decode for Ed25519PublicKey {
 
 impl Encode for Ed25519PublicKey {
     fn encoded_len(&self) -> Result<usize> {
-        Ok(4 + Self::BYTE_SIZE)
+        4usize.checked_add(Self::BYTE_SIZE).ok_or(Error::Length)
     }
 
     fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {

--- a/ssh-key/src/public/rsa.rs
+++ b/ssh-key/src/public/rsa.rs
@@ -3,7 +3,7 @@
 use crate::{
     decoder::{Decode, Decoder},
     encoder::{Encode, Encoder},
-    MPInt, Result,
+    Error, MPInt, Result,
 };
 
 /// RSA public key.
@@ -38,7 +38,10 @@ impl Decode for RsaPublicKey {
 
 impl Encode for RsaPublicKey {
     fn encoded_len(&self) -> Result<usize> {
-        Ok(self.e.encoded_len()? + self.n.encoded_len()?)
+        self.e
+            .encoded_len()?
+            .checked_add(self.n.encoded_len()?)
+            .ok_or(Error::Length)
     }
 
     fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {


### PR DESCRIPTION
Code is now warning-free under the `clippy::integer_arithmetic` lint.

Additionally adds a check that decoded ciphertexts are properly aligned to the expected block size.