### PR TITLE
pem-rfc7468 v0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,7 +665,7 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "base64ct",
 ]

--- a/pem-rfc7468/CHANGELOG.md
+++ b/pem-rfc7468/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.5.0 (2022-03-29)
+## 0.5.1 (2022-03-30)
+### Changed
+- Rename `PemLabel::TYPE_LABEL` => `::PEM_LABEL` ([#568])
+
+[#568]: https://github.com/RustCrypto/formats/pull/568
+
+## 0.5.0 (2022-03-29) [YANKED]
 ### Added
 - Clippy lints for checked arithmetic and panics ([#564])
 

--- a/pem-rfc7468/Cargo.toml
+++ b/pem-rfc7468/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pem-rfc7468"
-version = "0.5.0"
+version = "0.5.1"
 description = """
 PEM Encoding (RFC 7468) for PKIX, PKCS, and CMS Structures, implementing a
 strict subset of the original Privacy-Enhanced Mail encoding intended


### PR DESCRIPTION
### Changed
- Rename `PemLabel::TYPE_LABEL` => `::PEM_LABEL` ([#568])

[#568]: https://github.com/RustCrypto/formats/pull/568