### PR TITLE
der: make `Reader::remaining_len` infallible

### DIFF
--- a/der/src/length.rs
+++ b/der/src/length.rs
@@ -30,18 +30,28 @@ impl Length {
     ///
     /// This function is const-safe and therefore useful for [`Length`] constants.
     pub const fn new(value: u16) -> Self {
-        Length(value as u32)
+        Self(value as u32)
     }
 
     /// Is this length equal to zero?
     pub fn is_zero(self) -> bool {
-        self == Length::ZERO
+        self == Self::ZERO
     }
 
     /// Get the length of DER Tag-Length-Value (TLV) encoded data if `self`
     /// is the length of the inner "value" portion of the message.
     pub fn for_tlv(self) -> Result<Self> {
-        Length(1) + self.encoded_len()? + self
+        Self::ONE + self.encoded_len()? + self
+    }
+
+    /// Perform saturating addition of two lengths.
+    pub fn saturating_add(self, rhs: Self) -> Self {
+        Self(self.0.saturating_add(rhs.0))
+    }
+
+    /// Perform saturating subtraction of two lengths.
+    pub fn saturating_sub(self, rhs: Self) -> Self {
+        Self(self.0.saturating_sub(rhs.0))
     }
 
     /// Get initial octet of the encoded length (if one is required).

--- a/der/src/reader.rs
+++ b/der/src/reader.rs
@@ -19,12 +19,9 @@ pub trait Reader<'i>: Clone + Sized {
     /// Get the position within the buffer.
     fn position(&self) -> Length;
 
-    /// Get the number of bytes still remaining in the buffer.
-    fn remaining_len(&self) -> Result<Length>;
-
     /// Have we read all of the input data?
     fn is_finished(&self) -> bool {
-        self.remaining_len() == Ok(Length::ZERO)
+        self.remaining_len().is_zero()
     }
 
     /// Peek at the next byte in the decoder and attempt to decode it as a
@@ -64,5 +61,11 @@ pub trait Reader<'i>: Clone + Sized {
         let mut buf = [0];
         self.read_into(&mut buf)?;
         Ok(buf[0])
+    }
+
+    /// Get the number of bytes still remaining in the buffer.
+    fn remaining_len(&self) -> Length {
+        debug_assert!(self.position() <= self.input_len());
+        self.input_len().saturating_sub(self.position())
     }
 }


### PR DESCRIPTION
Like #607, this makes a length calculation infallible, and also adds a default implementation.

It uses saturating arithmetic to avoid panics, with `debug_assert!` to make sure the operands of the calculation make sense.

That said, if there is a bug where a reader's cursor/position exceeds the `input_len()`, it will still calculate a value that makes sense for `remaining_len()` when using saturating arithmetic: 0.