### PR TITLE
pem-rfc7468 v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,7 +431,7 @@ dependencies = [
  "der_derive",
  "flagset",
  "hex-literal",
- "pem-rfc7468 0.6.0-pre",
+ "pem-rfc7468 0.6.0",
  "proptest",
  "time",
  "zeroize",
@@ -841,7 +841,7 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.6.0-pre"
+version = "0.6.0"
 dependencies = [
  "base64ct 1.5.0",
 ]
@@ -1430,7 +1430,7 @@ dependencies = [
  "ed25519-dalek",
  "hex-literal",
  "p256",
- "pem-rfc7468 0.6.0-pre",
+ "pem-rfc7468 0.6.0",
  "rand_chacha",
  "rand_core 0.6.3",
  "rsa",

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.57"
 const-oid = { version = "0.9", optional = true, path = "../const-oid" }
 der_derive = { version = "=0.6.0-pre.3", optional = true, path = "derive" }
 flagset = { version = "0.4.3", optional = true }
-pem-rfc7468 = { version = "=0.6.0-pre", optional = true, path = "../pem-rfc7468" }
+pem-rfc7468 = { version = "0.6", optional = true, path = "../pem-rfc7468" }
 time = { version = "0.3.4", optional = true, default-features = false }
 zeroize = { version = "1.5", optional = true, default-features = false, features = ["alloc"] }
 

--- a/pem-rfc7468/CHANGELOG.md
+++ b/pem-rfc7468/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2022-04-26)
+### Added
+- `encapsulated_len_wrapped` ([#619])
+
+### Changed
+- `encapsulated_len` now accepts the length of the raw input bytes prior to
+  Base64 encoding, and computes the length of the full PEM encoded document
+  including newlines when the resulting Base64 is linewrapped ([#619])
+
+[#619]: https://github.com/RustCrypto/formats/pull/619
+
 ## 0.5.1 (2022-03-30)
 ### Changed
 - Rename `PemLabel::TYPE_LABEL` => `::PEM_LABEL` ([#568])

--- a/pem-rfc7468/Cargo.toml
+++ b/pem-rfc7468/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pem-rfc7468"
-version = "0.6.0-pre"
+version = "0.6.0"
 description = """
 PEM Encoding (RFC 7468) for PKIX, PKCS, and CMS Structures, implementing a
 strict subset of the original Privacy-Enhanced Mail encoding intended

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.57"
 
 [dependencies]
 base64ct = { version = "1.4", path = "../base64ct" }
-pem-rfc7468 = { version = "=0.6.0-pre", path = "../pem-rfc7468" }
+pem-rfc7468 = { version = "0.6", path = "../pem-rfc7468" }
 zeroize = { version = "1", default-features = false }
 
 # optional dependencies


### PR DESCRIPTION
### Added
- `encapsulated_len_wrapped` ([#619])

### Changed
- `encapsulated_len` now accepts the length of the raw input bytes prior to Base64 encoding, and computes the length of the full PEM encoded document including newlines when the resulting Base64 is linewrapped ([#619])

[#619]: https://github.com/RustCrypto/formats/pull/619