### PR TITLE
ssh-key: add internal `CheckedSum` trait

### DIFF
--- a/ssh-key/src/algorithm.rs
+++ b/ssh-key/src/algorithm.rs
@@ -1,6 +1,7 @@
 //! Algorithm support.
 
 use crate::{
+    checked::CheckedSum,
     decoder::{Decode, Decoder},
     encoder::{Encode, Encoder},
     Error, Result,
@@ -57,7 +58,7 @@ impl<T: AlgString> Decode for T {
 
 impl<T: AlgString> Encode for T {
     fn encoded_len(&self) -> Result<usize> {
-        4usize.checked_add(self.as_ref().len()).ok_or(Error::Length)
+        [4, self.as_ref().len()].checked_sum()
     }
 
     fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {

--- a/ssh-key/src/checked.rs
+++ b/ssh-key/src/checked.rs
@@ -1,0 +1,22 @@
+//! Checked arithmetic helpers.
+
+use crate::{Error, Result};
+
+/// Extension trait for providing checked [`Iterator::sum`]-like functionality.
+pub(crate) trait CheckedSum<A>: Sized {
+    /// Iterate over the values of this type, computing a checked sum.
+    ///
+    /// Returns [`Error::Length`] on overflow.
+    fn checked_sum(self) -> Result<A>;
+}
+
+impl<T> CheckedSum<usize> for T
+where
+    T: IntoIterator<Item = usize>,
+{
+    fn checked_sum(self) -> Result<usize> {
+        self.into_iter()
+            .try_fold(0usize, |acc, len| acc.checked_add(len))
+            .ok_or(Error::Length)
+    }
+}

--- a/ssh-key/src/lib.rs
+++ b/ssh-key/src/lib.rs
@@ -122,6 +122,7 @@ pub mod private;
 pub mod public;
 
 mod algorithm;
+mod checked;
 mod cipher;
 mod decoder;
 mod encoder;

--- a/ssh-key/src/mpint.rs
+++ b/ssh-key/src/mpint.rs
@@ -1,6 +1,7 @@
 //! Multiple precision integer
 
 use crate::{
+    checked::CheckedSum,
     decoder::{Decode, Decoder},
     encoder::{Encode, Encoder},
     Error, Result,
@@ -95,9 +96,7 @@ impl Decode for MPInt {
 
 impl Encode for MPInt {
     fn encoded_len(&self) -> Result<usize> {
-        4usize
-            .checked_add(self.as_bytes().len())
-            .ok_or(Error::Length)
+        [4, self.as_bytes().len()].checked_sum()
     }
 
     fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {

--- a/ssh-key/src/private/dsa.rs
+++ b/ssh-key/src/private/dsa.rs
@@ -1,10 +1,11 @@
 //! Digital Signature Algorithm (DSA) private keys.
 
 use crate::{
+    checked::CheckedSum,
     decoder::{Decode, Decoder},
     encoder::{Encode, Encoder},
     public::DsaPublicKey,
-    Error, MPInt, Result,
+    MPInt, Result,
 };
 use core::fmt;
 use zeroize::Zeroize;
@@ -113,10 +114,7 @@ impl Decode for DsaKeypair {
 
 impl Encode for DsaKeypair {
     fn encoded_len(&self) -> Result<usize> {
-        self.public
-            .encoded_len()?
-            .checked_add(self.private.encoded_len()?)
-            .ok_or(Error::Length)
+        [self.public.encoded_len()?, self.private.encoded_len()?].checked_sum()
     }
 
     fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {

--- a/ssh-key/src/private/ed25519.rs
+++ b/ssh-key/src/private/ed25519.rs
@@ -3,6 +3,7 @@
 //! Edwards Digital Signature Algorithm (EdDSA) over Curve25519.
 
 use crate::{
+    checked::CheckedSum,
     decoder::{Decode, Decoder},
     encoder::{Encode, Encoder},
     public::Ed25519PublicKey,
@@ -184,11 +185,7 @@ impl Decode for Ed25519Keypair {
 
 impl Encode for Ed25519Keypair {
     fn encoded_len(&self) -> Result<usize> {
-        self.public
-            .encoded_len()?
-            .checked_add(4)
-            .and_then(|len| len.checked_add(Self::BYTE_SIZE))
-            .ok_or(Error::Length)
+        [4, self.public.encoded_len()?, Self::BYTE_SIZE].checked_sum()
     }
 
     fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {

--- a/ssh-key/src/public/dsa.rs
+++ b/ssh-key/src/public/dsa.rs
@@ -1,9 +1,10 @@
 //! Digital Signature Algorithm (DSA) public keys.
 
 use crate::{
+    checked::CheckedSum,
     decoder::{Decode, Decoder},
     encoder::{Encode, Encoder},
-    Error, MPInt, Result,
+    MPInt, Result,
 };
 
 /// Digital Signature Algorithm (DSA) public key.
@@ -47,10 +48,13 @@ impl Decode for DsaPublicKey {
 
 impl Encode for DsaPublicKey {
     fn encoded_len(&self) -> Result<usize> {
-        [&self.p, &self.q, &self.g, &self.y]
-            .iter()
-            .try_fold(0usize, |acc, n| acc.checked_add(n.encoded_len().ok()?))
-            .ok_or(Error::Length)
+        [
+            self.p.encoded_len()?,
+            self.q.encoded_len()?,
+            self.g.encoded_len()?,
+            self.y.encoded_len()?,
+        ]
+        .checked_sum()
     }
 
     fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {

--- a/ssh-key/src/public/ecdsa.rs
+++ b/ssh-key/src/public/ecdsa.rs
@@ -1,6 +1,7 @@
 //! Elliptic Curve Digital Signature Algorithm (ECDSA) public keys.
 
 use crate::{
+    checked::CheckedSum,
     decoder::{Decode, Decoder},
     encoder::{Encode, Encoder},
     Algorithm, EcdsaCurve, Error, Result,
@@ -107,10 +108,7 @@ impl Decode for EcdsaPublicKey {
 
 impl Encode for EcdsaPublicKey {
     fn encoded_len(&self) -> Result<usize> {
-        4usize
-            .checked_add(self.curve().encoded_len()?)
-            .and_then(|len| len.checked_add(self.as_ref().len()))
-            .ok_or(Error::Length)
+        [4, self.curve().encoded_len()?, self.as_ref().len()].checked_sum()
     }
 
     fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {

--- a/ssh-key/src/public/ed25519.rs
+++ b/ssh-key/src/public/ed25519.rs
@@ -3,11 +3,15 @@
 //! Edwards Digital Signature Algorithm (EdDSA) over Curve25519.
 
 use crate::{
+    checked::CheckedSum,
     decoder::{Decode, Decoder},
     encoder::{Encode, Encoder},
-    Error, Result,
+    Result,
 };
 use core::fmt;
+
+#[cfg(feature = "ed25519")]
+use crate::Error;
 
 /// Ed25519 public key.
 // TODO(tarcieri): use `ed25519::PublicKey`? (doesn't exist yet)
@@ -35,7 +39,7 @@ impl Decode for Ed25519PublicKey {
 
 impl Encode for Ed25519PublicKey {
     fn encoded_len(&self) -> Result<usize> {
-        4usize.checked_add(Self::BYTE_SIZE).ok_or(Error::Length)
+        [4, Self::BYTE_SIZE].checked_sum()
     }
 
     fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {

--- a/ssh-key/src/public/rsa.rs
+++ b/ssh-key/src/public/rsa.rs
@@ -1,9 +1,10 @@
 //! Rivest–Shamir–Adleman (RSA) public keys.
 
 use crate::{
+    checked::CheckedSum,
     decoder::{Decode, Decoder},
     encoder::{Encode, Encoder},
-    Error, MPInt, Result,
+    MPInt, Result,
 };
 
 /// RSA public key.
@@ -38,10 +39,7 @@ impl Decode for RsaPublicKey {
 
 impl Encode for RsaPublicKey {
     fn encoded_len(&self) -> Result<usize> {
-        self.e
-            .encoded_len()?
-            .checked_add(self.n.encoded_len()?)
-            .ok_or(Error::Length)
+        [self.e.encoded_len()?, self.n.encoded_len()?].checked_sum()
     }
 
     fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {


### PR DESCRIPTION
Simplifies performing checked arithmetic of `usize`. In the context of this crate, it's primarily useful for clarity and eliminating boilerplate when summing multiple lengths.