### PR TITLE
ssh-key: refactor encoder/decoder

### DIFF
--- a/ssh-key/src/algorithm.rs
+++ b/ssh-key/src/algorithm.rs
@@ -77,7 +77,7 @@ impl<T: AlgString> Decode for T {
     fn decode(decoder: &mut impl Decoder) -> Result<Self> {
         let mut buf = [0u8; MAX_ALG_NAME_SIZE];
         decoder
-            .decode_str(buf.as_mut())
+            .read_string(buf.as_mut())
             .map_err(|_| Error::Algorithm)?
             .parse()
     }
@@ -89,7 +89,7 @@ impl<T: AlgString> Encode for T {
     }
 
     fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {
-        encoder.encode_str(self.as_ref())
+        self.as_ref().encode(encoder)
     }
 }
 

--- a/ssh-key/src/decoder.rs
+++ b/ssh-key/src/decoder.rs
@@ -17,14 +17,134 @@ const MAX_SIZE: usize = 0xFFFFF;
 pub(crate) type Base64Decoder<'i> = base64ct::Decoder<'i, base64ct::Base64>;
 
 /// Decoder trait.
+///
+/// This trait describes how to decode a given type.
 pub(crate) trait Decode: Sized {
     /// Attempt to decode a value of this type using the provided [`Decoder`].
     fn decode(decoder: &mut impl Decoder) -> Result<Self>;
 }
 
-/// Decoder extension trait.
-pub(crate) trait Decoder {
-    /// Decode as much data as is needed to exactly fill `out`.
+/// Decode a single byte from the input data.
+impl Decode for u8 {
+    fn decode(decoder: &mut impl Decoder) -> Result<Self> {
+        let mut buf = [0];
+        decoder.read(&mut buf)?;
+        Ok(buf[0])
+    }
+}
+
+/// Decode a `uint32` as described in [RFC4251 § 5]:
+///
+/// > Represents a 32-bit unsigned integer.  Stored as four bytes in the
+/// > order of decreasing significance (network byte order).
+/// > For example: the value 699921578 (0x29b7f4aa) is stored as 29 b7 f4 aa.
+///
+/// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
+impl Decode for u32 {
+    fn decode(decoder: &mut impl Decoder) -> Result<Self> {
+        let mut bytes = [0u8; 4];
+        decoder.read(&mut bytes)?;
+        Ok(u32::from_be_bytes(bytes))
+    }
+}
+
+/// Decode a `uint64` as described in [RFC4251 § 5]:
+///
+/// > Represents a 64-bit unsigned integer.  Stored as eight bytes in
+/// > the order of decreasing significance (network byte order).
+///
+/// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
+impl Decode for u64 {
+    fn decode(decoder: &mut impl Decoder) -> Result<Self> {
+        let mut bytes = [0u8; 8];
+        decoder.read(&mut bytes)?;
+        Ok(u64::from_be_bytes(bytes))
+    }
+}
+
+/// Decode a `usize`.
+///
+/// Uses [`Decode`] impl on `u32` and then converts to a `usize`, handling
+/// potential overflow if `usize` is smaller than `u32`.
+///
+/// Enforces a library-internal limit of 1048575, as the main use case for
+/// `usize` is length prefixes.
+impl Decode for usize {
+    fn decode(decoder: &mut impl Decoder) -> Result<Self> {
+        let n = usize::try_from(u32::decode(decoder)?)?;
+
+        if n <= MAX_SIZE {
+            Ok(n)
+        } else {
+            Err(Error::Length)
+        }
+    }
+}
+
+/// Decodes a byte array from `byte[n]` as described in [RFC4251 § 5]:
+///
+/// > A byte represents an arbitrary 8-bit value (octet).  Fixed length
+/// > data is sometimes represented as an array of bytes, written
+/// > byte[n], where n is the number of bytes in the array.
+///
+/// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
+impl<const N: usize> Decode for [u8; N] {
+    fn decode(decoder: &mut impl Decoder) -> Result<Self> {
+        decoder.read_nested(|decoder, _len| {
+            let mut result = [(); N].map(|_| 0);
+            decoder.read(&mut result)?;
+            Ok(result)
+        })
+    }
+}
+
+/// Decodes `Vec<u8>` from `byte[n]` as described in [RFC4251 § 5]:
+///
+/// > A byte represents an arbitrary 8-bit value (octet).  Fixed length
+/// > data is sometimes represented as an array of bytes, written
+/// > byte[n], where n is the number of bytes in the array.
+///
+/// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+impl Decode for Vec<u8> {
+    fn decode(decoder: &mut impl Decoder) -> Result<Self> {
+        decoder.read_nested(|decoder, len| {
+            let mut result = vec![0u8; len];
+            decoder.read(&mut result)?;
+            Ok(result)
+        })
+    }
+}
+
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+impl Decode for String {
+    fn decode(decoder: &mut impl Decoder) -> Result<Self> {
+        String::from_utf8(Vec::decode(decoder)?).map_err(|_| Error::CharacterEncoding)
+    }
+}
+
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+impl Decode for Vec<String> {
+    fn decode(decoder: &mut impl Decoder) -> Result<Self> {
+        decoder.read_nested(|decoder, len| {
+            let mut entries = Self::new();
+            let offset = decoder.remaining_len();
+
+            while offset.saturating_sub(decoder.remaining_len()) < len {
+                entries.push(String::decode(decoder)?);
+            }
+
+            Ok(entries)
+        })
+    }
+}
+
+/// Decoder trait.
+pub(crate) trait Decoder: Sized {
+    /// Read as much data as is needed to exactly fill `out`.
     ///
     /// This is the base decoding method on which the rest of the trait is
     /// implemented in terms of.
@@ -32,59 +152,14 @@ pub(crate) trait Decoder {
     /// # Returns
     /// - `Ok(bytes)` if the expected amount of data was read
     /// - `Err(Error::Length)` if the exact amount of data couldn't be read
-    fn decode_raw<'o>(&mut self, out: &'o mut [u8]) -> Result<&'o [u8]>;
+    fn read<'o>(&mut self, out: &'o mut [u8]) -> Result<&'o [u8]>;
 
     /// Get the length of the remaining data after Base64 decoding.
     fn remaining_len(&self) -> usize;
 
     /// Is decoding finished?
