### PR TITLE
der: use `&mut dyn Writer` as output for `Encode::encode`

### DIFF
--- a/der/derive/src/choice.rs
+++ b/der/derive/src/choice.rs
@@ -109,7 +109,7 @@ impl DeriveChoice {
             }
 
             impl<#lt_params> ::der::EncodeValue for #ident<#lt_params> {
-                fn encode_value(&self, encoder: &mut ::der::Encoder<'_>) -> ::der::Result<()> {
+                fn encode_value(&self, encoder: &mut dyn ::der::Writer) -> ::der::Result<()> {
                     match self {
                         #(#encode_body)*
                     }

--- a/der/derive/src/enumerated.rs
+++ b/der/derive/src/enumerated.rs
@@ -129,7 +129,7 @@ impl DeriveEnumerated {
                     ::der::EncodeValue::value_len(&(*self as #repr))
                 }
 
-                fn encode_value(&self, encoder: &mut ::der::Encoder<'_>) -> ::der::Result<()> {
+                fn encode_value(&self, encoder: &mut dyn ::der::Writer) -> ::der::Result<()> {
                     ::der::EncodeValue::encode_value(&(*self as #repr), encoder)
                 }
             }

--- a/der/derive/src/newtype.rs
+++ b/der/derive/src/newtype.rs
@@ -103,7 +103,7 @@ impl DeriveNewtype {
             }
 
             #limpl ::der::EncodeValue for #ltype {
-                fn encode_value(&self, encoder: &mut ::der::Encoder<'_>) -> ::der::Result<()> {
+                fn encode_value(&self, encoder: &mut dyn ::der::Writer) -> ::der::Result<()> {
                     self.0.encode_value(encoder)
                 }
 

--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -1,7 +1,7 @@
 //! ASN.1 `ANY` type.
 
 use crate::{
-    asn1::*, ByteSlice, Choice, Decode, DecodeValue, Decoder, DerOrd, EncodeValue, Encoder, Error,
+    asn1::*, ByteSlice, Choice, Decode, DecodeValue, Decoder, DerOrd, EncodeValue, Error,
     ErrorKind, FixedTag, Header, Length, Result, Tag, Tagged, ValueOrd, Writer,
 };
 use core::cmp::Ordering;
@@ -167,8 +167,8 @@ impl EncodeValue for Any<'_> {
         Ok(self.value.len())
     }
 
-    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        encoder.write(self.value())
+    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+        writer.write(self.value())
     }
 }
 

--- a/der/src/asn1/bit_string.rs
+++ b/der/src/asn1/bit_string.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `BIT STRING` support.
 
 use crate::{
-    asn1::Any, ByteSlice, DecodeValue, Decoder, DerOrd, EncodeValue, Encoder, Error, ErrorKind,
-    FixedTag, Header, Length, Reader, Result, Tag, ValueOrd, Writer,
+    asn1::Any, ByteSlice, DecodeValue, Decoder, DerOrd, EncodeValue, Error, ErrorKind, FixedTag,
+    Header, Length, Reader, Result, Tag, ValueOrd, Writer,
 };
 use core::{cmp::Ordering, iter::FusedIterator};
 
@@ -133,9 +133,9 @@ impl EncodeValue for BitString<'_> {
         self.byte_len() + Length::ONE
     }
 
-    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        encoder.write_byte(self.unused_bits)?;
-        encoder.write(self.raw_bytes())
+    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+        writer.write_byte(self.unused_bits)?;
+        writer.write(self.raw_bytes())
     }
 }
 
@@ -290,10 +290,10 @@ where
         BitString::new((lead % 8) as u8, buff)?.value_len()
     }
 
-    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
+    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
         let (lead, buff) = encode_flagset(self);
         let buff = &buff[..buff.len() - lead / 8];
-        BitString::new((lead % 8) as u8, buff)?.encode_value(encoder)
+        BitString::new((lead % 8) as u8, buff)?.encode_value(writer)
     }
 }
 

--- a/der/src/asn1/boolean.rs
+++ b/der/src/asn1/boolean.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `BOOLEAN` support.
 
 use crate::{
-    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error,
-    ErrorKind, FixedTag, Header, Length, Reader, Result, Tag, Writer,
+    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, Decoder, EncodeValue, Error, ErrorKind,
+    FixedTag, Header, Length, Reader, Result, Tag, Writer,
 };
 
 /// Byte used to encode `true` in ASN.1 DER. From X.690 Section 11.1:
@@ -33,8 +33,8 @@ impl EncodeValue for bool {
         Ok(Length::ONE)
     }
 
-    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        encoder.write_byte(if *self { TRUE_OCTET } else { FALSE_OCTET })
+    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+        writer.write_byte(if *self { TRUE_OCTET } else { FALSE_OCTET })
     }
 }
 

--- a/der/src/asn1/context_specific.rs
+++ b/der/src/asn1/context_specific.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     asn1::Any, Choice, Decode, DecodeValue, Decoder, DerOrd, Encode, EncodeValue, EncodeValueRef,
-    Encoder, Error, Header, Length, Reader, Result, Tag, TagMode, TagNumber, Tagged, ValueOrd,
+    Error, Header, Length, Reader, Result, Tag, TagMode, TagNumber, Tagged, ValueOrd, Writer,
 };
 use core::cmp::Ordering;
 
@@ -141,10 +141,10 @@ where
         }
     }
 
-    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
+    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
         match self.tag_mode {
-            TagMode::Explicit => self.value.encode(encoder),
-            TagMode::Implicit => self.value.encode_value(encoder),
+            TagMode::Explicit => self.value.encode(writer),
+            TagMode::Implicit => self.value.encode_value(writer),
         }
     }
 }
