### PR TITLE
ssh-key: RSA signature support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1167,6 +1167,7 @@ dependencies = [
  "rand_core 0.6.3",
  "sec1",
  "sha2 0.10.2",
+ "signature",
  "subtle",
  "tempfile",
  "zeroize",

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -28,6 +28,7 @@ ed25519-dalek = { version = "1.0.1", optional = true, default-features = false, 
 rand_core = { version = "0.6", optional = true, default-features = false }
 sec1 = { version = "=0.3.0-pre.1", optional = true, default-features = false, features = ["point"], path = "../sec1" }
 sha2 = { version = "0.10", optional = true, default-features = false }
+signature = { version = "1.3.1", optional = true, default-features = false }
 subtle = { version = "2", optional = true, default-features = false }
 
 [dev-dependencies]
@@ -37,7 +38,7 @@ zeroize_derive = "1.3" # hack to make minimal-versions lint happy (pulled in by 
 
 [features]
 default = ["ecdsa", "fingerprint", "rand_core", "std"]
-alloc = ["zeroize/alloc"]
+alloc = ["signature", "zeroize/alloc"]
 ecdsa = ["sec1"]
 ed25519 = ["ed25519-dalek", "rand_core"]
 encryption = ["aes", "alloc", "bcrypt-pbkdf", "ctr", "rand_core"]

--- a/ssh-key/src/lib.rs
+++ b/ssh-key/src/lib.rs
@@ -135,32 +135,28 @@ mod decoder;
 mod encoder;
 mod error;
 mod kdf;
-mod signature;
-
-#[cfg(feature = "alloc")]
-mod mpint;
 
 #[cfg(feature = "fingerprint")]
 mod fingerprint;
+#[cfg(feature = "alloc")]
+mod mpint;
+#[cfg(feature = "alloc")]
+mod signature;
 
 pub use crate::{
-    algorithm::{Algorithm, CertificateAlg, EcdsaCurve, HashAlg, KdfAlg},
+    algorithm::{Algorithm, EcdsaCurve, HashAlg, KdfAlg},
     authorized_keys::AuthorizedKeys,
     cipher::Cipher,
     error::{Error, Result},
     kdf::Kdf,
     private::PrivateKey,
     public::PublicKey,
-    signature::Signature,
 };
 pub use base64ct::LineEnding;
 pub use pem_rfc7468 as pem;
 
 #[cfg(feature = "alloc")]
-pub use crate::{
-    certificate::{CertType, Certificate, OptionsMap},
-    mpint::MPInt,
-};
+pub use crate::{certificate::Certificate, mpint::MPInt, signature::Signature};
 
 #[cfg(feature = "ecdsa")]
 pub use sec1;

--- a/ssh-key/src/private.rs
+++ b/ssh-key/src/private.rs
@@ -441,7 +441,7 @@ impl PrivateKey {
     /// Use [`Default::default()`] to use the default hash function (SHA-256).
     #[cfg(feature = "fingerprint")]
     #[cfg_attr(docsrs, doc(cfg(feature = "fingerprint")))]
-    pub fn fingerprint(&self, hash_alg: HashAlg) -> Fingerprint {
+    pub fn fingerprint(&self, hash_alg: HashAlg) -> Result<Fingerprint> {
         self.public_key.fingerprint(hash_alg)
     }
 

--- a/ssh-key/src/private/ecdsa.rs
+++ b/ssh-key/src/private/ecdsa.rs
@@ -163,7 +163,9 @@ pub enum EcdsaKeypair {
 impl EcdsaKeypair {
     /// Get the [`Algorithm`] for this public key type.
     pub fn algorithm(&self) -> Algorithm {
-        Algorithm::Ecdsa(self.curve())
+        Algorithm::Ecdsa {
+            curve: self.curve(),
+        }
     }
 
     /// Get the [`EcdsaCurve`] for this key.

--- a/ssh-key/src/private/keypair.rs
+++ b/ssh-key/src/private/keypair.rs
@@ -63,7 +63,7 @@ impl KeypairData {
             #[cfg(feature = "alloc")]
             Self::Encrypted(_) => return Err(Error::Encrypted),
             #[cfg(feature = "alloc")]
-            Self::Rsa(_) => Algorithm::Rsa,
+            Self::Rsa(_) => Algorithm::Rsa { hash: None },
         })
     }
 
@@ -187,13 +187,13 @@ impl Decode for KeypairData {
             #[cfg(feature = "alloc")]
             Algorithm::Dsa => DsaKeypair::decode(decoder).map(Self::Dsa),
             #[cfg(feature = "ecdsa")]
-            Algorithm::Ecdsa(curve) => match EcdsaKeypair::decode(decoder)? {
+            Algorithm::Ecdsa { curve } => match EcdsaKeypair::decode(decoder)? {
                 keypair if keypair.curve() == curve => Ok(Self::Ecdsa(keypair)),
                 _ => Err(Error::Algorithm),
             },
             Algorithm::Ed25519 => Ed25519Keypair::decode(decoder).map(Self::Ed25519),
             #[cfg(feature = "alloc")]
-            Algorithm::Rsa => RsaKeypair::decode(decoder).map(Self::Rsa),
+            Algorithm::Rsa { .. } => RsaKeypair::decode(decoder).map(Self::Rsa),
             #[allow(unreachable_patterns)]
             _ => Err(Error::Algorithm),
         }

--- a/ssh-key/src/public/ecdsa.rs
+++ b/ssh-key/src/public/ecdsa.rs
@@ -72,7 +72,9 @@ impl EcdsaPublicKey {
 
     /// Get the [`Algorithm`] for this public key type.
     pub fn algorithm(&self) -> Algorithm {
-        Algorithm::Ecdsa(self.curve())
+        Algorithm::Ecdsa {
+            curve: self.curve(),
+        }
     }
 
     /// Get the [`EcdsaCurve`] for this key.

--- a/ssh-key/tests/certificate.rs
+++ b/ssh-key/tests/certificate.rs
@@ -66,7 +66,9 @@ fn decode_dsa_openssh() {
 fn decode_ecdsa_p256_openssh() {
     let key = Certificate::from_str(ECDSA_P256_CERT_EXAMPLE).unwrap();
     assert_eq!(
-        Algorithm::Ecdsa(EcdsaCurve::NistP256),
+        Algorithm::Ecdsa {
+            curve: EcdsaCurve::NistP256
+        },
         key.public_key().algorithm(),
     );
 
@@ -99,7 +101,7 @@ fn decode_ed25519_openssh() {
 #[test]
 fn decode_rsa_4096_openssh() {
     let key = Certificate::from_str(RSA_4096_CERT_EXAMPLE).unwrap();
-    assert_eq!(Algorithm::Rsa, key.public_key().algorithm());
+    assert_eq!(Algorithm::Rsa { hash: None }, key.public_key().algorithm());
 
     let rsa_key = key.public_key().rsa().unwrap();
     assert_eq!(&hex!("010001"), rsa_key.e.as_bytes());

--- a/ssh-key/tests/private_key.rs
+++ b/ssh-key/tests/private_key.rs
@@ -91,7 +91,12 @@ fn decode_dsa_openssh() {
 #[test]
 fn decode_ecdsa_p256_openssh() {
     let key = PrivateKey::from_openssh(OPENSSH_ECDSA_P256_EXAMPLE).unwrap();
-    assert_eq!(Algorithm::Ecdsa(EcdsaCurve::NistP256), key.algorithm(),);
+    assert_eq!(
+        Algorithm::Ecdsa {
+            curve: EcdsaCurve::NistP256
+        },
+        key.algorithm(),
+    );
     assert_eq!(Cipher::None, key.cipher());
     assert_eq!(KdfAlg::None, key.kdf().algorithm());
     assert!(key.kdf().is_none());
@@ -118,7 +123,12 @@ fn decode_ecdsa_p256_openssh() {
 #[test]
 fn decode_ecdsa_p384_openssh() {
     let key = PrivateKey::from_openssh(OPENSSH_ECDSA_P384_EXAMPLE).unwrap();
-    assert_eq!(Algorithm::Ecdsa(EcdsaCurve::NistP384), key.algorithm(),);
+    assert_eq!(
+        Algorithm::Ecdsa {
+            curve: EcdsaCurve::NistP384
+        },
+        key.algorithm()
+    );
     assert_eq!(Cipher::None, key.cipher());
     assert_eq!(KdfAlg::None, key.kdf().algorithm());
     assert!(key.kdf().is_none());
@@ -149,7 +159,12 @@ fn decode_ecdsa_p384_openssh() {
 #[test]
 fn decode_ecdsa_p521_openssh() {
     let key = PrivateKey::from_openssh(OPENSSH_ECDSA_P521_EXAMPLE).unwrap();
-    assert_eq!(Algorithm::Ecdsa(EcdsaCurve::NistP521), key.algorithm(),);
+    assert_eq!(
+        Algorithm::Ecdsa {
+            curve: EcdsaCurve::NistP521
+        },
+        key.algorithm()
+    );
     assert_eq!(Cipher::None, key.cipher());
     assert_eq!(KdfAlg::None, key.kdf().algorithm());
     assert!(key.kdf().is_none());
@@ -203,7 +218,7 @@ fn decode_ed25519_openssh() {
 #[test]
 fn decode_rsa_3072_openssh() {
     let key = PrivateKey::from_openssh(OPENSSH_RSA_3072_EXAMPLE).unwrap();
-    assert_eq!(Algorithm::Rsa, key.algorithm());
+    assert_eq!(Algorithm::Rsa { hash: None }, key.algorithm());
     assert_eq!(Cipher::None, key.cipher());
     assert_eq!(KdfAlg::None, key.kdf().algorithm());
     assert!(key.kdf().is_none());
@@ -275,7 +290,7 @@ fn decode_rsa_3072_openssh() {
 #[test]
 fn decode_rsa_4096_openssh() {
     let key = PrivateKey::from_openssh(OPENSSH_RSA_4096_EXAMPLE).unwrap();
-    assert_eq!(Algorithm::Rsa, key.algorithm());
+    assert_eq!(Algorithm::Rsa { hash: None }, key.algorithm());
     assert_eq!(Cipher::None, key.cipher());
     assert_eq!(KdfAlg::None, key.kdf().algorithm());
     assert!(key.kdf().is_none());

--- a/ssh-key/tests/public_key.rs
+++ b/ssh-key/tests/public_key.rs
@@ -73,7 +73,7 @@ fn decode_dsa_openssh() {
 
     #[cfg(feature = "fingerprint")]
     assert_eq!(
-        &key.fingerprint(Default::default()).to_string(),
+        &key.fingerprint(Default::default()).unwrap().to_string(),
         "SHA256:Nh0Me49Zh9fDw/VYUfq43IJmI1T+XrjiYONPND8GzaM"
     );
 }
@@ -83,7 +83,9 @@ fn decode_dsa_openssh() {
 fn decode_ecdsa_p256_openssh() {
     let key = PublicKey::from_openssh(OPENSSH_ECDSA_P256_EXAMPLE).unwrap();
     assert_eq!(
-        Algorithm::Ecdsa(EcdsaCurve::NistP256),
+        Algorithm::Ecdsa {
+            curve: EcdsaCurve::NistP256
+        },
         key.key_data().algorithm(),
     );
 
@@ -102,7 +104,7 @@ fn decode_ecdsa_p256_openssh() {
 
     #[cfg(feature = "fingerprint")]
     assert_eq!(
-        &key.fingerprint(Default::default()).to_string(),
+        &key.fingerprint(Default::default()).unwrap().to_string(),
         "SHA256:JQ6FV0rf7qqJHZqIj4zNH8eV0oB8KLKh9Pph3FTD98g"
     );
 }
@@ -112,7 +114,9 @@ fn decode_ecdsa_p256_openssh() {
 fn decode_ecdsa_p384_openssh() {
     let key = PublicKey::from_openssh(OPENSSH_ECDSA_P384_EXAMPLE).unwrap();
     assert_eq!(
-        Algorithm::Ecdsa(EcdsaCurve::NistP384),
+        Algorithm::Ecdsa {
+            curve: EcdsaCurve::NistP384
+        },
         key.key_data().algorithm(),
     );
 
@@ -132,7 +136,7 @@ fn decode_ecdsa_p384_openssh() {
 
     #[cfg(feature = "fingerprint")]
     assert_eq!(
-        &key.fingerprint(Default::default()).to_string(),
+        &key.fingerprint(Default::default()).unwrap().to_string(),
         "SHA256:nkGE8oV7pHvOiPKHtQRs67WUPiVLRxbNu//gV/k4Vjw"
     );
 }
@@ -142,7 +146,9 @@ fn decode_ecdsa_p384_openssh() {
 fn decode_ecdsa_p521_openssh() {
     let key = PublicKey::from_openssh(OPENSSH_ECDSA_P521_EXAMPLE).unwrap();
     assert_eq!(
-        Algorithm::Ecdsa(EcdsaCurve::NistP521),
+        Algorithm::Ecdsa {
+            curve: EcdsaCurve::NistP521
+        },
         key.key_data().algorithm(),
     );
 
@@ -163,7 +169,7 @@ fn decode_ecdsa_p521_openssh() {
 
     #[cfg(feature = "fingerprint")]
     assert_eq!(
-        &key.fingerprint(Default::default()).to_string(),
+        &key.fingerprint(Default::default()).unwrap().to_string(),
         "SHA256:l3AUUMK6Q2BbuiqvMx2fs97f8LUYq7sWCAx7q5m3S6M"
     );
 }
@@ -183,7 +189,7 @@ fn decode_ed25519_openssh() {
 
     #[cfg(feature = "fingerprint")]
     assert_eq!(
-        &key.fingerprint(Default::default()).to_string(),
+        &key.fingerprint(Default::default()).unwrap().to_string(),
         "SHA256:UCUiLr7Pjs9wFFJMDByLgc3NrtdU344OgUM45wZPcIQ"
     );
 }
@@ -192,7 +198,7 @@ fn decode_ed25519_openssh() {
 #[test]
 fn decode_rsa_3072_openssh() {
     let key = PublicKey::from_openssh(OPENSSH_RSA_3072_EXAMPLE).unwrap();
-    assert_eq!(Algorithm::Rsa, key.key_data().algorithm());
+    assert_eq!(Algorithm::Rsa { hash: None }, key.key_data().algorithm());
 
     let rsa_key = key.key_data().rsa().unwrap();
     assert_eq!(&hex!("010001"), rsa_key.e.as_bytes());
@@ -215,7 +221,7 @@ fn decode_rsa_3072_openssh() {
 
     #[cfg(feature = "fingerprint")]
     assert_eq!(
-        &key.fingerprint(Default::default()).to_string(),
+        &key.fingerprint(Default::default()).unwrap().to_string(),
         "SHA256:Fmxts/GcV77PakFnf1Ueki5mpU4ZjUQWGRjZGAo3n/I"
     );
 }
@@ -224,7 +230,7 @@ fn decode_rsa_3072_openssh() {
 #[test]
 fn decode_rsa_4096_openssh() {
     let key = PublicKey::from_openssh(OPENSSH_RSA_4096_EXAMPLE).unwrap();
-    assert_eq!(Algorithm::Rsa, key.key_data().algorithm());
+    assert_eq!(Algorithm::Rsa { hash: None }, key.key_data().algorithm());
 
     let rsa_key = key.key_data().rsa().unwrap();
     assert_eq!(&hex!("010001"), rsa_key.e.as_bytes());
@@ -250,7 +256,7 @@ fn decode_rsa_4096_openssh() {
 
     #[cfg(feature = "fingerprint")]
     assert_eq!(
-        &key.fingerprint(Default::default()).to_string(),
+        &key.fingerprint(Default::default()).unwrap().to_string(),
         "SHA256:FKAyeywtQNZLl1YTzIzCV/ThadBlnWMaD7jHQYDseEY"
     );
 }


### PR DESCRIPTION
Support for parsing RFC8332-flavored RSASSA-PKCS#1v1.5 signatures on OpenSSH certificates.

Implementing this required further paramaterizing the `Algorithm` enum around a `HashAlg` associated with the `Algorithm::Rsa` variant. Separately, the `CertificateAlg` type was folded into `Algorithm`, which now also supports certificate-specific decoding/encoding functions.

Additionally, the `Signature` type has changed from an enum to a struct, which carries an algorithm and the signature data serialized as a byte vector.