### PR TITLE
pem-rfc7468: rename `PemLabel::TYPE_LABEL` => `::PEM_LABEL`

### DIFF
--- a/der/src/document.rs
+++ b/der/src/document.rs
@@ -61,7 +61,7 @@ pub trait Document<'a>: AsRef<[u8]> + Sized + TryFrom<Vec<u8>, Error = Error> {
     {
         let (label, der_bytes) = pem::decode_vec(s.as_bytes())?;
 
-        if label != Self::TYPE_LABEL {
+        if label != Self::PEM_LABEL {
             return Err(pem::Error::Label.into());
         }
 
@@ -76,7 +76,7 @@ pub trait Document<'a>: AsRef<[u8]> + Sized + TryFrom<Vec<u8>, Error = Error> {
         Self: pem::PemLabel,
     {
         Ok(pem::encode_string(
-            Self::TYPE_LABEL,
+            Self::PEM_LABEL,
             line_ending,
             self.as_ref(),
         )?)

--- a/pem-rfc7468/src/lib.rs
+++ b/pem-rfc7468/src/lib.rs
@@ -103,15 +103,15 @@ pub type Base64Encoder<'o> = base64ct::Encoder<'o, base64ct::Base64>;
 /// Marker trait for types with an associated PEM type label.
 pub trait PemLabel {
     /// Expected PEM type label for a given document, e.g. `"PRIVATE KEY"`
-    const TYPE_LABEL: &'static str;
+    const PEM_LABEL: &'static str;
 
     /// Validate that a given label matches the expected label.
     fn validate_pem_label(actual: &str) -> Result<()> {
-        if Self::TYPE_LABEL == actual {
+        if Self::PEM_LABEL == actual {
             Ok(())
         } else {
             Err(Error::UnexpectedTypeLabel {
-                expected: Self::TYPE_LABEL,
+                expected: Self::PEM_LABEL,
             })
         }
     }

--- a/pkcs1/src/private_key/document.rs
+++ b/pkcs1/src/private_key/document.rs
@@ -145,5 +145,5 @@ impl FromStr for RsaPrivateKeyDocument {
 #[cfg(feature = "pem")]
 #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl pem::PemLabel for RsaPrivateKeyDocument {
-    const TYPE_LABEL: &'static str = "RSA PRIVATE KEY";
+    const PEM_LABEL: &'static str = "RSA PRIVATE KEY";
 }

--- a/pkcs1/src/public_key/document.rs
+++ b/pkcs1/src/public_key/document.rs
@@ -139,5 +139,5 @@ impl FromStr for RsaPublicKeyDocument {
 #[cfg(feature = "pem")]
 #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl pem::PemLabel for RsaPublicKeyDocument {
-    const TYPE_LABEL: &'static str = "RSA PUBLIC KEY";
+    const PEM_LABEL: &'static str = "RSA PUBLIC KEY";
 }

--- a/pkcs8/src/document/encrypted_private_key.rs
+++ b/pkcs8/src/document/encrypted_private_key.rs
@@ -110,5 +110,5 @@ impl FromStr for EncryptedPrivateKeyDocument {
 #[cfg(feature = "pem")]
 #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl pem::PemLabel for EncryptedPrivateKeyDocument {
-    const TYPE_LABEL: &'static str = "ENCRYPTED PRIVATE KEY";
+    const PEM_LABEL: &'static str = "ENCRYPTED PRIVATE KEY";
 }

--- a/pkcs8/src/document/private_key.rs
+++ b/pkcs8/src/document/private_key.rs
@@ -198,5 +198,5 @@ impl FromStr for PrivateKeyDocument {
 #[cfg(feature = "pem")]
 #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl pem::PemLabel for PrivateKeyDocument {
-    const TYPE_LABEL: &'static str = "PRIVATE KEY";
+    const PEM_LABEL: &'static str = "PRIVATE KEY";
 }

--- a/sec1/src/private_key/document.rs
+++ b/sec1/src/private_key/document.rs
@@ -145,5 +145,5 @@ impl FromStr for EcPrivateKeyDocument {
 #[cfg(feature = "pem")]
 #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl pem::PemLabel for EcPrivateKeyDocument {
-    const TYPE_LABEL: &'static str = "EC PRIVATE KEY";
+    const PEM_LABEL: &'static str = "EC PRIVATE KEY";
 }

--- a/spki/src/document.rs
+++ b/spki/src/document.rs
@@ -142,5 +142,5 @@ impl FromStr for PublicKeyDocument {
 #[cfg(feature = "pem")]
 #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl pem::PemLabel for PublicKeyDocument {
-    const TYPE_LABEL: &'static str = "PUBLIC KEY";
+    const PEM_LABEL: &'static str = "PUBLIC KEY";
 }

--- a/ssh-key/src/private.rs
+++ b/ssh-key/src/private.rs
@@ -271,7 +271,7 @@ impl PrivateKey {
         out: &'o mut [u8],
     ) -> Result<&'o str> {
         let mut pem_encoder =
-            pem::Encoder::new_wrapped(Self::TYPE_LABEL, PEM_LINE_WIDTH, line_ending, out)?;
+            pem::Encoder::new_wrapped(Self::PEM_LABEL, PEM_LINE_WIDTH, line_ending, out)?;
 
         pem_encoder.encode(Self::AUTH_MAGIC)?;
         self.cipher.encode(&mut pem_encoder)?;
@@ -527,7 +527,7 @@ impl PrivateKey {
             .ok_or(Error::Length)?;
 
         Ok(pem::encapsulated_len(
-            Self::TYPE_LABEL,
+            Self::PEM_LABEL,
             line_ending,
             [base64_len, newline_len].checked_sum()?,
         )?)
@@ -562,7 +562,7 @@ impl From<&PrivateKey> for PublicKey {
 }
 
 impl PemLabel for PrivateKey {
-    const TYPE_LABEL: &'static str = "OPENSSH PRIVATE KEY";
+    const PEM_LABEL: &'static str = "OPENSSH PRIVATE KEY";
 }
 
 impl str::FromStr for PrivateKey {

--- a/x509/src/certificate/document.rs
+++ b/x509/src/certificate/document.rs
@@ -93,5 +93,5 @@ impl FromStr for CertificateDocument {
 #[cfg(feature = "pem")]
 #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl pem::PemLabel for CertificateDocument {
-    const TYPE_LABEL: &'static str = "CERTIFICATE";
+    const PEM_LABEL: &'static str = "CERTIFICATE";
 }


### PR DESCRIPTION
It's more intuitive for the names to match, and also clearer that the label is PEM-related.