### PR TITLE
ssh-key: integration with `ed25519-dalek`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ checksum = "3806a8db60cf56efee531616a34a6aaa9a114d6da2add861b0fa4a188881b2c7"
 dependencies = [
  "blowfish",
  "pbkdf2",
- "sha2",
+ "sha2 0.10.2",
 ]
 
 [[package]]
@@ -94,6 +94,15 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "block-buffer"
@@ -373,6 +382,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core 0.5.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "der"
 version = "0.6.0-pre.3"
 dependencies = [
@@ -406,13 +428,43 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "digest"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.2",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "ed25519"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d5c4b5e5959dc2c2b89918d8e2cc40fcdd623cef026ed09d2f0ee05199dc8e4"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "sha2 0.9.9",
+ "zeroize",
 ]
 
 [[package]]
@@ -490,7 +542,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -613,12 +665,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
 name = "pbkdf2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
- "digest",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -651,7 +709,7 @@ dependencies = [
  "pbkdf2",
  "scrypt",
  "sha1",
- "sha2",
+ "sha2 0.10.2",
  "spki",
 ]
 
@@ -671,7 +729,7 @@ dependencies = [
  "der",
  "hex-literal",
  "pkcs5",
- "rand_core",
+ "rand_core 0.6.3",
  "spki",
  "subtle",
  "zeroize",
@@ -793,7 +851,7 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -803,8 +861,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.3",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 
 [[package]]
 name = "rand_core"
@@ -821,7 +885,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -961,7 +1025,7 @@ dependencies = [
  "hmac",
  "pbkdf2",
  "salsa20",
- "sha2",
+ "sha2 0.10.2",
 ]
 
 [[package]]
@@ -1042,7 +1106,20 @@ checksum = "c77f4e7f65455545c2153c1253d25056825e77ee2533f0e41deb65a93a34852f"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.3",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -1053,8 +1130,14 @@ checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.3",
 ]
+
+[[package]]
+name = "signature"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f054c6c1a6e95179d6f23ed974060dcefb2d9388bb7256900badad682c499de4"
 
 [[package]]
 name = "spki"
@@ -1063,7 +1146,7 @@ dependencies = [
  "base64ct",
  "der",
  "hex-literal",
- "sha2",
+ "sha2 0.10.2",
 ]
 
 [[package]]
@@ -1074,14 +1157,16 @@ dependencies = [
  "base64ct",
  "bcrypt-pbkdf",
  "ctr",
+ "ed25519-dalek",
  "hex-literal",
  "pem-rfc7468",
- "rand_core",
+ "rand_core 0.6.3",
  "sec1",
- "sha2",
+ "sha2 0.10.2",
  "subtle",
  "tempfile",
  "zeroize",
+ "zeroize_derive",
 ]
 
 [[package]]
@@ -1098,6 +1183,18 @@ checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
 dependencies = [
  "proc-macro2",
  "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
  "unicode-xid",
 ]
 
@@ -1343,3 +1440,18 @@ name = "zeroize"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c88870063c39ee00ec285a2f8d6a966e5b6fb2becc4e8dac77ed0d370ed6006"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -24,19 +24,22 @@ zeroize = { version = "1", default-features = false }
 aes = { version = "0.8", optional = true, default-features = false }
 ctr = { version = "0.9", optional = true, default-features = false }
 bcrypt-pbkdf = { version = "0.9", optional = true, default-features = false }
-sec1 = { version = "=0.3.0-pre.1", optional = true, default-features = false, features = ["point"], path = "../sec1" }
+ed25519-dalek = { version = "1.0.1", optional = true, default-features = false, features = ["u64_backend"] }
 rand_core = { version = "0.6", optional = true, default-features = false }
+sec1 = { version = "=0.3.0-pre.1", optional = true, default-features = false, features = ["point"], path = "../sec1" }
 sha2 = { version = "0.10", optional = true, default-features = false }
 subtle = { version = "2", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.3"
 tempfile = "3"
+zeroize_derive = "1.3" # hack to make minimal-versions lint happy (pulled in by `ed25519-dalek`)
 
 [features]
-default = ["ecdsa", "encryption", "fingerprint", "std"]
+default = ["ecdsa", "encryption", "fingerprint", "rand_core", "std"]
 alloc = ["zeroize/alloc"]
 ecdsa = ["sec1"]
+ed25519 = ["ed25519-dalek", "rand_core"]
 encryption = ["aes", "alloc", "bcrypt-pbkdf", "ctr", "rand_core"]
 fingerprint = ["sha2"]
 getrandom = ["rand_core/getrandom"]

--- a/ssh-key/README.md
+++ b/ssh-key/README.md
@@ -24,6 +24,10 @@ specification  and `authorized_keys` files.
   - [x] ECDSA (`no_std` "heapless")
   - [x] Ed25519 (`no_std` "heapless")
   - [x] RSA (`no_std` + `alloc`)
+- [ ] Integrations with other crates
+  - [x] `ed25519-dalek`
+  - [ ] `p256`
+  - [ ] `rsa`
 - [x] Encrypted private key support
 - [x] Fingerprint support (SHA-256 only)
 - [x] Parsing `authorized_keys` files

--- a/ssh-key/src/lib.rs
+++ b/ssh-key/src/lib.rs
@@ -108,6 +108,27 @@
 //! # Ok(())
 //! # }
 //! ```
+//!
+//! ## Generating random keys
+//!
+//! This crate supports generation of random keys using algorithm-specific
+//! backends gated on cargo features.
+//!
+//! The examples below require enabling this crate's `getrandom` feature as
+//! well as the crate feature identified in backticks in the title of each
+//! example.
+//!
+//! ### `ed25519`: support for generating Ed25519 keys using `ed25519_dalek`
+//!
+#![cfg_attr(all(feature = "ed25519", feature = "getrandom"), doc = " ```")]
+#![cfg_attr(
+    not(all(feature = "ed25519", feature = "getrandom")),
+    doc = " ```ignore"
+)]
+//! use ssh_key::{PrivateKey, rand_core::OsRng};
+//!
+//! let private_key = PrivateKey::random_ed25519(&mut OsRng);
+//! ```
 
 #[cfg(feature = "alloc")]
 #[macro_use]

