### PR TITLE
ssh-key: FIDO/U2F "private" key support

### DIFF
--- a/ssh-key/README.md
+++ b/ssh-key/README.md
@@ -36,7 +36,6 @@ specification, certificates as specified in [PROTOCOL.certkeys]  and the
 
 - [ ] Key generation support (WIP - see table below)
 - [ ] OpenSSH certificate builder/signer (i.e. SSH CA support)
-- [ ] FIDO/U2F private key decoder/encoder
 - [ ] Interop with digital signature crates
   - [x] `ed25519-dalek`
   - [ ] `p256` (ECDSA)
@@ -58,8 +57,8 @@ specification, certificates as specified in [PROTOCOL.certkeys]  and the
 | `ssh-dsa`                            | ✅       | ✅       | ✅           | ⛔     | `alloc` ️  |
 | `ssh-ed25519`                        | ✅       | ✅       | ✅           | ✅️     | heapless  |
 | `ssh-rsa`                            | ✅       | ✅       | ✅           | ⛔️     | `alloc`   |
-| `sk-ecdsa-sha2-nistp256@openssh.com` | ⛔       | ⛔       | ⛔           | N/A    | -         |
-| `sk-ssh-ed25519@openssh.com`         | ⛔       | ⛔       | ⛔           | N/A    | -         |
+| `sk-ecdsa-sha2-nistp256@openssh.com` | ✅       | ✅       | ✅           | ⛔     | `alloc`   |
+| `sk-ssh-ed25519@openssh.com`         | ✅       | ✅       | ✅           | ⛔     | `alloc`   |
 
 ## Minimum Supported Rust Version
 

--- a/ssh-key/src/decode.rs
+++ b/ssh-key/src/decode.rs
@@ -19,7 +19,7 @@ pub(crate) trait Decode: Sized {
     fn decode(reader: &mut impl Reader) -> Result<Self>;
 }
 
-/// Decode a single byte from the input data.
+/// Decode a single `byte` from the input data.
 impl Decode for u8 {
     fn decode(reader: &mut impl Reader) -> Result<Self> {
         let mut buf = [0];

--- a/ssh-key/src/encode.rs
+++ b/ssh-key/src/encode.rs
@@ -29,6 +29,17 @@ pub(crate) trait Encode {
     }
 }
 
+/// Encode a single `byte` to the writer.
+impl Encode for u8 {
+    fn encoded_len(&self) -> Result<usize> {
+        Ok(1)
+    }
+
+    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
+        writer.write(&[*self])
+    }
+}
+
 /// Encode a `uint32` as described in [RFC4251 § 5]:
 ///
 /// > Represents a 32-bit unsigned integer.  Stored as four bytes in the

--- a/ssh-key/src/private.rs
+++ b/ssh-key/src/private.rs
@@ -108,16 +108,24 @@ mod ed25519;
 mod keypair;
 #[cfg(feature = "alloc")]
 mod rsa;
+#[cfg(feature = "alloc")]
+mod sk;
 
-#[cfg(feature = "ecdsa")]
-pub use self::ecdsa::{EcdsaKeypair, EcdsaPrivateKey};
 pub use self::ed25519::{Ed25519Keypair, Ed25519PrivateKey};
 pub use self::keypair::KeypairData;
+
 #[cfg(feature = "alloc")]
 pub use self::{
     dsa::{DsaKeypair, DsaPrivateKey},
     rsa::RsaKeypair,
+    sk::SkEd25519,
 };
