### PR TITLE
pem-rfc7468 v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,7 +665,7 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.5.0-pre"
+version = "0.5.0"
 dependencies = [
  "base64ct",
 ]

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.57"
 const-oid = { version = "0.9", optional = true, path = "../const-oid" }
 der_derive = { version = "=0.6.0-pre.3", optional = true, path = "derive" }
 flagset = { version = "0.4.3", optional = true }
-pem-rfc7468 = { version = "=0.5.0-pre", optional = true, path = "../pem-rfc7468" }
+pem-rfc7468 = { version = "0.5", optional = true, path = "../pem-rfc7468" }
 time = { version = "0.3.4", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/pem-rfc7468/CHANGELOG.md
+++ b/pem-rfc7468/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2022-03-29)
+### Added
+- Clippy lints for checked arithmetic and panics ([#564])
+
+### Changed
+- Use `str::from_utf8_unchecked` in `encode` ([#565])
+
+[#564]: https://github.com/RustCrypto/formats/pull/564
+[#565]: https://github.com/RustCrypto/formats/pull/565
+
 ## 0.4.0 (2022-03-12)
 ### Added
 - Buffered `Decoder` type ([#406])

--- a/pem-rfc7468/Cargo.toml
+++ b/pem-rfc7468/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pem-rfc7468"
-version = "0.5.0-pre"
+version = "0.5.0"
 description = """
 PEM Encoding (RFC 7468) for PKIX, PKCS, and CMS Structures, implementing a
 strict subset of the original Privacy-Enhanced Mail encoding intended

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.57"
 
 [dependencies]
 base64ct = { version = "1.4", path = "../base64ct" }
-pem-rfc7468 = { version = "=0.5.0-pre", path = "../pem-rfc7468" }
+pem-rfc7468 = { version = "0.5", path = "../pem-rfc7468" }
 zeroize = { version = "1", default-features = false }
 
 # optional dependencies


### PR DESCRIPTION
### Added
- Clippy lints for checked arithmetic and panics ([#564])

### Changed
- Use `str::from_utf8_unchecked` in `encode` ([#565])

[#564]: https://github.com/RustCrypto/formats/pull/564
[#565]: https://github.com/RustCrypto/formats/pull/565