### PR TITLE
base64ct: add `clippy::integer_arithmetic` lint

### DIFF
--- a/base64ct/src/decoder.rs
+++ b/base64ct/src/decoder.rs
@@ -121,7 +121,7 @@ impl<'i, E: Variant> Decoder<'i, E> {
             // If there's data in the block buffer, use it
             if !self.block_buffer.is_empty() {
                 let out_rem = out.len().checked_sub(out_pos).ok_or(InvalidLength)?;
-                let bytes = self.block_buffer.take(out_rem);
+                let bytes = self.block_buffer.take(out_rem)?;
                 out[out_pos..][..bytes.len()].copy_from_slice(bytes);
                 out_pos = out_pos.checked_add(bytes.len()).ok_or(InvalidLength)?;
             }
@@ -136,10 +136,10 @@ impl<'i, E: Variant> Decoder<'i, E> {
             let out_rem = out.len().checked_sub(out_pos).ok_or(InvalidLength)?;
             let out_blocks = out_rem / 3;
             let blocks = cmp::min(in_blocks, out_blocks);
-            let in_aligned = self.line.take(blocks * 4);
+            let in_aligned = self.line.take(blocks.checked_mul(4).ok_or(InvalidLength)?);
 
             if !in_aligned.is_empty() {
-                let out_buf = &mut out[out_pos..][..(blocks * 3)];
+                let out_buf = &mut out[out_pos..][..blocks.checked_mul(3).ok_or(InvalidLength)?];
                 let decoded_len = self.perform_decode(in_aligned, out_buf)?.len();
                 out_pos = out_pos.checked_add(decoded_len).ok_or(InvalidLength)?;
             }
@@ -176,10 +176,10 @@ impl<'i, E: Variant> Decoder<'i, E> {
     pub fn decode_to_end<'o>(&mut self, buf: &'o mut Vec<u8>) -> Result<&'o [u8], Error> {
         let start_len = buf.len();
         let remaining_len = self.remaining_len();
-        let total_len = start_len + remaining_len;
+        let total_len = start_len.checked_add(remaining_len).ok_or(InvalidLength)?;
 
         if total_len > buf.capacity() {
-            buf.reserve(total_len - buf.capacity());
+            buf.reserve(total_len.checked_sub(buf.capacity()).ok_or(InvalidLength)?);
         }
 
         // Append `decoded_len` zeroes to the vector
@@ -214,7 +214,8 @@ impl<'i, E: Variant> Decoder<'i, E> {
 
             // Advance the line and attempt to fill tmp
             self.advance_line()?;
-            let line_begin = self.line.take(4 - line_end.len());
+            let len = 4usize.checked_sub(line_end.len()).ok_or(InvalidLength)?;
+            let line_begin = self.line.take(len);
             tmp[line_end.len()..][..line_begin.len()].copy_from_slice(line_begin);
 
             let tmp_len = line_begin
@@ -314,17 +315,17 @@ impl BlockBuffer {
     ///
     /// Returns as many bytes as possible, or an empty slice if the buffer has
     /// already been read to completion.
-    fn take(&mut self, mut nbytes: usize) -> &[u8] {
+    fn take(&mut self, mut nbytes: usize) -> Result<&[u8], Error> {
         debug_assert!(self.position <= self.length);
         let start_pos = self.position;
-        let remaining_len = self.length - start_pos;
+        let remaining_len = self.length.checked_sub(start_pos).ok_or(InvalidLength)?;
 
         if nbytes > remaining_len {
             nbytes = remaining_len;
         }
 
-        self.position += nbytes;
-        &self.decoded[start_pos..][..nbytes]
+        self.position = self.position.checked_add(nbytes).ok_or(InvalidLength)?;
+        Ok(&self.decoded[start_pos..][..nbytes])
     }
 
     /// Have all of the bytes in this buffer been consumed?

--- a/base64ct/src/lib.rs
+++ b/base64ct/src/lib.rs
@@ -6,9 +6,12 @@
     html_root_url = "https://docs.rs/base64ct/1.4.1"
 )]
 #![doc = include_str!("../README.md")]
+#![forbid(clippy::unwrap_used)]
 #![warn(
+    clippy::integer_arithmetic,
     missing_docs,
     rust_2018_idioms,
+    unsafe_code,
     unused_lifetimes,
     unused_qualifications
 )]

--- a/base64ct/src/variant.rs
+++ b/base64ct/src/variant.rs
@@ -1,5 +1,8 @@
 //! Base64 variants
 
+// TODO(tarcieri): explicitly checked/wrapped arithmetic
+#![allow(clippy::integer_arithmetic)]
+
 use core::{fmt::Debug, ops::Range};
 
 pub mod bcrypt;


### PR DESCRIPTION
Ensures that (almost) all arithmetic is checked.

The lint is disabled in several places that need further review. Each of these places has an accompanying TODO.