### PR TITLE
der: remove decode-time SET OF ordering checks

### DIFF
--- a/der/src/arrayvec.rs
+++ b/der/src/arrayvec.rs
@@ -85,6 +85,18 @@ impl<T, const N: usize> ArrayVec<T, N> {
     }
 }
 
+impl<T, const N: usize> AsRef<[Option<T>]> for ArrayVec<T, N> {
+    fn as_ref(&self) -> &[Option<T>] {
+        &self.elements[..self.length]
+    }
+}
+
+impl<T, const N: usize> AsMut<[Option<T>]> for ArrayVec<T, N> {
+    fn as_mut(&mut self) -> &mut [Option<T>] {
+        &mut self.elements[..self.length]
+    }
+}
+
 impl<T, const N: usize> Default for ArrayVec<T, N> {
     fn default() -> Self {
         Self::new()
@@ -114,11 +126,12 @@ impl<'a, T> Iterator for Iter<'a, T> {
     type Item = &'a T;
 
     fn next(&mut self) -> Option<&'a T> {
-        if let Some(Some(res)) = self.elements.get(self.position) {
-            self.position = self.position.checked_add(1)?;
-            Some(res)
-        } else {
-            None
+        match self.elements.get(self.position) {
+            Some(Some(res)) => {
+                self.position = self.position.checked_add(1)?;
+                Some(res)
+            }
+            _ => None,
         }
     }
 

--- a/x509/tests/name.rs
+++ b/x509/tests/name.rs
@@ -126,11 +126,11 @@ fn decode_rdn() {
     // fails when caller adds items not in DER lexicographical order
     assert!(from_scratch2.0.add(*atav1a).is_err());
 
-    //parsing fails due to incorrect order
+    // allow out-of-order RDNs (see: RustCrypto/formats#625)
     assert!(RelativeDistinguishedName::from_der(
         &hex!("311F301106035504030C0A4A4F484E20534D495448300A060355040A0C03313233")[..],
     )
-    .is_err());
+    .is_ok());
 }
 
 // #[test]


### PR DESCRIPTION
Some DER serializer implementations fail to properly sort elements of a `SET OF`. This is technically non-canonical, but occurs frequently enough that most DER decoders tolerate it. Unfortunately because of that, we must also follow suit.

This commit builds an `ArrayVec` or `Vec` of the incoming decoded set elements, and then unconditionally sorts it retroactively, ensuring all `SET OF` types internally reflect the proper order, but out-of-order `SET OF` messages are tolerated when coming off-the-wire.

The sort implementation is merge sort, which should be efficient for already-in-order or mostly-in-order sets.