@@ -235,8 +235,8 @@ where
         self.encoder().value_len()
     }
 
-    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        self.encoder().encode_value(encoder)
+    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+        self.encoder().encode_value(writer)
     }
 }
 

--- a/der/src/asn1/generalized_time.rs
+++ b/der/src/asn1/generalized_time.rs
@@ -4,8 +4,8 @@ use crate::{
     asn1::Any,
     datetime::{self, DateTime},
     ord::OrdIsValueOrd,
-    ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, ErrorKind, FixedTag, Header,
-    Length, Result, Tag, Writer,
+    ByteSlice, DecodeValue, Decoder, EncodeValue, Error, ErrorKind, FixedTag, Header, Length,
+    Result, Tag, Writer,
 };
 use core::time::Duration;
 
@@ -104,18 +104,18 @@ impl EncodeValue for GeneralizedTime {
         Ok(Self::LENGTH)
     }
 
-    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
+    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
         let year_hi = u8::try_from(self.0.year() / 100)?;
         let year_lo = u8::try_from(self.0.year() % 100)?;
 
-        datetime::encode_decimal(encoder, Self::TAG, year_hi)?;
-        datetime::encode_decimal(encoder, Self::TAG, year_lo)?;
-        datetime::encode_decimal(encoder, Self::TAG, self.0.month())?;
-        datetime::encode_decimal(encoder, Self::TAG, self.0.day())?;
-        datetime::encode_decimal(encoder, Self::TAG, self.0.hour())?;
-        datetime::encode_decimal(encoder, Self::TAG, self.0.minutes())?;
-        datetime::encode_decimal(encoder, Self::TAG, self.0.seconds())?;
-        encoder.write_byte(b'Z')
+        datetime::encode_decimal(writer, Self::TAG, year_hi)?;
+        datetime::encode_decimal(writer, Self::TAG, year_lo)?;
+        datetime::encode_decimal(writer, Self::TAG, self.0.month())?;
+        datetime::encode_decimal(writer, Self::TAG, self.0.day())?;
+        datetime::encode_decimal(writer, Self::TAG, self.0.hour())?;
+        datetime::encode_decimal(writer, Self::TAG, self.0.minutes())?;
+        datetime::encode_decimal(writer, Self::TAG, self.0.seconds())?;
+        writer.write_byte(b'Z')
     }
 }
 
@@ -174,8 +174,8 @@ impl EncodeValue for DateTime {
         GeneralizedTime::from(self).value_len()
     }
 
-    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        GeneralizedTime::from(self).encode_value(encoder)
+    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+        GeneralizedTime::from(self).encode_value(writer)
     }
 }
 
@@ -200,8 +200,8 @@ impl EncodeValue for SystemTime {
         GeneralizedTime::try_from(self)?.value_len()
     }
 
-    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        GeneralizedTime::try_from(self)?.encode_value(encoder)
+    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+        GeneralizedTime::try_from(self)?.encode_value(writer)
     }
 }
 
@@ -276,8 +276,8 @@ impl EncodeValue for PrimitiveDateTime {
         GeneralizedTime::try_from(self)?.value_len()
     }
 
-    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        GeneralizedTime::try_from(self)?.encode_value(encoder)
+    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+        GeneralizedTime::try_from(self)?.encode_value(writer)
     }
 }
 

--- a/der/src/asn1/ia5_string.rs
+++ b/der/src/asn1/ia5_string.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `IA5String` support.
 
 use crate::{
-    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error,
-    FixedTag, Header, Length, Result, StrSlice, Tag,
+    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, Decoder, EncodeValue, Error, FixedTag,
+    Header, Length, Result, StrSlice, Tag, Writer,
 };
 use core::{fmt, str};
 
@@ -84,8 +84,8 @@ impl EncodeValue for Ia5String<'_> {
         self.inner.value_len()
     }
 
-    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        self.inner.encode_value(encoder)
+    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+        self.inner.encode_value(writer)
     }
 }
 

--- a/der/src/asn1/integer.rs
+++ b/der/src/asn1/integer.rs
@@ -6,7 +6,7 @@ pub(super) mod uint;
 
 use crate::{
     asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, FixedTag, Header,
-    Length, Result, Tag, ValueOrd,
+    Length, Result, Tag, ValueOrd, Writer,
 };
 use core::{cmp::Ordering, mem};
 
@@ -41,11 +41,11 @@ macro_rules! impl_int_encoding {
                     }
                 }
 
-                fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
+                fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
                     if *self < 0 {
-                        int::encode_bytes(encoder, &(*self as $uint).to_be_bytes())
+                        int::encode_bytes(writer, &(*self as $uint).to_be_bytes())
                     } else {
-                        uint::encode_bytes(encoder, &self.to_be_bytes())
+                        uint::encode_bytes(writer, &self.to_be_bytes())
                     }
                 }
             }
@@ -93,8 +93,8 @@ macro_rules! impl_uint_encoding {
                     uint::encoded_len(&self.to_be_bytes())
                 }
 
-                fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-                    uint::encode_bytes(encoder, &self.to_be_bytes())
+                fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+                    uint::encode_bytes(writer, &self.to_be_bytes())
                 }
             }
 

--- a/der/src/asn1/integer/bigint.rs
+++ b/der/src/asn1/integer/bigint.rs
@@ -2,8 +2,8 @@
 
 use super::uint;
 use crate::{
-    asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, ErrorKind, FixedTag,
-    Header, Length, Result, Tag, Writer,
+    asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Error, ErrorKind, FixedTag, Header,
+    Length, Result, Tag, Writer,
 };
 
 /// "Big" unsigned ASN.1 `INTEGER` type.
@@ -64,13 +64,13 @@ impl<'a> EncodeValue for UIntBytes<'a> {
         uint::encoded_len(self.inner.as_slice())
     }
 