+
+#[cfg(feature = "ecdsa")]
+pub use self::ecdsa::{EcdsaKeypair, EcdsaPrivateKey};
+
+#[cfg(all(feature = "alloc", feature = "ecdsa"))]
+pub use self::sk::SkEcdsaSha2NistP256;
 
 use crate::{
     checked::CheckedSum,

--- a/ssh-key/src/private/dsa.rs
+++ b/ssh-key/src/private/dsa.rs
@@ -92,6 +92,7 @@ impl PartialEq for DsaPrivateKey {
 impl Eq for DsaPrivateKey {}
 
 /// Digital Signature Algorithm (DSA) private/public keypair.
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[derive(Clone)]
 pub struct DsaKeypair {
     /// Public key.

--- a/ssh-key/src/private/ecdsa.rs
+++ b/ssh-key/src/private/ecdsa.rs
@@ -12,6 +12,7 @@ use zeroize::Zeroize;
 use subtle::{Choice, ConstantTimeEq};
 
 /// Elliptic Curve Digital Signature Algorithm (ECDSA) private key.
+#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
 #[derive(Clone)]
 pub struct EcdsaPrivateKey<const SIZE: usize> {
     /// Byte array containing serialized big endian private scalar.
@@ -127,6 +128,7 @@ impl<const SIZE: usize> PartialEq for EcdsaPrivateKey<SIZE> {
 impl<const SIZE: usize> Eq for EcdsaPrivateKey<SIZE> {}
 
 /// Elliptic Curve Digital Signature Algorithm (ECDSA) private/public keypair.
+#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
 #[derive(Clone, Debug)]
 pub enum EcdsaKeypair {
     /// NIST P-256 ECDSA keypair.

--- a/ssh-key/src/private/rsa.rs
+++ b/ssh-key/src/private/rsa.rs
@@ -89,6 +89,7 @@ impl PartialEq for RsaPrivateKey {
 impl Eq for RsaPrivateKey {}
 
 /// RSA private/public keypair.
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[derive(Clone)]
 pub struct RsaKeypair {
     /// Public key.

--- a/ssh-key/src/private/sk.rs
+++ b/ssh-key/src/private/sk.rs
@@ -1,0 +1,144 @@
+//! Security Key (FIDO/U2F) private keys as described in [PROTOCOL.u2f].
+//!
+//! [PROTOCOL.u2f]: https://cvsweb.openbsd.org/src/usr.bin/ssh/PROTOCOL.u2f?annotate=HEAD
+
+use crate::{
+    checked::CheckedSum, decode::Decode, encode::Encode, public, reader::Reader, writer::Writer,
+    Result,
+};
+use alloc::vec::Vec;
+
+/// Security Key (FIDO/U2F) ECDSA/NIST P-256 private key as specified in
+/// [PROTOCOL.u2f](https://cvsweb.openbsd.org/src/usr.bin/ssh/PROTOCOL.u2f?annotate=HEAD).
+#[cfg(all(feature = "alloc", feature = "ecdsa"))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "alloc", feature = "ecdsa"))))]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct SkEcdsaSha2NistP256 {
+    /// Public key.
+    public: public::SkEcdsaSha2NistP256,
+
+    /// Flags.
+    flags: u8,
+
+    /// FIDO/U2F key handle.
+    key_handle: Vec<u8>,
+
+    /// Reserved data.
+    reserved: Vec<u8>,
+}
+
+#[cfg(feature = "ecdsa")]
+impl SkEcdsaSha2NistP256 {
+    /// Get the ECDSA/NIST P-256 public key.
+    pub fn public(&self) -> &public::SkEcdsaSha2NistP256 {
+        &self.public
+    }
+
+    /// Get flags.
+    pub fn flags(&self) -> u8 {
+        self.flags
+    }
+
+    /// Get FIDO/U2F key handle.
+    pub fn key_handle(&self) -> &[u8] {
+        &self.key_handle
+    }
+}
+
+#[cfg(feature = "ecdsa")]
+impl Decode for SkEcdsaSha2NistP256 {
+    fn decode(reader: &mut impl Reader) -> Result<Self> {
+        Ok(Self {
+            public: public::SkEcdsaSha2NistP256::decode(reader)?,
+            flags: u8::decode(reader)?,
+            key_handle: Vec::decode(reader)?,
+            reserved: Vec::decode(reader)?,
+        })
+    }
+}
+
+#[cfg(feature = "ecdsa")]
+impl Encode for SkEcdsaSha2NistP256 {
+    fn encoded_len(&self) -> Result<usize> {
+        [
+            self.public.encoded_len()?,
+            self.flags.encoded_len()?,
+            self.key_handle.encoded_len()?,
+            self.reserved.encoded_len()?,
+        ]
+        .checked_sum()
+    }
+
+    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
+        self.public.encode(writer)?;
+        self.flags.encode(writer)?;
+        self.key_handle.encode(writer)?;
+        self.reserved.encode(writer)
+    }
+}
+
+/// Security Key (FIDO/U2F) Ed25519 private key as specified in
+/// [PROTOCOL.u2f](https://cvsweb.openbsd.org/src/usr.bin/ssh/PROTOCOL.u2f?annotate=HEAD).
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct SkEd25519 {
+    /// Public key.
+    public: public::SkEd25519,
+
+    /// Flags.
+    flags: u8,
+
+    /// FIDO/U2F key handle.
+    key_handle: Vec<u8>,
+
+    /// Reserved data.
+    reserved: Vec<u8>,
+}
+
+impl SkEd25519 {
+    /// Get the Ed25519 public key.
+    pub fn public(&self) -> &public::SkEd25519 {
+        &self.public
+    }
+
+    /// Get flags.
+    pub fn flags(&self) -> u8 {
+        self.flags
+    }
+
+    /// Get FIDO/U2F key handle.
+    pub fn key_handle(&self) -> &[u8] {
+        &self.key_handle
+    }
+}
+
+impl Decode for SkEd25519 {
+    fn decode(reader: &mut impl Reader) -> Result<Self> {
+        Ok(Self {
+            public: public::SkEd25519::decode(reader)?,
+            flags: u8::decode(reader)?,
+            key_handle: Vec::decode(reader)?,
+            reserved: Vec::decode(reader)?,
+        })
+    }
+}
+
+impl Encode for SkEd25519 {
+    fn encoded_len(&self) -> Result<usize> {
+        [
+            self.public.encoded_len()?,
+            self.flags.encoded_len()?,
+            self.key_handle.encoded_len()?,
+            self.reserved.encoded_len()?,
+        ]
+        .checked_sum()
+    }
+
+    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
+        self.public.encode(writer)?;
+        self.flags.encode(writer)?;
+        self.key_handle.encode(writer)?;
+        self.reserved.encode(writer)
+    }
+}


### PR DESCRIPTION
The `sk-*` algorithms support a "private" key format which includes some additional information including flags and a key handle. Note that the actual private key lives on or is derived by the Security Key hardware token itself.

This commit adds decoding/encoding support for these formats.