### PR TITLE
ssh-key: further restrict maximum allowed timestamps

### DIFF
--- a/ssh-key/src/certificate/unix_time.rs
+++ b/ssh-key/src/certificate/unix_time.rs
@@ -7,8 +7,13 @@ use core::fmt::Formatter;
 #[cfg(feature = "std")]
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-/// Maximum number of seconds since the Unix epoch allowed.
-pub const MAX_SECS: u64 = i64::MAX as u64;
+/// Maximum allowed value for a Unix timestamp:
+///
+/// 9999-12-31 23:59:59 UTC
+///
+/// This is a sanity limit intended to catch nonsense values which are
+/// excessively far in the future. Otherwise the limit is `i64::MAX`.
+pub const MAX_SECS: u64 = 253402300799;
 
 /// Unix timestamps as used in OpenSSH certificates.
 #[derive(Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]


### PR DESCRIPTION
Caps maximum allowed Unix timestamps to:

9999-12-31 23:59:59 UTC

This is a sanity limit intended to catch nonsense values which are excessively distant in the future.