### PR TITLE
ssh-key: encoding improvements

### DIFF
--- a/ssh-key/src/error.rs
+++ b/ssh-key/src/error.rs
@@ -55,6 +55,12 @@ pub enum Error {
 
     /// Public key does not match private key.
     PublicKey,
+
+    /// Unexpected trailing data at end of message.
+    TrailingData {
+        /// Number of bytes of remaining data at end of message.
+        remaining: usize,
+    },
 }
 
 impl fmt::Display for Error {
@@ -76,6 +82,11 @@ impl fmt::Display for Error {
             Error::Overflow => f.write_str("internal overflow error"),
             Error::Pem(err) => write!(f, "{}", err),
             Error::PublicKey => f.write_str("public key is incorrect"),
+            Error::TrailingData { remaining } => write!(
+                f,
+                "unexpected trailing data at end of message ({} bytes)",
+                remaining
+            ),
         }
     }
 }

--- a/ssh-key/src/reader.rs
+++ b/ssh-key/src/reader.rs
@@ -117,6 +117,18 @@ pub(crate) trait Reader: Sized {
             Ok(len)
         })
     }
+
+    /// Finish decoding, returning the given value if there is no remaining
+    /// data, or an error otherwise.
+    fn finish<T>(self, value: T) -> Result<T> {
+        if self.is_finished() {
+            Ok(value)
+        } else {
+            Err(Error::TrailingData {
+                remaining: self.remaining_len(),
+            })
+        }
+    }
 }
 
 impl Reader for Base64Reader<'_> {


### PR DESCRIPTION
- Adds `Reader::finish` method which checks all data has been consumed
- Adds `Error::TrailingData` with a `remaining` field which returns the number of bytes of unexpected trailing data at the end of the input
- Impls `PrivateKey` encoding in terms of the `Decode`/`Encode` traits
- Adds `PrivateKey::{from_bytes, to_bytes}`
- Adds `Certificate::{read_file, write_file}