### PR TITLE
pem-rfc7468: use `str::from_utf8_unchecked` in `encode`

### DIFF
--- a/pem-rfc7468/src/lib.rs
+++ b/pem-rfc7468/src/lib.rs
@@ -1,10 +1,11 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 #![warn(
     clippy::integer_arithmetic,
     clippy::panic,
@@ -14,7 +15,6 @@
     rust_2018_idioms,
     unused_qualifications
 )]
-#![doc = include_str!("../README.md")]
 
 //! # Usage
 //!


### PR DESCRIPTION
There's a unsafety versus sidechannel resistence tradeoff in converting PEM output by the `Encoder` type to a `str` (which performs branch-heavy UTF-8 validity checks).

This commit introduces a tiny bit of `unsafe` code (the very first `unsafe` code in this crate) to bypass these checks.

In their place, there is both a `debug_assert!` which performs the full `str::from_utf8` check when `debug_assertions` are enabled, as well as an always-on constant time-ish runtime check to ensure characters in the output document are all in the 7-bit ASCII set.