### PR TITLE
ssh-key: `certificate::Builder` (i.e. SSH CA support)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1164,6 +1164,7 @@ dependencies = [
  "ed25519-dalek",
  "hex-literal",
  "pem-rfc7468",
+ "rand_chacha",
  "rand_core 0.6.3",
  "sec1",
  "serde",

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -3,7 +3,8 @@ name = "ssh-key"
 version = "0.4.0-pre"
 description = """
 Pure Rust implementation of SSH key file format decoders/encoders as described
-in RFC4251 and RFC4253 as well as the OpenSSH key formats, certificates, and
+in RFC4251 and RFC4253 as well as the OpenSSH key formats, certificates
+(including certificate validation and certificate authority support), and
 the `authorized_keys` file format. Supports `no_std` embedded targets.
 """
 authors = ["RustCrypto Developers"]
@@ -34,6 +35,7 @@ subtle = { version = "2", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.3"
+rand_chacha = "0.3"
 tempfile = "3"
 zeroize_derive = "1.3" # hack to make minimal-versions lint happy (pulled in by `ed25519-dalek`)
 

--- a/ssh-key/README.md
+++ b/ssh-key/README.md
@@ -13,8 +13,14 @@
 
 Pure Rust implementation of SSH key file format decoders/encoders as described
 in [RFC4251] and [RFC4253] as well as OpenSSH's [PROTOCOL.key] format
-specification, certificates as specified in [PROTOCOL.certkeys]  and the
-`authorized_keys` file format.
+specification.
+
+Provides support for certificates as specified in [PROTOCOL.certkeys]
+(including certificate validation and certificate authority support),
+FIDO/U2F keys as specified in [PROTOCOL.u2f] (and certificates thereof),
+and the `authorized_keys` file format.
+
+Supports a minimal profile which works on heapless `no_std` targets.
 
 ## Features
 
@@ -23,7 +29,9 @@ specification, certificates as specified in [PROTOCOL.certkeys]  and the
   - [x] OpenSSH public keys
   - [x] OpenSSH private keys (i.e. `BEGIN OPENSSH PRIVATE KEY`)
   - [x] OpenSSH certificates
-- [x] OpenSSH certificate validation (Ed25519 only)
+- [x] OpenSSH certificates
+  - [x] Certificate validation (Ed25519 only)
+  - [x] Certificate builder/signer (i.e. SSH CA support)
 - [x] Private key encryption/decryption (`bcrypt-pbkdf` + `aes256-ctr` only)
 - [x] FIDO/U2F key support (`sk-*`) as specified in [PROTOCOL.u2f]
 - [x] Fingerprint support (SHA-256 only)
@@ -35,7 +43,6 @@ specification, certificates as specified in [PROTOCOL.certkeys]  and the
 #### TODO
 
 - [ ] Key generation support (WIP - see table below)
-- [ ] OpenSSH certificate builder/signer (i.e. SSH CA support)
 - [ ] Interop with digital signature crates
   - [x] `ed25519-dalek`
   - [ ] `p256` (ECDSA)

--- a/ssh-key/src/algorithm.rs
+++ b/ssh-key/src/algorithm.rs
@@ -281,6 +281,12 @@ impl AsRef<str> for Algorithm {
 
 impl AlgString for Algorithm {}
 
+impl Default for Algorithm {
+    fn default() -> Algorithm {
+        Algorithm::Ed25519
+    }
+}
+
 impl fmt::Display for Algorithm {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())

--- a/ssh-key/src/certificate/builder.rs
+++ b/ssh-key/src/certificate/builder.rs
@@ -1,0 +1,247 @@
+//! OpenSSH certificate builder.
+
+use super::{CertType, Certificate, OptionsMap, SigningKey};
+use crate::{public, Error, Result, Signature};
+use alloc::{string::String, vec::Vec};
+
+#[cfg(feature = "rand_core")]
+use rand_core::{CryptoRng, RngCore};
+
+#[cfg(doc)]
+use crate::PrivateKey;
+
+/// OpenSSH certificate builder.
+///
+/// This type provides the core functionality of an OpenSSH certificate
+/// authority.
+///
+/// It can build and sign OpenSSH certificates.
+///
+/// ## Principals
+///
+/// Certificates are valid for a specific set of principal names:
+///
+/// - Usernames for [`CertType::User`].
+/// - Hostnames for [`CertType::Host`].
+///
+/// When building a certificate, you will either need to specify principals
+/// by calling [`Builder::valid_principal`] one or more times, or explicitly
+/// marking a certificate as valid for all principals (i.e. "golden ticket")
+/// using the [`Builder::all_principals_valid`] method.
+pub struct Builder {
+    public_key: public::KeyData,
+    nonce: Vec<u8>,
+    serial: Option<u64>,
+    cert_type: Option<CertType>,
+    key_id: Option<String>,
+    valid_principals: Option<Vec<String>>,
+    valid_after: u64,
+    valid_before: u64,
+    critical_options: OptionsMap,
+    extensions: OptionsMap,
+    comment: Option<String>,
+}
+
+impl Builder {
+    /// Recommended size for a nonce.
+    pub const RECOMMENDED_NONCE_SIZE: usize = 16;
+
+    /// Create a new certificate builder for the given subject's public key.
+    ///
+    /// Also requires a nonce (random value typically 16 or 32 bytes long) and
+    /// the validity window of the certificate as Unix seconds.
+    pub fn new(
+        nonce: impl Into<Vec<u8>>,
+        public_key: impl Into<public::KeyData>,
+        valid_after: u64,
+        valid_before: u64,
+    ) -> Self {
+        Self {
+            nonce: nonce.into(),
+            public_key: public_key.into(),
+            serial: None,
+            cert_type: None,
+            key_id: None,
+            valid_principals: None,
+            valid_after,
+            valid_before,
+            critical_options: OptionsMap::new(),
+            extensions: OptionsMap::new(),
+            comment: None,
+        }
+    }
+
+    /// Create a new certificate builder, generating a random nonce using the
+    /// provided random number generator.
+    #[cfg(feature = "rand_core")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
+    pub fn new_with_random_nonce(
+        mut rng: impl CryptoRng + RngCore,
+        public_key: impl Into<public::KeyData>,
+        valid_after: u64,
+        valid_before: u64,
+    ) -> Self {
+        let mut nonce = vec![0u8; Self::RECOMMENDED_NONCE_SIZE];
+        rng.fill_bytes(&mut nonce);
+        Self::new(nonce, public_key, valid_after, valid_before)
+    }
+
+    /// Set certificate serial number.
+    ///
+    /// Default: `0`.
+    pub fn serial(&mut self, serial: u64) -> Result<&mut Self> {
+        if self.serial.is_some() {
+            field_invalid("serial")?;
+        }
+
+        self.serial = Some(serial);
+        Ok(self)
+    }
+
+    /// Set certificate type: user or host.
+    ///
+    /// Default: [`CertType::User`].
+    pub fn cert_type(&mut self, cert_type: CertType) -> Result<&mut Self> {
+        if self.cert_type.is_some() {
+            field_invalid("cert_type")?;
+        }
+
+        self.cert_type = Some(cert_type);
+        Ok(self)
+    }
+
+    /// Set key ID: label to identify this particular certificate.
+    ///
+    /// Default `""`
+    pub fn key_id(&mut self, key_id: impl Into<String>) -> Result<&mut Self> {
+        if self.key_id.is_some() {
+            field_invalid("key_id")?;
+        }
+
+        self.key_id = Some(key_id.into());
+        Ok(self)
+    }
+
+    /// Add a principal (i.e. username or hostname) to `valid_principals`.
+    pub fn valid_principal(&mut self, principal: impl Into<String>) -> Result<&mut Self> {
+        if let Some(principals) = &mut self.valid_principals {
+            principals.push(principal.into());
+        } else {
+            self.valid_principals = Some(vec![principal.into()]);
+        }
+
+        Ok(self)
+    }
+
+    /// Mark this certificate as being valid for all principals.
+    ///
+    /// # ⚠️ Security Warning
+    ///
+    /// Use this method with care! It generates "golden ticket" certificates
+    /// which can e.g. authenticate as any user on a system, or impersonate
+    /// any host.
+    pub fn all_principals_valid(&mut self) -> Result<&mut Self> {
+        self.valid_principals = Some(Vec::new());
+        Ok(self)
+    }
+
+    /// Add a critical option to this certificate.
+    ///
+    /// Critical options must be recognized or the certificate must be rejected.
+    pub fn critical_option(
+        &mut self,
+        name: impl Into<String>,
+        data: impl Into<String>,
+    ) -> Result<&mut Self> {
+        let name = name.into();
+        let data = data.into();
+
+        if self.critical_options.contains_key(&name) {
+            field_invalid("critical_options")?;
+        }
+
+        self.critical_options.insert(name, data);
+        Ok(self)
+    }
+
+    /// Add an extension to this certificate.
+    ///
+    /// Extensions can be unrecognized without impacting the certificate.
+    pub fn extension(
+        &mut self,
+        name: impl Into<String>,
+        data: impl Into<String>,
+    ) -> Result<&mut Self> {
+        let name = name.into();
+        let data = data.into();
+
+        if self.extensions.contains_key(&name) {
+            field_invalid("extensions")?;
+        }
+
+        self.extensions.insert(name, data);
+        Ok(self)
+    }
+
+    /// Add a comment to this certificate.
+    ///
+    /// Default `""`
+    pub fn comment(&mut self, comment: impl Into<String>) -> Result<&mut Self> {
+        if self.comment.is_some() {
+            field_invalid("comment")?;
+        }
+
+        self.comment = Some(comment.into());
+        Ok(self)
+    }
+
+    /// Sign the certificate using the provided signer type.
+    ///
+    /// The [`PrivateKey`] type can be used as a signer.
+    pub fn sign<S: SigningKey>(self, signing_key: &S) -> Result<Certificate> {
+        // Empty valid principals result in a "golden ticket", so this check
+        // ensures that was explicitly configured via `all_principals_valid`.
+        let valid_principals = match self.valid_principals {
+            Some(principals) => principals,
+            None => {
+                return Err(Error::CertificateFieldInvalid {
+                    name: "valid_principals",
+                })
+            }
+        };
+
+        let mut cert = Certificate {
+            nonce: self.nonce,
+            public_key: self.public_key,
+            serial: self.serial.unwrap_or_default(),
+            cert_type: self.cert_type.unwrap_or_default(),
+            key_id: self.key_id.unwrap_or_default(),
+            valid_principals,
+            valid_after: self.valid_after,
+            valid_before: self.valid_before,
+            critical_options: self.critical_options,
+            extensions: self.extensions,
+            reserved: Vec::new(),
+            comment: self.comment.unwrap_or_default(),
+            signature_key: signing_key.public_key(),
+            signature: Signature::placeholder(),
+        };
+
+        let mut tbs_cert = Vec::new();
+        cert.encode_tbs(&mut tbs_cert)?;
+        cert.signature = signing_key.try_sign(&tbs_cert)?;
+
+        #[cfg(all(debug_assertions, feature = "fingerprint"))]
+        cert.validate_at(
+            cert.valid_after,
+            &[cert.signature_key.fingerprint(Default::default())?],
+        )?;
+
+        Ok(cert)
+    }
+}
+
+/// Return an error for an invalid certificate field.
+fn field_invalid(name: &'static str) -> Result<()> {
+    Err(Error::CertificateFieldInvalid { name })
+}

--- a/ssh-key/src/certificate/cert_type.rs
+++ b/ssh-key/src/certificate/cert_type.rs
@@ -1,0 +1,65 @@
+/// OpenSSH certificate types.
+use crate::{decode::Decode, encode::Encode, reader::Reader, writer::Writer, Error, Result};
+
+/// Types of OpenSSH certificates: user or host.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum CertType {
+    /// User certificate
+    User = 1,
+
+    /// Host certificate
+    Host = 2,
+}
+
+impl CertType {
+    /// Is this a host certificate?
+    pub fn is_host(self) -> bool {
+        self == CertType::Host
+    }
+
+    /// Is this a user certificate?
+    pub fn is_user(self) -> bool {
+        self == CertType::User
+    }
+}
+
+impl Decode for CertType {
+    fn decode(reader: &mut impl Reader) -> Result<Self> {
+        u32::decode(reader)?.try_into()
+    }
+}
+
+impl Default for CertType {
+    fn default() -> Self {
+        Self::User
+    }
+}
+
+impl Encode for CertType {
+    fn encoded_len(&self) -> Result<usize> {
+        Ok(4)
+    }
+
+    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
+        u32::from(*self).encode(writer)
+    }
+}
+
+impl From<CertType> for u32 {
+    fn from(cert_type: CertType) -> u32 {
+        cert_type as u32
+    }
+}
+
+impl TryFrom<u32> for CertType {
+    type Error = Error;
+
+    fn try_from(n: u32) -> Result<CertType> {
+        match n {
+            1 => Ok(CertType::User),
+            2 => Ok(CertType::Host),
+            _ => Err(Error::FormatEncoding),
+        }
+    }
+}

--- a/ssh-key/src/certificate/options_map.rs
+++ b/ssh-key/src/certificate/options_map.rs
@@ -1,0 +1,59 @@
+//! OpenSSH certificate options used by critical options and extensions.
+
+use crate::{
+    checked::CheckedSum, decode::Decode, encode::Encode, reader::Reader, writer::Writer, Error,
+    Result,
+};
+use alloc::{string::String, vec::Vec};
+use core::cmp::Ordering;
+
+/// Key/value map type used for certificate's critical options and extensions.
+pub type OptionsMap = alloc::collections::BTreeMap<String, String>;
+
+impl Decode for OptionsMap {
+    fn decode(reader: &mut impl Reader) -> Result<Self> {
+        reader.read_nested(|reader| {
+            let mut entries = Vec::<(String, String)>::new();
+
+            while !reader.is_finished() {
+                let name = String::decode(reader)?;
+                let data = String::decode(reader)?;
+
+                // Options must be lexically ordered by "name" if they appear in
+                // the sequence. Each named option may only appear once in a
+                // certificate.
+                if let Some((prev_name, _)) = entries.last() {
+                    if prev_name.cmp(&name) != Ordering::Less {
+                        return Err(Error::FormatEncoding);
+                    }
+                }
+
+                entries.push((name, data));
+            }
+
+            Ok(OptionsMap::from_iter(entries))
+        })
+    }
+}
+
+impl Encode for OptionsMap {
+    fn encoded_len(&self) -> Result<usize> {
+        self.iter().try_fold(4, |acc, (name, data)| {
+            [acc, 4, name.len(), 4, data.len()].checked_sum()
+        })
+    }
+
+    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
+        self.encoded_len()?
+            .checked_sub(4)
+            .ok_or(Error::Length)?
+            .encode(writer)?;
+
+        for (name, data) in self {
+            name.encode(writer)?;
+            data.encode(writer)?;
+        }
+
+        Ok(())
+    }
+}