-    fn is_finished(&self) -> bool;
-
-    /// Decodes a single byte.
-    #[cfg(feature = "ecdsa")]
-    fn decode_u8(&mut self) -> Result<u8> {
-        let mut buf = [0];
-        self.decode_raw(&mut buf)?;
-        Ok(buf[0])
-    }
-
-    /// Decode a `uint32` as described in [RFC4251 § 5]:
-    ///
-    /// > Represents a 32-bit unsigned integer.  Stored as four bytes in the
-    /// > order of decreasing significance (network byte order).
-    /// > For example: the value 699921578 (0x29b7f4aa) is stored as 29 b7 f4 aa.
-    ///
-    /// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
-    fn decode_u32(&mut self) -> Result<u32> {
-        let mut bytes = [0u8; 4];
-        self.decode_raw(&mut bytes)?;
-        Ok(u32::from_be_bytes(bytes))
-    }
-
-    /// Decode a `uint64` as described in [RFC4251 § 5]:
-    ///
-    /// > Represents a 64-bit unsigned integer.  Stored as eight bytes in
-    /// > the order of decreasing significance (network byte order).
-    ///
-    /// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
-    fn decode_u64(&mut self) -> Result<u64> {
-        let mut bytes = [0u8; 8];
-        self.decode_raw(&mut bytes)?;
-        Ok(u64::from_be_bytes(bytes))
-    }
-
-    /// Decode a `usize`.
-    ///
-    /// Uses [`Decoder::decode_u32`] and then converts to a `usize`, handling
-    /// potential overflow if `usize` is smaller than `u32`.
-    fn decode_usize(&mut self) -> Result<usize> {
-        let result = usize::try_from(self.decode_u32()?)?;
-
-        if result <= MAX_SIZE {
-            Ok(result)
-        } else {
-            Err(Error::Length)
-        }
+    fn is_finished(&self) -> bool {
+        self.remaining_len() == 0
     }
 
     /// Decode length-prefixed nested data.
@@ -96,11 +171,12 @@ pub(crate) trait Decoder {
     /// As a postcondition, this function checks that the total amount of data
     /// consumed matches the length prefix.
     // TODO(tarcieri): enforce that data can't be read past the given length
-    fn decode_length_prefixed<T, F>(&mut self, f: F) -> Result<T>
+    fn read_nested<T, F>(&mut self, f: F) -> Result<T>
     where
+        Self: Sized,
         F: FnOnce(&mut Self, usize) -> Result<T>,
     {
-        let len = self.decode_usize()?;
+        let len = usize::decode(self)?;
         let offset = self.remaining_len();
         let ret = f(self, len)?;
 
@@ -117,28 +193,18 @@ pub(crate) trait Decoder {
     /// > data is sometimes represented as an array of bytes, written
     /// > byte[n], where n is the number of bytes in the array.
     ///
+    /// Storage for the byte array must be provided as mutable byte slice in
+    /// order to accommodate `no_std` use cases.
+    ///
+    /// The [`Decode`] impl on [`Vec<u8>`] can be used to allocate a buffer for
+    /// the result.
+    ///
     /// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
-    fn decode_byte_slice<'o>(&mut self, out: &'o mut [u8]) -> Result<&'o [u8]> {
-        self.decode_length_prefixed(|decoder, len| {
+    fn read_byten<'o>(&mut self, out: &'o mut [u8]) -> Result<&'o [u8]> {
+        self.read_nested(|decoder, len| {
             let slice = out.get_mut(..len).ok_or(Error::Length)?;
-            decoder.decode_raw(slice)?;
+            decoder.read(slice)?;
             Ok(&slice[..])
-        })
-    }
-
-    /// Decodes `Vec<u8>` from `byte[n]` as described in [RFC4251 § 5]:
-    ///
-    /// > A byte represents an arbitrary 8-bit value (octet).  Fixed length
-    /// > data is sometimes represented as an array of bytes, written
-    /// > byte[n], where n is the number of bytes in the array.
-    ///
-    /// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
-    #[cfg(feature = "alloc")]
-    fn decode_byte_vec(&mut self) -> Result<Vec<u8>> {
-        self.decode_length_prefixed(|decoder, len| {
-            let mut result = vec![0u8; len];
-            decoder.decode_raw(&mut result)?;
-            Ok(result)
         })
     }
 
@@ -158,62 +224,60 @@ pub(crate) trait Decoder {
     /// > string "testing" is represented as 00 00 00 07 t e s t i n g.  The
     /// > UTF-8 mapping does not alter the encoding of US-ASCII characters.
     ///
+    /// Storage for the string data must be provided as mutable byte slice in
+    /// order to accommodate `no_std` use cases.
+    ///
+    /// The [`Decode`] impl on [`String`] can be used to allocate a buffer for
+    /// the result.
+    ///
     /// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
-    fn decode_str<'o>(&mut self, buf: &'o mut [u8]) -> Result<&'o str> {
-        Ok(str::from_utf8(self.decode_byte_slice(buf)?)?)
-    }
-
-    /// Decodes heap allocated `String`: owned equivalent of [`Decoder::decode_str`].
-    #[cfg(feature = "alloc")]
-    fn decode_string(&mut self) -> Result<String> {
-        String::from_utf8(self.decode_byte_vec()?).map_err(|_| Error::CharacterEncoding)
+    fn read_string<'o>(&mut self, buf: &'o mut [u8]) -> Result<&'o str> {
+        Ok(str::from_utf8(self.read_byten(buf)?)?)
     }
 
     /// Drain the given number of bytes from the decoder, discarding them.
     fn drain(&mut self, n_bytes: usize) -> Result<()> {
         let mut byte = [0];
         for _ in 0..n_bytes {
-            self.decode_raw(&mut byte)?;
+            self.read(&mut byte)?;
         }
         Ok(())
     }
 
     /// Decode a `u32` length prefix, and then drain the length of the body.
-    fn drain_prefixed(&mut self) -> Result<()> {
-        self.decode_length_prefixed(|decoder, len| decoder.drain(len))
+    ///
+    /// Upon success, returns the number of bytes drained sans the length of
+    /// the `u32` length prefix (4-bytes).
+    fn drain_prefixed(&mut self) -> Result<usize> {
+        self.read_nested(|decoder, len| {
+            decoder.drain(len)?;
+            Ok(len)
+        })
     }
 }
 
 impl Decoder for Base64Decoder<'_> {
-    fn decode_raw<'o>(&mut self, out: &'o mut [u8]) -> Result<&'o [u8]> {
+    fn read<'o>(&mut self, out: &'o mut [u8]) -> Result<&'o [u8]> {
         Ok(self.decode(out)?)
     }
 
     fn remaining_len(&self) -> usize {
         self.remaining_len()
-    }
-
-    fn is_finished(&self) -> bool {
-        self.is_finished()
     }
 }
 
 impl Decoder for pem::Decoder<'_> {
