### PR TITLE
der: initial `Reader` trait

### DIFF
--- a/der/derive/src/choice.rs
+++ b/der/derive/src/choice.rs
@@ -96,6 +96,7 @@ impl DeriveChoice {
 
             impl<#lt_params> ::der::Decode<#lifetime> for #ident<#lt_params> {
                 fn decode(decoder: &mut ::der::Decoder<#lifetime>) -> ::der::Result<Self> {
+                    use der::Reader as _;
                     match decoder.peek_tag()? {
                         #(#decode_body)*
                         actual => Err(der::ErrorKind::TagUnexpected {

--- a/der/src/asn1/bit_string.rs
+++ b/der/src/asn1/bit_string.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     asn1::Any, ByteSlice, DecodeValue, Decoder, DerOrd, EncodeValue, Encoder, Error, ErrorKind,
-    FixedTag, Header, Length, Result, Tag, ValueOrd, Writer,
+    FixedTag, Header, Length, Reader, Result, Tag, ValueOrd, Writer,
 };
 use core::{cmp::Ordering, iter::FusedIterator};
 
@@ -122,7 +122,7 @@ impl<'a> DecodeValue<'a> for BitString<'a> {
             length: (header.length - Length::ONE)?,
         };
 
-        let unused_bits = decoder.byte()?;
+        let unused_bits = decoder.read_byte()?;
         let inner = ByteSlice::decode_value(decoder, header)?;
         Self::new(unused_bits, inner.as_bytes())
     }

--- a/der/src/asn1/boolean.rs
+++ b/der/src/asn1/boolean.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error,
-    ErrorKind, FixedTag, Header, Length, Result, Tag, Writer,
+    ErrorKind, FixedTag, Header, Length, Reader, Result, Tag, Writer,
 };
 
 /// Byte used to encode `true` in ASN.1 DER. From X.690 Section 11.1:
@@ -20,7 +20,7 @@ impl<'a> DecodeValue<'a> for bool {
             return Err(decoder.error(ErrorKind::Length { tag: Self::TAG }));
         }
 
-        match decoder.byte()? {
+        match decoder.read_byte()? {
             FALSE_OCTET => Ok(false),
             TRUE_OCTET => Ok(true),
             _ => Err(Self::TAG.non_canonical_error()),

--- a/der/src/asn1/context_specific.rs
+++ b/der/src/asn1/context_specific.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     asn1::Any, Choice, Decode, DecodeValue, Decoder, DerOrd, Encode, EncodeValue, EncodeValueRef,
-    Encoder, Error, Header, Length, Result, Tag, TagMode, TagNumber, Tagged, ValueOrd,
+    Encoder, Error, Header, Length, Reader, Result, Tag, TagMode, TagNumber, Tagged, ValueOrd,
 };
 use core::cmp::Ordering;
 

--- a/der/src/asn1/optional.rs
+++ b/der/src/asn1/optional.rs
@@ -1,6 +1,6 @@
 //! ASN.1 `OPTIONAL` as mapped to Rust's `Option` type
 
-use crate::{Choice, Decode, Decoder, DerOrd, Encode, Encoder, Length, Result, Tag};
+use crate::{Choice, Decode, Decoder, DerOrd, Encode, Encoder, Length, Reader, Result, Tag};
 use core::cmp::Ordering;
 
 impl<'a, T> Decode<'a> for Option<T>

--- a/der/src/asn1/sequence.rs
+++ b/der/src/asn1/sequence.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     ByteSlice, Decode, DecodeValue, Decoder, Encode, EncodeValue, Encoder, FixedTag, Header,
-    Length, Result, Tag,
+    Length, Reader, Result, Tag,
 };
 
 /// ASN.1 `SEQUENCE` trait.

--- a/der/src/asn1/sequence_of.rs
+++ b/der/src/asn1/sequence_of.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     arrayvec, ord::iter_cmp, ArrayVec, Decode, DecodeValue, Decoder, DerOrd, Encode, EncodeValue,
-    Encoder, ErrorKind, FixedTag, Header, Length, Result, Tag, ValueOrd,
+    Encoder, ErrorKind, FixedTag, Header, Length, Reader, Result, Tag, ValueOrd,
 };
 use core::cmp::Ordering;
 

--- a/der/src/asn1/set_of.rs
+++ b/der/src/asn1/set_of.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     arrayvec, ord::iter_cmp, ArrayVec, Decode, DecodeValue, Decoder, DerOrd, Encode, EncodeValue,
-    Encoder, Error, ErrorKind, FixedTag, Header, Length, Result, Tag, ValueOrd,
+    Encoder, Error, ErrorKind, FixedTag, Header, Length, Reader, Result, Tag, ValueOrd,
 };
 use core::cmp::Ordering;
 

--- a/der/src/byte_slice.rs
+++ b/der/src/byte_slice.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     str_slice::StrSlice, DecodeValue, Decoder, DerOrd, EncodeValue, Encoder, Error, Header, Length,
-    Result, Writer,
+    Reader, Result, Writer,
 };
 use core::cmp::Ordering;
 
