### PR TITLE
base64ct: bound `Encoding` on `Variant`

### DIFF
--- a/base64ct/src/encoder.rs
+++ b/base64ct/src/encoder.rs
@@ -1,7 +1,6 @@
 //! Buffered Base64 encoder.
 
 use crate::{
-    variant::Variant,
     Encoding,
     Error::{self, InvalidLength},
     LineEnding, MIN_LINE_WIDTH,
@@ -18,12 +17,7 @@ use crate::{Base64, Base64Unpadded};
 ///
 /// The `E` type parameter can be any type which impls [`Encoding`] such as
 /// [`Base64`] or [`Base64Unpadded`].
-///
-/// Internally it uses a sealed `Variant` trait which is an implementation
-/// detail of this crate, and leverages a [blanket impl] of [`Encoding`].
-///
-/// [blanket impl]: ./trait.Encoding.html#impl-Encoding
-pub struct Encoder<'o, E: Variant> {
+pub struct Encoder<'o, E: Encoding> {
     /// Output buffer.
     output: &'o mut [u8],
 
@@ -41,7 +35,7 @@ pub struct Encoder<'o, E: Variant> {
     encoding: PhantomData<E>,
 }
 
-impl<'o, E: Variant> Encoder<'o, E> {
+impl<'o, E: Encoding> Encoder<'o, E> {
     /// Create a new encoder which writes output to the given byte slice.
     ///
     /// Output constructed using this method is not line-wrapped.
@@ -173,7 +167,7 @@ impl<'o, E: Variant> Encoder<'o, E> {
 
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl<'o, E: Variant> io::Write for Encoder<'o, E> {
+impl<'o, E: Encoding> io::Write for Encoder<'o, E> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.encode(buf)?;
         Ok(buf.len())

--- a/base64ct/src/encoding.rs
+++ b/base64ct/src/encoding.rs
@@ -4,7 +4,7 @@ use crate::{
     errors::{Error, InvalidEncodingError, InvalidLengthError},
     variant::Variant,
 };
-use core::{fmt::Debug, str};
+use core::str;
 
 #[cfg(feature = "alloc")]
 use alloc::{string::String, vec::Vec};
@@ -16,7 +16,7 @@ const PAD: u8 = b'=';
 ///
 /// This trait must be imported to make use of any Base64 variant defined
 /// in this crate.
-pub trait Encoding: 'static + Copy + Debug + Eq + Send + Sized + Sync {
+pub trait Encoding: Variant {
     /// Decode a Base64 string into the provided destination buffer.
     fn decode(src: impl AsRef<[u8]>, dst: &mut [u8]) -> Result<&[u8], Error>;
 


### PR DESCRIPTION
The `Encoding` trait defines this crate's public API, however internally it's implemented in terms of `Variant`.

`Variant` is a sealed trait. Previously it was exposed as the bound on the generic parameter of `Decoder` and `Encoder`.

This is technically a breaking change but it theoretically corrects a deficiency/bug: it was technically possible before for a user of `base64ct` to impl the `Encoding` trait themselves. But this was never intended to be supported, and in theory adding this bound on a sealed trait should both otherwise get the sealed trait out of the public API as well as ensuring that nothing but `base64ct` itself can impl `Encoding`.