### PR TITLE
ssh-key: preliminary certificate encoder support

### DIFF
--- a/ssh-key/src/encoder.rs
+++ b/ssh-key/src/encoder.rs
@@ -54,6 +54,16 @@ pub(crate) trait Encoder: Sized {
         self.encode_raw(&num.to_be_bytes())
     }
 
+    /// Encode a `uint64` as described in [RFC4251 § 5]:
+    ///
+    /// > Represents a 64-bit unsigned integer.  Stored as eight bytes in
+    /// > the order of decreasing significance (network byte order).
+    ///
+    /// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
+    fn encode_u64(&mut self, num: u64) -> Result<()> {
+        self.encode_raw(&num.to_be_bytes())
+    }
+
     /// Encode a `usize` as a `uint32` as described in [RFC4251 § 5].
     ///
     /// Uses [`Encoder::encode_u32`] after converting from a `usize`, handling

--- a/ssh-key/tests/certificate.rs
+++ b/ssh-key/tests/certificate.rs
@@ -123,3 +123,31 @@ fn decode_rsa_4096_openssh() {
 
     assert_eq!("user@example.com", key.comment());
 }
+
+#[test]
+fn encode_dsa_openssh() {
+    let key = Certificate::from_str(DSA_CERT_EXAMPLE).unwrap();
+    assert_eq!(DSA_CERT_EXAMPLE.trim_end(), &key.to_string().unwrap());
+}
+
+#[cfg(feature = "ecdsa")]
+#[test]
+fn encode_ecdsa_p256_openssh() {
+    let key = Certificate::from_str(ECDSA_P256_CERT_EXAMPLE).unwrap();
+    assert_eq!(
+        ECDSA_P256_CERT_EXAMPLE.trim_end(),
+        &key.to_string().unwrap()
+    );
+}
+
+#[test]
+fn encode_ed25519_openssh() {
+    let key = Certificate::from_str(ED25519_CERT_EXAMPLE).unwrap();
+    assert_eq!(ED25519_CERT_EXAMPLE.trim_end(), &key.to_string().unwrap());
+}
+
+#[test]
+fn encode_rsa_4096_openssh() {
+    let key = Certificate::from_str(RSA_4096_CERT_EXAMPLE).unwrap();
+    assert_eq!(RSA_4096_CERT_EXAMPLE.trim_end(), &key.to_string().unwrap());
+}


### PR DESCRIPTION
Support for encoding OpenSSH certificates from the `Certificate` type.