### PR TITLE
ssh-key: add FIDO/U2F algorithms to algorithm registry

### DIFF
--- a/ssh-key/README.md
+++ b/ssh-key/README.md
@@ -27,14 +27,14 @@ specification  and `authorized_keys` files.
 
 #### TODO
 
+- [ ] FIDO/U2F key support (`sk-*`)
 - [ ] Key generation support (WIP - see table below)
+- [ ] OpenSSH certificate support
 - [ ] Interop with digital signature crates
   - [x] `ed25519-dalek`
   - [ ] `p256` (ECDSA)
   - [ ] `p384` (ECDSA)
   - [ ] `rsa`
-- [ ] OpenSSH certificate support
-- [ ] U2F/FIDO2 key support (`sk-*`)
 - [ ] Legacy (pre-OpenSSH) SSH key format support
   - [ ] PKCS#1
   - [ ] PKCS#8
@@ -43,16 +43,16 @@ specification  and `authorized_keys` files.
 
 ## Supported algorithms
 
-| Name                                 | Decoding | Encoding | `no_std`  | Keygen |
-|--------------------------------------|----------|----------|-----------|--------|
-| `ecdsa-sha2-nistp256`                | ✅        | ✅        | heapless  | ⛔️     |
-| `ecdsa-sha2-nistp384`                | ✅        | ✅        | heapless  | ⛔️     |
-| `ecdsa-sha2-nistp521`                | ✅        | ✅        | heapless  | ⛔️     |
-| `ssh-dsa`                            | ✅        | ✅        | `alloc` ️ | ⛔      |
-| `ssh-ed25519`                        | ✅        | ✅        | heapless  | ✅️     |
-| `ssh-rsa`                            | ✅        | ✅        | `alloc`   | ⛔️     |
-| `sk-ecdsa-sha2-nistp256@openssh.com` | ⛔        | ⛔        | -         | ⛔️     |
-| `sk-ssh-ed25519@openssh.com`         | ⛔        | ⛔        | -         | ⛔️     |
+| Name                                 | Decoding | Encoding | Certificates | Keygen | `no_std`  |
+|--------------------------------------|----------|----------|--------------|--------|-----------|
+| `ecdsa-sha2-nistp256`                | ✅       | ✅       | ✅           | ⛔️     | heapless  |
+| `ecdsa-sha2-nistp384`                | ✅       | ✅       | ✅           | ⛔️     | heapless  |
+| `ecdsa-sha2-nistp521`                | ✅       | ✅       | ✅           | ⛔️     | heapless  |
+| `ssh-dsa`                            | ✅       | ✅       | ✅           | ⛔     | `alloc` ️  |
+| `ssh-ed25519`                        | ✅       | ✅       | ✅           | ✅️     | heapless  |
+| `ssh-rsa`                            | ✅       | ✅       | ✅           | ⛔️     | `alloc`   |
+| `sk-ecdsa-sha2-nistp256@openssh.com` | ⛔       | ⛔       | ⛔           | N/A    | -         |
+| `sk-ssh-ed25519@openssh.com`         | ⛔       | ⛔       | ⛔           | N/A    | -         |
 
 ## Minimum Supported Rust Version
 

--- a/ssh-key/src/cipher.rs
+++ b/ssh-key/src/cipher.rs
@@ -30,9 +30,6 @@ pub enum Cipher {
 }
 
 impl Cipher {
-    /// Maximum length of an algorithm string: `aes256-ctr` (10 chars)
-    const MAX_SIZE: usize = 10;
-
     /// Decode cipher algorithm from the given `ciphername`.
     ///
     /// # Supported cipher names
@@ -129,9 +126,7 @@ impl AsRef<str> for Cipher {
     }
 }
 
-impl AlgString for Cipher {
-    type DecodeBuf = [u8; Self::MAX_SIZE];
-}
+impl AlgString for Cipher {}
 
 impl Default for Cipher {
     fn default() -> Cipher {


### PR DESCRIPTION
This commit does *NOT* actually implement support for the FIDO/U2F key formats as described in:

https://cvsweb.openbsd.org/src/usr.bin/ssh/PROTOCOL.u2f?annotate=HEAD

Instead, it only adds support for the algorithm and certificate names to the `Algorithm` and `CertificateAlg` enums:

- `sk-ecdsa-sha2-nistp256@openssh.com`
- `sk-ecdsa-sha2-nistp256-cert-v01@openssh.com`
- `sk-ssh-ed25519@openssh.com`
- `sk-ssh-ed25519-cert-v01@openssh.com`

Actual support for these algorithms remains to be implemented.