### PR TITLE
ssh-key: add internal `UnixTime` helper type

### DIFF
--- a/ssh-key/src/certificate/unix_time.rs
+++ b/ssh-key/src/certificate/unix_time.rs
@@ -1,0 +1,128 @@
+//! Unix timestamps.
+
+use crate::{decode::Decode, encode::Encode, reader::Reader, writer::Writer, Error, Result};
+use core::fmt;
+use core::fmt::Formatter;
+
+#[cfg(feature = "std")]
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// Maximum number of seconds since the Unix epoch allowed.
+pub const MAX_SECS: u64 = i64::MAX as u64;
+
+/// Unix timestamps as used in OpenSSH certificates.
+#[derive(Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
+pub(super) struct UnixTime {
+    /// Number of seconds since the Unix epoch
+    secs: u64,
+
+    /// System time corresponding to this Unix timestamp
+    #[cfg(feature = "std")]
+    time: SystemTime,
+}
+
+impl UnixTime {
+    /// Create a new Unix timestamp.
+    ///
+    /// `secs` is the number of seconds since the Unix epoch and must be less
+    /// than or equal to `i64::MAX`.
+    #[cfg(not(feature = "std"))]
+    pub fn new(secs: u64) -> Result<Self> {
+        if secs <= MAX_SECS {
+            Ok(Self { secs })
+        } else {
+            Err(Error::Time)
+        }
+    }
+
+    /// Create a new Unix timestamp.
+    ///
+    /// This version requires `std` and ensures there's a valid `SystemTime`
+    /// representation with an infallible conversion (which also improves the
+    /// `Debug` output)
+    #[cfg(feature = "std")]
+    pub fn new(secs: u64) -> Result<Self> {
+        if secs > MAX_SECS {
+            return Err(Error::Time);
+        }
+
+        match UNIX_EPOCH.checked_add(Duration::from_secs(secs)) {
+            Some(time) => Ok(Self { secs, time }),
+            None => Err(Error::Time),
+        }
+    }
+
+    /// Get the current time as a Unix timestamp.
+    #[cfg(all(feature = "std", feature = "fingerprint"))]
+    pub fn now() -> Result<Self> {
+        SystemTime::now().try_into()
+    }
+}
+
+impl Decode for UnixTime {
+    fn decode(reader: &mut impl Reader) -> Result<Self> {
+        u64::decode(reader)?.try_into()
+    }
+}
+
+impl Encode for UnixTime {
+    fn encoded_len(&self) -> Result<usize> {
+        self.secs.encoded_len()
+    }
+
+    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
+        self.secs.encode(writer)
+    }
+}
+
+impl From<UnixTime> for u64 {
+    fn from(unix_time: UnixTime) -> u64 {
+        unix_time.secs
+    }
+}
+
+#[cfg(feature = "std")]
+impl From<UnixTime> for SystemTime {
+    fn from(unix_time: UnixTime) -> SystemTime {
+        unix_time.time
+    }
+}
+
+impl TryFrom<u64> for UnixTime {
+    type Error = Error;
+
+    fn try_from(unix_secs: u64) -> Result<UnixTime> {
+        Self::new(unix_secs)
+    }
+}
+
+#[cfg(feature = "std")]
+impl TryFrom<SystemTime> for UnixTime {
+    type Error = Error;
+
+    fn try_from(time: SystemTime) -> Result<UnixTime> {
+        Self::new(time.duration_since(UNIX_EPOCH)?.as_secs())
+    }
+}
+
+impl fmt::Debug for UnixTime {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.secs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{UnixTime, MAX_SECS};
+    use crate::Error;
+
+    #[test]
+    fn new_with_max_secs() {
+        assert!(UnixTime::new(MAX_SECS).is_ok());
+    }
+
+    #[test]
+    fn new_over_max_secs_returns_error() {
+        assert_eq!(UnixTime::new(MAX_SECS + 1), Err(Error::Time));
+    }
+}

--- a/ssh-key/src/error.rs
+++ b/ssh-key/src/error.rs
@@ -64,6 +64,9 @@ pub enum Error {
     /// Public key does not match private key.
     PublicKey,
 
+    /// Invalid timestamp (e.g. in a certificate)
+    Time,
+
     /// Unexpected trailing data at end of message.
     TrailingData {
         /// Number of bytes of remaining data at end of message.
@@ -74,26 +77,27 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::Algorithm => f.write_str("unknown or unsupported algorithm"),
+            Error::Algorithm => write!(f, "unknown or unsupported algorithm"),
             Error::Base64(err) => write!(f, "Base64 encoding error: {}", err),
             #[cfg(feature = "alloc")]
             Error::CertificateFieldInvalid(field) => {
                 write!(f, "certificate field invalid: {}", field)
             }
-            Error::CertificateValidation => f.write_str("certificate validation failed"),
-            Error::CharacterEncoding => f.write_str("character encoding invalid"),
-            Error::Crypto => f.write_str("cryptographic error"),
-            Error::Decrypted => f.write_str("private key is already decrypted"),
+            Error::CertificateValidation => write!(f, "certificate validation failed"),
+            Error::CharacterEncoding => write!(f, "character encoding invalid"),
+            Error::Crypto => write!(f, "cryptographic error"),
+            Error::Decrypted => write!(f, "private key is already decrypted"),
             #[cfg(feature = "ecdsa")]
             Error::Ecdsa(err) => write!(f, "ECDSA encoding error: {}", err),
-            Error::Encrypted => f.write_str("private key is encrypted"),
-            Error::FormatEncoding => f.write_str("format encoding error"),
+            Error::Encrypted => write!(f, "private key is encrypted"),
+            Error::FormatEncoding => write!(f, "format encoding error"),
             #[cfg(feature = "std")]
             Error::Io(err) => write!(f, "I/O error: {}", std::io::Error::from(*err)),
-            Error::Length => f.write_str("length invalid"),
-            Error::Overflow => f.write_str("internal overflow error"),
+            Error::Length => write!(f, "length invalid"),
+            Error::Overflow => write!(f, "internal overflow error"),
             Error::Pem(err) => write!(f, "{}", err),
-            Error::PublicKey => f.write_str("public key is incorrect"),
+            Error::PublicKey => write!(f, "public key is incorrect"),
+            Error::Time => write!(f, "invalid time"),
             Error::TrailingData { remaining } => write!(
                 f,
                 "unexpected trailing data at end of message ({} bytes)",
@@ -102,9 +106,6 @@ impl fmt::Display for Error {
         }
     }
 }
-
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
 
 impl From<base64ct::Error> for Error {
     fn from(err: base64ct::Error) -> Error {
@@ -189,3 +190,13 @@ impl From<std::io::Error> for Error {
         Error::Io(err.kind())
     }
 }
+
+#[cfg(feature = "std")]
+impl From<std::time::SystemTimeError> for Error {
+    fn from(_: std::time::SystemTimeError) -> Error {
+        Error::Time
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}


### PR DESCRIPTION
Adds a type for modeling Unix timestamps for use in OpenSSH certificate validity windows.

This puts all time-related code in a single place.