-    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
+    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
         // Add leading `0x00` byte if required
         if self.value_len()? > self.len() {
-            encoder.write_byte(0)?;
+            writer.write_byte(0)?;
         }
 
-        encoder.write(self.as_bytes())
+        writer.write(self.as_bytes())
     }
 }
 

--- a/der/src/asn1/integer/int.rs
+++ b/der/src/asn1/integer/int.rs
@@ -1,7 +1,7 @@
 //! Support for encoding negative integers
 
 use super::is_highest_bit_set;
-use crate::{Encoder, ErrorKind, Length, Result, Writer};
+use crate::{ErrorKind, Length, Result, Writer};
 
 /// Decode an unsigned integer of the specified size.
 ///
@@ -27,8 +27,11 @@ pub(super) fn decode_to_array<const N: usize>(bytes: &[u8]) -> Result<[u8; N]> {
 }
 
 /// Encode the given big endian bytes representing an integer as ASN.1 DER.
-pub(super) fn encode_bytes(encoder: &mut Encoder<'_>, bytes: &[u8]) -> Result<()> {
-    encoder.write(strip_leading_ones(bytes))
+pub(super) fn encode_bytes<W>(writer: &mut W, bytes: &[u8]) -> Result<()>
+where
+    W: Writer + ?Sized,
+{
+    writer.write(strip_leading_ones(bytes))
 }
 
 /// Get the encoded length for the given unsigned integer serialized as bytes.

--- a/der/src/asn1/integer/uint.rs
+++ b/der/src/asn1/integer/uint.rs
@@ -1,6 +1,6 @@
 //! Unsigned integer decoders/encoders.
 
-use crate::{Encoder, Length, Result, Tag, Writer};
+use crate::{Length, Result, Tag, Writer};
 
 /// Decode an unsigned integer into a big endian byte slice with all leading
 /// zeroes removed.
@@ -40,7 +40,10 @@ pub(super) fn decode_to_array<const N: usize>(bytes: &[u8]) -> Result<[u8; N]> {
 }
 
 /// Encode the given big endian bytes representing an integer as ASN.1 DER.
-pub(crate) fn encode_bytes(encoder: &mut Encoder<'_>, bytes: &[u8]) -> Result<()> {
+pub(crate) fn encode_bytes<W>(encoder: &mut W, bytes: &[u8]) -> Result<()>
+where
+    W: Writer + ?Sized,
+{
     let bytes = strip_leading_zeroes(bytes);
 
     if needs_leading_zero(bytes) {

--- a/der/src/asn1/null.rs
+++ b/der/src/asn1/null.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `NULL` support.
 
 use crate::{
-    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, Decoder, Encode, EncodeValue, Encoder,
-    Error, ErrorKind, FixedTag, Header, Length, Result, Tag,
+    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, Decoder, EncodeValue, Error, ErrorKind,
+    FixedTag, Header, Length, Result, Tag, Writer,
 };
 
 /// ASN.1 `NULL` type.
@@ -24,7 +24,7 @@ impl EncodeValue for Null {
         Ok(Length::ZERO)
     }
 
-    fn encode_value(&self, _encoder: &mut Encoder<'_>) -> Result<()> {
+    fn encode_value(&self, _writer: &mut dyn Writer) -> Result<()> {
         Ok(())
     }
 }
@@ -70,13 +70,13 @@ impl DecodeValue<'_> for () {
     }
 }
 
-impl Encode for () {
-    fn encoded_len(&self) -> Result<Length> {
-        Null.encoded_len()
+impl EncodeValue for () {
+    fn value_len(&self) -> Result<Length> {
+        Ok(Length::ZERO)
     }
 
-    fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        Null.encode(encoder)
+    fn encode_value(&self, _writer: &mut dyn Writer) -> Result<()> {
+        Ok(())
     }
 }
 

--- a/der/src/asn1/octet_string.rs
+++ b/der/src/asn1/octet_string.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `OCTET STRING` support.
 
 use crate::{
-    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error,
-    ErrorKind, FixedTag, Header, Length, Result, Tag,
+    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, Decoder, EncodeValue, Error, ErrorKind,
+    FixedTag, Header, Length, Result, Tag, Writer,
 };
 
 /// ASN.1 `OCTET STRING` type.
@@ -54,8 +54,8 @@ impl EncodeValue for OctetString<'_> {
         self.inner.value_len()
     }
 
-    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        self.inner.encode_value(encoder)
+    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+        self.inner.encode_value(writer)
     }
 }
 

--- a/der/src/asn1/oid.rs
+++ b/der/src/asn1/oid.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `OBJECT IDENTIFIER`
 
 use crate::{
-    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error,
-    FixedTag, Header, Length, Result, Tag, Tagged, Writer,
+    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, Decoder, EncodeValue, Error, FixedTag,
+    Header, Length, Result, Tag, Tagged, Writer,
 };
 use const_oid::ObjectIdentifier;
 
@@ -18,8 +18,8 @@ impl EncodeValue for ObjectIdentifier {
         Length::try_from(self.as_bytes().len())
     }
 
-    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        encoder.write(self.as_bytes())
+    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+        writer.write(self.as_bytes())
     }
 }
 

--- a/der/src/asn1/printable_string.rs
+++ b/der/src/asn1/printable_string.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `PrintableString` support.
 
 use crate::{
-    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error,
-    FixedTag, Header, Length, Result, StrSlice, Tag,
+    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, Decoder, EncodeValue, Error, FixedTag,
+    Header, Length, Result, StrSlice, Tag, Writer,
 };
 use core::{fmt, str};
 
@@ -117,8 +117,8 @@ impl<'a> EncodeValue for PrintableString<'a> {
         self.inner.value_len()
     }
 
