### PR TITLE
Add support for parsing keys out of the ssh known_hosts file format

### DIFF
--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -43,7 +43,7 @@ zeroize_derive = "1.3" # hack to make minimal-versions lint happy (pulled in by 
 
 [features]
 default = ["ecdsa", "fingerprint", "rand_core", "std"]
-alloc = ["signature", "zeroize/alloc"]
+alloc = ["signature", "zeroize/alloc", "base64ct/alloc"]
 ecdsa = ["sec1"]
 ed25519 = ["ed25519-dalek", "rand_core"]
 encryption = ["aes", "alloc", "bcrypt-pbkdf", "ctr", "rand_core"]

--- a/ssh-key/README.md
+++ b/ssh-key/README.md
@@ -18,7 +18,8 @@ specification.
 Additionally provides support for OpenSSH certificates as specified in
 [PROTOCOL.certkeys] including certificate validation and certificate authority
 (CA) support, as well as FIDO/U2F keys as specified in [PROTOCOL.u2f] (and
-certificates thereof), and also the `authorized_keys` file format.
+certificates thereof), and also the `authorized_keys` and `known_hosts`
+file formats.
 
 Supports a minimal profile which works on heapless `no_std` targets. See
 "Supported algorithms" table below for which key formats work on heapless
@@ -44,6 +45,7 @@ respective SSH key algorithm.
 - [x] Fingerprint support
 - [x] `no_std` support including support for "heapless" (no-`alloc`) targets
 - [x] Parsing `authorized_keys` files
+- [x] Parsing `known_hosts` files
 - [x] `serde` support
 - [x] `zeroize` support for private keys
 

--- a/ssh-key/src/known_hosts.rs
+++ b/ssh-key/src/known_hosts.rs
@@ -25,7 +25,7 @@ const MAGIC_HASH_PREFIX: &str = "|1|";
 /// For a full description of the format, see:
 /// <https://man7.org/linux/man-pages/man8/sshd.8.html#SSH_KNOWN_HOSTS_FILE_FORMAT>
 ///
-/// Each line of the file consists of a single public key tied to one or more hosts. 
+/// Each line of the file consists of a single public key tied to one or more hosts.
 /// Blank lines are ignored.
 ///
 /// Public keys consist of the following space-separated fields:
