### PR TITLE
ssh-key: `serde` support for `Fingerprint`

### DIFF
--- a/ssh-key/README.md
+++ b/ssh-key/README.md
@@ -36,24 +36,22 @@ respective SSH key algorithm.
   - [x] OpenSSH private keys (i.e. `BEGIN OPENSSH PRIVATE KEY`)
   - [x] OpenSSH certificates
 - [x] OpenSSH certificates
-  - [x] Certificate validation (ECDSA/NIST P-256 and Ed25519 only)
+  - [x] Certificate validation
   - [x] Certificate authority (CA) support i.e. cert builder/signer
 - [x] Private key encryption/decryption (`bcrypt-pbkdf` + `aes256-ctr` only)
+- [x] Private key generation support: Ed25519, ECDSA/P-256, and RSA
 - [x] FIDO/U2F key support (`sk-*`) as specified in [PROTOCOL.u2f]
-- [x] Fingerprint support (SHA-256 only)
+- [x] Fingerprint support
 - [x] `no_std` support including support for "heapless" (no-`alloc`) targets
 - [x] Parsing `authorized_keys` files
-- [x] Serde support (certificates and public keys only)
-- [x] Zeroization support for private keys
+- [x] `serde` support
+- [x] `zeroize` support for private keys
 
 #### TODO
 
-- [ ] Key generation support (WIP - see table below)
-- [ ] Interop with digital signature crates
-  - [x] `ed25519-dalek`
-  - [x] `p256` (ECDSA)
-  - [ ] `p384` (ECDSA)
-  - [ ] `rsa`
+- [ ] ECDSA/P-384 support
+- [ ] ECDSA/P-512 support
+- [ ] FIDO/U2F signature support
 - [ ] Legacy (pre-OpenSSH) SSH key format support
   - [ ] PKCS#1
   - [ ] PKCS#8

--- a/ssh-key/src/certificate.rs
+++ b/ssh-key/src/certificate.rs
@@ -53,6 +53,15 @@ use std::{
 /// See documentation for [`Certificate::validate`] and
 /// [`Certificate::validate_at`] methods for more information.
 ///
+/// # `serde` support
+///
+/// When the `serde` feature of this crate is enabled, this type receives impls
+/// of [`Deserialize`][`serde::Deserialize`] and [`Serialize`][`serde::Serialize`].
+///
+/// The serialization uses a binary encoding with binary formats like bincode
+/// and CBOR, and the OpenSSH string serialization when used with
+/// human-readable formats like JSON and TOML.
+///
 /// [PROTOCOL.certkeys]: https://cvsweb.openbsd.org/src/usr.bin/ssh/PROTOCOL.certkeys?annotate=HEAD
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Certificate {

--- a/ssh-key/src/lib.rs
+++ b/ssh-key/src/lib.rs
@@ -116,9 +116,10 @@
 //!
 //! ## `serde` support
 //!
-//! When the `serde` feature of this crate is enabled, the [`Certificate`] and
-//! [`PublicKey`] types receive impls of `serde`'s `Deserialize` and
-//! `Serialize` traits.
+//! When the `serde` feature of this crate is enabled, the [`Certificate`],
+//! [`Fingerprint`], and [`PublicKey`] types receive impls of `serde`'s
+//! [`Deserialize`][`serde::Deserialize`] and [`Serialize`][`serde::Serialize`]
+//! traits.
 //!
 //! Serializing/deserializing [`PrivateKey`] using `serde` is presently
 //! unsupported.

--- a/ssh-key/src/public.rs
+++ b/ssh-key/src/public.rs
@@ -51,6 +51,19 @@ use serde::{de, ser, Deserialize, Serialize};
 use std::{fs, path::Path};
 
 /// SSH public key.
+///
+/// # OpenSSH encoding
+///
+/// The OpenSSH encoding of an SSH public key looks like following:
+///
+/// # `serde` support
+///
+/// When the `serde` feature of this crate is enabled, this type receives impls
+/// of [`Deserialize`][`serde::Deserialize`] and [`Serialize`][`serde::Serialize`].
+///
+/// The serialization uses a binary encoding with binary formats like bincode
+/// and CBOR, and the OpenSSH string serialization when used with
+/// human-readable formats like JSON and TOML.
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct PublicKey {
     /// Key data.


### PR DESCRIPTION
Support for serializing OpenSSH fingerprints using `serde`.

Additionally includes documentation improvements.