-    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        self.inner.encode_value(encoder)
+    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+        self.inner.encode_value(writer)
     }
 }
 

--- a/der/src/asn1/real.rs
+++ b/der/src/asn1/real.rs
@@ -8,8 +8,8 @@
 )]
 
 use crate::{
-    str_slice::StrSlice, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, FixedTag, Header,
-    Length, Result, Tag, Writer,
+    str_slice::StrSlice, ByteSlice, DecodeValue, Decoder, EncodeValue, FixedTag, Header, Length,
+    Result, Tag, Writer,
 };
 
 use super::integer::uint::strip_leading_zeroes;
@@ -122,7 +122,7 @@ impl EncodeValue for f64 {
         }
     }
 
-    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
+    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
         // Check if special value
         // Encode zero first, if it's zero
         // Special value from section 8.5.9 if non zero
@@ -136,28 +136,30 @@ impl EncodeValue for f64 {
                 return Ok(());
             } else if self.is_nan() {
                 // Not a number
-                encoder.write_byte(0b0100_0010)?;
+                writer.write_byte(0b0100_0010)?;
             } else if self.is_infinite() {
                 if self.is_sign_negative() {
                     // Negative infinity
-                    encoder.write_byte(0b0100_0001)?;
+                    writer.write_byte(0b0100_0001)?;
                 } else {
                     // Plus infinity
-                    encoder.write_byte(0b0100_0000)?;
+                    writer.write_byte(0b0100_0000)?;
                 }
             } else {
                 // Minus zero
-                encoder.write_byte(0b0100_0011)?;
+                writer.write_byte(0b0100_0011)?;
             }
         } else {
             // Always use binary encoding, set bit 8 to 1
             let mut first_byte = 0b1000_0000;
+
             if self.is_sign_negative() {
                 // Section 8.5.7.1: set bit 7 to 1 if negative
                 first_byte |= 0b0100_0000;
             }
-            // Bits 6 and 5 are set to 0 to specify that binary encoding is used
 
+            // Bits 6 and 5 are set to 0 to specify that binary encoding is used
+            //
             // NOTE: the scaling factor is only used to align the implicit point of the mantissa.
             // This is unnecessary in DER because the base is 2, and therefore necessarily aligned.
             // Therefore, we do not modify the mantissa in anyway after this function call, which
@@ -178,17 +180,18 @@ impl EncodeValue for f64 {
                 }
             }
 
-            encoder.write_byte(first_byte)?;
+            writer.write_byte(first_byte)?;
 
             // Encode both bytes or just the last one, handled by encode_bytes directly
             // Rust already encodes the data as two's complement, so no further processing is needed
-            encoder.write(ebytes)?;
+            writer.write(ebytes)?;
 
             // Now, encode the mantissa as unsigned binary number
             let mantissa_bytes = mantissa.to_be_bytes();
             let mbytes = strip_leading_zeroes(&mantissa_bytes);
-            encoder.write(mbytes)?;
+            writer.write(mbytes)?;
         }
+
         Ok(())
     }
 }

--- a/der/src/asn1/sequence.rs
+++ b/der/src/asn1/sequence.rs
@@ -2,8 +2,8 @@
 //! `SEQUENCE`s to Rust structs.
 
 use crate::{
-    ByteSlice, Decode, DecodeValue, Decoder, Encode, EncodeValue, Encoder, FixedTag, Header,
-    Length, Reader, Result, Tag,
+    ByteSlice, Decode, DecodeValue, Decoder, Encode, EncodeValue, FixedTag, Header, Length, Reader,
+    Result, Tag, Writer,
 };
 
 /// ASN.1 `SEQUENCE` trait.
@@ -34,10 +34,10 @@ where
         })
     }
 
-    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
+    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
         self.fields(|fields| {
             for &field in fields {
-                field.encode(encoder)?;
+                field.encode(writer)?;
             }
 
             Ok(())
@@ -87,8 +87,8 @@ impl EncodeValue for SequenceRef<'_> {
         Ok(self.body.len())
     }
 
-    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        self.body.encode_value(encoder)
+    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+        self.body.encode_value(writer)
     }
 }
 

--- a/der/src/asn1/sequence_of.rs
+++ b/der/src/asn1/sequence_of.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     arrayvec, ord::iter_cmp, ArrayVec, Decode, DecodeValue, Decoder, DerOrd, Encode, EncodeValue,
-    Encoder, ErrorKind, FixedTag, Header, Length, Reader, Result, Tag, ValueOrd,
+    ErrorKind, FixedTag, Header, Length, Reader, Result, Tag, ValueOrd, Writer,
 };
 use core::cmp::Ordering;
 
@@ -91,9 +91,9 @@ where
             .fold(Ok(Length::ZERO), |len, elem| len + elem.encoded_len()?)
     }
 
-    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
+    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
         for elem in self.iter() {
-            elem.encode(encoder)?;
+            elem.encode(writer)?;
         }
 
         Ok(())
@@ -150,9 +150,9 @@ where
             .fold(Ok(Length::ZERO), |len, elem| len + elem.encoded_len()?)
     }
 
-    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
+    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
         for elem in self {
-            elem.encode(encoder)?;
+            elem.encode(writer)?;
         }
 
         Ok(())
@@ -205,9 +205,9 @@ where
             .fold(Ok(Length::ZERO), |len, elem| len + elem.encoded_len()?)
     }
 
-    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
+    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
         for elem in self {
-            elem.encode(encoder)?;
+            elem.encode(writer)?;
         }
 
         Ok(())

