### PR TITLE
ssh-key: add more key conversions

### DIFF
--- a/ssh-key/src/private.rs
+++ b/ssh-key/src/private.rs
@@ -121,7 +121,7 @@ pub use self::keypair::KeypairData;
 #[cfg(feature = "alloc")]
 pub use self::{
     dsa::{DsaKeypair, DsaPrivateKey},
-    rsa::RsaKeypair,
+    rsa::{RsaKeypair, RsaPrivateKey},
     sk::SkEd25519,
 };
 
@@ -163,6 +163,9 @@ use std::{io::Write, os::unix::fs::OpenOptionsExt};
 
 #[cfg(feature = "subtle")]
 use subtle::{Choice, ConstantTimeEq};
+
+/// Error message for infallible conversions (used by `expect`)
+const CONVERSION_ERROR_MSG: &str = "SSH private key conversion error";
 
 /// Default key size to use for RSA keys in bits.
 #[cfg(feature = "rsa")]
@@ -733,6 +736,64 @@ impl From<PrivateKey> for public::KeyData {
 impl From<&PrivateKey> for public::KeyData {
     fn from(private_key: &PrivateKey) -> public::KeyData {
         private_key.public_key.key_data.clone()
+    }
+}
+
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+impl From<DsaKeypair> for PrivateKey {
+    fn from(keypair: DsaKeypair) -> PrivateKey {
+        KeypairData::from(keypair)
+            .try_into()
+            .expect(CONVERSION_ERROR_MSG)
+    }
+}
+
+#[cfg(feature = "ecdsa")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
+impl From<EcdsaKeypair> for PrivateKey {
+    fn from(keypair: EcdsaKeypair) -> PrivateKey {
+        KeypairData::from(keypair)
+            .try_into()
+            .expect(CONVERSION_ERROR_MSG)
+    }
+}
+
+impl From<Ed25519Keypair> for PrivateKey {
+    fn from(keypair: Ed25519Keypair) -> PrivateKey {
+        KeypairData::from(keypair)
+            .try_into()
+            .expect(CONVERSION_ERROR_MSG)
+    }
+}
+
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+impl From<RsaKeypair> for PrivateKey {
+    fn from(keypair: RsaKeypair) -> PrivateKey {
+        KeypairData::from(keypair)
+            .try_into()
+            .expect(CONVERSION_ERROR_MSG)
+    }
+}
+
+#[cfg(all(feature = "alloc", feature = "ecdsa"))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "alloc", feature = "ecdsa"))))]
+impl From<SkEcdsaSha2NistP256> for PrivateKey {
+    fn from(keypair: SkEcdsaSha2NistP256) -> PrivateKey {
+        KeypairData::from(keypair)
+            .try_into()
+            .expect(CONVERSION_ERROR_MSG)
+    }
+}
+
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+impl From<SkEd25519> for PrivateKey {
+    fn from(keypair: SkEd25519) -> PrivateKey {
+        KeypairData::from(keypair)
+            .try_into()
+            .expect(CONVERSION_ERROR_MSG)
     }
 }
 

--- a/ssh-key/src/private/keypair.rs
+++ b/ssh-key/src/private/keypair.rs
@@ -362,6 +362,22 @@ impl From<RsaKeypair> for KeypairData {
     }
 }
 
+#[cfg(all(feature = "alloc", feature = "ecdsa"))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "alloc", feature = "ecdsa"))))]
+impl From<SkEcdsaSha2NistP256> for KeypairData {
+    fn from(keypair: SkEcdsaSha2NistP256) -> KeypairData {
+        Self::SkEcdsaSha2NistP256(keypair)
+    }
+}
+
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+impl From<SkEd25519> for KeypairData {
+    fn from(keypair: SkEd25519) -> KeypairData {
+        Self::SkEd25519(keypair)
+    }
+}
+
 #[cfg(feature = "subtle")]
 #[cfg_attr(docsrs, doc(cfg(feature = "subtle")))]
 impl ConstantTimeEq for KeypairData {

--- a/ssh-key/src/public.rs
+++ b/ssh-key/src/public.rs
@@ -263,6 +263,50 @@ impl From<&PublicKey> for KeyData {
     }
 }
 
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+impl From<DsaPublicKey> for PublicKey {
+    fn from(public_key: DsaPublicKey) -> PublicKey {
+        KeyData::from(public_key).into()
+    }
+}
+
+#[cfg(feature = "ecdsa")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
+impl From<EcdsaPublicKey> for PublicKey {
+    fn from(public_key: EcdsaPublicKey) -> PublicKey {
+        KeyData::from(public_key).into()
+    }
+}
+
+impl From<Ed25519PublicKey> for PublicKey {
+    fn from(public_key: Ed25519PublicKey) -> PublicKey {
+        KeyData::from(public_key).into()
+    }
+}
+
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+impl From<RsaPublicKey> for PublicKey {
+    fn from(public_key: RsaPublicKey) -> PublicKey {
+        KeyData::from(public_key).into()
+    }
+}
+
+#[cfg(feature = "ecdsa")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
+impl From<SkEcdsaSha2NistP256> for PublicKey {
+    fn from(public_key: SkEcdsaSha2NistP256) -> PublicKey {
+        KeyData::from(public_key).into()
+    }
+}
+
+impl From<SkEd25519> for PublicKey {
+    fn from(public_key: SkEd25519) -> PublicKey {
+        KeyData::from(public_key).into()
+    }
+}
+
 impl FromStr for PublicKey {
     type Err = Error;
 

--- a/ssh-key/src/public/key_data.rs
+++ b/ssh-key/src/public/key_data.rs
@@ -249,3 +249,47 @@ impl Encode for KeyData {
         self.encode_key_data(writer)
     }
 }
+
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+impl From<DsaPublicKey> for KeyData {
+    fn from(public_key: DsaPublicKey) -> KeyData {
+        Self::Dsa(public_key)
+    }
+}
+
+#[cfg(feature = "ecdsa")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
+impl From<EcdsaPublicKey> for KeyData {
+    fn from(public_key: EcdsaPublicKey) -> KeyData {
+        Self::Ecdsa(public_key)
+    }
+}
+
+impl From<Ed25519PublicKey> for KeyData {
+    fn from(public_key: Ed25519PublicKey) -> KeyData {
+        Self::Ed25519(public_key)
+    }
+}
+
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+impl From<RsaPublicKey> for KeyData {
+    fn from(public_key: RsaPublicKey) -> KeyData {
+        Self::Rsa(public_key)
+    }
+}
+
+#[cfg(feature = "ecdsa")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
+impl From<SkEcdsaSha2NistP256> for KeyData {
+    fn from(public_key: SkEcdsaSha2NistP256) -> KeyData {
+        Self::SkEcdsaSha2NistP256(public_key)
+    }
+}
+
+impl From<SkEd25519> for KeyData {
+    fn from(public_key: SkEd25519) -> KeyData {
+        Self::SkEd25519(public_key)
+    }
+}


### PR DESCRIPTION
Adds support for converting the various algorithm-specific key types (e.g. `RsaPublicKey`, `RsaPrivateKey`) directly into `PublicKey` and `PrivateKey` using the `From` trait.

Unlike `private::KeypairData`, these conversions can be infallible.