### PR TITLE
ssh-key: add `certificate::Builder::new_with_validity_times`

### DIFF
--- a/ssh-key/src/certificate/field.rs
+++ b/ssh-key/src/certificate/field.rs
@@ -1,5 +1,6 @@
 //! Certificate fields.
 
+use crate::Error;
 use core::fmt;
 
 /// Certificate fields.
@@ -66,6 +67,11 @@ impl Field {
             Self::Signature => "signature",
             Self::Comment => "comment",
         }
+    }
+
+    /// Get an [`Error`] that this field is invalid.
+    pub fn invalid_error(self) -> Error {
+        Error::CertificateFieldInvalid(self)
     }
 }
 


### PR DESCRIPTION
Adds a `std` feature-gated constructor method for `certificate::Builder` which allows specifying the validity window in terms of `SystemTime`.

This is helpful when computing the validity window relative to the system clock as queried with `SystemTime::now()`.