--- a/der/src/asn1/set_of.rs
+++ b/der/src/asn1/set_of.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     arrayvec, ord::iter_cmp, ArrayVec, Decode, DecodeValue, Decoder, DerOrd, Encode, EncodeValue,
-    Encoder, Error, ErrorKind, FixedTag, Header, Length, Reader, Result, Tag, ValueOrd,
+    Error, ErrorKind, FixedTag, Header, Length, Reader, Result, Tag, ValueOrd, Writer,
 };
 use core::cmp::Ordering;
 
@@ -110,9 +110,9 @@ where
             .fold(Ok(Length::ZERO), |len, elem| len + elem.encoded_len()?)
     }
 
-    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
+    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
         for elem in self.iter() {
-            elem.encode(encoder)?;
+            elem.encode(writer)?;
         }
 
         Ok(())
@@ -299,9 +299,9 @@ where
             .fold(Ok(Length::ZERO), |len, elem| len + elem.encoded_len()?)
     }
 
-    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
+    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
         for elem in self.iter() {
-            elem.encode(encoder)?;
+            elem.encode(writer)?;
         }
 
         Ok(())

--- a/der/src/asn1/utc_time.rs
+++ b/der/src/asn1/utc_time.rs
@@ -4,8 +4,8 @@ use crate::{
     asn1::Any,
     datetime::{self, DateTime},
     ord::OrdIsValueOrd,
-    ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, ErrorKind, FixedTag, Header,
-    Length, Result, Tag, Writer,
+    ByteSlice, DecodeValue, Decoder, EncodeValue, Error, ErrorKind, FixedTag, Header, Length,
+    Result, Tag, Writer,
 };
 use core::time::Duration;
 
@@ -113,7 +113,7 @@ impl EncodeValue for UtcTime {
         Ok(Self::LENGTH)
     }
 
-    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
+    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
         let year = match self.0.year() {
             y @ 1950..=1999 => y.checked_sub(1900),
             y @ 2000..=2049 => y.checked_sub(2000),
@@ -122,13 +122,13 @@ impl EncodeValue for UtcTime {
         .and_then(|y| u8::try_from(y).ok())
         .ok_or(ErrorKind::DateTime)?;
 
-        datetime::encode_decimal(encoder, Self::TAG, year)?;
-        datetime::encode_decimal(encoder, Self::TAG, self.0.month())?;
-        datetime::encode_decimal(encoder, Self::TAG, self.0.day())?;
-        datetime::encode_decimal(encoder, Self::TAG, self.0.hour())?;
-        datetime::encode_decimal(encoder, Self::TAG, self.0.minutes())?;
-        datetime::encode_decimal(encoder, Self::TAG, self.0.seconds())?;
-        encoder.write_byte(b'Z')
+        datetime::encode_decimal(writer, Self::TAG, year)?;
+        datetime::encode_decimal(writer, Self::TAG, self.0.month())?;
+        datetime::encode_decimal(writer, Self::TAG, self.0.day())?;
+        datetime::encode_decimal(writer, Self::TAG, self.0.hour())?;
+        datetime::encode_decimal(writer, Self::TAG, self.0.minutes())?;
+        datetime::encode_decimal(writer, Self::TAG, self.0.seconds())?;
+        writer.write_byte(b'Z')
     }
 }
 

--- a/der/src/asn1/utf8_string.rs
+++ b/der/src/asn1/utf8_string.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `UTF8String` support.
 
 use crate::{
-    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error,
-    FixedTag, Header, Length, Result, StrSlice, Tag,
+    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, Decoder, EncodeValue, Error, FixedTag,
+    Header, Length, Result, StrSlice, Tag, Writer,
 };
 use core::{fmt, str};
 
@@ -80,8 +80,8 @@ impl EncodeValue for Utf8String<'_> {
         self.inner.value_len()
     }
 
-    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        self.inner.encode_value(encoder)
+    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+        self.inner.encode_value(writer)
     }
 }
 
@@ -142,8 +142,8 @@ impl EncodeValue for str {
         Utf8String::new(self)?.value_len()
     }
 
-    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        Utf8String::new(self)?.encode_value(encoder)
+    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+        Utf8String::new(self)?.encode_value(writer)
     }
 }
 
@@ -178,8 +178,8 @@ impl EncodeValue for String {
         Utf8String::new(self)?.value_len()
     }
 
-    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        Utf8String::new(self)?.encode_value(encoder)
+    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+        Utf8String::new(self)?.encode_value(writer)
     }
 }
 

--- a/der/src/byte_slice.rs
+++ b/der/src/byte_slice.rs
@@ -2,8 +2,8 @@
 //! library-level length limitation i.e. `Length::max()`.
 
 use crate::{
-    str_slice::StrSlice, DecodeValue, Decoder, DerOrd, EncodeValue, Encoder, Error, Header, Length,
-    Reader, Result, Writer,
+    str_slice::StrSlice, DecodeValue, Decoder, DerOrd, EncodeValue, Error, Header, Length, Reader,
+    Result, Writer,
 };
 use core::cmp::Ordering;
 
@@ -66,8 +66,8 @@ impl EncodeValue for ByteSlice<'_> {
         Ok(self.length)
     }
 
-    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        encoder.write(self.as_ref())
+    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+        writer.write(self.as_ref())
     }
 }
 

--- a/der/src/datetime.rs
+++ b/der/src/datetime.rs
@@ -5,7 +5,7 @@
 // Copyright (c) 2016 The humantime Developers
 // Released under the MIT OR Apache 2.0 licenses
 
-use crate::{Encoder, Error, ErrorKind, Result, Tag, Writer};
+use crate::{Error, ErrorKind, Result, Tag, Writer};
 use core::{fmt, str::FromStr, time::Duration};
 
 #[cfg(feature = "std")]
@@ -372,15 +372,18 @@ pub(crate) fn decode_decimal(tag: Tag, hi: u8, lo: u8) -> Result<u8> {
 }
 
 /// Encode 2-digit decimal value
