### PR TITLE
spki: streaming fingerprint builder

### DIFF
--- a/spki/src/fingerprint.rs
+++ b/spki/src/fingerprint.rs
@@ -1,0 +1,43 @@
+//! SPKI fingerprint support.
+
+use der::Writer;
+use sha2::{Digest, Sha256};
+
+/// Size of a SHA-256 SPKI fingerprint in bytes.
+pub(crate) const SIZE: usize = 32;
+
+/// Raw bytes of a SPKI fingerprint i.e. SHA-256 digest of
+/// `SubjectPublicKeyInfo`'s DER encoding.
+///
+/// See [RFC7469 § 2.1.1] for more information.
+///
+/// [RFC7469 § 2.1.1]: https://datatracker.ietf.org/doc/html/rfc7469#section-2.1.1
+#[cfg_attr(docsrs, doc(cfg(feature = "fingerprint")))]
+pub type FingerprintBytes = [u8; SIZE];
+
+/// Writer newtype which accepts DER being serialized on-the-fly and computes a
+/// hash of the contents.
+#[derive(Clone, Default)]
+pub(crate) struct Builder {
+    /// In-progress digest being computed from streaming DER.
+    digest: Sha256,
+}
+
+impl Builder {
+    /// Create a new fingerprint builder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Finish computing a fingerprint, returning the computed digest.
+    pub fn finish(self) -> FingerprintBytes {
+        self.digest.finalize().into()
+    }
+}
+
+impl Writer for Builder {
+    fn write(&mut self, der_bytes: &[u8]) -> der::Result<()> {
+        self.digest.update(der_bytes);
+        Ok(())
+    }
+}

--- a/spki/src/lib.rs
+++ b/spki/src/lib.rs
@@ -38,6 +38,9 @@ mod error;
 mod spki;
 mod traits;
 
+#[cfg(feature = "fingerprint")]
+mod fingerprint;
+
 pub use crate::{
     algorithm::AlgorithmIdentifier,
     error::{Error, Result},
@@ -48,3 +51,6 @@ pub use der::{self, asn1::ObjectIdentifier};
 
 #[cfg(feature = "alloc")]
 pub use {crate::traits::EncodePublicKey, der::Document};
+
+#[cfg(feature = "fingerprint")]
+pub use crate::fingerprint::FingerprintBytes;

--- a/spki/tests/spki.rs
+++ b/spki/tests/spki.rs
@@ -73,7 +73,7 @@ fn decode_ed25519_and_fingerprint_spki() {
 
     // Check the fingerprint
     assert_eq!(
-        spki.fingerprint().unwrap().as_slice(),
+        spki.fingerprint_bytes().unwrap().as_slice(),
         ED25519_SPKI_FINGERPRINT
     );
 }


### PR DESCRIPTION
Uses the `Writer` trait to compute SPKI fingerprints by hashing output DER on-the-fly as opposed to encoding it first to an intermediate buffer then computing the SHA-256 digest.

Besides simply being more efficient, the buffered method had a hardcoded limit of 4096-bytes. The new implementation has no such limit because it hashes data as soon as it's encoded.

This additionally renames `SubjectPublicKeyInfo::fingerprint` to `::fingerprint_bytes`. "True" SPKI fingerprints are Base64-encoded, and this commit also promotes `fingerprint_base64` to being earlier in the impl block so it's the first fingerprinting method people see.