@@ -153,17 +153,13 @@ impl str::FromStr for Entry {
         // the optional marker field starts with an @, so look for that
         // and act accordingly.
         let (marker, line) = if line.starts_with('@') {
-            let (marker_str, line) = line
-                .split_once(' ')
-                .ok_or(Error::FormatEncoding)?;
+            let (marker_str, line) = line.split_once(' ').ok_or(Error::FormatEncoding)?;
             (Some(marker_str.parse()?), line)
         } else {
             (None, line)
         };
-        let (hosts_str, public_key_str) = line
-            .split_once(' ')
-            .ok_or(Error::FormatEncoding)?;
-        
+        let (hosts_str, public_key_str) = line.split_once(' ').ok_or(Error::FormatEncoding)?;
+
         let host_patterns = hosts_str.parse()?;
         let public_key = public_key_str.parse()?;
 
@@ -294,12 +290,12 @@ impl ToString for HostPatterns {
 
 #[cfg(test)]
 mod tests {
-    use core::str::FromStr;
     use alloc::string::ToString;
+    use core::str::FromStr;
 
-    use super::Marker;
-    use super::HostPatterns;
     use super::Entry;
+    use super::HostPatterns;
+    use super::Marker;
 
     #[test]
     fn simple_markers() {
@@ -319,7 +315,10 @@ mod tests {
 
     #[test]
     fn single_host_pattern() {
-        assert_eq!(Ok(HostPatterns::Patterns(vec!["cvs.example.net".to_string()])), "cvs.example.net".parse());
+        assert_eq!(
+            Ok(HostPatterns::Patterns(vec!["cvs.example.net".to_string()])),
+            "cvs.example.net".parse()
+        );
     }
     #[test]
     fn multiple_host_patterns() {
@@ -335,12 +334,16 @@ mod tests {
     #[test]
     fn single_hashed_host() {
         assert_eq!(
-            Ok(
-                HostPatterns::HashedName {
-                    salt: vec![37, 242, 147, 116, 24, 123, 172, 214, 215, 145, 80, 16, 9, 26, 120, 57, 10, 15, 126, 98],
-                    hash: [81, 33, 2, 175, 116, 150, 127, 82, 84, 62, 201, 172, 228, 10, 159, 15, 148, 31, 198, 67],
-                }
-            ), 
+            Ok(HostPatterns::HashedName {
+                salt: vec![
+                    37, 242, 147, 116, 24, 123, 172, 214, 215, 145, 80, 16, 9, 26, 120, 57, 10, 15,
+                    126, 98
+                ],
+                hash: [
+                    81, 33, 2, 175, 116, 150, 127, 82, 84, 62, 201, 172, 228, 10, 159, 15, 148, 31,
+                    198, 67
+                ],
+            }),
             "|1|JfKTdBh7rNbXkVAQCRp4OQoPfmI=|USECr3SWf1JUPsms5AqfD5QfxkM=".parse()
         );
     }
@@ -350,10 +353,19 @@ mod tests {
         let line = "@revoked |1|lcY/In3lsGnkJikLENb0DM70B/I=|Qs4e9Nr7mM6avuEv02fw2uFnwQo= ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB9dG4kjRhQTtWTVzd2t27+t0DEHBPW7iOD23TUiYLio comment";
         let entry = Entry::from_str(line).expect("Valid entry");
         assert_eq!(entry.marker(), Some(&Marker::Revoked));
-        assert_eq!(entry.host_patterns(), &HostPatterns::HashedName {
-            salt: vec![149, 198, 63, 34, 125, 229, 176, 105, 228, 38, 41, 11, 16, 214, 244, 12, 206, 244, 7, 242],
-            hash: [66, 206, 30, 244, 218, 251, 152, 206, 154, 190, 225, 47, 211, 103, 240, 218, 225, 103, 193, 10],
-        });
+        assert_eq!(
+            entry.host_patterns(),
+            &HostPatterns::HashedName {
+                salt: vec![
+                    149, 198, 63, 34, 125, 229, 176, 105, 228, 38, 41, 11, 16, 214, 244, 12, 206,
+                    244, 7, 242
+                ],
+                hash: [
+                    66, 206, 30, 244, 218, 251, 152, 206, 154, 190, 225, 47, 211, 103, 240, 218,
+                    225, 103, 193, 10
+                ],
+            }
+        );
         // key parsing is tested elsewhere
     }
 }

--- a/ssh-key/src/known_hosts.rs
+++ b/ssh-key/src/known_hosts.rs
@@ -1,0 +1,359 @@
+//! Parser for `KnownHostsFile`-formatted data.
+
+use base64ct::{Base64, Encoding};
+
+use crate::{Error, PublicKey, Result};
+use core::str;
+
+use {
+    alloc::string::{String, ToString},
+    alloc::vec::Vec,
+    core::fmt,
+};
+
+#[cfg(feature = "std")]
+use std::{fs, path::Path};
+
+/// Character that begins a comment
+const COMMENT_DELIMITER: char = '#';
+/// The magic string prefix of a hashed hostname
+const MAGIC_HASH_PREFIX: &str = "|1|";
+
+/// Parser for `KnownHostsFile`-formatted data, typically found in
+/// `~/.ssh/known_hosts`.
+///
+/// For a full description of the format, see:
+/// <https://man7.org/linux/man-pages/man8/sshd.8.html#SSH_KNOWN_HOSTS_FILE_FORMAT>
+///
+/// Each line of the file consists of a single public key tied to one or more hosts. 
+/// Blank lines are ignored.
+///
+/// Public keys consist of the following space-separated fields:
+///
+/// ```text
+/// marker, hostnames, keytype, base64-encoded key, comment
+/// ```
+///
+/// - The marker field is optional, but if present begins with an `@`. Known markers are `@cert-authority`
+///   and `@revoked`.
+/// - The hostnames is a comma-separated list of patterns (with `*` and '?' as glob-style wildcards)
+///   against which hosts are matched. If it begins with a `!` it is a negation of the pattern. If the
+///   pattern starts with `[` and ends with `]`, it contains a hostname pattern and a port number separated
+///   by a `:`. If it begins with `|1|`, the hostname is hashed. In that case, there can only be one exact
+///   hostname and it can't also be negated (ie. `!|1|x|y` is not legal and you can't hash `*.example.org`).
+/// - The keytype is `ecdsa-sha2-nistp256`, `ecdsa-sha2-nistp384`, `ecdsa-sha2-nistp521`,
+///   `ssh-ed25519`, `ssh-dss` or `ssh-rsa`
+/// - The comment field is not used for anything (but may be convenient for the user to identify
+///   the key).
+pub struct KnownHosts<'a> {
+    /// Lines of the file being iterated over
+    lines: core::str::Lines<'a>,
+}
+
+impl<'a> KnownHosts<'a> {
+    /// Create a new parser for the given input buffer.
+    pub fn new(input: &'a str) -> Self {
+        Self {
+            lines: input.lines(),
+        }
+    }
+
+    /// Read a [`KnownHosts`] file from the filesystem, returning an
+    /// [`Entry`] vector on success.
+    #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    pub fn read_file(path: impl AsRef<Path>) -> Result<Vec<Entry>> {
+        // TODO(tarcieri): permissions checks
+        let input = fs::read_to_string(path)?;
+        KnownHosts::new(&input).collect()
+    }
+
+    /// Get the next line, trimming any comments and trailing whitespace.
+    ///
+    /// Ignores empty lines.
+    fn next_line_trimmed(&mut self) -> Option<&'a str> {
+        loop {
+            let mut line = self.lines.next()?;
+
+            // Strip comment if present
+            if let Some((l, _)) = line.split_once(COMMENT_DELIMITER) {
+                line = l;
+            }
+
+            // Trim trailing whitespace
+            line = line.trim_end();
+
+            if !line.is_empty() {
+                return Some(line);
+            }
+        }
+    }
+}
+
+impl Iterator for KnownHosts<'_> {
+    type Item = Result<Entry>;
+
+    fn next(&mut self) -> Option<Result<Entry>> {
+        self.next_line_trimmed().map(|line| line.parse())
+    }
+}
+
+/// Individual entry in an `known_hosts` file containing a single public key.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Entry {
+    /// Marker field, if present.
+    marker: Option<Marker>,
+
+    /// Host patterns
+    host_patterns: HostPatterns,
+
+    /// Public key
+    public_key: PublicKey,
+}
+
+impl Entry {
+    /// Get the marker for this entry, if present.
+    pub fn marker(&self) -> Option<&Marker> {
+        self.marker.as_ref()
+    }
+
+    /// Get the host pattern enumerator for this entry
+    pub fn host_patterns(&self) -> &HostPatterns {
+        &self.host_patterns
+    }
+
+    /// Get public key for this entry.
+    pub fn public_key(&self) -> &PublicKey {
+        &self.public_key
+    }
+}
+impl From<Entry> for Option<Marker> {
+    fn from(entry: Entry) -> Option<Marker> {
+        entry.marker
+    }
+}
+impl From<Entry> for HostPatterns {
+    fn from(entry: Entry) -> HostPatterns {
+        entry.host_patterns
+    }
+}
+impl From<Entry> for PublicKey {
+    fn from(entry: Entry) -> PublicKey {
+        entry.public_key
+    }
+}
+
+impl str::FromStr for Entry {
+    type Err = Error;
+
+    fn from_str(line: &str) -> Result<Self> {
+        // Unlike authorized_keys, in known_hosts it's pretty common
+        // to not include a key comment, so the number of spaces is
+        // not a reliable indicator of the fields in the line. Instead,
+        // the optional marker field starts with an @, so look for that
+        // and act accordingly.
+        let (marker, line) = if line.starts_with('@') {
+            let (marker_str, line) = line
+                .split_once(' ')
+                .ok_or(Error::FormatEncoding)?;
+            (Some(marker_str.parse()?), line)
+        } else {
+            (None, line)
+        };
+        let (hosts_str, public_key_str) = line
+            .split_once(' ')
+            .ok_or(Error::FormatEncoding)?;
+        
+        let host_patterns = hosts_str.parse()?;
+        let public_key = public_key_str.parse()?;
+
+        Ok(Self {
+            marker,
+            host_patterns,
+            public_key,
+        })
+    }
+}
+
+impl ToString for Entry {
+    fn to_string(&self) -> String {
+        let mut s = String::new();
+
+        if let Some(marker) = &self.marker {
+            s.push_str(marker.as_str());
+            s.push(' ');
+        }
+
+        s.push_str(&self.host_patterns.to_string());
+        s.push(' ');
+
+        s.push_str(&self.public_key.to_string());
+        s
+    }
+}
+
+/// Markers associated with this host key entry.
+///
+/// There can only be one of these per host key entry.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Marker {
+    /// This host entry's public key is for a certificate authority's private key
+    CertAuthority,
+    /// This host entry's public key has been revoked, and should not be allowed to connect
+    /// regardless of any other entry.
+    Revoked,
+}
+
+impl Marker {
+    /// Get the string form of the marker
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::CertAuthority => "@cert-authority",
+            Self::Revoked => "@revoked",
+        }
+    }
+}
+
+impl AsRef<str> for Marker {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl str::FromStr for Marker {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        Ok(match s {
+            "@cert-authority" => Marker::CertAuthority,
+            "@revoked" => Marker::Revoked,
+            _ => return Err(Error::FormatEncoding),
+        })
+    }
+}
+
+impl fmt::Display for Marker {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// The host pattern(s) for this host entry.
+///
+/// The host patterns can either be a comma separated list of host patterns
+/// (which may include glob patterns (`*` and `?`), negations (a `!` prefix),
+/// or `pattern:port` pairs inside square brackets), or a single hashed
+/// hostname prefixed with `|1|`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum HostPatterns {
+    /// A comma separated list of hostname patterns.
+    Patterns(Vec<String>),
+    /// A single hashed hostname
+    HashedName {
+        /// The salt used for the hash
+        salt: Vec<u8>,
+        /// An SHA-1 hash of the hostname along with the salt
+        hash: [u8; 20],
+    },
+}
+
+impl str::FromStr for HostPatterns {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        if let Some(s) = s.strip_prefix(MAGIC_HASH_PREFIX) {
+            let mut hash = [0; 20];
+            let (salt, hash_str) = s.split_once('|').ok_or(Error::FormatEncoding)?;
+
+            let salt = Base64::decode_vec(salt)?;
+            Base64::decode(hash_str, &mut hash)?;
+
+            Ok(HostPatterns::HashedName { salt, hash })
+        } else if !s.is_empty() {
+            Ok(HostPatterns::Patterns(
+                s.split_terminator(',').map(str::to_string).collect(),
+            ))
+        } else {
+            Err(Error::FormatEncoding)
+        }
+    }
+}
+
+impl ToString for HostPatterns {
+    fn to_string(&self) -> String {
+        match &self {
+            HostPatterns::Patterns(patterns) => patterns.join(","),
+            HostPatterns::HashedName { salt, hash } => {
+                let salt = Base64::encode_string(salt);
+                let hash = Base64::encode_string(hash);
+                format!("|1|{}|{}", salt, hash)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::str::FromStr;
+    use alloc::string::ToString;
+
+    use super::Marker;
+    use super::HostPatterns;
+    use super::Entry;
+
+    #[test]
+    fn simple_markers() {
+        assert_eq!(Ok(Marker::CertAuthority), "@cert-authority".parse());
+        assert_eq!(Ok(Marker::Revoked), "@revoked".parse());
+        assert!(Marker::from_str("@gibberish").is_err());
+    }
+
+    #[test]
+    fn empty_host_patterns() {
+        assert!(HostPatterns::from_str("").is_err());
+    }
+
+    // Note: The sshd man page has this completely incomprehensible 'example known_hosts entry':
+    // closenet,...,192.0.2.53 1024 37 159...93 closenet.example.net
+    // I'm not sure how this one is supposed to work or what it means.
+
+    #[test]
+    fn single_host_pattern() {
+        assert_eq!(Ok(HostPatterns::Patterns(vec!["cvs.example.net".to_string()])), "cvs.example.net".parse());
+    }
+    #[test]
+    fn multiple_host_patterns() {
+        assert_eq!(
+            Ok(HostPatterns::Patterns(vec![
+                "cvs.example.net".to_string(),
+                "!test.example.???".to_string(),
+                "[*.example.net]:999".to_string(),
+            ])),
+            "cvs.example.net,!test.example.???,[*.example.net]:999".parse()
+        );
+    }
+    #[test]
+    fn single_hashed_host() {
+        assert_eq!(
+            Ok(
+                HostPatterns::HashedName {
+                    salt: vec![37, 242, 147, 116, 24, 123, 172, 214, 215, 145, 80, 16, 9, 26, 120, 57, 10, 15, 126, 98],
+                    hash: [81, 33, 2, 175, 116, 150, 127, 82, 84, 62, 201, 172, 228, 10, 159, 15, 148, 31, 198, 67],
+                }
+            ), 
+            "|1|JfKTdBh7rNbXkVAQCRp4OQoPfmI=|USECr3SWf1JUPsms5AqfD5QfxkM=".parse()
+        );
+    }
+
+    #[test]
+    fn full_line_hashed() {
+        let line = "@revoked |1|lcY/In3lsGnkJikLENb0DM70B/I=|Qs4e9Nr7mM6avuEv02fw2uFnwQo= ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB9dG4kjRhQTtWTVzd2t27+t0DEHBPW7iOD23TUiYLio comment";
+        let entry = Entry::from_str(line).expect("Valid entry");
+        assert_eq!(entry.marker(), Some(&Marker::Revoked));
+        assert_eq!(entry.host_patterns(), &HostPatterns::HashedName {
+            salt: vec![149, 198, 63, 34, 125, 229, 176, 105, 228, 38, 41, 11, 16, 214, 244, 12, 206, 244, 7, 242],
+            hash: [66, 206, 30, 244, 218, 251, 152, 206, 154, 190, 225, 47, 211, 103, 240, 218, 225, 103, 193, 10],
+        });
+        // key parsing is tested elsewhere
+    }
+}

--- a/ssh-key/src/lib.rs
+++ b/ssh-key/src/lib.rs
@@ -178,7 +178,9 @@ pub use base64ct::LineEnding;
 pub use pem_rfc7468 as pem;
 
 #[cfg(feature = "alloc")]
-pub use crate::{certificate::Certificate, known_hosts::KnownHosts, mpint::MPInt, signature::Signature};
+pub use crate::{
+    certificate::Certificate, known_hosts::KnownHosts, mpint::MPInt, signature::Signature,
+};
 
 #[cfg(feature = "ecdsa")]
 pub use sec1;

--- a/ssh-key/src/lib.rs
+++ b/ssh-key/src/lib.rs
@@ -138,6 +138,9 @@ extern crate alloc;
 extern crate std;
 
 pub mod authorized_keys;
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+pub mod known_hosts;
 pub mod private;
 pub mod public;
 

--- a/ssh-key/src/lib.rs
+++ b/ssh-key/src/lib.rs
@@ -178,7 +178,7 @@ pub use base64ct::LineEnding;
 pub use pem_rfc7468 as pem;
 
 #[cfg(feature = "alloc")]
-pub use crate::{certificate::Certificate, mpint::MPInt, signature::Signature};
+pub use crate::{certificate::Certificate, known_hosts::KnownHosts, mpint::MPInt, signature::Signature};
 
 #[cfg(feature = "ecdsa")]
 pub use sec1;

--- a/ssh-key/src/public/openssh.rs
+++ b/ssh-key/src/public/openssh.rs
@@ -67,8 +67,10 @@ impl<'a> Encapsulation<'a> {
         let base64_len = writer.finish()?.len();
 
         offset = offset.checked_add(base64_len).ok_or(Error::Length)?;
-        encode_str(out, &mut offset, " ")?;
-        encode_str(out, &mut offset, comment)?;
+        if !comment.is_empty() {
+            encode_str(out, &mut offset, " ")?;
+            encode_str(out, &mut offset, comment)?;
+        }
         Ok(str::from_utf8(&out[..offset])?)
     }
 }

--- a/ssh-key/src/public/openssh.rs
+++ b/ssh-key/src/public/openssh.rs
@@ -37,12 +37,10 @@ impl<'a> Encapsulation<'a> {
         let comment = str::from_utf8(bytes)
             .map_err(|_| Error::CharacterEncoding)?
             .trim_end();
-
-        if algorithm_id.is_empty() || base64_data.is_empty() || comment.is_empty() {
+        if algorithm_id.is_empty() || base64_data.is_empty() {
             // TODO(tarcieri): better errors for these cases?
             return Err(Error::Length);
         }
-
         Ok(Self {
             algorithm_id,
             base64_data,
@@ -98,8 +96,8 @@ fn decode_segment<'a>(bytes: &mut &'a [u8]) -> Result<&'a [u8]> {
                 return Err(Error::CharacterEncoding);
             }
             [] => {
-                // Truncated public key
-                return Err(Error::Length);
+                // End of input, could be truncated or could be no comment
+                return start.get(..len).ok_or(Error::Length);
             }
         }
     }

--- a/ssh-key/tests/authorized_keys.rs
+++ b/ssh-key/tests/authorized_keys.rs
@@ -11,11 +11,11 @@ fn read_example_file() {
     assert_eq!(authorized_keys.len(), 4);
 
     assert_eq!(authorized_keys[0].config_opts().to_string(), "");
-    assert_eq!(authorized_keys[0].public_key().to_string(), "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILM+rvN+ot98qgEN796jTiQfZfG1KaT0PtFDJ/XFSqti");
     assert_eq!(
-        authorized_keys[0].public_key().comment(),
-        ""
+        authorized_keys[0].public_key().to_string(),
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILM+rvN+ot98qgEN796jTiQfZfG1KaT0PtFDJ/XFSqti"
     );
+    assert_eq!(authorized_keys[0].public_key().comment(), "");
 
     assert_eq!(
         authorized_keys[1].config_opts().to_string(),

--- a/ssh-key/tests/authorized_keys.rs
+++ b/ssh-key/tests/authorized_keys.rs
@@ -11,10 +11,10 @@ fn read_example_file() {
     assert_eq!(authorized_keys.len(), 4);
 
     assert_eq!(authorized_keys[0].config_opts().to_string(), "");
-    assert_eq!(authorized_keys[0].public_key().to_string(), "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILM+rvN+ot98qgEN796jTiQfZfG1KaT0PtFDJ/XFSqti user1@example.com");
+    assert_eq!(authorized_keys[0].public_key().to_string(), "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILM+rvN+ot98qgEN796jTiQfZfG1KaT0PtFDJ/XFSqti");
     assert_eq!(
         authorized_keys[0].public_key().comment(),
-        "user1@example.com"
+        ""
     );
 
     assert_eq!(

--- a/ssh-key/tests/examples/authorized_keys
+++ b/ssh-key/tests/examples/authorized_keys
@@ -15,8 +15,8 @@
 # - The comment field is not used for anything (but may be convenient for the user to
 #   identify the key).
 
-# Public key with no options
-ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILM+rvN+ot98qgEN796jTiQfZfG1KaT0PtFDJ/XFSqti user1@example.com
+# Public key with no options and no comment
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILM+rvN+ot98qgEN796jTiQfZfG1KaT0PtFDJ/XFSqti
 
 # Public key which can only read the current date
 command="/usr/bin/date" ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHwf2HMM5TRXvo2SQJjsNkiDD5KqiiNjrGVv3UUh+mMT5RHxiRtOnlqvjhQtBq0VpmpCV/PwUdhOig4vkbqAcEc= user2@example.com

--- a/ssh-key/tests/examples/known_hosts
+++ b/ssh-key/tests/examples/known_hosts
@@ -1,0 +1,34 @@
+# Example authorized keys file
+#
+# - Comments in these files begin with `#`
+# - They can also contain blank lines
+# - Lines which are not blank each contain a single host-pattern's public key
+# - Maximum line length is 8 kilobytes
+#
+# Known hosts consist of the following space-separated fields:
+#
+# marker, hostnames, keytype, base64-encoded key, comment
+#
+# - The marker field is optional, but if present begins with an `@`. Known markers are `@cert-authority`
+#   and `@revoked`.
+# - The hostnames is a comma-separated list of patterns (with `*` and '?' as glob-style wildcards)
+#   against which hosts are matched. If it begins with a `!` it is a negation of the pattern. If the
+#   pattern starts with `[` and ends with `]`, it contains a hostname pattern and a port number separated
+#   by a `:`. If it begins with `|1|`, the hostname is hashed. In that case, there can only be one exact
+#   hostname and it can't also be negated (ie. `!|1|x|y` is not legal and you can't hash `*.example.org`).
+# - The keytype is `ecdsa-sha2-nistp256`, `ecdsa-sha2-nistp384`, `ecdsa-sha2-nistp521`,
+#   `ssh-ed25519`, `ssh-dss` or `ssh-rsa`
+# - The comment field is not used for anything (but may be convenient for the user to identify
+#   the key).
+
+# Single simple patterned hostname with no comment in the key
+test.example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILM+rvN+ot98qgEN796jTiQfZfG1KaT0PtFDJ/XFSqti
+
+# Multiple hostnames with various patterns and a comment
+cvs.example.net,!test.example.???,[*.example.net]:999 ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHwf2HMM5TRXvo2SQJjsNkiDD5KqiiNjrGVv3UUh+mMT5RHxiRtOnlqvjhQtBq0VpmpCV/PwUdhOig4vkbqAcEc= example.com
+
+# A revoked, hashed hostname
+@revoked |1|JfKTdBh7rNbXkVAQCRp4OQoPfmI=|USECr3SWf1JUPsms5AqfD5QfxkM= ssh-dss AAAAB3NzaC1kc3MAAACBANw9iSUO2UYhFMssjUgW46URqv8bBrDgHeF8HLBOWBvKuXF2Rx2J/XyhgX48SOLMuv0hcPaejlyLarabnF9F2V4dkpPpZSJ+7luHmxEjNxwhsdtg8UteXAWkeCzrQ6MvRJZHcDBjYh56KGvslbFnJsGLXlI4PQCyl6awNImwYGilAAAAFQCJGBU3hZf+QtP9Jh/nbfNlhFu7hwAAAIBHObOQioQVRm3HsVb7mOy3FVKhcLoLO3qoG9gTkd4KeuehtFAC3+rckiX7xSCnE/5BBKdL7VP9WRXac2Nlr9Pwl3e7zPut96wrCHt/TZX6vkfXKkbpUIj5zSqfvyNrWKaYJkfzwAQwrXNS1Hol676Ud/DDEn2oatdEhkS3beWHXAAAAIBgQqaz/YYTRMshzMzYcZ4lqgvgmA55y6v0h39e8HH2A5dwNS6sPUw2jyna+le0dceNRJifFld1J+WYM0vmquSr11DDavgEidOSaXwfMvPPPJqLmbzdtT16N+Gij9U9STQTHPQcQ3xnNNHgQAStzZJbhLOVbDDDo5BO7LMUALDfSA==
+
+# A certificate authority with a comment
+@cert-authority *.example.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC0WRHtxuxefSJhpIxGq4ibGFgwYnESPm8C3JFM88A1JJLoprenklrd7VJ+VH3Ov/bQwZwLyRU5dRmfR/SWTtIPWs7tToJVayKKDB+/qoXmM5ui/0CU2U4rCdQ6PdaCJdC7yFgpPL8WexjWN06+eSIKYz1AAXbx9rRv1iasslK/KUqtsqzVliagI6jl7FPO2GhRZMcso6LsZGgSxuYf/Lp0D/FcBU8GkeOo1Sx5xEt8H8bJcErtCe4Blb8JxcW6EXO3sReb4z+zcR07gumPgFITZ6hDA8sSNuvo/AlWg0IKTeZSwHHVknWdQqDJ0uczE837caBxyTZllDNIGkBjCIIOFzuTT76HfYc/7CTTGk07uaNkUFXKN79xDiFOX8JQ1ZZMZvGOTwWjuT9CqgdTvQRORbRWwOYv3MH8re9ykw3Ip6lrPifY7s6hOaAKry/nkGPMt40m1TdiW98MTIpooE7W+WXu96ax2l2OJvxX8QR7l+LFlKnkIEEJd/ItF1G22UmOjkVwNASTwza/hlY+8DoVvEmwum/nMgH2TwQT3bTQzF9s9DOJkH4d8p4Mw4gEDjNx0EgUFA91ysCAeUMQQyIvuR8HXXa+VcvhOOO5mmBcVhxJ3qUOJTyDBsT0932Zb4mNtkxdigoVxu+iiwk0vwtvKwGVDYdyMP5EAQeEIP1t0w== authority@example.com

--- a/ssh-key/tests/known_hosts.rs
+++ b/ssh-key/tests/known_hosts.rs
@@ -15,7 +15,7 @@ fn read_example_file() {
         known_hosts[0].host_patterns(), 
         &HostPatterns::Patterns(vec!["test.example.com".to_string()])
     );
-    assert_eq!(known_hosts[0].public_key().to_string(), "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILM+rvN+ot98qgEN796jTiQfZfG1KaT0PtFDJ/XFSqti ");
+    assert_eq!(known_hosts[0].public_key().to_string(), "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILM+rvN+ot98qgEN796jTiQfZfG1KaT0PtFDJ/XFSqti");
     assert_eq!(
         known_hosts[0].public_key().comment(),
         ""
@@ -44,7 +44,7 @@ fn read_example_file() {
             hash: [81, 33, 2, 175, 116, 150, 127, 82, 84, 62, 201, 172, 228, 10, 159, 15, 148, 31, 198, 67],
         }
     );
-    assert_eq!(known_hosts[2].public_key().to_string(), "ssh-dss AAAAB3NzaC1kc3MAAACBANw9iSUO2UYhFMssjUgW46URqv8bBrDgHeF8HLBOWBvKuXF2Rx2J/XyhgX48SOLMuv0hcPaejlyLarabnF9F2V4dkpPpZSJ+7luHmxEjNxwhsdtg8UteXAWkeCzrQ6MvRJZHcDBjYh56KGvslbFnJsGLXlI4PQCyl6awNImwYGilAAAAFQCJGBU3hZf+QtP9Jh/nbfNlhFu7hwAAAIBHObOQioQVRm3HsVb7mOy3FVKhcLoLO3qoG9gTkd4KeuehtFAC3+rckiX7xSCnE/5BBKdL7VP9WRXac2Nlr9Pwl3e7zPut96wrCHt/TZX6vkfXKkbpUIj5zSqfvyNrWKaYJkfzwAQwrXNS1Hol676Ud/DDEn2oatdEhkS3beWHXAAAAIBgQqaz/YYTRMshzMzYcZ4lqgvgmA55y6v0h39e8HH2A5dwNS6sPUw2jyna+le0dceNRJifFld1J+WYM0vmquSr11DDavgEidOSaXwfMvPPPJqLmbzdtT16N+Gij9U9STQTHPQcQ3xnNNHgQAStzZJbhLOVbDDDo5BO7LMUALDfSA== ");
+    assert_eq!(known_hosts[2].public_key().to_string(), "ssh-dss AAAAB3NzaC1kc3MAAACBANw9iSUO2UYhFMssjUgW46URqv8bBrDgHeF8HLBOWBvKuXF2Rx2J/XyhgX48SOLMuv0hcPaejlyLarabnF9F2V4dkpPpZSJ+7luHmxEjNxwhsdtg8UteXAWkeCzrQ6MvRJZHcDBjYh56KGvslbFnJsGLXlI4PQCyl6awNImwYGilAAAAFQCJGBU3hZf+QtP9Jh/nbfNlhFu7hwAAAIBHObOQioQVRm3HsVb7mOy3FVKhcLoLO3qoG9gTkd4KeuehtFAC3+rckiX7xSCnE/5BBKdL7VP9WRXac2Nlr9Pwl3e7zPut96wrCHt/TZX6vkfXKkbpUIj5zSqfvyNrWKaYJkfzwAQwrXNS1Hol676Ud/DDEn2oatdEhkS3beWHXAAAAIBgQqaz/YYTRMshzMzYcZ4lqgvgmA55y6v0h39e8HH2A5dwNS6sPUw2jyna+le0dceNRJifFld1J+WYM0vmquSr11DDavgEidOSaXwfMvPPPJqLmbzdtT16N+Gij9U9STQTHPQcQ3xnNNHgQAStzZJbhLOVbDDDo5BO7LMUALDfSA==");
     assert_eq!(
         known_hosts[2].public_key().comment(),
         ""

--- a/ssh-key/tests/known_hosts.rs
+++ b/ssh-key/tests/known_hosts.rs
@@ -1,0 +1,63 @@
+//! Tests for parsing `known_hosts` files.
+
+#![cfg(all(feature = "ecdsa", feature = "std"))]
+
+use ssh_key::known_hosts::{KnownHosts, HostPatterns, Marker};
+
+// TODO(tarcieri): test file permissions
+#[test]
+fn read_example_file() {
+    let known_hosts = KnownHosts::read_file("./tests/examples/known_hosts").unwrap();
+    assert_eq!(known_hosts.len(), 4);
+
+    assert_eq!(known_hosts[0].marker(), None);
+    assert_eq!(
+        known_hosts[0].host_patterns(), 
+        &HostPatterns::Patterns(vec!["test.example.com".to_string()])
+    );
+    assert_eq!(known_hosts[0].public_key().to_string(), "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILM+rvN+ot98qgEN796jTiQfZfG1KaT0PtFDJ/XFSqti ");
+    assert_eq!(
+        known_hosts[0].public_key().comment(),
+        ""
+    );
+
+    assert_eq!(known_hosts[1].marker(), None);
+    assert_eq!(
+        known_hosts[1].host_patterns(), 
+        &HostPatterns::Patterns(vec![
+            "cvs.example.net".to_string(),
+            "!test.example.???".to_string(),
+            "[*.example.net]:999".to_string(),
+        ])
+    );
+    assert_eq!(known_hosts[1].public_key().to_string(), "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHwf2HMM5TRXvo2SQJjsNkiDD5KqiiNjrGVv3UUh+mMT5RHxiRtOnlqvjhQtBq0VpmpCV/PwUdhOig4vkbqAcEc= example.com");
+    assert_eq!(
+        known_hosts[1].public_key().comment(),
+        "example.com"
+    );
+
+    assert_eq!(known_hosts[2].marker(), Some(&Marker::Revoked));
+    assert_eq!(
+        known_hosts[2].host_patterns(),
+        &HostPatterns::HashedName {
+            salt: vec![37, 242, 147, 116, 24, 123, 172, 214, 215, 145, 80, 16, 9, 26, 120, 57, 10, 15, 126, 98],
+            hash: [81, 33, 2, 175, 116, 150, 127, 82, 84, 62, 201, 172, 228, 10, 159, 15, 148, 31, 198, 67],
+        }
+    );
+    assert_eq!(known_hosts[2].public_key().to_string(), "ssh-dss AAAAB3NzaC1kc3MAAACBANw9iSUO2UYhFMssjUgW46URqv8bBrDgHeF8HLBOWBvKuXF2Rx2J/XyhgX48SOLMuv0hcPaejlyLarabnF9F2V4dkpPpZSJ+7luHmxEjNxwhsdtg8UteXAWkeCzrQ6MvRJZHcDBjYh56KGvslbFnJsGLXlI4PQCyl6awNImwYGilAAAAFQCJGBU3hZf+QtP9Jh/nbfNlhFu7hwAAAIBHObOQioQVRm3HsVb7mOy3FVKhcLoLO3qoG9gTkd4KeuehtFAC3+rckiX7xSCnE/5BBKdL7VP9WRXac2Nlr9Pwl3e7zPut96wrCHt/TZX6vkfXKkbpUIj5zSqfvyNrWKaYJkfzwAQwrXNS1Hol676Ud/DDEn2oatdEhkS3beWHXAAAAIBgQqaz/YYTRMshzMzYcZ4lqgvgmA55y6v0h39e8HH2A5dwNS6sPUw2jyna+le0dceNRJifFld1J+WYM0vmquSr11DDavgEidOSaXwfMvPPPJqLmbzdtT16N+Gij9U9STQTHPQcQ3xnNNHgQAStzZJbhLOVbDDDo5BO7LMUALDfSA== ");
+    assert_eq!(
+        known_hosts[2].public_key().comment(),
+        ""
+    );
+
+    assert_eq!(known_hosts[3].marker(), Some(&Marker::CertAuthority));
+    assert_eq!(
+        known_hosts[3].host_patterns(), 
+        &HostPatterns::Patterns(vec!["*.example.com".to_string()])
+    );
+    assert_eq!(known_hosts[3].public_key().to_string(), "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC0WRHtxuxefSJhpIxGq4ibGFgwYnESPm8C3JFM88A1JJLoprenklrd7VJ+VH3Ov/bQwZwLyRU5dRmfR/SWTtIPWs7tToJVayKKDB+/qoXmM5ui/0CU2U4rCdQ6PdaCJdC7yFgpPL8WexjWN06+eSIKYz1AAXbx9rRv1iasslK/KUqtsqzVliagI6jl7FPO2GhRZMcso6LsZGgSxuYf/Lp0D/FcBU8GkeOo1Sx5xEt8H8bJcErtCe4Blb8JxcW6EXO3sReb4z+zcR07gumPgFITZ6hDA8sSNuvo/AlWg0IKTeZSwHHVknWdQqDJ0uczE837caBxyTZllDNIGkBjCIIOFzuTT76HfYc/7CTTGk07uaNkUFXKN79xDiFOX8JQ1ZZMZvGOTwWjuT9CqgdTvQRORbRWwOYv3MH8re9ykw3Ip6lrPifY7s6hOaAKry/nkGPMt40m1TdiW98MTIpooE7W+WXu96ax2l2OJvxX8QR7l+LFlKnkIEEJd/ItF1G22UmOjkVwNASTwza/hlY+8DoVvEmwum/nMgH2TwQT3bTQzF9s9DOJkH4d8p4Mw4gEDjNx0EgUFA91ysCAeUMQQyIvuR8HXXa+VcvhOOO5mmBcVhxJ3qUOJTyDBsT0932Zb4mNtkxdigoVxu+iiwk0vwtvKwGVDYdyMP5EAQeEIP1t0w== authority@example.com");
+    assert_eq!(
+        known_hosts[3].public_key().comment(),
+        "authority@example.com"
+    );
+}

--- a/ssh-key/tests/known_hosts.rs
+++ b/ssh-key/tests/known_hosts.rs
@@ -2,7 +2,7 @@
 
 #![cfg(all(feature = "ecdsa", feature = "std"))]
 
-use ssh_key::known_hosts::{KnownHosts, HostPatterns, Marker};
+use ssh_key::known_hosts::{HostPatterns, KnownHosts, Marker};
 
 // TODO(tarcieri): test file permissions
 #[test]
@@ -12,18 +12,18 @@ fn read_example_file() {
 
     assert_eq!(known_hosts[0].marker(), None);
     assert_eq!(
-        known_hosts[0].host_patterns(), 
+        known_hosts[0].host_patterns(),
         &HostPatterns::Patterns(vec!["test.example.com".to_string()])
     );
-    assert_eq!(known_hosts[0].public_key().to_string(), "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILM+rvN+ot98qgEN796jTiQfZfG1KaT0PtFDJ/XFSqti");
     assert_eq!(
-        known_hosts[0].public_key().comment(),
-        ""
+        known_hosts[0].public_key().to_string(),
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILM+rvN+ot98qgEN796jTiQfZfG1KaT0PtFDJ/XFSqti"
     );
+    assert_eq!(known_hosts[0].public_key().comment(), "");
 
     assert_eq!(known_hosts[1].marker(), None);
     assert_eq!(
-        known_hosts[1].host_patterns(), 
+        known_hosts[1].host_patterns(),
         &HostPatterns::Patterns(vec![
             "cvs.example.net".to_string(),
             "!test.example.???".to_string(),
@@ -31,28 +31,28 @@ fn read_example_file() {
         ])
     );
     assert_eq!(known_hosts[1].public_key().to_string(), "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHwf2HMM5TRXvo2SQJjsNkiDD5KqiiNjrGVv3UUh+mMT5RHxiRtOnlqvjhQtBq0VpmpCV/PwUdhOig4vkbqAcEc= example.com");
-    assert_eq!(
-        known_hosts[1].public_key().comment(),
-        "example.com"
-    );
+    assert_eq!(known_hosts[1].public_key().comment(), "example.com");
 
     assert_eq!(known_hosts[2].marker(), Some(&Marker::Revoked));
     assert_eq!(
         known_hosts[2].host_patterns(),
         &HostPatterns::HashedName {
-            salt: vec![37, 242, 147, 116, 24, 123, 172, 214, 215, 145, 80, 16, 9, 26, 120, 57, 10, 15, 126, 98],
-            hash: [81, 33, 2, 175, 116, 150, 127, 82, 84, 62, 201, 172, 228, 10, 159, 15, 148, 31, 198, 67],
+            salt: vec![
+                37, 242, 147, 116, 24, 123, 172, 214, 215, 145, 80, 16, 9, 26, 120, 57, 10, 15,
+                126, 98
+            ],
+            hash: [
+                81, 33, 2, 175, 116, 150, 127, 82, 84, 62, 201, 172, 228, 10, 159, 15, 148, 31,
+                198, 67
+            ],
         }
     );
     assert_eq!(known_hosts[2].public_key().to_string(), "ssh-dss AAAAB3NzaC1kc3MAAACBANw9iSUO2UYhFMssjUgW46URqv8bBrDgHeF8HLBOWBvKuXF2Rx2J/XyhgX48SOLMuv0hcPaejlyLarabnF9F2V4dkpPpZSJ+7luHmxEjNxwhsdtg8UteXAWkeCzrQ6MvRJZHcDBjYh56KGvslbFnJsGLXlI4PQCyl6awNImwYGilAAAAFQCJGBU3hZf+QtP9Jh/nbfNlhFu7hwAAAIBHObOQioQVRm3HsVb7mOy3FVKhcLoLO3qoG9gTkd4KeuehtFAC3+rckiX7xSCnE/5BBKdL7VP9WRXac2Nlr9Pwl3e7zPut96wrCHt/TZX6vkfXKkbpUIj5zSqfvyNrWKaYJkfzwAQwrXNS1Hol676Ud/DDEn2oatdEhkS3beWHXAAAAIBgQqaz/YYTRMshzMzYcZ4lqgvgmA55y6v0h39e8HH2A5dwNS6sPUw2jyna+le0dceNRJifFld1J+WYM0vmquSr11DDavgEidOSaXwfMvPPPJqLmbzdtT16N+Gij9U9STQTHPQcQ3xnNNHgQAStzZJbhLOVbDDDo5BO7LMUALDfSA==");
-    assert_eq!(
-        known_hosts[2].public_key().comment(),
-        ""
-    );
+    assert_eq!(known_hosts[2].public_key().comment(), "");
 
     assert_eq!(known_hosts[3].marker(), Some(&Marker::CertAuthority));
     assert_eq!(
-        known_hosts[3].host_patterns(), 
+        known_hosts[3].host_patterns(),
         &HostPatterns::Patterns(vec!["*.example.com".to_string()])
     );
     assert_eq!(known_hosts[3].public_key().to_string(), "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC0WRHtxuxefSJhpIxGq4ibGFgwYnESPm8C3JFM88A1JJLoprenklrd7VJ+VH3Ov/bQwZwLyRU5dRmfR/SWTtIPWs7tToJVayKKDB+/qoXmM5ui/0CU2U4rCdQ6PdaCJdC7yFgpPL8WexjWN06+eSIKYz1AAXbx9rRv1iasslK/KUqtsqzVliagI6jl7FPO2GhRZMcso6LsZGgSxuYf/Lp0D/FcBU8GkeOo1Sx5xEt8H8bJcErtCe4Blb8JxcW6EXO3sReb4z+zcR07gumPgFITZ6hDA8sSNuvo/AlWg0IKTeZSwHHVknWdQqDJ0uczE837caBxyTZllDNIGkBjCIIOFzuTT76HfYc/7CTTGk07uaNkUFXKN79xDiFOX8JQ1ZZMZvGOTwWjuT9CqgdTvQRORbRWwOYv3MH8re9ykw3Ip6lrPifY7s6hOaAKry/nkGPMt40m1TdiW98MTIpooE7W+WXu96ax2l2OJvxX8QR7l+LFlKnkIEEJd/ItF1G22UmOjkVwNASTwza/hlY+8DoVvEmwum/nMgH2TwQT3bTQzF9s9DOJkH4d8p4Mw4gEDjNx0EgUFA91ysCAeUMQQyIvuR8HXXa+VcvhOOO5mmBcVhxJ3qUOJTyDBsT0932Zb4mNtkxdigoVxu+iiwk0vwtvKwGVDYdyMP5EAQeEIP1t0w== authority@example.com");


### PR DESCRIPTION
This is largely based on the authorized_keys parse functionality already present, and there are probably some opportunities to remove redundancy between them, but this is a functional start.

Note that also in this PR is making it so that it treats the comments field of an ssh key as optional. This is correct both according to the ssh(8) man page and the comments all over the codebase here, but it was using a lack of comment as an indication that the key was truncated. This does mean that a validity check has been removed, but this was probably always the wrong place to do it (the key parser itself should know the expected length of the key).
