### PR TITLE
ssh-key v0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1421,7 +1421,7 @@ dependencies = [
 
 [[package]]
 name = "ssh-key"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "aes",
  "base64ct 1.5.0",

--- a/ssh-key/CHANGELOG.md
+++ b/ssh-key/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.1 (2022-04-26)
+### Added
+- Internal `UnixTime` helper type ([#613])
+
+### Changed
+- Bump `pem-rfc7468` dependency to v0.6.0 ([#620])
+- Further restrict maximum allowed timestamps ([#621])
+
+[#613]: https://github.com/RustCrypto/formats/pull/613
+[#620]: https://github.com/RustCrypto/formats/pull/620
+[#621]: https://github.com/RustCrypto/formats/pull/621
+
 ## 0.4.0 (2022-04-12)
 ### Added
 - Private key decryption support ([#535], [#539])

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssh-key"
-version = "0.4.0"
+version = "0.4.1"
 description = """
 Pure Rust implementation of SSH key file format decoders/encoders as described
 in RFC4251 and RFC4253 as well as the OpenSSH key formats, certificates


### PR DESCRIPTION
### Added
- Internal `UnixTime` helper type ([#613])

### Changed
- Bump `pem-rfc7468` dependency to v0.6.0 ([#620])
- Further restrict maximum allowed timestamps ([#621])

[#613]: https://github.com/RustCrypto/formats/pull/613
[#620]: https://github.com/RustCrypto/formats/pull/620
[#621]: https://github.com/RustCrypto/formats/pull/621