-    fn decode_raw<'o>(&mut self, out: &'o mut [u8]) -> Result<&'o [u8]> {
+    fn read<'o>(&mut self, out: &'o mut [u8]) -> Result<&'o [u8]> {
         Ok(self.decode(out)?)
     }
 
     fn remaining_len(&self) -> usize {
         self.remaining_len()
     }
-
-    fn is_finished(&self) -> bool {
-        self.is_finished()
-    }
 }
 
 impl Decoder for &[u8] {
-    fn decode_raw<'o>(&mut self, out: &'o mut [u8]) -> Result<&'o [u8]> {
+    fn read<'o>(&mut self, out: &'o mut [u8]) -> Result<&'o [u8]> {
         if self.len() >= out.len() {
             let (head, tail) = self.split_at(out.len());
             *self = tail;
@@ -226,9 +290,5 @@ impl Decoder for &[u8] {
 
     fn remaining_len(&self) -> usize {
         self.len()
-    }
-
-    fn is_finished(&self) -> bool {
-        self.is_empty()
     }
 }

--- a/ssh-key/src/encoder.rs
+++ b/ssh-key/src/encoder.rs
@@ -3,12 +3,15 @@
 //!
 //! [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
 
-use crate::Result;
+use crate::{checked::CheckedSum, Result};
 use core::str;
 use pem_rfc7468 as pem;
 
 #[cfg(feature = "alloc")]
-use alloc::vec::Vec;
+use {
+    crate::Error,
+    alloc::{string::String, vec::Vec},
+};
 
 #[cfg(feature = "fingerprint")]
 use sha2::{Digest, Sha256};
@@ -26,105 +29,196 @@ pub(crate) fn base64_encoded_len(input_len: usize) -> usize {
 /// Stateful Base64 encoder.
 pub(crate) type Base64Encoder<'o> = base64ct::Encoder<'o, base64ct::Base64>;
 
-/// Encoder trait.
-pub(crate) trait Encode: Sized {
+/// Encoding trait.
+///
+/// This trait describes how to encode a given type.
+pub(crate) trait Encode {
     /// Get the length of this type encoded in bytes, prior to Base64 encoding.
     fn encoded_len(&self) -> Result<usize>;
 
-    /// Attempt to encode a value of this type using the provided [`Encoder`].
+    /// Encode this value using the provided [`Encoder`].
     fn encode(&self, encoder: &mut impl Encoder) -> Result<()>;
+
+    /// Encode this value, first prepending a `uint32` length prefix
+    /// set to [`Encode::encoded_len`].
+    fn encode_nested(&self, encoder: &mut impl Encoder) -> Result<()> {
+        self.encoded_len()?.encode(encoder)?;
+        self.encode(encoder)
+    }
+}
+
+/// Encode a `uint32` as described in [RFC4251 § 5]:
+///
+/// > Represents a 32-bit unsigned integer.  Stored as four bytes in the
+/// > order of decreasing significance (network byte order).
+/// > For example: the value 699921578 (0x29b7f4aa) is stored as 29 b7 f4 aa.
+///
+/// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
+impl Encode for u32 {
+    fn encoded_len(&self) -> Result<usize> {
+        Ok(4)
+    }
+
+    fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {
+        encoder.write(&self.to_be_bytes())
+    }
+}
+
+/// Encode a `uint64` as described in [RFC4251 § 5]:
+///
+/// > Represents a 64-bit unsigned integer.  Stored as eight bytes in
+/// > the order of decreasing significance (network byte order).
+///
+/// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
+impl Encode for u64 {
+    fn encoded_len(&self) -> Result<usize> {
+        Ok(8)
+    }
+
+    fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {
+        encoder.write(&self.to_be_bytes())
+    }
+}
+
+/// Encode a `usize` as a `uint32` as described in [RFC4251 § 5].
+///
+/// Uses [`Encode`] impl on `u32` after converting from a `usize`, handling
+/// potential overflow if `usize` is bigger than `u32`.
+///
+/// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
+impl Encode for usize {
+    fn encoded_len(&self) -> Result<usize> {
+        Ok(4)
+    }
+
+    fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {
+        u32::try_from(*self)?.encode(encoder)
+    }
+}
+
+/// Encodes `[u8]` into `byte[n]` as described in [RFC4251 § 5]:
+///
+/// > A byte represents an arbitrary 8-bit value (octet).  Fixed length
+/// > data is sometimes represented as an array of bytes, written
+/// > byte[n], where n is the number of bytes in the array.
+///
+/// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
+impl Encode for [u8] {
+    fn encoded_len(&self) -> Result<usize> {
+        [4, self.len()].checked_sum()
+    }
+
+    fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {
+        self.len().encode(encoder)?;
+        encoder.write(self)
+    }
+}
+
+/// Encodes `[u8; N]` into `byte[n]` as described in [RFC4251 § 5]:
+///
+/// > A byte represents an arbitrary 8-bit value (octet).  Fixed length
+/// > data is sometimes represented as an array of bytes, written
+/// > byte[n], where n is the number of bytes in the array.
+///
+/// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
+impl<const N: usize> Encode for [u8; N] {
+    fn encoded_len(&self) -> Result<usize> {
+        self.as_slice().encoded_len()
+    }
+
+    fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {
+        self.as_slice().encode(encoder)
+    }
+}
+
+/// Encode a `string` as described in [RFC4251 § 5]:
+///
+/// > Arbitrary length binary string.  Strings are allowed to contain
+/// > arbitrary binary data, including null characters and 8-bit
+/// > characters.  They are stored as a uint32 containing its length
+/// > (number of bytes that follow) and zero (= empty string) or more
+/// > bytes that are the value of the string.  Terminating null
+/// > characters are not used.
+/// >
+/// > Strings are also used to store text.  In that case, US-ASCII is
+/// > used for internal names, and ISO-10646 UTF-8 for text that might
+/// > be displayed to the user.  The terminating null character SHOULD
+/// > NOT normally be stored in the string.  For example: the US-ASCII
+/// > string "testing" is represented as 00 00 00 07 t e s t i n g.  The
+/// > UTF-8 mapping does not alter the encoding of US-ASCII characters.
+///
+/// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
+impl Encode for &str {
+    fn encoded_len(&self) -> Result<usize> {
+        self.as_bytes().encoded_len()
+    }
+
+    fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {
+        self.as_bytes().encode(encoder)
+    }
+}
+
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+impl Encode for Vec<u8> {
+    fn encoded_len(&self) -> Result<usize> {
+        self.as_slice().encoded_len()
+    }
+
+    fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {
+        self.as_slice().encode(encoder)
+    }
+}
+
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+impl Encode for String {
+    fn encoded_len(&self) -> Result<usize> {
+        self.as_str().encoded_len()
+    }
+
+    fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {
+        self.as_str().encode(encoder)
+    }
+}
+
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+impl Encode for Vec<String> {
+    fn encoded_len(&self) -> Result<usize> {
+        self.iter().try_fold(4usize, |acc, string| {
+            acc.checked_add(string.encoded_len()?).ok_or(Error::Length)
+        })
+    }
+
+    fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {
+        self.encoded_len()?
+            .checked_sub(4)
+            .ok_or(Error::Length)?
+            .encode(encoder)?;
+
+        for entry in self {
+            entry.encode(encoder)?;
+        }
+
+        Ok(())
+    }
 }
 
 /// Encoder extension trait.
 pub(crate) trait Encoder: Sized {
-    /// Encode the given byte slice containing raw unstructured data.
-    ///
-    /// This is the base encoding method on which the rest of the trait is
-    /// implemented in terms of.
-    fn encode_raw(&mut self, bytes: &[u8]) -> Result<()>;
-
-    /// Encode a `uint32` as described in [RFC4251 § 5]:
-    ///
-    /// > Represents a 32-bit unsigned integer.  Stored as four bytes in the
-    /// > order of decreasing significance (network byte order).
-    /// > For example: the value 699921578 (0x29b7f4aa) is stored as 29 b7 f4 aa.
-    ///
-    /// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
-    fn encode_u32(&mut self, num: u32) -> Result<()> {
-        self.encode_raw(&num.to_be_bytes())
-    }
-
-    /// Encode a `uint64` as described in [RFC4251 § 5]:
-    ///
-    /// > Represents a 64-bit unsigned integer.  Stored as eight bytes in
-    /// > the order of decreasing significance (network byte order).
-    ///
-    /// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
-    fn encode_u64(&mut self, num: u64) -> Result<()> {
-        self.encode_raw(&num.to_be_bytes())
-    }
-
-    /// Encode a `usize` as a `uint32` as described in [RFC4251 § 5].
-    ///
-    /// Uses [`Encoder::encode_u32`] after converting from a `usize`, handling
-    /// potential overflow if `usize` is bigger than `u32`.
-    ///
-    /// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
-    fn encode_usize(&mut self, num: usize) -> Result<()> {
-        self.encode_u32(u32::try_from(num)?)
-    }
-
-    /// Encodes length-prefixed nested data.
-    ///
-    /// Encodes a `uint32` which identifies the length of some encapsulated
-    /// data, then encodes the value.
-    fn encode_length_prefixed<T: Encode>(&mut self, value: &T) -> Result<()> {
-        self.encode_usize(value.encoded_len()?)?;
-        value.encode(self)
-    }
-
-    /// Encodes `[u8]` into `byte[n]` as described in [RFC4251 § 5]:
-    ///
-    /// > A byte represents an arbitrary 8-bit value (octet).  Fixed length
-    /// > data is sometimes represented as an array of bytes, written
-    /// > byte[n], where n is the number of bytes in the array.
-    ///
-    /// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
-    fn encode_byte_slice(&mut self, bytes: &[u8]) -> Result<()> {
-        self.encode_usize(bytes.len())?;
-        self.encode_raw(bytes)
-    }
-
-    /// Encode a `string` as described in [RFC4251 § 5]:
-    ///
-    /// > Arbitrary length binary string.  Strings are allowed to contain
-    /// > arbitrary binary data, including null characters and 8-bit
-    /// > characters.  They are stored as a uint32 containing its length
-    /// > (number of bytes that follow) and zero (= empty string) or more
-    /// > bytes that are the value of the string.  Terminating null
-    /// > characters are not used.
-    /// >
-    /// > Strings are also used to store text.  In that case, US-ASCII is
-    /// > used for internal names, and ISO-10646 UTF-8 for text that might
-    /// > be displayed to the user.  The terminating null character SHOULD
-    /// > NOT normally be stored in the string.  For example: the US-ASCII
-    /// > string "testing" is represented as 00 00 00 07 t e s t i n g.  The
-    /// > UTF-8 mapping does not alter the encoding of US-ASCII characters.
-    ///
-    /// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
-    fn encode_str(&mut self, s: &str) -> Result<()> {
-        self.encode_byte_slice(s.as_bytes())
-    }
+    /// Write the given bytes to the encoder.
+    fn write(&mut self, bytes: &[u8]) -> Result<()>;
 }
 
 impl Encoder for Base64Encoder<'_> {
-    fn encode_raw(&mut self, bytes: &[u8]) -> Result<()> {
+    fn write(&mut self, bytes: &[u8]) -> Result<()> {
         Ok(self.encode(bytes)?)
     }
 }
 
 impl Encoder for pem::Encoder<'_, '_> {
-    fn encode_raw(&mut self, bytes: &[u8]) -> Result<()> {
+    fn write(&mut self, bytes: &[u8]) -> Result<()> {
         Ok(self.encode(bytes)?)
     }
 }
@@ -132,7 +226,7 @@ impl Encoder for pem::Encoder<'_, '_> {
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl Encoder for Vec<u8> {
-    fn encode_raw(&mut self, bytes: &[u8]) -> Result<()> {
+    fn write(&mut self, bytes: &[u8]) -> Result<()> {
         self.extend_from_slice(bytes);
         Ok(())
     }
@@ -140,7 +234,7 @@ impl Encoder for Vec<u8> {
 
 #[cfg(feature = "fingerprint")]
 impl Encoder for Sha256 {
-    fn encode_raw(&mut self, bytes: &[u8]) -> Result<()> {
+    fn write(&mut self, bytes: &[u8]) -> Result<()> {
         self.update(bytes);
         Ok(())
     }

--- a/ssh-key/src/mpint.rs
+++ b/ssh-key/src/mpint.rs
@@ -90,7 +90,7 @@ impl AsRef<[u8]> for MPInt {
 
 impl Decode for MPInt {
     fn decode(decoder: &mut impl Decoder) -> Result<Self> {
-        decoder.decode_byte_vec()?.try_into()
+        Vec::decode(decoder)?.try_into()
     }
 }
 
@@ -100,7 +100,7 @@ impl Encode for MPInt {
     }
 
     fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {
-        encoder.encode_byte_slice(self.as_bytes())
+        self.as_bytes().encode(encoder)
     }
 }
 

--- a/ssh-key/src/private/ed25519.rs
+++ b/ssh-key/src/private/ed25519.rs
@@ -169,7 +169,7 @@ impl Decode for Ed25519Keypair {
         // a serialization of `private_key[32] || public_key[32]` immediately
         // following the public key.
         let mut bytes = Zeroizing::new([0u8; Self::BYTE_SIZE]);
-        decoder.decode_length_prefixed(|decoder, _len| decoder.decode_raw(&mut *bytes))?;
+        decoder.read_nested(|decoder, _len| decoder.read(&mut *bytes))?;
 
         let (priv_bytes, pub_bytes) = bytes.split_at(Ed25519PrivateKey::BYTE_SIZE);
         let private = Ed25519PrivateKey(priv_bytes.try_into()?);
@@ -190,7 +190,7 @@ impl Encode for Ed25519Keypair {
 
     fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {
         self.public.encode(encoder)?;
-        encoder.encode_byte_slice(&*Zeroizing::new(self.to_bytes()))
+        Zeroizing::new(self.to_bytes()).as_ref().encode(encoder)
     }
 }
 

--- a/ssh-key/src/private/keypair.rs
+++ b/ssh-key/src/private/keypair.rs
@@ -202,11 +202,6 @@ impl Decode for KeypairData {
 
 impl Encode for KeypairData {
     fn encoded_len(&self) -> Result<usize> {
-        #[cfg(feature = "alloc")]
-        if let Some(ciphertext) = self.encrypted() {
-            return Ok(ciphertext.len());
-        }
-
         let key_len = match self {
             #[cfg(feature = "alloc")]
             Self::Dsa(key) => key.encoded_len()?,
@@ -214,7 +209,7 @@ impl Encode for KeypairData {
             Self::Ecdsa(key) => key.encoded_len()?,
             Self::Ed25519(key) => key.encoded_len()?,
             #[cfg(feature = "alloc")]
-            Self::Encrypted(_) => return Err(Error::Encrypted),
+            Self::Encrypted(ciphertext) => return Ok(ciphertext.len()),
             #[cfg(feature = "alloc")]
             Self::Rsa(key) => key.encoded_len()?,
         };
@@ -234,7 +229,7 @@ impl Encode for KeypairData {
             Self::Ecdsa(key) => key.encode(encoder),
             Self::Ed25519(key) => key.encode(encoder),
             #[cfg(feature = "alloc")]
-            Self::Encrypted(ciphertext) => encoder.encode_raw(ciphertext),
+            Self::Encrypted(ciphertext) => encoder.write(ciphertext),
             #[cfg(feature = "alloc")]
             Self::Rsa(key) => key.encode(encoder),
         }

--- a/ssh-key/src/public.rs
+++ b/ssh-key/src/public.rs
@@ -190,7 +190,7 @@ impl PublicKey {
     /// Decode comment (e.g. email address)
     #[cfg(feature = "alloc")]
     pub(crate) fn decode_comment(&mut self, decoder: &mut impl Decoder) -> Result<()> {
-        self.comment = decoder.decode_string()?;
+        self.comment = String::decode(decoder)?;
         Ok(())
     }
 }

--- a/ssh-key/src/public/ed25519.rs
+++ b/ssh-key/src/public/ed25519.rs
@@ -32,7 +32,7 @@ impl AsRef<[u8; Self::BYTE_SIZE]> for Ed25519PublicKey {
 impl Decode for Ed25519PublicKey {
     fn decode(decoder: &mut impl Decoder) -> Result<Self> {
         let mut bytes = [0u8; Self::BYTE_SIZE];
-        decoder.decode_length_prefixed(|decoder, _len| decoder.decode_raw(&mut bytes))?;
+        decoder.read_nested(|decoder, _len| decoder.read(&mut bytes))?;
         Ok(Self(bytes))
     }
 }
@@ -43,7 +43,7 @@ impl Encode for Ed25519PublicKey {
     }
 
     fn encode(&self, encoder: &mut impl Encoder) -> Result<()> {
-        encoder.encode_byte_slice(self.as_ref())
+        self.0.encode(encoder)
     }
 }
 

--- a/ssh-key/tests/private_key.rs
+++ b/ssh-key/tests/private_key.rs
@@ -400,8 +400,8 @@ fn encoding_test(private_key: &str) {
     let key = PrivateKey::from_openssh(private_key).unwrap();
 
     // Ensure key round-trips
-    let ossh_pem = key.to_openssh(LineEnding::LF).unwrap();
-    let key2 = PrivateKey::from_openssh(&*ossh_pem).unwrap();
+    let pem = key.to_openssh(LineEnding::LF).unwrap();
+    let key2 = PrivateKey::from_openssh(&*pem).unwrap();
     assert_eq!(key, key2);
 
     #[cfg(feature = "std")]


### PR DESCRIPTION
Refactors encoding to be trait-based, removing most of the previous inherent methods on `Decoder` and `Encoder` and replacing them with impls of the `Encode` and `Decode` traits on the respective types.