-pub(crate) fn encode_decimal(encoder: &mut Encoder<'_>, tag: Tag, value: u8) -> Result<()> {
+pub(crate) fn encode_decimal<W>(writer: &mut W, tag: Tag, value: u8) -> Result<()>
+where
+    W: Writer + ?Sized,
+{
     let hi_val = value / 10;
 
     if hi_val >= 10 {
         return Err(tag.value_error());
     }
 
-    encoder.write_byte(b'0'.checked_add(hi_val).ok_or(ErrorKind::Overflow)?)?;
-    encoder.write_byte(b'0'.checked_add(value % 10).ok_or(ErrorKind::Overflow)?)
+    writer.write_byte(b'0'.checked_add(hi_val).ok_or(ErrorKind::Overflow)?)?;
+    writer.write_byte(b'0'.checked_add(value % 10).ok_or(ErrorKind::Overflow)?)
 }
 
 #[cfg(test)]

--- a/der/src/document.rs
+++ b/der/src/document.rs
@@ -1,8 +1,6 @@
 //! ASN.1 DER-encoded documents stored on the heap.
 
-use crate::{
-    Decode, Decoder, Encode, Encoder, Error, FixedTag, Length, Reader, Result, Tag, Writer,
-};
+use crate::{Decode, Decoder, Encode, Error, FixedTag, Length, Reader, Result, Tag, Writer};
 use alloc::vec::Vec;
 use core::fmt::{self, Debug};
 
@@ -167,8 +165,8 @@ impl Encode for Document {
         Ok(self.len())
     }
 
-    fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        encoder.write(self.as_bytes())
+    fn encode(&self, writer: &mut dyn Writer) -> Result<()> {
+        writer.write(self.as_bytes())
     }
 }
 

--- a/der/src/encode.rs
+++ b/der/src/encode.rs
@@ -1,6 +1,6 @@
 //! Trait definition for [`Encode`].
 
-use crate::{Encoder, Header, Length, Result, Tagged};
+use crate::{Encoder, Header, Length, Result, Tagged, Writer};
 
 #[cfg(feature = "alloc")]
 use {crate::ErrorKind, alloc::vec::Vec, core::iter};
@@ -21,7 +21,7 @@ pub trait Encode {
     fn encoded_len(&self) -> Result<Length>;
 
     /// Encode this value as ASN.1 DER using the provided [`Encoder`].
-    fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()>;
+    fn encode(&self, encoder: &mut dyn Writer) -> Result<()>;
 
     /// Encode this value to the provided byte slice, returning a sub-slice
     /// containing the encoded message.
@@ -75,9 +75,9 @@ where
     }
 
     /// Encode this value as ASN.1 DER using the provided [`Encoder`].
-    fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        self.header()?.encode(encoder)?;
-        self.encode_value(encoder)
+    fn encode(&self, writer: &mut dyn Writer) -> Result<()> {
+        self.header()?.encode(writer)?;
+        self.encode_value(writer)
     }
 }
 
@@ -119,5 +119,5 @@ pub trait EncodeValue {
 
     /// Encode value (sans [`Tag`]+[`Length`] header) as ASN.1 DER using the
     /// provided [`Encoder`].
-    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()>;
+    fn encode_value(&self, encoder: &mut dyn Writer) -> Result<()>;
 }

--- a/der/src/encode_ref.rs
+++ b/der/src/encode_ref.rs
@@ -1,7 +1,7 @@
 //! Wrapper object for encoding reference types.
 // TODO(tarcieri): replace with blanket impls of `Encode(Value)` for reference types?
 
-use crate::{Encode, EncodeValue, Encoder, Length, Result, Tag, Tagged, ValueOrd};
+use crate::{Encode, EncodeValue, Length, Result, Tag, Tagged, ValueOrd, Writer};
 use core::cmp::Ordering;
 
 /// Reference encoder: wrapper type which impls `Encode` for any reference to a
@@ -22,8 +22,8 @@ where
         self.0.encoded_len()
     }
 
-    fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        self.0.encode(encoder)
+    fn encode(&self, writer: &mut dyn Writer) -> Result<()> {
+        self.0.encode(writer)
     }
 }
 
@@ -47,8 +47,8 @@ where
         self.0.value_len()
     }
 
-    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        self.0.encode_value(encoder)
+    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+        self.0.encode_value(writer)
     }
 }
 

--- a/der/src/header.rs
+++ b/der/src/header.rs
@@ -1,6 +1,6 @@
 //! ASN.1 DER headers.
 
-use crate::{Decode, Decoder, DerOrd, Encode, Encoder, ErrorKind, Length, Result, Tag};
+use crate::{Decode, Decoder, DerOrd, Encode, ErrorKind, Length, Result, Tag, Writer};
 use core::cmp::Ordering;
 
 /// ASN.1 DER headers: tag + length component of TLV-encoded values
@@ -44,9 +44,9 @@ impl Encode for Header {
         self.tag.encoded_len()? + self.length.encoded_len()?
     }
 
-    fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        self.tag.encode(encoder)?;
-        self.length.encode(encoder)
+    fn encode(&self, writer: &mut dyn Writer) -> Result<()> {
+        self.tag.encode(writer)?;
+        self.length.encode(writer)
     }
 }
 

--- a/der/src/str_slice.rs
+++ b/der/src/str_slice.rs
@@ -1,9 +1,7 @@
 //! Common handling for types backed by `str` slices with enforcement of a
 //! library-level length limitation i.e. `Length::max()`.
 
-use crate::{
-    ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Header, Length, Result, Writer,
-};
+use crate::{ByteSlice, DecodeValue, Decoder, EncodeValue, Header, Length, Result, Writer};
 use core::str;
 
 /// String slice newtype which respects the [`Length::max`] limit.