--- a/ssh-key/src/certificate/signing_key.rs
+++ b/ssh-key/src/certificate/signing_key.rs
@@ -1,0 +1,27 @@
+//! Certificate signing key trait.
+
+use crate::{public, Signature};
+use signature::Signer;
+
+#[cfg(doc)]
+use super::Builder;
+
+/// Certificate signing key trait for the certificate [`Builder`].
+///
+/// This trait is automatically impl'd for any types which impl the
+/// [`Signer`] trait for the OpenSSH certificate [`Signature`] type and also
+/// support a [`From`] conversion for [`public::KeyData`].
+pub trait SigningKey: Signer<Signature> {
+    /// Get the [`public::KeyData`] for this signing key.
+    fn public_key(&self) -> public::KeyData;
+}
+
+impl<T> SigningKey for T
+where
+    T: Signer<Signature>,
+    public::KeyData: for<'a> From<&'a T>,
+{
+    fn public_key(&self) -> public::KeyData {
+        self.into()
+    }
+}

--- a/ssh-key/src/error.rs
+++ b/ssh-key/src/error.rs
@@ -16,6 +16,12 @@ pub enum Error {
     /// Base64-related errors.
     Base64(base64ct::Error),
 
+    /// Certificate field is invalid or already set.
+    CertificateFieldInvalid {
+        /// Name of the invalid field.
+        name: &'static str,
+    },
+
     /// Certificate validation failed.
     CertificateValidation,
 
@@ -68,6 +74,9 @@ impl fmt::Display for Error {
         match self {
             Error::Algorithm => f.write_str("unknown or unsupported algorithm"),
             Error::Base64(err) => write!(f, "Base64 encoding error: {}", err),
+            Error::CertificateFieldInvalid { name } => {
+                write!(f, "certificate field invalid: {}", name)
+            }
             Error::CertificateValidation => f.write_str("certificate validation failed"),
             Error::CharacterEncoding => f.write_str("character encoding invalid"),
             Error::Crypto => f.write_str("cryptographic error"),

--- a/ssh-key/src/private.rs
+++ b/ssh-key/src/private.rs
@@ -149,7 +149,7 @@ use {
 #[cfg(feature = "fingerprint")]
 use crate::{Fingerprint, HashAlg};
 
-#[cfg(any(feature = "ed25519", feature = "encryption"))]
+#[cfg(feature = "rand_core")]
 use rand_core::{CryptoRng, RngCore};
 
 #[cfg(feature = "std")]
@@ -424,6 +424,21 @@ impl PrivateKey {
     /// Get the [`PublicKey`] which corresponds to this private key.
     pub fn public_key(&self) -> &PublicKey {
         &self.public_key
+    }
+
+    /// Generate a random key which uses the given algorithm.
+    ///
+    /// # Returns
+    /// - `Error::Algorithm` if the algorithm is unsupported.
+    #[cfg(feature = "rand_core")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
+    #[allow(unused_variables)]
+    pub fn random(rng: impl CryptoRng + RngCore, algorithm: Algorithm) -> Result<Self> {
+        match algorithm {
+            #[cfg(feature = "ed25519")]
+            Algorithm::Ed25519 => Ok(Self::random_ed25519(rng)),
+            _ => Err(Error::Algorithm),
+        }
     }
 
     /// Generate a random Ed25519 private key.
@@ -716,6 +731,18 @@ impl From<PrivateKey> for PublicKey {
 impl From<&PrivateKey> for PublicKey {
     fn from(private_key: &PrivateKey) -> PublicKey {
         private_key.public_key.clone()
+    }
+}
+
+impl From<PrivateKey> for public::KeyData {
+    fn from(private_key: PrivateKey) -> public::KeyData {
+        private_key.public_key.key_data
+    }
+}
+
+impl From<&PrivateKey> for public::KeyData {
+    fn from(private_key: &PrivateKey) -> public::KeyData {
+        private_key.public_key.key_data.clone()
     }
 }
 

--- a/ssh-key/src/public.rs
+++ b/ssh-key/src/public.rs
@@ -224,6 +224,18 @@ impl From<KeyData> for PublicKey {
     }
 }
 
+impl From<PublicKey> for KeyData {
+    fn from(public_key: PublicKey) -> KeyData {
+        public_key.key_data
+    }
+}
+
+impl From<&PublicKey> for KeyData {
+    fn from(public_key: &PublicKey) -> KeyData {
+        public_key.key_data.clone()
+    }
+}
+
 impl FromStr for PublicKey {
     type Err = Error;
 

--- a/ssh-key/tests/certificate_builder.rs
+++ b/ssh-key/tests/certificate_builder.rs
@@ -1,0 +1,100 @@
+//! Certificate builder tests.
+
+#![cfg(all(feature = "alloc", feature = "fingerprint", feature = "ed25519"))]
+
+use hex_literal::hex;
+use rand_chacha::{rand_core::SeedableRng, ChaCha8Rng};
+use ssh_key::{
+    certificate::{self, CertType},
+    Algorithm, PrivateKey,
+};
+
+/// Example Unix timestamp when a certificate was issued (2020-09-13 12:26:40 UTC).
+const ISSUED_AT: u64 = 1600000000;
+
+/// Example Unix timestamp when a certificate is valid (2022-04-15 05:20:00 UTC).
+const VALID_AT: u64 = 1650000000;
+
+/// Example Unix timestamp when a certificate expires (2023-11-14 22:13:20 UTC).
+const EXPIRES_AT: u64 = 1700000000;
+
+/// Example serial number.
+const SERIAL: u64 = 42;
+
+/// Example key ID.
+const KEY_ID: &str = "example";
+
+/// Example principal name.
+const PRINCIPAL: &str = "nobody";
+
+/// Critical extension 1.
+const CRITICAL_EXTENSION_1: (&str, &str) = ("critical name 1", "critical data 2");
+
+/// Critical extension 1.
+const CRITICAL_EXTENSION_2: (&str, &str) = ("critical name 2", "critical data 2");
+
+/// Non critical extension 1.
+const EXTENSION_1: (&str, &str) = ("extension name 1", "extension data 1");
+
+/// Non critical extension 2.
+const EXTENSION_2: (&str, &str) = ("extension name 2", "extension data 2");
+
+/// Example comment.
+const COMMENT: &str = "user@example.com";
+
+/// Happy path test.
+#[test]
+fn sign_and_verify() {
+    let mut rng = ChaCha8Rng::from_seed([42; 32]);
+
+    let ca_key = PrivateKey::random(&mut rng, Algorithm::Ed25519).unwrap();
+    let subject_key = PrivateKey::random(&mut rng, Algorithm::Ed25519).unwrap();
+
+    let mut cert_builder = certificate::Builder::new_with_random_nonce(
+        &mut rng,
+        subject_key.public_key(),
+        ISSUED_AT,
+        EXPIRES_AT,
+    );
+    cert_builder.serial(SERIAL).unwrap();
+    cert_builder.key_id(KEY_ID).unwrap();
+    cert_builder.valid_principal(PRINCIPAL).unwrap();
+    cert_builder
+        .critical_option(CRITICAL_EXTENSION_1.0, CRITICAL_EXTENSION_1.1)
+        .unwrap();
+    cert_builder
+        .critical_option(CRITICAL_EXTENSION_2.0, CRITICAL_EXTENSION_2.1)
+        .unwrap();
+    cert_builder
+        .extension(EXTENSION_1.0, EXTENSION_1.1)
+        .unwrap();
+    cert_builder
+        .extension(EXTENSION_2.0, EXTENSION_2.1)
+        .unwrap();
+    cert_builder.comment(COMMENT).unwrap();
+
+    let cert = cert_builder.sign(&ca_key).unwrap();
+    assert_eq!(cert.nonce(), &hex!("321fdf7e0a2afe803308f394f54c6abe"));
+    assert_eq!(cert.public_key(), subject_key.public_key().key_data());
+    assert_eq!(cert.serial(), SERIAL);
+    assert_eq!(cert.cert_type(), CertType::User);
+    assert_eq!(cert.key_id(), KEY_ID);
+    assert_eq!(cert.valid_principals().len(), 1);
+    assert_eq!(cert.valid_principals()[0], PRINCIPAL);
+    assert_eq!(cert.valid_after(), ISSUED_AT);
+    assert_eq!(cert.valid_before(), EXPIRES_AT);
+    assert_eq!(cert.critical_options().len(), 2);
+    assert_eq!(
+        cert.critical_options().get(CRITICAL_EXTENSION_1.0).unwrap(),
+        CRITICAL_EXTENSION_1.1
+    );
+    assert_eq!(cert.extensions().get(EXTENSION_2.0).unwrap(), EXTENSION_2.1);
+    assert_eq!(cert.extensions().len(), 2);
+    assert_eq!(cert.extensions().get(EXTENSION_1.0).unwrap(), EXTENSION_1.1);
+    assert_eq!(cert.extensions().get(EXTENSION_2.0).unwrap(), EXTENSION_2.1);
+    assert_eq!(cert.signature_key(), ca_key.public_key().key_data());
+    assert_eq!(cert.comment(), COMMENT);
+
+    let ca_fingerprint = ca_key.fingerprint(Default::default()).unwrap();
+    assert!(cert.validate_at(VALID_AT, &[ca_fingerprint]).is_ok());
+}


### PR DESCRIPTION
Adds a builder/signer type for `ssh_key::Certificate` which is able to sign OpenSSH certificates as a certificate authority.

Currently Ed25519 only.