### PR TITLE
ssh-key v0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1421,7 +1421,7 @@ dependencies = [
 
 [[package]]
 name = "ssh-key"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "aes",
  "base64ct 1.5.0",

--- a/ssh-key/CHANGELOG.md
+++ b/ssh-key/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.2 (2022-05-02)
+### Added
+- Support for parsing keys out of the ssh known_hosts file format ([#624])
+- Export `RsaPrivateKey` ([#629])
+- `From` conversions between algorithmic-specific key types and `PublicKey`/`PrivateKey` ([#629])
+
+[#624]: https://github.com/RustCrypto/formats/pull/624
+[#629]: https://github.com/RustCrypto/formats/pull/629
+
 ## 0.4.1 (2022-04-26)
 ### Added
 - Internal `UnixTime` helper type ([#613])

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "ssh-key"
-version = "0.4.1"
+version = "0.4.2"
 description = """
 Pure Rust implementation of SSH key file format decoders/encoders as described
 in RFC4251 and RFC4253 as well as the OpenSSH key formats, certificates
 (including certificate validation and certificate authority support), and
-the `authorized_keys` file format. Supports `no_std` embedded targets.
+the `authorized_keys` and `known_hosts` file formats. Supports a `no_std`
+profile for embedded targets.
 """
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
### Added
- Support for parsing keys out of the ssh known_hosts file format ([#624])
- Export `RsaPrivateKey` ([#629])
- `From` conversions between algorithmic-specific key types and `PublicKey`/`PrivateKey` ([#629])

[#624]: https://github.com/RustCrypto/formats/pull/624
[#629]: https://github.com/RustCrypto/formats/pull/629