### PR TITLE
der: enable arithmetic and casting clippy lints

### DIFF
--- a/der/src/arrayvec.rs
+++ b/der/src/arrayvec.rs
@@ -123,7 +123,7 @@ impl<'a, T> Iterator for Iter<'a, T> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = self.elements.len() - self.position;
+        let len = self.elements.len().saturating_sub(self.position);
         (len, Some(len))
     }
 }

--- a/der/src/asn1/bit_string.rs
+++ b/der/src/asn1/bit_string.rs
@@ -205,6 +205,7 @@ pub struct BitStringIter<'a> {
 impl<'a> Iterator for BitStringIter<'a> {
     type Item = bool;
 
+    #[allow(clippy::integer_arithmetic)]
     fn next(&mut self) -> Option<bool> {
         if self.position >= self.bit_string.bit_len() {
             return None;
@@ -231,6 +232,7 @@ impl<T: flagset::Flags> FixedTag for flagset::FlagSet<T> {
 }
 
 #[cfg(feature = "flagset")]
+#[allow(clippy::integer_arithmetic)]
 impl<'a, T> DecodeValue<'a> for flagset::FlagSet<T>
 where
     T: flagset::Flags,
@@ -256,8 +258,9 @@ where
 }
 
 #[cfg(feature = "flagset")]
+#[allow(clippy::integer_arithmetic)]
 #[inline(always)]
-fn encode<T>(set: &flagset::FlagSet<T>) -> (usize, [u8; 16])
+fn encode_flagset<T>(set: &flagset::FlagSet<T>) -> (usize, [u8; 16])
 where
     T: flagset::Flags,
     u128: From<T::Type>,
@@ -274,6 +277,7 @@ where
 }
 
 #[cfg(feature = "flagset")]
+#[allow(clippy::cast_possible_truncation, clippy::integer_arithmetic)]
 impl<T: flagset::Flags> EncodeValue for flagset::FlagSet<T>
 where
     T::Type: From<bool>,
@@ -281,13 +285,13 @@ where
     u128: From<T::Type>,
 {
     fn value_len(&self) -> Result<Length> {
-        let (lead, buff) = encode(self);
+        let (lead, buff) = encode_flagset(self);
         let buff = &buff[..buff.len() - lead / 8];
         BitString::new((lead % 8) as u8, buff)?.value_len()
     }
 
     fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        let (lead, buff) = encode(self);
+        let (lead, buff) = encode_flagset(self);
         let buff = &buff[..buff.len() - lead / 8];
         BitString::new((lead % 8) as u8, buff)?.encode_value(encoder)
     }

--- a/der/src/asn1/generalized_time.rs
+++ b/der/src/asn1/generalized_time.rs
@@ -4,8 +4,8 @@ use crate::{
     asn1::Any,
     datetime::{self, DateTime},
     ord::OrdIsValueOrd,
-    ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, FixedTag, Header, Length, Result,
-    Tag,
+    ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, ErrorKind, FixedTag, Header,
+    Length, Result, Tag,
 };
 use core::time::Duration;
 
@@ -78,8 +78,12 @@ impl DecodeValue<'_> for GeneralizedTime {
         match *ByteSlice::decode_value(decoder, header)?.as_bytes() {
             // RFC 5280 requires mandatory seconds and Z-normalized time zone
             [y1, y2, y3, y4, mon1, mon2, day1, day2, hour1, hour2, min1, min2, sec1, sec2, b'Z'] => {
-                let year = datetime::decode_decimal(Self::TAG, y1, y2)? as u16 * 100
-                    + datetime::decode_decimal(Self::TAG, y3, y4)? as u16;
+                let year = u16::from(datetime::decode_decimal(Self::TAG, y1, y2)?)
+                    .checked_mul(100)
+                    .and_then(|y| {
+                        y.checked_add(datetime::decode_decimal(Self::TAG, y3, y4).ok()?.into())
+                    })
+                    .ok_or(ErrorKind::DateTime)?;
                 let month = datetime::decode_decimal(Self::TAG, mon1, mon2)?;
                 let day = datetime::decode_decimal(Self::TAG, day1, day2)?;
                 let hour = datetime::decode_decimal(Self::TAG, hour1, hour2)?;
@@ -101,8 +105,8 @@ impl EncodeValue for GeneralizedTime {
     }
 
     fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        let year_hi = (self.0.year() / 100) as u8;
-        let year_lo = (self.0.year() % 100) as u8;
+        let year_hi = u8::try_from(self.0.year() / 100)?;
+        let year_lo = u8::try_from(self.0.year() % 100)?;
 
         datetime::encode_decimal(encoder, Self::TAG, year_hi)?;
         datetime::encode_decimal(encoder, Self::TAG, year_lo)?;

--- a/der/src/asn1/integer/uint.rs
+++ b/der/src/asn1/integer/uint.rs
@@ -54,7 +54,7 @@ pub(crate) fn encode_bytes(encoder: &mut Encoder<'_>, bytes: &[u8]) -> Result<()
 #[inline]
 pub(crate) fn encoded_len(bytes: &[u8]) -> Result<Length> {
     let bytes = strip_leading_zeroes(bytes);
-    Length::try_from(bytes.len())? + needs_leading_zero(bytes) as u8
+    Length::try_from(bytes.len())? + u8::from(needs_leading_zero(bytes))
 }
 
 /// Strip the leading zeroes from the given byte slice

--- a/der/src/asn1/real.rs
+++ b/der/src/asn1/real.rs
@@ -1,5 +1,12 @@
 //! ASN.1 `REAL` support.
 
+// TODO(tarcieri): checked arithmetic
+#![allow(
+    clippy::cast_lossless,
+    clippy::cast_sign_loss,
+    clippy::integer_arithmetic
+)]
+
 use crate::{
     str_slice::StrSlice, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, FixedTag, Header,
     Length, Result, Tag,
@@ -212,6 +219,7 @@ pub(crate) fn mnth_bits_to_u8<const M: usize, const N: usize>(bytes: &[u8]) -> u
 
 /// Decode an f64 as its sign, exponent, and mantissa in u64 and in that order, using bit shifts and masks.
 /// Note: this function **removes** the 1023 bias from the exponent and adds the implicit 1
+#[allow(clippy::cast_possible_truncation)]
 pub(crate) fn decode_f64(f: f64) -> (u64, u64, u64) {
     let bits = f.to_bits();
     let sign = bits >> 63;

--- a/der/src/asn1/set_of.rs
+++ b/der/src/asn1/set_of.rs
@@ -376,9 +376,10 @@ where
 /// This function is used rather than Rust's built-in `[T]::sort_by` in order
 /// to support heapless `no_std` targets as well as to enable bubbling up
 /// sorting errors.
+#[allow(clippy::integer_arithmetic)]
 fn der_sort<T: DerOrd>(slice: &mut [T]) -> Result<()> {
-    for i in 1..=slice.len() {
-        let mut j = i - 1;
+    for i in 0..slice.len() {
+        let mut j = i;
 
         while j > 0 && slice[j - 1].der_cmp(&slice[j])? == Ordering::Greater {
             slice.swap(j - 1, j);

--- a/der/src/error.rs
+++ b/der/src/error.rs
@@ -3,7 +3,7 @@
 pub use core::str::Utf8Error;
 
 use crate::{Length, Tag};
-use core::{convert::Infallible, fmt};
+use core::{convert::Infallible, fmt, num::TryFromIntError};
 
 #[cfg(feature = "oid")]
 use crate::asn1::ObjectIdentifier;
@@ -88,6 +88,15 @@ impl From<ErrorKind> for Error {
 impl From<Infallible> for Error {
     fn from(_: Infallible) -> Error {
         unreachable!()
+    }
+}
+
+impl From<TryFromIntError> for Error {
+    fn from(_: TryFromIntError) -> Error {
+        Error {
+            kind: ErrorKind::Overflow,
+            position: None,
+        }
     }
 }
 

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -8,6 +8,14 @@
 )]
 #![forbid(unsafe_code)]
 #![warn(
+    clippy::cast_lossless,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss,
+    clippy::checked_conversions,
+    clippy::implicit_saturating_sub,
+    clippy::integer_arithmetic,
     clippy::panic,
     clippy::panic_in_result_fn,
     clippy::unwrap_used,

--- a/der/src/tag.rs
+++ b/der/src/tag.rs
@@ -353,7 +353,8 @@ impl fmt::Display for Tag {
             } => write!(
                 f,
                 "APPLICATION [{}] ({})",
-                number, FIELD_TYPE[constructed as usize]
+                number,
+                FIELD_TYPE[usize::from(constructed)]
             ),
             Tag::ContextSpecific {
                 constructed,
@@ -361,7 +362,8 @@ impl fmt::Display for Tag {
             } => write!(
                 f,
                 "CONTEXT-SPECIFIC [{}] ({})",
-                number, FIELD_TYPE[constructed as usize]
+                number,
+                FIELD_TYPE[usize::from(constructed)]
             ),
             Tag::Private {
                 constructed,
@@ -369,7 +371,8 @@ impl fmt::Display for Tag {
             } => write!(
                 f,
                 "PRIVATE [{}] ({})",
-                number, FIELD_TYPE[constructed as usize]
+                number,
+                FIELD_TYPE[usize::from(constructed)]
             ),
         }
     }

--- a/der/src/tag/class.rs
+++ b/der/src/tag/class.rs
@@ -32,8 +32,9 @@ pub enum Class {
 
 impl Class {
     /// Compute the identifier octet for a tag number of this class.
+    #[allow(clippy::integer_arithmetic)]
     pub(super) fn octet(self, constructed: bool, number: TagNumber) -> u8 {
-        self as u8 | number.value() | (constructed as u8 * CONSTRUCTED_FLAG)
+        self as u8 | number.value() | (u8::from(constructed) * CONSTRUCTED_FLAG)
     }
 }
 


### PR DESCRIPTION
Enables the following lints globally:

- `clippy::cast_lossless`
- `clippy::cast_possible_truncation`
- `clippy::cast_possible_wrap`
- `clippy::cast_precision_loss`
- `clippy::cast_sign_loss`
- `clippy::checked_conversions`
- `clippy::implicit_saturating_sub`
- `clippy::integer_arithmetic`

Some code related to datetime-handling and ASN.1 REAL has been grandfathered in and allows these lints, although it's been labeled with TODOs to convert it to checked arithmetic.