### PR TITLE
ssh-key: factor out `public::Sk*` types

### DIFF
--- a/ssh-key/src/public.rs
+++ b/ssh-key/src/public.rs
@@ -11,13 +11,15 @@ mod key_data;
 mod openssh;
 #[cfg(feature = "alloc")]
 mod rsa;
+mod sk;
 
-pub use self::{ed25519::Ed25519PublicKey, key_data::KeyData};
+pub use self::{ed25519::Ed25519PublicKey, key_data::KeyData, sk::SkEd25519};
 
-#[cfg(feature = "ecdsa")]
-pub use self::ecdsa::EcdsaPublicKey;
 #[cfg(feature = "alloc")]
 pub use self::{dsa::DsaPublicKey, rsa::RsaPublicKey};
+
+#[cfg(feature = "ecdsa")]
+pub use self::{ecdsa::EcdsaPublicKey, sk::SkEcdsaSha2NistP256};
 
 pub(crate) use self::openssh::Encapsulation;
 

--- a/ssh-key/src/public/sk.rs
+++ b/ssh-key/src/public/sk.rs
@@ -1,0 +1,161 @@
+//! Security Key (FIDO/U2F) public keys as described in [PROTOCOL.u2f].
+//!
+//! [PROTOCOL.u2f]: https://cvsweb.openbsd.org/src/usr.bin/ssh/PROTOCOL.u2f?annotate=HEAD
+
+use super::Ed25519PublicKey;
+use crate::{
+    checked::CheckedSum, decode::Decode, encode::Encode, reader::Reader, writer::Writer, Result,
+};
+
+#[cfg(feature = "alloc")]
+use alloc::string::String;
+
+#[cfg(feature = "ecdsa")]
+use {
+    super::ecdsa::EcdsaNistP256PublicKey,
+    crate::{EcdsaCurve, Error},
+};
+
+/// Default FIDO/U2F Security Key application string.
+#[cfg(not(feature = "alloc"))]
+const DEFAULT_APPLICATION_STRING: &str = "ssh:";
+
+/// Security Key (FIDO/U2F) using ECDSA/NIST P-256 as specified in [PROTOCOL.u2f].
+///
+/// [PROTOCOL.u2f]: https://cvsweb.openbsd.org/src/usr.bin/ssh/PROTOCOL.u2f?annotate=HEAD
+#[cfg(feature = "ecdsa")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct SkEcdsaSha2NistP256 {
+    /// Elliptic curve point representing a public key.
+    ec_point: EcdsaNistP256PublicKey,
+
+    /// FIDO/U2F application (typically `ssh:`)
+    #[cfg(feature = "alloc")]
+    application: String,
+}
+
+#[cfg(feature = "ecdsa")]
+impl SkEcdsaSha2NistP256 {
+    /// Get the elliptic curve point for this Security Key.
+    pub fn ec_point(&self) -> &EcdsaNistP256PublicKey {
+        &self.ec_point
+    }
+
+    /// Get the FIDO/U2F application (typically `ssh:`).
+    #[cfg(not(feature = "alloc"))]
+    pub fn application(&self) -> &str {
+        DEFAULT_APPLICATION_STRING
+    }
+
+    /// Get the FIDO/U2F application (typically `ssh:`).
+    #[cfg(feature = "alloc")]
+    pub fn application(&self) -> &str {
+        &self.application
+    }
+}
+
+#[cfg(feature = "ecdsa")]
+impl Decode for SkEcdsaSha2NistP256 {
+    fn decode(reader: &mut impl Reader) -> Result<Self> {
+        if EcdsaCurve::decode(reader)? != EcdsaCurve::NistP256 {
+            return Err(Error::Crypto);
+        }
+
+        let mut buf = [0u8; 65];
+        let ec_point = EcdsaNistP256PublicKey::from_bytes(reader.read_byten(&mut buf)?)?;
+
+        // application string (e.g. `ssh:`)
+        #[cfg(not(feature = "alloc"))]
+        reader.drain_prefixed()?;
+
+        Ok(Self {
+            ec_point,
+
+            #[cfg(feature = "alloc")]
+            application: String::decode(reader)?,
+        })
+    }
+}
+
+#[cfg(feature = "ecdsa")]
+impl Encode for SkEcdsaSha2NistP256 {
+    fn encoded_len(&self) -> Result<usize> {
+        [
+            EcdsaCurve::NistP256.encoded_len()?,
+            self.ec_point.as_bytes().encoded_len()?,
+            self.application().encoded_len()?,
+        ]
+        .checked_sum()
+    }
+
+    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
+        EcdsaCurve::NistP256.encode(writer)?;
+        self.ec_point.as_bytes().encode(writer)?;
+        self.application().encode(writer)
+    }
+}
+
+/// Security Key (FIDO/U2F) using Ed25519 as specified in [PROTOCOL.u2f].
+///
+/// [PROTOCOL.u2f]: https://cvsweb.openbsd.org/src/usr.bin/ssh/PROTOCOL.u2f?annotate=HEAD
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct SkEd25519 {
+    /// Ed25519 public key.
+    public_key: Ed25519PublicKey,
+
+    /// FIDO/U2F application (typically `ssh:`)
+    #[cfg(feature = "alloc")]
+    application: String,
+}
+
+impl SkEd25519 {
+    /// Get the Ed25519 private key for this security key.
+    pub fn public_key(&self) -> &Ed25519PublicKey {
+        &self.public_key
+    }
+
+    /// Get the FIDO/U2F application (typically `ssh:`).
+    #[cfg(not(feature = "alloc"))]
+    pub fn application(&self) -> &str {
+        DEFAULT_APPLICATION_STRING
+    }
+
+    /// Get the FIDO/U2F application (typically `ssh:`).
+    #[cfg(feature = "alloc")]
+    pub fn application(&self) -> &str {
+        &self.application
+    }
+}
+
+impl Decode for SkEd25519 {
+    fn decode(reader: &mut impl Reader) -> Result<Self> {
+        let public_key = Ed25519PublicKey::decode(reader)?;
+
+        // application string (e.g. `ssh:`)
+        #[cfg(not(feature = "alloc"))]
+        reader.drain_prefixed()?;
+
+        Ok(Self {
+            public_key,
+
+            #[cfg(feature = "alloc")]
+            application: String::decode(reader)?,
+        })
+    }
+}
+
+impl Encode for SkEd25519 {
+    fn encoded_len(&self) -> Result<usize> {
+        [
+            self.public_key.encoded_len()?,
+            self.application().encoded_len()?,
+        ]
+        .checked_sum()
+    }
+
+    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
+        self.public_key.encode(writer)?;
+        self.application().encode(writer)
+    }
+}

