### PR TITLE
ssh-key: private key checkint improvements

### DIFF
--- a/ssh-key/src/public.rs
+++ b/ssh-key/src/public.rs
@@ -322,30 +322,6 @@ impl KeyData {
         matches!(self, Self::Rsa(_))
     }
 
-    /// Compute a "checkint" from a public key.
-    ///
-    /// This is a sort of primitive pseudo-MAC used by the OpenSSH key format.
-    // TODO(tarcieri): true randomness or a better algorithm?
-    pub(crate) fn checkint(&self) -> u32 {
-        let bytes = match self {
-            #[cfg(feature = "alloc")]
-            Self::Dsa(dsa) => dsa.checkint_bytes(),
-            #[cfg(feature = "ecdsa")]
-            Self::Ecdsa(ecdsa) => ecdsa.as_sec1_bytes(),
-            Self::Ed25519(ed25519) => ed25519.as_ref(),
-            #[cfg(feature = "alloc")]
-            Self::Rsa(rsa) => rsa.checkint_bytes(),
-        };
-
-        let mut n = 0u32;
-
-        for chunk in bytes.chunks_exact(4) {
-            n ^= u32::from_be_bytes(chunk.try_into().expect("not 4 bytes"));
-        }
-
-        n
-    }
-
     /// Decode [`KeyData`] for the specified algorithm.
     pub(crate) fn decode_algorithm(
         decoder: &mut impl Decoder,

--- a/ssh-key/src/public/dsa.rs
+++ b/ssh-key/src/public/dsa.rs
@@ -27,15 +27,6 @@ pub struct DsaPublicKey {
     pub y: MPInt,
 }
 
-impl DsaPublicKey {
-    /// Borrow the bytes used to compute a "checkint" for this key.
-    ///
-    /// This is a sort of primitive pseudo-MAC used by the OpenSSH key format.
-    pub(super) fn checkint_bytes(&self) -> &[u8] {
-        self.y.as_bytes()
-    }
-}
-
 impl Decode for DsaPublicKey {
     fn decode(decoder: &mut impl Decoder) -> Result<Self> {
         let p = MPInt::decode(decoder)?;

--- a/ssh-key/src/public/rsa.rs
+++ b/ssh-key/src/public/rsa.rs
@@ -20,15 +20,6 @@ pub struct RsaPublicKey {
     pub n: MPInt,
 }
 
-impl RsaPublicKey {
-    /// Borrow the bytes used to compute a "checkint" for this key.
-    ///
-    /// This is a sort of primitive pseudo-MAC used by the OpenSSH key format.
-    pub(super) fn checkint_bytes(&self) -> &[u8] {
-        self.n.as_bytes()
-    }
-}
-
 impl Decode for RsaPublicKey {
     fn decode(decoder: &mut impl Decoder) -> Result<Self> {
         let e = MPInt::decode(decoder)?;


### PR DESCRIPTION
This commit adds support for storing the "checkint" for a private key in the `PrivateKey` type. This makes it possible to reserialize a decoded private key byte-for-byte.

Additionally, encryption and random key generation now generate a random "checkint".

The fallback deterministic method is moved from the public to private key, ensuring that a "checkint" is always secret. This should help prevent hypothetical bitflipping attacks which would be possible if the deterministic checkint were computed from public data.