### PR TITLE
ssh-key: additional `Signature` documentation

### DIFF
--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -3,14 +3,14 @@ name = "ssh-key"
 version = "0.4.0-pre"
 description = """
 Pure Rust implementation of SSH key file format decoders/encoders as described
-in RFC4251 and RFC4253 as well as the OpenSSH key formats and `authorized_keys`.
-Supports "heapless" `no_std` embedded targets with an optional `alloc` feature.
+in RFC4251 and RFC4253 as well as the OpenSSH key formats, certificates, and
+the `authorized_keys` file format. Supports `no_std` embedded targets.
 """
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/formats/tree/master/ssh-key"
-categories = ["cryptography", "data-structures", "encoding", "no-std", "parser-implementations"]
-keywords = ["crypto", "key", "openssh", "ssh"]
+categories = ["authentication", "cryptography", "encoding", "no-std", "parser-implementations"]
+keywords = ["crypto", "certificate", "key", "openssh", "ssh"]
 readme = "README.md"
 edition = "2021"
 rust-version = "1.57"

--- a/ssh-key/README.md
+++ b/ssh-key/README.md
@@ -13,16 +13,19 @@
 
 Pure Rust implementation of SSH key file format decoders/encoders as described
 in [RFC4251] and [RFC4253] as well as OpenSSH's [PROTOCOL.key] format
-specification  and `authorized_keys` files.
+specification, certificates as specified in [PROTOCOL.certkeys]  and the
+`authorized_keys` file format.
 
 ## Features
 
-- [x] Constant-time Base64 decoding/encoding using `base64ct`/`pem-rfc7468` crates
-- [x] `no_std` support including support for "heapless" (no-`alloc`) targets
-- [x] Decoding/encoding OpenSSH-formatted public/private keys
+- [x] Constant-time Base64 decoder/encoder using `base64ct`/`pem-rfc7468` crates
+- [x] Decoder/encoder support for the following OpenSSH formats:
+  - [x] OpenSSH public keys
+  - [x] OpenSSH private keys (i.e. `BEGIN OPENSSH PRIVATE KEY`)
+  - [x] OpenSSH certificates
 - [x] Private key encryption/decryption (`bcrypt-pbkdf` + `aes256-ctr` only)
-- [x] OpenSSH certificate support
 - [x] Fingerprint support (SHA-256 only)
+- [x] `no_std` support including support for "heapless" (no-`alloc`) targets
 - [x] Parsing `authorized_keys` files
 - [x] Built-in zeroize support for private keys
 
@@ -30,6 +33,7 @@ specification  and `authorized_keys` files.
 
 - [ ] FIDO/U2F key support (`sk-*`)
 - [ ] Key generation support (WIP - see table below)
+- [ ] OpenSSH certificate signature verification/signing
 - [ ] Interop with digital signature crates
   - [x] `ed25519-dalek`
   - [ ] `p256` (ECDSA)
@@ -96,3 +100,4 @@ dual licensed as above, without any additional terms or conditions.
 [RFC4253]: https://datatracker.ietf.org/doc/html/rfc4253
 [RFC4716]: https://datatracker.ietf.org/doc/html/rfc4716
 [PROTOCOL.key]: https://cvsweb.openbsd.org/src/usr.bin/ssh/PROTOCOL.key?annotate=HEAD
+[PROTOCOL.certkeys]: https://cvsweb.openbsd.org/src/usr.bin/ssh/PROTOCOL.certkeys?annotate=HEAD

--- a/ssh-key/src/signature.rs
+++ b/ssh-key/src/signature.rs
@@ -7,9 +7,22 @@ use crate::{
     Algorithm, EcdsaCurve, Error, Result,
 };
 
-/// Digital signature.
+/// Digital signature (e.g. DSA, ECDSA, Ed25519).
 ///
-/// The main application for these is CA signatures over an SSH certificate.
+/// These are used as part of the OpenSSH certificate format to represent
+/// signatures by certificate authorities (CAs).
+///
+/// From OpenSSH's [PROTOCOL.certkeys] specification:
+///
+/// > Signatures are computed and encoded according to the rules defined for
+/// > the CA's public key algorithm ([RFC4253 section 6.6] for ssh-rsa and
+/// > ssh-dss, [RFC5656] for the ECDSA types, and [RFC8032] for Ed25519).
+///
+/// [PROTOCOL.certkeys]: https://cvsweb.openbsd.org/src/usr.bin/ssh/PROTOCOL.certkeys?annotate=HEAD
+/// [RFC4253 section 6.6]: https://datatracker.ietf.org/doc/html/rfc4253#section-6.6
+/// [RFC5656]: https://datatracker.ietf.org/doc/html/rfc5656
+/// [RFC8032]: https://datatracker.ietf.org/doc/html/rfc8032
+// TODO(tarcieri): RSA support
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub enum Signature {
     /// DSA signature.


### PR DESCRIPTION
Adds RFC citations for signature formats