### PR TITLE
ssh-key: fix CI

### DIFF
--- a/.github/workflows/ssh-key.yml
+++ b/.github/workflows/ssh-key.yml
@@ -19,28 +19,6 @@ env:
   RUSTFLAGS: "-Dwarnings"
 
 jobs:
-  test:
-    strategy:
-      matrix:
-        platform:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
-        toolchain:
-          - 1.51.0 # MSRV
-          - stable
-    runs-on: ${{ matrix.platform }}
-    steps:
-      - uses: actions/checkout@v2
-      - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.toolchain }}
-          override: true
-          profile: minimal
-      - run: cargo test --release
-      - run: cargo test --release --features alloc,derive
-
   build:
     strategy:
       matrix:

--- a/ssh-key/src/private.rs
+++ b/ssh-key/src/private.rs
@@ -157,10 +157,10 @@ use crate::{Fingerprint, HashAlg};
 use rand_core::{CryptoRng, RngCore};
 
 #[cfg(feature = "std")]
-use std::{fs, io::Write, path::Path};
+use std::{fs, path::Path};
 
 #[cfg(all(unix, feature = "std"))]
-use std::os::unix::fs::OpenOptionsExt;
+use std::{io::Write, os::unix::fs::OpenOptionsExt};
 
 #[cfg(feature = "subtle")]
 use subtle::{Choice, ConstantTimeEq};


### PR DESCRIPTION
Whoops, it seems #614 contained a parse error and CI didn't actually do a proper run. This fixes the configuration.