### PR TITLE
pem-rfc7468:  add clippy lints for checked arithmetic and panics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,7 +665,7 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.4.0"
+version = "0.5.0-pre"
 dependencies = [
  "base64ct",
 ]

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.57"
 const-oid = { version = "0.9", optional = true, path = "../const-oid" }
 der_derive = { version = "=0.6.0-pre.3", optional = true, path = "derive" }
 flagset = { version = "0.4.3", optional = true }
-pem-rfc7468 = { version = "0.4", optional = true, path = "../pem-rfc7468" }
+pem-rfc7468 = { version = "=0.5.0-pre", optional = true, path = "../pem-rfc7468" }
 time = { version = "0.3.4", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/pem-rfc7468/Cargo.toml
+++ b/pem-rfc7468/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pem-rfc7468"
-version = "0.4.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.5.0-pre"
 description = """
 PEM Encoding (RFC 7468) for PKIX, PKCS, and CMS Structures, implementing a
 strict subset of the original Privacy-Enhanced Mail encoding intended

--- a/pem-rfc7468/src/decoder.rs
+++ b/pem-rfc7468/src/decoder.rs
@@ -210,9 +210,8 @@ impl<'a> Encapsulation<'a> {
                 return Err(Error::PostEncapsulationBoundary);
             }
 
-            body = body
-                .get(..(body.len() - slice.len()))
-                .ok_or(Error::PostEncapsulationBoundary)?;
+            let len = body.len().checked_sub(slice.len()).ok_or(Error::Length)?;
+            body = body.get(..len).ok_or(Error::PostEncapsulationBoundary)?;
         }
 
         let encapsulated_text =

--- a/pem-rfc7468/src/grammar.rs
+++ b/pem-rfc7468/src/grammar.rs
@@ -131,7 +131,7 @@ pub(crate) fn strip_trailing_eol(bytes: &[u8]) -> Option<&[u8]> {
 /// - Whitespace MUST NOT contain more than one consecutive WSP character
 // TODO(tarcieri): evaluate whether this is too strict; support '-'
 pub(crate) fn split_label(bytes: &[u8]) -> Option<(&str, &[u8])> {
-    let mut n = 0;
+    let mut n = 0usize;
 
     // TODO(tarcieri): handle hyphens in labels as well as spaces
     let mut last_was_wsp = false;
@@ -154,7 +154,7 @@ pub(crate) fn split_label(bytes: &[u8]) -> Option<(&str, &[u8])> {
             return None;
         }
 
-        n += 1;
+        n = n.checked_add(1)?;
     }
 
     let (raw_label, rest) = bytes.split_at(n);

--- a/pem-rfc7468/src/lib.rs
+++ b/pem-rfc7468/src/lib.rs
@@ -2,11 +2,18 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/pem-rfc7468/0.4.0"
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
-#![forbid(unsafe_code, clippy::unwrap_used)]
-#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+#![forbid(unsafe_code)]
+#![warn(
+    clippy::integer_arithmetic,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_used,
+    missing_docs,
+    rust_2018_idioms,
+    unused_qualifications
+)]
 #![doc = include_str!("../README.md")]
 
 //! # Usage

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.57"
 
 [dependencies]
 base64ct = { version = "1.4", path = "../base64ct" }
-pem-rfc7468 = { version = "0.4", path = "../pem-rfc7468" }
+pem-rfc7468 = { version = "=0.5.0-pre", path = "../pem-rfc7468" }
 zeroize = { version = "1", default-features = false }
 
 # optional dependencies

--- a/ssh-key/src/private.rs
+++ b/ssh-key/src/private.rs
@@ -530,7 +530,7 @@ impl PrivateKey {
             Self::TYPE_LABEL,
             line_ending,
             [base64_len, newline_len].checked_sum()?,
-        ))
+        )?)
     }
 }
 


### PR DESCRIPTION
Enforces checked arithmetic (where possible) and that production builds don't use panicking macros.

This is a breaking change because it makes previously infallible length calculation functions infallible, so it bumps the version to v0.5.0-pre.