### PR TITLE
Use crates.io info badges from buildstats.info in README.mds

### DIFF
--- a/base16ct/README.md
+++ b/base16ct/README.md
@@ -42,7 +42,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/base16ct.svg
+[crate-image]: https://buildstats.info/crate/base16ct
 [crate-link]: https://crates.io/crates/base16ct
 [docs-image]: https://docs.rs/base16ct/badge.svg
 [docs-link]: https://docs.rs/base16ct/

--- a/base64ct/README.md
+++ b/base64ct/README.md
@@ -63,7 +63,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/base64ct.svg
+[crate-image]: https://buildstats.info/crate/base64ct
 [crate-link]: https://crates.io/crates/base64ct
 [docs-image]: https://docs.rs/base64ct/badge.svg
 [docs-link]: https://docs.rs/base64ct/

--- a/const-oid/README.md
+++ b/const-oid/README.md
@@ -79,7 +79,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/const-oid.svg
+[crate-image]: https://buildstats.info/crate/const-oid
 [crate-link]: https://crates.io/crates/const-oid
 [docs-image]: https://docs.rs/const-oid/badge.svg
 [docs-link]: https://docs.rs/const-oid/

--- a/der/README.md
+++ b/der/README.md
@@ -2,7 +2,6 @@
 
 [![Crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
-[![Downloads][downloads-image]][crate-link]
 [![Build Status][build-image]][build-link]
 ![Apache2/MIT licensed][license-image]
 ![Rust Version][rustc-image]
@@ -72,11 +71,10 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/der.svg
+[crate-image]: https://buildstats.info/crate/der
 [crate-link]: https://crates.io/crates/der
 [docs-image]: https://docs.rs/der/badge.svg
 [docs-link]: https://docs.rs/der/
-[downloads-image]: https://img.shields.io/crates/d/der.svg
 [build-image]: https://github.com/RustCrypto/formats/actions/workflows/der.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/formats/actions/workflows/der.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg

--- a/pem-rfc7468/README.md
+++ b/pem-rfc7468/README.md
@@ -81,7 +81,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/pem-rfc7468.svg
+[crate-image]: https://buildstats.info/crate/pem-rfc7468
 [crate-link]: https://crates.io/crates/pem-rfc7468
 [docs-image]: https://docs.rs/pem-rfc7468/badge.svg
 [docs-link]: https://docs.rs/pem-rfc7468/

--- a/pkcs1/README.md
+++ b/pkcs1/README.md
@@ -53,7 +53,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/pkcs1.svg
+[crate-image]: https://buildstats.info/crate/pkcs1
 [crate-link]: https://crates.io/crates/pkcs1
 [docs-image]: https://docs.rs/pkcs1/badge.svg
 [docs-link]: https://docs.rs/pkcs1/

--- a/pkcs5/README.md
+++ b/pkcs5/README.md
@@ -36,7 +36,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/pkcs5.svg
+[crate-image]: https://buildstats.info/crate/pkcs5
 [crate-link]: https://crates.io/crates/pkcs5
 [docs-image]: https://docs.rs/pkcs5/badge.svg
 [docs-link]: https://docs.rs/pkcs5/

--- a/pkcs7/README.md
+++ b/pkcs7/README.md
@@ -36,7 +36,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/pkcs7.svg
+[crate-image]: https://buildstats.info/crate/pkcs7
 [crate-link]: https://crates.io/crates/pkcs7
 [docs-image]: https://docs.rs/pkcs7/badge.svg
 [docs-link]: https://docs.rs/pkcs7/

--- a/pkcs8/README.md
+++ b/pkcs8/README.md
@@ -76,7 +76,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/pkcs8.svg
+[crate-image]: https://buildstats.info/crate/pkcs8
 [crate-link]: https://crates.io/crates/pkcs8
 [docs-image]: https://docs.rs/pkcs8/badge.svg
 [docs-link]: https://docs.rs/pkcs8/

--- a/sec1/README.md
+++ b/sec1/README.md
@@ -40,7 +40,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/sec1.svg
+[crate-image]: https://buildstats.info/crate/sec1
 [crate-link]: https://crates.io/crates/sec1
 [docs-image]: https://docs.rs/sec1/badge.svg
 [docs-link]: https://docs.rs/sec1/

--- a/serdect/README.md
+++ b/serdect/README.md
@@ -55,7 +55,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/serdect.svg
+[crate-image]: https://buildstats.info/crate/serdect
 [crate-link]: https://crates.io/crates/serdect
 [docs-image]: https://docs.rs/serdect/badge.svg
 [docs-link]: https://docs.rs/serdect/

--- a/spki/README.md
+++ b/spki/README.md
@@ -38,7 +38,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/spki.svg
+[crate-image]: https://buildstats.info/crate/spki
 [crate-link]: https://crates.io/crates/spki
 [docs-image]: https://docs.rs/spki/badge.svg
 [docs-link]: https://docs.rs/spki/

--- a/ssh-key/README.md
+++ b/ssh-key/README.md
@@ -101,7 +101,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/ssh-key.svg
+[crate-image]: https://buildstats.info/crate/ssh-key
 [crate-link]: https://crates.io/crates/ssh-key
 [docs-image]: https://docs.rs/ssh-key/badge.svg
 [docs-link]: https://docs.rs/ssh-key/

--- a/tai64/README.md
+++ b/tai64/README.md
@@ -36,7 +36,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/tai64.svg
+[crate-image]: https://buildstats.info/crate/tai64
 [crate-link]: https://crates.io/crates/tai64
 [docs-image]: https://docs.rs/tai64/badge.svg
 [docs-link]: https://docs.rs/tai64/

--- a/x509/README.md
+++ b/x509/README.md
@@ -1,4 +1,4 @@
-# [RustCrypto]: X.509
+# [RustCrypto]: X.509 Certificates
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
@@ -43,7 +43,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/x509.svg
+[crate-image]: https://buildstats.info/crate/x509-cert
 [crate-link]: https://crates.io/crates/x509-cert
 [docs-image]: https://docs.rs/x509-cert/badge.svg
 [docs-link]: https://docs.rs/x509-cert/


### PR DESCRIPTION
These badges include download figures, which eliminates the need to have a separate badge that measures downloads.