@@ -75,7 +73,7 @@ impl<'a> EncodeValue for StrSlice<'a> {
         Ok(self.length)
     }
 
-    fn encode_value(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        encoder.write(self.as_ref())
+    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+        writer.write(self.as_ref())
     }
 }

--- a/der/src/tag.rs
+++ b/der/src/tag.rs
@@ -6,9 +6,7 @@ mod number;
 
 pub use self::{class::Class, mode::TagMode, number::TagNumber};
 
-use crate::{
-    Decode, Decoder, DerOrd, Encode, Encoder, Error, ErrorKind, Length, Reader, Result, Writer,
-};
+use crate::{Decode, Decoder, DerOrd, Encode, Error, ErrorKind, Length, Reader, Result, Writer};
 use core::{cmp::Ordering, fmt};
 
 /// Indicator bit for constructed form encoding (i.e. vs primitive form)
@@ -315,8 +313,8 @@ impl Encode for Tag {
         Ok(Length::ONE)
     }
 
-    fn encode(&self, encoder: &mut Encoder<'_>) -> Result<()> {
-        encoder.write_byte(self.into())
+    fn encode(&self, writer: &mut dyn Writer) -> Result<()> {
+        writer.write_byte(self.into())
     }
 }
 

--- a/der/src/writer.rs
+++ b/der/src/writer.rs
@@ -3,7 +3,7 @@
 use crate::Result;
 
 /// Writer trait which outputs encoded DER.