--- a/ssh-key/tests/certificate.rs
+++ b/ssh-key/tests/certificate.rs
@@ -169,9 +169,10 @@ fn decode_sk_ecdsa_p256_openssh() {
             "04810b409d8382f697d72425285a247d6336b2eb9a085236aa9d1e268747ca0e8ee227f17375e944a775392
              f1d35842d13f6237574ab03e00e9cc1799ecd8d931e"
         ),
-        ecdsa_key.as_ref(),
+        ecdsa_key.ec_point().as_ref(),
     );
 
+    assert_eq!("ssh:", ecdsa_key.application());
     assert_eq!("user@example.com", cert.comment());
 }
 
@@ -181,11 +182,13 @@ fn decode_sk_ed25519_openssh() {
 
     assert_eq!(Algorithm::SkEd25519, cert.public_key().algorithm());
 
+    let ed25519_key = cert.public_key().sk_ed25519().unwrap();
     assert_eq!(
         &hex!("2168fe4e4b53cf3adeeeba602f5e50edb5ef441dba884f5119109db2dafdd733"),
-        cert.public_key().sk_ed25519().unwrap().as_ref(),
+        ed25519_key.public_key().as_ref(),
     );
 
+    assert_eq!("ssh:", ed25519_key.application());
     assert_eq!("user@example.com", cert.comment());
 }
 

--- a/ssh-key/tests/public_key.rs
+++ b/ssh-key/tests/public_key.rs
@@ -280,8 +280,10 @@ fn decode_sk_ecdsa_p256_openssh() {
             "04810b409d8382f697d72425285a247d6336b2eb9a085236aa9d1e268747ca0e8ee227f17375e944a775392
              f1d35842d13f6237574ab03e00e9cc1799ecd8d931e"
         ),
-        ecdsa_key.as_ref(),
+        ecdsa_key.ec_point().as_ref(),
     );
+
+    assert_eq!("ssh:", ecdsa_key.application());
 
     #[cfg(feature = "alloc")]
     assert_eq!("user@example.com", key.comment());
@@ -298,10 +300,13 @@ fn decode_sk_ed25519_openssh() {
     let key = PublicKey::from_openssh(OPENSSH_SK_ED25519_EXAMPLE).unwrap();
     assert_eq!(Algorithm::SkEd25519, key.key_data().algorithm());
 
+    let ed25519_key = key.key_data().sk_ed25519().unwrap();
     assert_eq!(
         &hex!("2168fe4e4b53cf3adeeeba602f5e50edb5ef441dba884f5119109db2dafdd733"),
-        key.key_data().sk_ed25519().unwrap().as_ref(),
+        ed25519_key.public_key().as_ref(),
     );
+
+    assert_eq!("ssh:", ed25519_key.application());
 
     #[cfg(feature = "alloc")]
     assert_eq!("user@example.com", key.comment());


### PR DESCRIPTION
Factors out Security Key (FIDO/U2F) types which can store the associated `application` string when the `alloc` feature is enabled.