### PR TITLE
der: feature-gate `real` implementation

### DIFF
--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -32,6 +32,7 @@ alloc = []
 derive = ["der_derive"]
 oid = ["const-oid"]
 pem = ["alloc", "pem-rfc7468/alloc", "zeroize"]
+real = []
 std = ["alloc"]
 
 [package.metadata.docs.rs]

--- a/der/src/asn1.rs
+++ b/der/src/asn1.rs
@@ -15,6 +15,7 @@ mod octet_string;
 mod oid;
 mod optional;
 mod printable_string;
+#[cfg(feature = "real")]
 mod real;
 mod sequence;
 mod sequence_of;

--- a/der/src/asn1/real.rs
+++ b/der/src/asn1/real.rs
@@ -14,8 +14,7 @@ use crate::{
 
 use super::integer::uint::strip_leading_zeroes;
 
-// TODO: panic-free implementation
-#[allow(clippy::panic_in_result_fn)]
+#[cfg_attr(docsrs, doc(cfg(feature = "real")))]
 impl DecodeValue<'_> for f64 {
     fn decode_value(decoder: &mut Decoder<'_>, header: Header) -> Result<Self> {
         let bytes = ByteSlice::decode_value(decoder, header)?.as_slice();
@@ -72,23 +71,20 @@ impl DecodeValue<'_> for f64 {
                 1 => Ok(f64::NEG_INFINITY),
                 2 => Ok(f64::NAN),
                 3 => Ok(-0.0_f64),
-                _ => {
-                    unreachable!()
-                }
+                _ => Err(Tag::Real.value_error()),
             }
         } else {
             let astr = StrSlice::from_bytes(&bytes[1..])?;
             match astr.inner.parse::<f64>() {
                 Ok(val) => Ok(val),
-                Err(_) => {
-                    // Real related error: encoding not supported or malformed
-                    Err(Tag::Real.value_error())
-                }
+                // Real related error: encoding not supported or malformed
+                Err(_) => Err(Tag::Real.value_error()),
             }
         }
     }
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "real")))]
 impl EncodeValue for f64 {
     fn value_len(&self) -> Result<Length> {
         if self.is_sign_positive() && (*self) < f64::MIN_POSITIVE {
@@ -196,6 +192,7 @@ impl EncodeValue for f64 {
     }
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "real")))]
 impl FixedTag for f64 {
     const TAG: Tag = Tag::Real;
 }

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -36,7 +36,7 @@
 //! - [`bool`]: ASN.1 `BOOLEAN`.
 //! - [`i8`], [`i16`], [`i32`], [`i64`], [`i128`]: ASN.1 `INTEGER`.
 //! - [`u8`], [`u16`], [`u32`], [`u64`], [`u128`]: ASN.1 `INTEGER`.
-//! - [`f64`]: ASN.1 `REAL`
+//! - [`f64`]: ASN.1 `REAL` (gated on `real` crate feature)
 //! - [`str`], [`String`][`alloc::string::String`]: ASN.1 `UTF8String`.
 //!   `String` requires `alloc` feature. See also [`Utf8String`].
 //!   Requires `alloc` feature. See also [`SetOf`].


### PR DESCRIPTION
Most users of this crate do not need `real`, however its implementation may be problematic in environments that don't have access to floating point, e.g. UEFI or uCs with no FPU.

Feature gating it ensures there will be no complications building in these environments.