-pub trait Writer: Sized {
+pub trait Writer {
     /// Write the given DER-encoded bytes as output.
     fn write(&mut self, slice: &[u8]) -> Result<()>;
 

--- a/pkcs1/src/version.rs
+++ b/pkcs1/src/version.rs
@@ -1,7 +1,7 @@
 //! PKCS#1 version identifier.
 
 use crate::Error;
-use der::{Decode, Decoder, Encode, Encoder, FixedTag, Tag};
+use der::{Decode, Decoder, Encode, FixedTag, Tag, Writer};
 
 /// Version identifier for PKCS#1 documents as defined in
 /// [RFC 8017 Appendix 1.2].
@@ -62,8 +62,8 @@ impl Encode for Version {
         der::Length::ONE.for_tlv()
     }
 
-    fn encode(&self, encoder: &mut Encoder<'_>) -> der::Result<()> {
-        u8::from(*self).encode(encoder)
+    fn encode(&self, writer: &mut dyn Writer) -> der::Result<()> {
+        u8::from(*self).encode(writer)
     }
 }
 

--- a/pkcs5/src/pbes2.rs
+++ b/pkcs5/src/pbes2.rs
@@ -15,7 +15,7 @@ pub use self::kdf::{
 use crate::{AlgorithmIdentifier, Error, Result};
 use der::{
     asn1::{Any, ObjectIdentifier, OctetString},
-    Decode, Decoder, Encode, Encoder, ErrorKind, Length, Sequence, Tag,
+    Decode, Decoder, Encode, ErrorKind, Length, Sequence, Tag, Writer,
 };
 
 #[cfg(all(feature = "alloc", feature = "pbes2"))]
@@ -378,7 +378,7 @@ impl<'a> Encode for EncryptionScheme<'a> {
         AlgorithmIdentifier::try_from(*self)?.encoded_len()
     }
 
-    fn encode(&self, encoder: &mut Encoder<'_>) -> der::Result<()> {
-        AlgorithmIdentifier::try_from(*self)?.encode(encoder)
+    fn encode(&self, writer: &mut dyn Writer) -> der::Result<()> {
+        AlgorithmIdentifier::try_from(*self)?.encode(writer)
     }
 }

--- a/pkcs5/src/pbes2/kdf.rs
+++ b/pkcs5/src/pbes2/kdf.rs
@@ -3,7 +3,7 @@
 use crate::{AlgorithmIdentifier, Error, Result};
 use der::{
     asn1::{Any, ObjectIdentifier, OctetString},
-    Decode, Decoder, Encode, Encoder, ErrorKind, Length, Sequence, Tag, Tagged,
+    Decode, Decoder, Encode, ErrorKind, Length, Sequence, Tag, Tagged, Writer,
 };
 
 /// Password-Based Key Derivation Function (PBKDF2) OID.
@@ -342,8 +342,8 @@ impl Encode for Pbkdf2Prf {
         AlgorithmIdentifier::try_from(*self)?.encoded_len()
     }
 
-    fn encode(&self, encoder: &mut Encoder<'_>) -> der::Result<()> {
-        AlgorithmIdentifier::try_from(*self)?.encode(encoder)
+    fn encode(&self, writer: &mut dyn Writer) -> der::Result<()> {
+        AlgorithmIdentifier::try_from(*self)?.encode(writer)
     }
 }
 

--- a/pkcs7/src/content_info.rs
+++ b/pkcs7/src/content_info.rs
@@ -132,7 +132,7 @@ mod tests {
 
         let mut encoder = Encoder::new(&mut in_buf);
         encoder.sequence(crate::PKCS_7_DATA_OID.encoded_len()?, |encoder| {
-            encoder.oid(crate::PKCS_7_DATA_OID)
+            crate::PKCS_7_DATA_OID.encode(encoder)
         })?;
         let encoded_der = encoder.finish().expect("encoding success");
 
@@ -156,7 +156,7 @@ mod tests {
 
         let mut encoder = Encoder::new(&mut in_buf);
         encoder.sequence(crate::PKCS_7_ENCRYPTED_DATA_OID.encoded_len()?, |encoder| {
-            encoder.oid(crate::PKCS_7_ENCRYPTED_DATA_OID)
+            (crate::PKCS_7_ENCRYPTED_DATA_OID).encode(encoder)
         })?;
         let encoded_der = encoder.finish().expect("encoding success");
 
@@ -195,7 +195,7 @@ mod tests {
 
         let mut encoder = Encoder::new(&mut in_buf);
         encoder.sequence(inner_len, |encoder| {
-            encoder.oid(crate::PKCS_7_DATA_OID)?;
+            crate::PKCS_7_DATA_OID.encode(encoder)?;
             encoder.context_specific(
                 TagNumber::new(0),
                 TagMode::Explicit,

--- a/pkcs7/src/content_type.rs
+++ b/pkcs7/src/content_type.rs
@@ -1,5 +1,5 @@
 use der::asn1::ObjectIdentifier;
-use der::{DecodeValue, Decoder, EncodeValue, Encoder, ErrorKind, FixedTag, Header, Length, Tag};
+use der::{DecodeValue, Decoder, EncodeValue, ErrorKind, FixedTag, Header, Length, Tag, Writer};
 
 /// Indicates the type of content.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -57,8 +57,8 @@ impl EncodeValue for ContentType {
         self.to_oid().value_len()
     }
 
-    fn encode_value(&self, encoder: &mut Encoder<'_>) -> der::Result<()> {
-        self.to_oid().encode_value(encoder)
+    fn encode_value(&self, writer: &mut dyn Writer) -> der::Result<()> {
+        self.to_oid().encode_value(writer)
     }
 }
 

--- a/pkcs7/src/data_content.rs
+++ b/pkcs7/src/data_content.rs
@@ -2,7 +2,7 @@
 
 use core::convert::{From, TryFrom};
 use der::{
-    asn1::OctetString, DecodeValue, Decoder, EncodeValue, Encoder, FixedTag, Header, Length, Tag,
+    asn1::OctetString, DecodeValue, Decoder, EncodeValue, FixedTag, Header, Length, Tag, Writer,
 };
 
 /// The content that is just an octet string.
@@ -43,8 +43,8 @@ impl<'a> EncodeValue for DataContent<'a> {
         Length::try_from(self.content.len())
     }
 
-    fn encode_value(&self, encoder: &mut Encoder<'_>) -> der::Result<()> {
-        OctetString::new(self.content)?.encode_value(encoder)
+    fn encode_value(&self, writer: &mut dyn Writer) -> der::Result<()> {
+        OctetString::new(self.content)?.encode_value(writer)
     }
 }
 

--- a/pkcs7/src/encrypted_data_content.rs
+++ b/pkcs7/src/encrypted_data_content.rs
@@ -2,8 +2,8 @@
 
 use crate::enveloped_data_content::EncryptedContentInfo;
 use der::{
-    Decode, DecodeValue, Decoder, Encode, EncodeValue, Encoder, FixedTag, Header, Length, Sequence,
-    Tag,
+    Decode, DecodeValue, Decoder, Encode, EncodeValue, FixedTag, Header, Length, Sequence, Tag,
+    Writer,
 };
 
 /// Syntax version of the `encrypted-data` content type.
@@ -51,8 +51,8 @@ impl EncodeValue for Version {
         u8::from(*self).value_len()
     }
 
-    fn encode_value(&self, encoder: &mut Encoder<'_>) -> der::Result<()> {
-        u8::from(*self).encode_value(encoder)
+    fn encode_value(&self, writer: &mut dyn Writer) -> der::Result<()> {
+        u8::from(*self).encode_value(writer)
     }
 }
 

--- a/pkcs8/src/version.rs
+++ b/pkcs8/src/version.rs
@@ -1,7 +1,7 @@
 //! PKCS#8 version identifier.
 
 use crate::Error;
-use der::{Decode, Decoder, Encode, Encoder, FixedTag, Tag};
+use der::{Decode, Decoder, Encode, FixedTag, Tag, Writer};
 
 /// Version identifier for PKCS#8 documents.
 ///
@@ -36,8 +36,8 @@ impl Encode for Version {
         der::Length::from(1u8).for_tlv()
     }
 
-    fn encode(&self, encoder: &mut Encoder<'_>) -> der::Result<()> {
-        u8::from(*self).encode(encoder)
+    fn encode(&self, writer: &mut dyn Writer) -> der::Result<()> {
+        u8::from(*self).encode(writer)
     }
 }
 

--- a/sec1/src/parameters.rs
+++ b/sec1/src/parameters.rs
@@ -1,6 +1,6 @@
 use der::{
     asn1::{Any, ObjectIdentifier},
-    DecodeValue, Decoder, EncodeValue, Encoder, FixedTag, Header, Length, Tag,
+    DecodeValue, Decoder, EncodeValue, FixedTag, Header, Length, Tag, Writer,
 };
 
 /// Elliptic curve parameters as described in
@@ -41,9 +41,9 @@ impl EncodeValue for EcParameters {
         }
     }
 
-    fn encode_value(&self, encoder: &mut Encoder<'_>) -> der::Result<()> {
+    fn encode_value(&self, writer: &mut dyn Writer) -> der::Result<()> {
         match self {
-            Self::NamedCurve(oid) => oid.encode_value(encoder),
+            Self::NamedCurve(oid) => oid.encode_value(writer),
         }
     }
 }


### PR DESCRIPTION
Implements encoding in terms of the `Writer` trait.

To allow `Encode` to continue to function as a trait object, the `Writer` must also be a trait object.

This approach should enable 1-pass PEM encoding as well as computing key fingerprints without an output buffer. It might come at a cost to performance due to the increased use of trait objects.

It might be possible to retain monomorphization using `Encode<W: Writer>` but at a cost to ergonomics. However, that might be worth exploring depending on the performance.