### PR TITLE
der: make `Reader::input_len` infallible

### DIFF
--- a/der/src/error.rs
+++ b/der/src/error.rs
@@ -33,9 +33,18 @@ impl Error {
         }
     }
 
-    /// If the error's `kind` is an [`ErrorKind::Incomplete`], return the `expected_len`.
-    pub fn incomplete(self) -> Option<usize> {
-        self.kind().incomplete()
+    /// Create a new [`ErrorKind::Incomplete`] for the given length.
+    ///
+    /// Computes the expected len as being one greater than `actual_len`.
+    pub fn incomplete(actual_len: Length) -> Self {
+        match actual_len + Length::ONE {
+            Ok(expected_len) => ErrorKind::Incomplete {
+                expected_len,
+                actual_len,
+            }
+            .at(actual_len),
+            Err(err) => err.kind().at(actual_len),
+        }
     }
 
     /// Get the [`ErrorKind`] which occurred.
@@ -284,14 +293,6 @@ impl ErrorKind {
     /// returning an error.
     pub fn at(self, position: Length) -> Error {
         Error::new(self, position)
-    }
-
-    /// If this is an [`ErrorKind::Incomplete`], return the `expected_len`.
-    pub fn incomplete(self) -> Option<usize> {
-        match self {
-            ErrorKind::Incomplete { expected_len, .. } => usize::try_from(expected_len).ok(),
-            _ => None,
-        }
     }
 }
 

--- a/der/src/reader.rs
+++ b/der/src/reader.rs
@@ -1,11 +1,11 @@
 //! Reader trait.
 
-use crate::{ErrorKind, Header, Length, Result, Tag};
+use crate::{Error, Header, Length, Result, Tag};
 
 /// Reader trait which reads DER-encoded input.
 pub trait Reader<'i>: Clone + Sized {
     /// Get the length of the input.
-    fn input_len(&self) -> Result<Length>;
+    fn input_len(&self) -> Length;
 
     /// Peek at the next byte of input without modifying the cursor.
     fn peek_byte(&self) -> Option<u8>;
@@ -34,15 +34,7 @@ pub trait Reader<'i>: Clone + Sized {
     fn peek_tag(&self) -> Result<Tag> {
         match self.peek_byte() {
             Some(byte) => byte.try_into(),
-            None => {
-                let actual_len = self.input_len()?;
-                let expected_len = (actual_len + Length::ONE)?;
-                Err(ErrorKind::Incomplete {
-                    expected_len,
-                    actual_len,
-                }
-                .into())
-            }
+            None => Err(Error::incomplete(self.input_len())),
         }
     }
 

--- a/x509/tests/pkix_extensions.rs
+++ b/x509/tests/pkix_extensions.rs
@@ -1020,8 +1020,8 @@ fn decode_idp() {
     let err = reason_flags.err().unwrap();
     assert_eq!(
         ErrorKind::Incomplete {
-            expected_len: 3u8.into(),
-            actual_len: 2u8.into()
+            expected_len: 6u8.into(),
+            actual_len: 5u8.into()
         },
         err.kind()
     );
@@ -1032,8 +1032,8 @@ fn decode_idp() {
     let err = idp.err().unwrap();
     assert_eq!(
         ErrorKind::Incomplete {
-            expected_len: 3u8.into(),
-            actual_len: 2u8.into()
+            expected_len: 104u8.into(),
+            actual_len: 103u8.into()
         },
         err.kind()
     );
@@ -1043,8 +1043,8 @@ fn decode_idp() {
     let err = reason_flags.err().unwrap();
     assert_eq!(
         ErrorKind::Incomplete {
-            expected_len: 2u8.into(),
-            actual_len: 1u8.into()
+            expected_len: 5u8.into(),
+            actual_len: 4u8.into()
         },
         err.kind()
     );


### PR DESCRIPTION
It was previously fallible to support runtime calculations, but with a bit of refactoring and simplification it's possible to query this for the current `Decoder` type using `ByteSlice::len`.

Other readers may need to compute it, but this can be performed as an eager calculation of a fallible constructor (similar to how `ByteSlice` does it). Since it's a static, non-changing value for the lifecycle of any given reader it makes sense to make it infallible.

This decision may need to be revisited if we ever want to support "streaming" readers which don't know the total size of the input data ahead of time.