@@ -57,7 +57,7 @@ impl AsRef<[u8]> for ByteSlice<'_> {
 
 impl<'a> DecodeValue<'a> for ByteSlice<'a> {
     fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> Result<Self> {
-        decoder.bytes(header.length).and_then(Self::new)
+        decoder.read_slice(header.length).and_then(Self::new)
     }
 }
 

--- a/der/src/document.rs
+++ b/der/src/document.rs
@@ -1,6 +1,8 @@
 //! ASN.1 DER-encoded documents stored on the heap.
 
-use crate::{Decode, Decoder, Encode, Encoder, Error, FixedTag, Length, Result, Tag, Writer};
+use crate::{
+    Decode, Decoder, Encode, Encoder, Error, FixedTag, Length, Reader, Result, Tag, Writer,
+};
 use alloc::vec::Vec;
 use core::fmt::{self, Debug};
 
@@ -152,7 +154,7 @@ impl Decode<'_> for Document {
     fn decode(decoder: &mut Decoder<'_>) -> Result<Document> {
         let header = decoder.peek_header()?;
         let length = (header.encoded_len()? + header.length)?;
-        let bytes = decoder.bytes(length)?;
+        let bytes = decoder.read_slice(length)?;
         Ok(Self {
             der_bytes: bytes.into(),
             length,
@@ -335,7 +337,7 @@ fn decode_sequence<'a>(decoder: &mut Decoder<'a>) -> Result<&'a [u8]> {
     header.tag.assert_eq(Tag::Sequence)?;
 
     let len = (header.encoded_len()? + header.length)?;
-    decoder.bytes(len)
+    decoder.read_slice(len)
 }
 
 /// Write a file containing secret data to the filesystem, restricting the

--- a/der/src/error.rs
+++ b/der/src/error.rs
@@ -229,6 +229,9 @@ pub enum ErrorKind {
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     PermissionDenied,
 
+    /// Reader does not support the requested operation.
+    Reader,
+
     /// Unknown tag mode.
     TagModeUnknown,
 
@@ -298,7 +301,7 @@ impl fmt::Display for ErrorKind {
             ErrorKind::DateTime => write!(f, "date/time error"),
             ErrorKind::Failed => write!(f, "operation failed"),
             #[cfg(feature = "std")]
-            ErrorKind::FileNotFound => f.write_str("file not found"),
+            ErrorKind::FileNotFound => write!(f, "file not found"),
             ErrorKind::Incomplete {
                 expected_len,
                 actual_len,
@@ -318,13 +321,14 @@ impl fmt::Display for ErrorKind {
             ErrorKind::OidUnknown { oid } => {
                 write!(f, "unknown/unsupported OID: {}", oid)
             }
-            ErrorKind::SetOrdering => write!(f, "ordering error"),
+            ErrorKind::SetOrdering => write!(f, "SET OF ordering error"),
             ErrorKind::Overflow => write!(f, "integer overflow"),
             ErrorKind::Overlength => write!(f, "ASN.1 DER message is too long"),
             #[cfg(feature = "pem")]
             ErrorKind::Pem(e) => write!(f, "PEM error: {}", e),
             #[cfg(feature = "std")]
-            ErrorKind::PermissionDenied => f.write_str("permission denied"),
+            ErrorKind::PermissionDenied => write!(f, "permission denied"),
+            ErrorKind::Reader => write!(f, "reader does not support the requested operation"),
             ErrorKind::TagModeUnknown => write!(f, "unknown tag mode"),
             ErrorKind::TagNumberInvalid => write!(f, "invalid tag number"),
             ErrorKind::TagUnexpected { expected, actual } => {

--- a/der/src/length.rs
+++ b/der/src/length.rs
@@ -1,6 +1,6 @@
 //! Length calculations for encoded ASN.1 DER values
 
-use crate::{Decode, Decoder, DerOrd, Encode, Encoder, Error, ErrorKind, Result, Writer};
+use crate::{Decode, Decoder, DerOrd, Encode, Encoder, Error, ErrorKind, Reader, Result, Writer};
 use core::{
     cmp::Ordering,
     fmt,
@@ -193,7 +193,7 @@ impl TryFrom<Length> for usize {
 
 impl Decode<'_> for Length {
     fn decode(decoder: &mut Decoder<'_>) -> Result<Length> {
-        match decoder.byte()? {
+        match decoder.read_byte()? {
             // Note: per X.690 Section 8.1.3.6.1 the byte 0x80 encodes indefinite
             // lengths, which are not allowed in DER, so disallow that byte.
             len if len < 0x80 => Ok(len.into()),
@@ -205,7 +205,7 @@ impl Decode<'_> for Length {
                 let mut decoded_len = 0u32;
                 for _ in 0..nbytes {
                     decoded_len = decoded_len.checked_shl(8).ok_or(ErrorKind::Overflow)?
-                        | u32::from(decoder.byte()?);
+                        | u32::from(decoder.read_byte()?);
                 }
 
                 let length = Length::try_from(decoded_len)?;

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -357,6 +357,7 @@ mod error;
 mod header;
 mod length;
 mod ord;
+mod reader;
 mod str_slice;
 mod tag;
 mod writer;
@@ -376,6 +377,7 @@ pub use crate::{
     header::Header,
     length::Length,
     ord::{DerOrd, ValueOrd},
+    reader::Reader,
     tag::{Class, FixedTag, Tag, TagMode, TagNumber, Tagged},
     writer::Writer,
 };

--- a/der/src/reader.rs
+++ b/der/src/reader.rs
@@ -1,0 +1,76 @@
+//! Reader trait.
+
+use crate::{ErrorKind, Header, Length, Result, Tag};
+
+/// Reader trait which reads DER-encoded input.
+pub trait Reader<'i>: Clone + Sized {
+    /// Get the length of the input.
+    fn input_len(&self) -> Result<Length>;
+
+    /// Peek at the next byte of input without modifying the cursor.
+    fn peek_byte(&self) -> Option<u8>;
+
+    /// Peek forward in the input data, attempting to decode a [`Header`] from
+    /// the data at the current position in the decoder.
+    ///
+    /// Does not modify the decoder's state.
+    fn peek_header(&self) -> Result<Header>;
+
+    /// Get the position within the buffer.
+    fn position(&self) -> Length;
+
+    /// Get the number of bytes still remaining in the buffer.
+    fn remaining_len(&self) -> Result<Length>;
+
+    /// Have we read all of the input data?
+    fn is_finished(&self) -> bool {
+        self.remaining_len() == Ok(Length::ZERO)
+    }
+
+    /// Peek at the next byte in the decoder and attempt to decode it as a
+    /// [`Tag`] value.
+    ///
+    /// Does not modify the decoder's state.
+    fn peek_tag(&self) -> Result<Tag> {
+        match self.peek_byte() {
+            Some(byte) => byte.try_into(),
+            None => {
+                let actual_len = self.input_len()?;
+                let expected_len = (actual_len + Length::ONE)?;
+                Err(ErrorKind::Incomplete {
+                    expected_len,
+                    actual_len,
+                }
+                .into())
+            }
+        }
+    }
+
+    /// Attempt to read data borrowed directly from the input as a slice,
+    /// updating the internal cursor position.
+    ///
+    /// # Returns
+    /// - `Ok(slice)` on success
+    /// - `Err(ErrorKind::Incomplete)` if there is not enough data
+    /// - `Err(ErrorKind::Reader)` if the reader can't borrow from the input
+    fn read_slice(&mut self, len: impl TryInto<Length>) -> Result<&'i [u8]>;
+
+    /// Attempt to read input data, writing it into the provided buffer, and
+    /// returning a slice on success.
+    ///
+    /// # Returns
+    /// - `Ok(slice)` if there is sufficient data
+    /// - `Err(ErrorKind::Incomplete)` if there is not enough data
+    fn read_into<'o>(&mut self, buf: &'o mut [u8]) -> Result<&'o [u8]> {
+        let input = self.read_slice(buf.len())?;
+        buf.copy_from_slice(input);
+        Ok(buf)
+    }
+
+    /// Read a single byte.
+    fn read_byte(&mut self) -> Result<u8> {
+        let mut buf = [0];
+        self.read_into(&mut buf)?;
+        Ok(buf[0])
+    }
+}

--- a/der/src/tag.rs
+++ b/der/src/tag.rs
@@ -6,7 +6,9 @@ mod number;
 
 pub use self::{class::Class, mode::TagMode, number::TagNumber};
 
-use crate::{Decode, Decoder, DerOrd, Encode, Encoder, Error, ErrorKind, Length, Result, Writer};
+use crate::{
+    Decode, Decoder, DerOrd, Encode, Encoder, Error, ErrorKind, Length, Reader, Result, Writer,
+};
 use core::{cmp::Ordering, fmt};
 
 /// Indicator bit for constructed form encoding (i.e. vs primitive form)
@@ -304,7 +306,7 @@ impl From<&Tag> for u8 {
 
 impl Decode<'_> for Tag {
     fn decode(decoder: &mut Decoder<'_>) -> Result<Self> {
-        decoder.byte().and_then(Self::try_from)
+        decoder.read_byte().and_then(Self::try_from)
     }
 }
 

--- a/pkcs8/src/private_key_info.rs
+++ b/pkcs8/src/private_key_info.rs
@@ -4,7 +4,7 @@ use crate::{AlgorithmIdentifier, Error, Result, Version};
 use core::fmt;
 use der::{
     asn1::{Any, BitString, ContextSpecific, OctetString},
-    Decode, Decoder, Encode, Sequence, TagMode, TagNumber,
+    Decode, Decoder, Encode, Reader, Sequence, TagMode, TagNumber,
 };
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
Begins moving core decoding functionality into a `Reader` trait.

The longer-term goal is to move enough functionality to the trait to support things like one-pass decoding directly from PEM for `DecodeOwned` types.