### PR TITLE
ssh-key: initial `serde` support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,6 +1166,7 @@ dependencies = [
  "pem-rfc7468",
  "rand_core 0.6.3",
  "sec1",
+ "serde",
  "sha2 0.10.2",
  "signature",
  "subtle",

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -27,6 +27,7 @@ bcrypt-pbkdf = { version = "0.9", optional = true, default-features = false }
 ed25519-dalek = { version = "1.0.1", optional = true, default-features = false, features = ["u64_backend"] }
 rand_core = { version = "0.6", optional = true, default-features = false }
 sec1 = { version = "=0.3.0-pre.1", optional = true, default-features = false, features = ["point"], path = "../sec1" }
+serde = { version = "1", optional = true }
 sha2 = { version = "0.10", optional = true, default-features = false }
 signature = { version = "1.3.1", optional = true, default-features = false }
 subtle = { version = "2", optional = true, default-features = false }

--- a/ssh-key/README.md
+++ b/ssh-key/README.md
@@ -27,7 +27,8 @@ specification, certificates as specified in [PROTOCOL.certkeys]  and the
 - [x] Fingerprint support (SHA-256 only)
 - [x] `no_std` support including support for "heapless" (no-`alloc`) targets
 - [x] Parsing `authorized_keys` files
-- [x] Built-in zeroize support for private keys
+- [x] Serde support (certificates and public keys only)
+- [x] Zeroize support for private keys
 
 #### TODO
 

--- a/ssh-key/src/lib.rs
+++ b/ssh-key/src/lib.rs
@@ -113,6 +113,15 @@
 //! # Ok(())
 //! # }
 //! ```
+//!
+//! ## `serde` support
+//!
+//! When the `serde` feature of this crate is enabled, the [`Certificate`] and
+//! [`PublicKey`] types receive impls of `serde`'s `Deserialize` and
+//! `Serialize` traits.
+//!
+//! Serializing/deserializing [`PrivateKey`] using `serde` is presently
+//! unsupported.
 
 #[cfg(feature = "alloc")]
 #[macro_use]

--- a/ssh-key/src/public/key_data.rs
+++ b/ssh-key/src/public/key_data.rs
@@ -1,0 +1,198 @@
+//! Public key data.
+
+use super::Ed25519PublicKey;
+use crate::{
+    checked::CheckedSum, decode::Decode, encode::Encode, reader::Reader, writer::Writer, Algorithm,
+    Error, Result,
+};
+
+#[cfg(feature = "alloc")]
+use super::{DsaPublicKey, RsaPublicKey};
+
+#[cfg(feature = "ecdsa")]
+pub use super::EcdsaPublicKey;
+
+#[cfg(feature = "fingerprint")]
+use crate::{Fingerprint, HashAlg, Sha256Fingerprint};
+
+/// Public key data.
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[non_exhaustive]
+pub enum KeyData {
+    /// Digital Signature Algorithm (DSA) public key data.
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    Dsa(DsaPublicKey),
+
+    /// Elliptic Curve Digital Signature Algorithm (ECDSA) public key data.
+    #[cfg(feature = "ecdsa")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
+    Ecdsa(EcdsaPublicKey),
+
+    /// Ed25519 public key data.
+    Ed25519(Ed25519PublicKey),
+
+    /// RSA public key data.
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    Rsa(RsaPublicKey),
+}
+
+impl KeyData {
+    /// Get the [`Algorithm`] for this public key.
+    pub fn algorithm(&self) -> Algorithm {
+        match self {
+            #[cfg(feature = "alloc")]
+            Self::Dsa(_) => Algorithm::Dsa,
+            #[cfg(feature = "ecdsa")]
+            Self::Ecdsa(key) => key.algorithm(),
+            Self::Ed25519(_) => Algorithm::Ed25519,
+            #[cfg(feature = "alloc")]
+            Self::Rsa(_) => Algorithm::Rsa { hash: None },
+        }
+    }
+
+    /// Get DSA public key if this key is the correct type.
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    pub fn dsa(&self) -> Option<&DsaPublicKey> {
+        match self {
+            Self::Dsa(key) => Some(key),
+            _ => None,
+        }
+    }
+
+    /// Get ECDSA public key if this key is the correct type.
+    #[cfg(feature = "ecdsa")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
+    pub fn ecdsa(&self) -> Option<&EcdsaPublicKey> {
+        match self {
+            Self::Ecdsa(key) => Some(key),
+            _ => None,
+        }
+    }
+
+    /// Get Ed25519 public key if this key is the correct type.
+    pub fn ed25519(&self) -> Option<&Ed25519PublicKey> {
+        match self {
+            Self::Ed25519(key) => Some(key),
+            #[allow(unreachable_patterns)]
+            _ => None,
+        }
+    }
+
+    /// Compute key fingerprint.
+    ///
+    /// Use [`Default::default()`] to use the default hash function (SHA-256).
+    #[cfg(feature = "fingerprint")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "fingerprint")))]
+    pub fn fingerprint(&self, hash_alg: HashAlg) -> Result<Fingerprint> {
+        match hash_alg {
+            HashAlg::Sha256 => Sha256Fingerprint::try_from(self).map(Into::into),
+            _ => Err(Error::Algorithm),
+        }
+    }
+
+    /// Get RSA public key if this key is the correct type.
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    pub fn rsa(&self) -> Option<&RsaPublicKey> {
+        match self {
+            Self::Rsa(key) => Some(key),
+            _ => None,
+        }
+    }
+
+    /// Is this key a DSA key?
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    pub fn is_dsa(&self) -> bool {
+        matches!(self, Self::Dsa(_))
+    }
+
+    /// Is this key an ECDSA key?
+    #[cfg(feature = "ecdsa")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
+    pub fn is_ecdsa(&self) -> bool {
+        matches!(self, Self::Ecdsa(_))
+    }
+
+    /// Is this key an Ed25519 key?
+    pub fn is_ed25519(&self) -> bool {
+        matches!(self, Self::Ed25519(_))
+    }
+
+    /// Is this key an RSA key?
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    pub fn is_rsa(&self) -> bool {
+        matches!(self, Self::Rsa(_))
+    }
+
+    /// Decode [`KeyData`] for the specified algorithm.
+    pub(crate) fn decode_algorithm(reader: &mut impl Reader, algorithm: Algorithm) -> Result<Self> {
+        match algorithm {
+            #[cfg(feature = "alloc")]
+            Algorithm::Dsa => DsaPublicKey::decode(reader).map(Self::Dsa),
+            #[cfg(feature = "ecdsa")]
+            Algorithm::Ecdsa { curve } => match EcdsaPublicKey::decode(reader)? {
+                key if key.curve() == curve => Ok(Self::Ecdsa(key)),
+                _ => Err(Error::Algorithm),
+            },
+            Algorithm::Ed25519 => Ed25519PublicKey::decode(reader).map(Self::Ed25519),
+            #[cfg(feature = "alloc")]
+            Algorithm::Rsa { .. } => RsaPublicKey::decode(reader).map(Self::Rsa),
+            #[allow(unreachable_patterns)]
+            _ => Err(Error::Algorithm),
+        }
+    }
+
+    /// Get the encoded length of this key data without a leading algorithm
+    /// identifier.
+    pub(crate) fn encoded_key_data_len(&self) -> Result<usize> {
+        match self {
+            #[cfg(feature = "alloc")]
+            Self::Dsa(key) => key.encoded_len(),
+            #[cfg(feature = "ecdsa")]
+            Self::Ecdsa(key) => key.encoded_len(),
+            Self::Ed25519(key) => key.encoded_len(),
+            #[cfg(feature = "alloc")]
+            Self::Rsa(key) => key.encoded_len(),
+        }
+    }
+
+    /// Encode the key data without a leading algorithm identifier.
+    pub(crate) fn encode_key_data(&self, writer: &mut impl Writer) -> Result<()> {
+        match self {
+            #[cfg(feature = "alloc")]
+            Self::Dsa(key) => key.encode(writer),
+            #[cfg(feature = "ecdsa")]
+            Self::Ecdsa(key) => key.encode(writer),
+            Self::Ed25519(key) => key.encode(writer),
+            #[cfg(feature = "alloc")]
+            Self::Rsa(key) => key.encode(writer),
+        }
+    }
+}
+
+impl Decode for KeyData {
+    fn decode(reader: &mut impl Reader) -> Result<Self> {
+        let algorithm = Algorithm::decode(reader)?;
+        Self::decode_algorithm(reader, algorithm)
+    }
+}
+
+impl Encode for KeyData {
+    fn encoded_len(&self) -> Result<usize> {
+        [
+            self.algorithm().encoded_len()?,
+            self.encoded_key_data_len()?,
+        ]
+        .checked_sum()
+    }
+
+    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
+        self.algorithm().encode(writer)?;
+        self.encode_key_data(writer)
+    }
+}

