### PR TITLE
base64ct v1.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,7 +48,7 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "base64ct"
-version = "1.4.1"
+version = "1.5.0"
 dependencies = [
  "base64",
  "proptest",

--- a/base64ct/CHANGELOG.md
+++ b/base64ct/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.5.0 (2022-03-29)
+### Fixed
+- Ensure checked arithmetic with `clippy::integer_arithmetic` lint ([#557])
+- Prevent foreign impls of `Encoding` by bounding sealed `Variant` trait ([#562])
+
+[#557]: https://github.com/RustCrypto/formats/pull/557
+[#562]: https://github.com/RustCrypto/formats/pull/562
+
 ## 1.4.1 (2022-03-11)
 ### Changed
 - Rename `Decoder::decoded_len` => `::remaining_len` ([#500])

--- a/base64ct/Cargo.toml
+++ b/base64ct/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base64ct"
-version = "1.4.1" # Also update html_root_url in lib.rs when bumping this
+version = "1.5.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Base64 (RFC 4648) which avoids any usages of
 data-dependent branches/LUTs and thereby provides portable "best effort"


### PR DESCRIPTION
### Fixed
- Ensure checked arithmetic with `clippy::integer_arithmetic` lint ([#557])
- Prevent foreign impls of `Encoding` by bounding on sealed `Variant` trait ([#562])

[#557]: https://github.com/RustCrypto/formats/pull/557
[#562]: https://github.com/RustCrypto/formats/pull/562