### PR TITLE
ssh-key: fingerprint simplification + SHA-512 support

### DIFF
--- a/ssh-key/src/algorithm.rs
+++ b/ssh-key/src/algorithm.rs
@@ -375,6 +375,7 @@ impl str::FromStr for EcdsaCurve {
 
 /// Hashing algorithms a.k.a. digest functions.
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[non_exhaustive]
 pub enum HashAlg {
     /// SHA-256
     Sha256,

--- a/ssh-key/src/certificate.rs
+++ b/ssh-key/src/certificate.rs
@@ -353,7 +353,7 @@ impl Certificate {
         self.verify_signature()?;
 
         // TODO(tarcieri): support non SHA-256 public key fingerprints?
-        let cert_fingerprint = self.signature_key.fingerprint(HashAlg::Sha256)?;
+        let cert_fingerprint = self.signature_key.fingerprint(HashAlg::Sha256);
 
         if !ca_fingerprints.into_iter().any(|f| f == &cert_fingerprint) {
             return Err(Error::CertificateValidation);

--- a/ssh-key/src/certificate/builder.rs
+++ b/ssh-key/src/certificate/builder.rs
@@ -233,7 +233,7 @@ impl Builder {
         #[cfg(all(debug_assertions, feature = "fingerprint"))]
         cert.validate_at(
             cert.valid_after,
-            &[cert.signature_key.fingerprint(Default::default())?],
+            &[cert.signature_key.fingerprint(Default::default())],
         )?;
 
         Ok(cert)

--- a/ssh-key/src/lib.rs
+++ b/ssh-key/src/lib.rs
@@ -173,7 +173,7 @@ pub use crate::{certificate::Certificate, mpint::MPInt, signature::Signature};
 pub use sec1;
 
 #[cfg(feature = "fingerprint")]
-pub use crate::fingerprint::{Fingerprint, Sha256Fingerprint};
+pub use crate::fingerprint::Fingerprint;
 
 #[cfg(feature = "rand_core")]
 pub use rand_core;

--- a/ssh-key/src/private.rs
+++ b/ssh-key/src/private.rs
@@ -406,7 +406,7 @@ impl PrivateKey {
     /// Use [`Default::default()`] to use the default hash function (SHA-256).
     #[cfg(feature = "fingerprint")]
     #[cfg_attr(docsrs, doc(cfg(feature = "fingerprint")))]
-    pub fn fingerprint(&self, hash_alg: HashAlg) -> Result<Fingerprint> {
+    pub fn fingerprint(&self, hash_alg: HashAlg) -> Fingerprint {
         self.public_key.fingerprint(hash_alg)
     }
 

--- a/ssh-key/src/public.rs
+++ b/ssh-key/src/public.rs
@@ -186,7 +186,7 @@ impl PublicKey {
     /// Use [`Default::default()`] to use the default hash function (SHA-256).
     #[cfg(feature = "fingerprint")]
     #[cfg_attr(docsrs, doc(cfg(feature = "fingerprint")))]
-    pub fn fingerprint(&self, hash_alg: HashAlg) -> Result<Fingerprint> {
+    pub fn fingerprint(&self, hash_alg: HashAlg) -> Fingerprint {
         self.key_data.fingerprint(hash_alg)
     }
 

--- a/ssh-key/src/public/key_data.rs
+++ b/ssh-key/src/public/key_data.rs
@@ -13,7 +13,7 @@ use super::{DsaPublicKey, RsaPublicKey};
 use super::{EcdsaPublicKey, SkEcdsaSha2NistP256};
 
 #[cfg(feature = "fingerprint")]
-use crate::{Fingerprint, HashAlg, Sha256Fingerprint};
+use crate::{Fingerprint, HashAlg};
 
 /// Public key data.
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -101,11 +101,8 @@ impl KeyData {
     /// Use [`Default::default()`] to use the default hash function (SHA-256).
     #[cfg(feature = "fingerprint")]
     #[cfg_attr(docsrs, doc(cfg(feature = "fingerprint")))]
-    pub fn fingerprint(&self, hash_alg: HashAlg) -> Result<Fingerprint> {
-        match hash_alg {
-            HashAlg::Sha256 => Sha256Fingerprint::try_from(self).map(Into::into),
-            _ => Err(Error::Algorithm),
-        }
+    pub fn fingerprint(&self, hash_alg: HashAlg) -> Fingerprint {
+        Fingerprint::new(hash_alg, self)
     }
 
     /// Get RSA public key if this key is the correct type.

--- a/ssh-key/src/writer.rs
+++ b/ssh-key/src/writer.rs
@@ -7,7 +7,7 @@ use pem_rfc7468 as pem;
 use alloc::vec::Vec;
 
 #[cfg(feature = "fingerprint")]
-use sha2::{Digest, Sha256};
+use sha2::{Digest, Sha256, Sha512};
 
 /// Get the estimated length of data when encoded as Base64.
 ///
@@ -52,6 +52,14 @@ impl Writer for Vec<u8> {
 
 #[cfg(feature = "fingerprint")]
 impl Writer for Sha256 {
+    fn write(&mut self, bytes: &[u8]) -> Result<()> {
+        self.update(bytes);
+        Ok(())
+    }
+}
+
+#[cfg(feature = "fingerprint")]
+impl Writer for Sha512 {
     fn write(&mut self, bytes: &[u8]) -> Result<()> {
         self.update(bytes);
         Ok(())

--- a/ssh-key/tests/certificate.rs
+++ b/ssh-key/tests/certificate.rs
@@ -282,8 +282,7 @@ fn reject_certificate_with_untrusted_ca() {
     let ca = Certificate::from_str(DSA_CERT_EXAMPLE)
         .unwrap()
         .public_key()
-        .fingerprint(Default::default())
-        .unwrap();
+        .fingerprint(Default::default());
 
     assert!(cert.validate_at(VALID_TIMESTAMP, &[ca]).is_err());
 }

--- a/ssh-key/tests/certificate_builder.rs
+++ b/ssh-key/tests/certificate_builder.rs
@@ -106,7 +106,7 @@ fn ed25519_sign_and_verify() {
     assert_eq!(cert.signature_key(), ca_key.public_key().key_data());
     assert_eq!(cert.comment(), COMMENT);
 
-    let ca_fingerprint = ca_key.fingerprint(Default::default()).unwrap();
+    let ca_fingerprint = ca_key.fingerprint(Default::default());
     assert!(cert.validate_at(VALID_AT, &[ca_fingerprint]).is_ok());
 }
 
@@ -134,7 +134,7 @@ fn ecdsa_nistp256_sign_and_verify() {
     assert_eq!(cert.public_key(), subject_key.public_key().key_data());
     assert_eq!(cert.signature_key(), ca_key.public_key().key_data());
 
-    let ca_fingerprint = ca_key.fingerprint(Default::default()).unwrap();
+    let ca_fingerprint = ca_key.fingerprint(Default::default());
     assert!(cert.validate_at(VALID_AT, &[ca_fingerprint]).is_ok());
 }
 
@@ -160,6 +160,6 @@ fn rsa_sign_and_verify() {
     assert_eq!(cert.public_key(), subject_key.public_key().key_data());
     assert_eq!(cert.signature_key(), ca_key.public_key().key_data());
 
-    let ca_fingerprint = ca_key.fingerprint(Default::default()).unwrap();
+    let ca_fingerprint = ca_key.fingerprint(Default::default());
     assert!(cert.validate_at(VALID_AT, &[ca_fingerprint]).is_ok());
 }

--- a/ssh-key/tests/public_key.rs
+++ b/ssh-key/tests/public_key.rs
@@ -81,7 +81,7 @@ fn decode_dsa_openssh() {
     #[cfg(feature = "fingerprint")]
     assert_eq!(
         "SHA256:Nh0Me49Zh9fDw/VYUfq43IJmI1T+XrjiYONPND8GzaM",
-        &key.fingerprint(Default::default()).unwrap().to_string(),
+        &key.fingerprint(Default::default()).to_string(),
     );
 }
 
@@ -112,7 +112,7 @@ fn decode_ecdsa_p256_openssh() {
     #[cfg(feature = "fingerprint")]
     assert_eq!(
         "SHA256:JQ6FV0rf7qqJHZqIj4zNH8eV0oB8KLKh9Pph3FTD98g",
-        &key.fingerprint(Default::default()).unwrap().to_string(),
+        &key.fingerprint(Default::default()).to_string(),
     );
 }
 
@@ -144,7 +144,7 @@ fn decode_ecdsa_p384_openssh() {
     #[cfg(feature = "fingerprint")]
     assert_eq!(
         "SHA256:nkGE8oV7pHvOiPKHtQRs67WUPiVLRxbNu//gV/k4Vjw",
-        &key.fingerprint(Default::default()).unwrap().to_string(),
+        &key.fingerprint(Default::default()).to_string(),
     );
 }
 
@@ -177,7 +177,7 @@ fn decode_ecdsa_p521_openssh() {
     #[cfg(feature = "fingerprint")]
     assert_eq!(
         "SHA256:l3AUUMK6Q2BbuiqvMx2fs97f8LUYq7sWCAx7q5m3S6M",
-        &key.fingerprint(Default::default()).unwrap().to_string(),
+        &key.fingerprint(Default::default()).to_string(),
     );
 }
 
@@ -197,7 +197,7 @@ fn decode_ed25519_openssh() {
     #[cfg(feature = "fingerprint")]
     assert_eq!(
         "SHA256:UCUiLr7Pjs9wFFJMDByLgc3NrtdU344OgUM45wZPcIQ",
-        &key.fingerprint(Default::default()).unwrap().to_string(),
+        &key.fingerprint(Default::default()).to_string(),
     );
 }
 
@@ -229,7 +229,7 @@ fn decode_rsa_3072_openssh() {
     #[cfg(feature = "fingerprint")]
     assert_eq!(
         "SHA256:Fmxts/GcV77PakFnf1Ueki5mpU4ZjUQWGRjZGAo3n/I",
-        &key.fingerprint(Default::default()).unwrap().to_string(),
+        &key.fingerprint(Default::default()).to_string(),
     );
 }
 
@@ -264,7 +264,7 @@ fn decode_rsa_4096_openssh() {
     #[cfg(feature = "fingerprint")]
     assert_eq!(
         "SHA256:FKAyeywtQNZLl1YTzIzCV/ThadBlnWMaD7jHQYDseEY",
-        &key.fingerprint(Default::default()).unwrap().to_string(),
+        &key.fingerprint(Default::default()).to_string(),
     );
 }
 
@@ -291,7 +291,7 @@ fn decode_sk_ecdsa_p256_openssh() {
     #[cfg(feature = "fingerprint")]
     assert_eq!(
         "SHA256:UINe2WXFh3SiqwLxsBv34fBO2ei+g7uOeJJXVEK95iE",
-        &key.fingerprint(Default::default()).unwrap().to_string(),
+        &key.fingerprint(Default::default()).to_string(),
     );
 }
 
@@ -314,7 +314,7 @@ fn decode_sk_ed25519_openssh() {
     #[cfg(feature = "fingerprint")]
     assert_eq!(
         "SHA256:6WZVJ44bqhAWLVP4Ns0TDkoSQSsZo/h2K+mEvOaNFbw",
-        &key.fingerprint(Default::default()).unwrap().to_string(),
+        &key.fingerprint(Default::default()).to_string(),
     );
 }
 


### PR DESCRIPTION
Simplifies and unifies the fingerprint implementation into a single `Fingerprint` enum type which makes it simple to plug in new hash functions.

Also adds SHA-512 support, which makes it possible for the fingerprint methods to be infallible.