--- a/ssh-key/tests/certificate.rs
+++ b/ssh-key/tests/certificate.rs
@@ -150,7 +150,7 @@ fn decode_rsa_4096_openssh() {
 #[test]
 fn encode_dsa_openssh() {
     let cert = Certificate::from_str(DSA_CERT_EXAMPLE).unwrap();
-    assert_eq!(DSA_CERT_EXAMPLE.trim_end(), &cert.to_string().unwrap());
+    assert_eq!(DSA_CERT_EXAMPLE.trim_end(), &cert.to_openssh().unwrap());
 }
 
 #[cfg(feature = "ecdsa")]
@@ -159,20 +159,23 @@ fn encode_ecdsa_p256_openssh() {
     let cert = Certificate::from_str(ECDSA_P256_CERT_EXAMPLE).unwrap();
     assert_eq!(
         ECDSA_P256_CERT_EXAMPLE.trim_end(),
-        &cert.to_string().unwrap()
+        &cert.to_openssh().unwrap()
     );
 }
 
 #[test]
 fn encode_ed25519_openssh() {
     let cert = Certificate::from_str(ED25519_CERT_EXAMPLE).unwrap();
-    assert_eq!(ED25519_CERT_EXAMPLE.trim_end(), &cert.to_string().unwrap());
+    assert_eq!(ED25519_CERT_EXAMPLE.trim_end(), &cert.to_openssh().unwrap());
 }
 
 #[test]
 fn encode_rsa_4096_openssh() {
     let cert = Certificate::from_str(RSA_4096_CERT_EXAMPLE).unwrap();
-    assert_eq!(RSA_4096_CERT_EXAMPLE.trim_end(), &cert.to_string().unwrap());
+    assert_eq!(
+        RSA_4096_CERT_EXAMPLE.trim_end(),
+        &cert.to_openssh().unwrap()
+    );
 }
 
 #[cfg(all(feature = "ed25519", feature = "fingerprint"))]

--- a/ssh-key/tests/private_key.rs
+++ b/ssh-key/tests/private_key.rs
@@ -440,7 +440,8 @@ fn encoding_integration_test(private_key: PrivateKey) {
     {
         Ok(output) => {
             assert_eq!(output.status.code().unwrap(), 0);
-            PublicKey::from_openssh(&output.stdout).unwrap()
+            let ssh_keygen_output = std::str::from_utf8(&output.stdout).unwrap();
+            PublicKey::from_openssh(ssh_keygen_output).unwrap()
         }
         Err(err) => {
             if err.kind() == io::ErrorKind::NotFound {


### PR DESCRIPTION
Support for serializing/deserializing `Certificate` and `PublicKey` using `serde`'s traits.

Uses the OpenSSH string serialization with human-readable formats, and the binary serialization with binary formats.