### PR TITLE
const-oid: add clippy lints for checked arithmetic and panics

### DIFF
--- a/const-oid/src/checked.rs
+++ b/const-oid/src/checked.rs
@@ -1,0 +1,11 @@
+//! Checked arithmetic helpers.
+
+/// `const fn`-friendly checked addition helper.
+macro_rules! checked_add {
+    ($a:expr, $b:expr) => {
+        match $a.checked_add($b) {
+            Some(n) => n,
+            None => return Err(Error::Length),
+        }
+    };
+}

--- a/const-oid/src/db.rs
+++ b/const-oid/src/db.rs
@@ -9,7 +9,7 @@
 //! [RFC 5280]: https://datatracker.ietf.org/doc/html/rfc5280
 //! [Object Identifier Descriptors]: https://www.iana.org/assignments/ldap-parameters/ldap-parameters.xhtml#ldap-parameters-3
 
-#![allow(missing_docs)]
+#![allow(clippy::integer_arithmetic, missing_docs)]
 
 mod gen;
 

--- a/const-oid/src/error.rs
+++ b/const-oid/src/error.rs
@@ -44,6 +44,24 @@ pub enum Error {
     TrailingDot,
 }
 
+impl Error {
+    /// Escalate this error into a panic.
+    ///
+    /// This is a workaround until `Result::unwrap` is allowed in `const fn`.
+    #[allow(clippy::panic)]
+    pub(crate) const fn panic(self) -> ! {
+        match self {
+            Error::ArcInvalid { .. } | Error::ArcTooBig => panic!("OID contains invalid arc"),
+            Error::Base128 => panic!("OID contains arc with invalid base 128 encoding"),
+            Error::DigitExpected { .. } => panic!("OID expected to start with digit"),
+            Error::Empty => panic!("OID value is empty"),
+            Error::Length => panic!("OID length invalid"),
+            Error::NotEnoughArcs => panic!("OID requires minimum of 3 arcs"),
+            Error::TrailingDot => panic!("OID ends with invalid trailing '.'"),
+        }
+    }
+}
+
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {

--- a/const-oid/src/parser.rs
+++ b/const-oid/src/parser.rs
@@ -49,6 +49,8 @@ impl Parser {
                 }
                 Err(err) => Err(err),
             },
+            // TODO(tarcieri): checked arithmetic
+            #[allow(clippy::integer_arithmetic)]
             [byte @ b'0'..=b'9', remaining @ ..] => {
                 let digit = byte.saturating_sub(b'0');
                 self.current_arc = self.current_arc * 10 + digit as Arc;


### PR DESCRIPTION
Enforces checked arithmetic (where possible) and that production builds don't use panicking macros.

For now some of the arithmetic is annotated with an explicit allow, along with an explanation of why it shouldn't overflow.