--- a/ssh-key/src/private/keypair.rs
+++ b/ssh-key/src/private/keypair.rs
@@ -49,6 +49,7 @@ pub enum KeypairData {
 
     /// Encrypted private key (ciphertext).
     #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     Encrypted(Vec<u8>),
 
     /// RSA keypair.
@@ -345,6 +346,36 @@ impl TryFrom<&KeypairData> for public::KeyData {
             #[cfg(feature = "alloc")]
             KeypairData::Rsa(rsa) => public::KeyData::Rsa(rsa.into()),
         })
+    }
+}
+
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+impl From<DsaKeypair> for KeypairData {
+    fn from(keypair: DsaKeypair) -> KeypairData {
+        Self::Dsa(keypair)
+    }
+}
+
+#[cfg(feature = "ecdsa")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
+impl From<EcdsaKeypair> for KeypairData {
+    fn from(keypair: EcdsaKeypair) -> KeypairData {
+        Self::Ecdsa(keypair)
+    }
+}
+
+impl From<Ed25519Keypair> for KeypairData {
+    fn from(keypair: Ed25519Keypair) -> KeypairData {
+        Self::Ed25519(keypair)
+    }
+}
+
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+impl From<RsaKeypair> for KeypairData {
+    fn from(keypair: RsaKeypair) -> KeypairData {
+        Self::Rsa(keypair)
     }
 }
 

--- a/ssh-key/src/public.rs
+++ b/ssh-key/src/public.rs
@@ -170,6 +170,13 @@ impl PublicKey {
         .expect("error calculating fingerprint")
     }
 
+    /// Set the comment on the key.
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    pub fn set_comment(&mut self, comment: impl Into<String>) {
+        self.comment = comment.into();
+    }
+
     /// Decode comment (e.g. email address).
     ///
     /// This is a stub implementation that ignores the comment.

--- a/ssh-key/src/public/ed25519.rs
+++ b/ssh-key/src/public/ed25519.rs
@@ -66,3 +66,39 @@ impl fmt::UpperHex for Ed25519PublicKey {
         Ok(())
     }
 }
+
+#[cfg(feature = "ed25519")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ed25519")))]
+impl TryFrom<Ed25519PublicKey> for ed25519_dalek::PublicKey {
+    type Error = Error;
+
+    fn try_from(key: Ed25519PublicKey) -> Result<ed25519_dalek::PublicKey> {
+        ed25519_dalek::PublicKey::try_from(&key)
+    }
+}
+
+#[cfg(feature = "ed25519")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ed25519")))]
+impl TryFrom<&Ed25519PublicKey> for ed25519_dalek::PublicKey {
+    type Error = Error;
+
+    fn try_from(key: &Ed25519PublicKey) -> Result<ed25519_dalek::PublicKey> {
+        ed25519_dalek::PublicKey::from_bytes(key.as_ref()).map_err(|_| Error::Crypto)
+    }
+}
+
+#[cfg(feature = "ed25519")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ed25519")))]
+impl From<ed25519_dalek::PublicKey> for Ed25519PublicKey {
+    fn from(key: ed25519_dalek::PublicKey) -> Ed25519PublicKey {
+        Ed25519PublicKey::from(&key)
+    }
+}
+
+#[cfg(feature = "ed25519")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ed25519")))]
+impl From<&ed25519_dalek::PublicKey> for Ed25519PublicKey {
+    fn from(key: &ed25519_dalek::PublicKey) -> Ed25519PublicKey {
+        Ed25519PublicKey(key.to_bytes())
+    }
+}


### PR DESCRIPTION
Support for converting the following types:

- `Ed25519PrivateKey` <=> `ed25519_dalek::SecretKey`
- `Ed25519PublicKey`  <=> `ed25519_dalek::PublicKey`
- `Ed25519Keypair`    <=> `ed25519_dalek::Keypair`

Also adds `PrivateKey::random_ed25519` to support generating random Ed25519 keys.