### PR TITLE
der: use `Reader<'a>` as input for `Decode::decode`

### DIFF
--- a/der/derive/src/asn1_type.rs
+++ b/der/derive/src/asn1_type.rs
@@ -47,13 +47,13 @@ impl Asn1Type {
     /// Get a `der::Decoder` object for a particular ASN.1 type
     pub fn decoder(self) -> TokenStream {
         match self {
-            Asn1Type::BitString => quote!(decoder.bit_string()?),
-            Asn1Type::Ia5String => quote!(decoder.ia5_string()?),
-            Asn1Type::GeneralizedTime => quote!(decoder.generalized_time()?),
-            Asn1Type::OctetString => quote!(decoder.octet_string()?),
-            Asn1Type::PrintableString => quote!(decoder.printable_string()?),
-            Asn1Type::UtcTime => quote!(decoder.utc_time()?),
-            Asn1Type::Utf8String => quote!(decoder.utf8_string()?),
+            Asn1Type::BitString => quote!(::der::asn1::BitString::decode(reader)?),
+            Asn1Type::Ia5String => quote!(::der::asn1::Ia5String::decode(reader)?),
+            Asn1Type::GeneralizedTime => quote!(::der::asn1::GeneralizedTime::decode(reader)?),
+            Asn1Type::OctetString => quote!(::der::asn1::OctetString::decode(reader)?),
+            Asn1Type::PrintableString => quote!(::der::asn1::PrintableString::decode(reader)?),
+            Asn1Type::UtcTime => quote!(::der::asn1::UtcTime::decode(reader)?),
+            Asn1Type::Utf8String => quote!(::der::asn1::Utf8String::decode(reader)?),
         }
     }
 

--- a/der/derive/src/choice/variant.rs
+++ b/der/derive/src/choice/variant.rs
@@ -169,7 +169,7 @@ mod tests {
             variant.to_decode_tokens().to_string(),
             quote! {
                 ::der::Tag::Utf8String => Ok(Self::ExampleVariant(
-                    decoder.decode()?
+                    reader.decode()?
                 )),
             }
             .to_string()
@@ -214,7 +214,7 @@ mod tests {
             variant.to_decode_tokens().to_string(),
             quote! {
                 ::der::Tag::Utf8String => Ok(Self::ExampleVariant(
-                    decoder.utf8_string()?
+                    ::der::asn1::Utf8String::decode(reader)?
                     .try_into()?
                 )),
             }
@@ -273,7 +273,7 @@ mod tests {
                             constructed: #constructed,
                             number: #tag_number,
                         } => Ok(Self::ExplicitVariant(
-                            match ::der::asn1::ContextSpecific::<>::decode(decoder)? {
+                            match ::der::asn1::ContextSpecific::<>::decode(reader)? {
                                 field if field.tag_number == #tag_number => Some(field),
                                 _ => None
                             }
@@ -359,7 +359,7 @@ mod tests {
                             number: #tag_number,
                         } => Ok(Self::ImplicitVariant(
                             ::der::asn1::ContextSpecific::<>::decode_implicit(
-                                decoder,
+                                reader,
                                 #tag_number
                             )?
                             .ok_or_else(|| {

--- a/der/derive/src/enumerated.rs
+++ b/der/derive/src/enumerated.rs
@@ -2,7 +2,7 @@
 //! the purposes of decoding/encoding ASN.1 `ENUMERATED` types as mapped to
 //! enum variants.
 
-use crate::ATTR_NAME;
+use crate::{default_lifetime, ATTR_NAME};
 use proc_macro2::TokenStream;
 use proc_macro_error::abort;
 use quote::quote;
@@ -102,6 +102,7 @@ impl DeriveEnumerated {
 
     /// Lower the derived output into a [`TokenStream`].
     pub fn to_tokens(&self) -> TokenStream {
+        let default_lifetime = default_lifetime();
         let ident = &self.ident;
         let repr = &self.repr;
         let tag = match self.integer {
@@ -115,12 +116,12 @@ impl DeriveEnumerated {
         }
 
         quote! {
-            impl ::der::DecodeValue<'_> for #ident {
-                fn decode_value(
-                    decoder: &mut ::der::Decoder<'_>,
+            impl<#default_lifetime> ::der::DecodeValue<#default_lifetime> for #ident {
+                fn decode_value<R: ::der::Reader<#default_lifetime>>(
+                    reader: &mut R,
                     header: ::der::Header
                 ) -> ::der::Result<Self> {
-                    <#repr as ::der::DecodeValue>::decode_value(decoder, header)?.try_into()
+                    <#repr as ::der::DecodeValue>::decode_value(reader, header)?.try_into()
                 }
             }
 

--- a/der/derive/src/lib.rs
+++ b/der/derive/src/lib.rs
@@ -134,8 +134,16 @@ use crate::{
     value_ord::DeriveValueOrd,
 };
 use proc_macro::TokenStream;
+use proc_macro2::Span;
 use proc_macro_error::proc_macro_error;
-use syn::{parse_macro_input, DeriveInput};
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput, Lifetime};
+
+/// Get the default lifetime.
+fn default_lifetime() -> proc_macro2::TokenStream {
+    let lifetime = Lifetime::new("'__der_lifetime", Span::call_site());
+    quote!(#lifetime)
+}
 
 /// Derive the [`Choice`][1] trait on an `enum`.
 ///

--- a/der/derive/src/sequence/field.rs
+++ b/der/derive/src/sequence/field.rs
@@ -146,8 +146,8 @@ impl LowerFieldDecoder {
     /// Handle default value for a type.
     fn apply_default(&mut self, default: &Path, field_type: &Type) {
         self.decoder = quote! {
-            decoder.decode::<Option<#field_type>>()?.unwrap_or_else(#default);
-        }
+            Option::<#field_type>::decode(reader)?.unwrap_or_else(#default);
+        };
     }
 }
 
@@ -287,7 +287,7 @@ mod tests {
         assert_eq!(
             field.to_decode_tokens().to_string(),
             quote! {
-                let example_field = decoder.decode()?;
+                let example_field = reader.decode()?;
             }
             .to_string()
         );
@@ -328,7 +328,7 @@ mod tests {
             field.to_decode_tokens().to_string(),
             quote! {
                 let implicit_field = ::der::asn1::ContextSpecific::<>::decode_implicit(
-                        decoder,
+                        reader,
                         ::der::TagNumber::N0
                     )?
                     .ok_or_else(|| {

--- a/der/src/arrayvec.rs
+++ b/der/src/arrayvec.rs
@@ -66,22 +66,9 @@ impl<T, const N: usize> ArrayVec<T, N> {
         self.length.checked_sub(1).and_then(|n| self.get(n))
     }
 
-    /// Try to convert this [`ArrayVec`] into a `[T; N]`.
-    ///
-    /// Returns `None` if the [`ArrayVec`] does not contain `N` elements.
-    pub fn try_into_array(self) -> Result<[T; N]> {
-        if self.length != N {
-            return Err(ErrorKind::Incomplete {
-                expected_len: N.try_into()?,
-                actual_len: self.length.try_into()?,
-            }
-            .into());
-        }
-
-        Ok(self.elements.map(|elem| match elem {
-            Some(e) => e,
-            None => unreachable!(),
-        }))
+    /// Extract the inner array.
+    pub fn into_array(self) -> [Option<T>; N] {
+        self.elements
     }
 }
 

--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     asn1::*, ByteSlice, Choice, Decode, DecodeValue, Decoder, DerOrd, EncodeValue, Error,
-    ErrorKind, FixedTag, Header, Length, Result, Tag, Tagged, ValueOrd, Writer,
+    ErrorKind, FixedTag, Header, Length, Reader, Result, Tag, Tagged, ValueOrd, Writer,
 };
 use core::cmp::Ordering;
 
@@ -153,11 +153,12 @@ impl<'a> Choice<'a> for Any<'a> {
 }
 
 impl<'a> Decode<'a> for Any<'a> {
-    fn decode(decoder: &mut Decoder<'a>) -> Result<Any<'a>> {
-        let header = Header::decode(decoder)?;
+    fn decode<R: Reader<'a>>(reader: &mut R) -> Result<Any<'a>> {
+        let header = Header::decode(reader)?;
+
         Ok(Self {
             tag: header.tag,
-            value: ByteSlice::decode_value(decoder, header)?,
+            value: ByteSlice::decode_value(reader, header)?,
         })
     }
 }

--- a/der/src/asn1/boolean.rs
+++ b/der/src/asn1/boolean.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `BOOLEAN` support.
 
 use crate::{
-    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, Decoder, EncodeValue, Error, ErrorKind,
-    FixedTag, Header, Length, Reader, Result, Tag, Writer,
+    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, EncodeValue, Error, ErrorKind, FixedTag,
+    Header, Length, Reader, Result, Tag, Writer,
 };
 
 /// Byte used to encode `true` in ASN.1 DER. From X.690 Section 11.1:
@@ -15,12 +15,12 @@ const TRUE_OCTET: u8 = 0b11111111;
 const FALSE_OCTET: u8 = 0b00000000;
 
 impl<'a> DecodeValue<'a> for bool {
-    fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> Result<Self> {
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         if header.length != Length::ONE {
-            return Err(decoder.error(ErrorKind::Length { tag: Self::TAG }));
+            return Err(reader.error(ErrorKind::Length { tag: Self::TAG }));
         }
 
-        match decoder.read_byte()? {
+        match reader.read_byte()? {
             FALSE_OCTET => Ok(false),
             TRUE_OCTET => Ok(true),
             _ => Err(Self::TAG.non_canonical_error()),

--- a/der/src/asn1/generalized_time.rs
+++ b/der/src/asn1/generalized_time.rs
@@ -4,7 +4,7 @@ use crate::{
     asn1::Any,
     datetime::{self, DateTime},
     ord::OrdIsValueOrd,
-    ByteSlice, DecodeValue, Decoder, EncodeValue, Error, ErrorKind, FixedTag, Header, Length,
+    ByteSlice, DecodeValue, EncodeValue, Error, ErrorKind, FixedTag, Header, Length, Reader,
     Result, Tag, Writer,
 };
 use core::time::Duration;
@@ -73,9 +73,9 @@ impl GeneralizedTime {
     }
 }
 
-impl DecodeValue<'_> for GeneralizedTime {
-    fn decode_value(decoder: &mut Decoder<'_>, header: Header) -> Result<Self> {
-        match *ByteSlice::decode_value(decoder, header)?.as_slice() {
+impl<'a> DecodeValue<'a> for GeneralizedTime {
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
+        match *ByteSlice::decode_value(reader, header)?.as_slice() {
             // RFC 5280 requires mandatory seconds and Z-normalized time zone
             [y1, y2, y3, y4, mon1, mon2, day1, day2, hour1, hour2, min1, min2, sec1, sec2, b'Z'] => {
                 let year = u16::from(datetime::decode_decimal(Self::TAG, y1, y2)?)
@@ -163,9 +163,9 @@ impl TryFrom<Any<'_>> for GeneralizedTime {
     }
 }
 
-impl DecodeValue<'_> for DateTime {
-    fn decode_value(decoder: &mut Decoder<'_>, header: Header) -> Result<Self> {
-        Ok(GeneralizedTime::decode_value(decoder, header)?.into())
+impl<'a> DecodeValue<'a> for DateTime {
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
+        Ok(GeneralizedTime::decode_value(reader, header)?.into())
     }
 }
 
@@ -187,9 +187,9 @@ impl OrdIsValueOrd for DateTime {}
 
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl DecodeValue<'_> for SystemTime {
-    fn decode_value(decoder: &mut Decoder<'_>, header: Header) -> Result<Self> {
-        Ok(GeneralizedTime::decode_value(decoder, header)?.into())
+impl<'a> DecodeValue<'a> for SystemTime {
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
+        Ok(GeneralizedTime::decode_value(reader, header)?.into())
     }
 }
 
@@ -263,9 +263,9 @@ impl OrdIsValueOrd for SystemTime {}
 
 #[cfg(feature = "time")]
 #[cfg_attr(docsrs, doc(cfg(feature = "time")))]
-impl DecodeValue<'_> for PrimitiveDateTime {
-    fn decode_value(decoder: &mut Decoder<'_>, header: Header) -> Result<Self> {
-        GeneralizedTime::decode_value(decoder, header)?.try_into()
+impl<'a> DecodeValue<'a> for PrimitiveDateTime {
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
+        GeneralizedTime::decode_value(reader, header)?.try_into()
     }
 }
 

--- a/der/src/asn1/ia5_string.rs
+++ b/der/src/asn1/ia5_string.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `IA5String` support.
 
 use crate::{
-    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, Decoder, EncodeValue, Error, FixedTag,
-    Header, Length, Result, StrSlice, Tag, Writer,
+    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, EncodeValue, Error, FixedTag, Header,
+    Length, Reader, Result, StrSlice, Tag, Writer,
 };
 use core::{fmt, str};
 
@@ -74,8 +74,8 @@ impl AsRef<[u8]> for Ia5String<'_> {
 }
 
 impl<'a> DecodeValue<'a> for Ia5String<'a> {
-    fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> Result<Self> {
-        Self::new(ByteSlice::decode_value(decoder, header)?.as_slice())
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
+        Self::new(ByteSlice::decode_value(reader, header)?.as_slice())
     }
 }
 

--- a/der/src/asn1/integer.rs
+++ b/der/src/asn1/integer.rs
@@ -5,8 +5,8 @@ pub(super) mod int;
 pub(super) mod uint;
 
 use crate::{
-    asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Encoder, Error, FixedTag, Header,
-    Length, Result, Tag, ValueOrd, Writer,
+    asn1::Any, ByteSlice, DecodeValue, EncodeValue, Encoder, Error, FixedTag, Header, Length,
+    Reader, Result, Tag, ValueOrd, Writer,
 };
 use core::{cmp::Ordering, mem};
 
@@ -14,8 +14,8 @@ macro_rules! impl_int_encoding {
     ($($int:ty => $uint:ty),+) => {
         $(
             impl<'a> DecodeValue<'a> for $int {
-                fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> Result<Self> {
-                    let bytes = ByteSlice::decode_value(decoder, header)?.as_slice();
+                fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
+                    let bytes = ByteSlice::decode_value(reader, header)?.as_slice();
 
                     let result = if is_highest_bit_set(bytes) {
                         <$uint>::from_be_bytes(int::decode_to_array(bytes)?) as $int
@@ -75,8 +75,8 @@ macro_rules! impl_uint_encoding {
     ($($uint:ty),+) => {
         $(
             impl<'a> DecodeValue<'a> for $uint {
-                fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> Result<Self> {
-                    let bytes = ByteSlice::decode_value(decoder, header)?.as_slice();
+                fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
+                    let bytes = ByteSlice::decode_value(reader, header)?.as_slice();
                     let result = Self::from_be_bytes(uint::decode_to_array(bytes)?);
 
                     // Ensure we compute the same encoded length as the original any value

--- a/der/src/asn1/integer/bigint.rs
+++ b/der/src/asn1/integer/bigint.rs
@@ -2,8 +2,8 @@
 
 use super::uint;
 use crate::{
-    asn1::Any, ByteSlice, DecodeValue, Decoder, EncodeValue, Error, ErrorKind, FixedTag, Header,
-    Length, Result, Tag, Writer,
+    asn1::Any, ByteSlice, DecodeValue, EncodeValue, Error, ErrorKind, FixedTag, Header, Length,
+    Reader, Result, Tag, Writer,
 };
 
 /// "Big" unsigned ASN.1 `INTEGER` type.
@@ -46,8 +46,8 @@ impl<'a> UIntBytes<'a> {
 }
 
 impl<'a> DecodeValue<'a> for UIntBytes<'a> {
-    fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> Result<Self> {
-        let bytes = ByteSlice::decode_value(decoder, header)?.as_slice();
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
+        let bytes = ByteSlice::decode_value(reader, header)?.as_slice();
         let result = Self::new(uint::decode_to_slice(bytes)?)?;
 
         // Ensure we compute the same encoded length as the original any value.

--- a/der/src/asn1/null.rs
+++ b/der/src/asn1/null.rs
@@ -1,20 +1,20 @@
 //! ASN.1 `NULL` support.
 
 use crate::{
-    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, Decoder, EncodeValue, Error, ErrorKind,
-    FixedTag, Header, Length, Result, Tag, Writer,
+    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, EncodeValue, Error, ErrorKind, FixedTag,
+    Header, Length, Reader, Result, Tag, Writer,
 };
 
 /// ASN.1 `NULL` type.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Null;
 
-impl DecodeValue<'_> for Null {
-    fn decode_value(decoder: &mut Decoder<'_>, header: Header) -> Result<Self> {
+impl<'a> DecodeValue<'a> for Null {
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         if header.length.is_zero() {
             Ok(Null)
         } else {
-            Err(decoder.error(ErrorKind::Length { tag: Self::TAG }))
+            Err(reader.error(ErrorKind::Length { tag: Self::TAG }))
         }
     }
 }
@@ -63,9 +63,9 @@ impl<'a> From<()> for Any<'a> {
     }
 }
 
-impl DecodeValue<'_> for () {
-    fn decode_value(decoder: &mut Decoder<'_>, header: Header) -> Result<Self> {
-        Null::decode_value(decoder, header)?;
+impl<'a> DecodeValue<'a> for () {
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
+        Null::decode_value(reader, header)?;
         Ok(())
     }
 }

--- a/der/src/asn1/octet_string.rs
+++ b/der/src/asn1/octet_string.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `OCTET STRING` support.
 
 use crate::{
-    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, Decoder, EncodeValue, Error, ErrorKind,
-    FixedTag, Header, Length, Result, Tag, Writer,
+    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, EncodeValue, Error, ErrorKind, FixedTag,
+    Header, Length, Reader, Result, Tag, Writer,
 };
 
 /// ASN.1 `OCTET STRING` type.
@@ -43,8 +43,8 @@ impl AsRef<[u8]> for OctetString<'_> {
 }
 
 impl<'a> DecodeValue<'a> for OctetString<'a> {
-    fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> Result<Self> {
-        let inner = ByteSlice::decode_value(decoder, header)?;
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
+        let inner = ByteSlice::decode_value(reader, header)?;
         Ok(Self { inner })
     }
 }

--- a/der/src/asn1/oid.rs
+++ b/der/src/asn1/oid.rs
@@ -1,15 +1,16 @@
 //! ASN.1 `OBJECT IDENTIFIER`
 
 use crate::{
-    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, Decoder, EncodeValue, Error, FixedTag,
-    Header, Length, Result, Tag, Tagged, Writer,
+    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, EncodeValue, Error, FixedTag, Header,
+    Length, Reader, Result, Tag, Tagged, Writer,
 };
 use const_oid::ObjectIdentifier;
 
-impl DecodeValue<'_> for ObjectIdentifier {
-    fn decode_value(decoder: &mut Decoder<'_>, header: Header) -> Result<Self> {
-        let bytes = ByteSlice::decode_value(decoder, header)?.as_slice();
-        Ok(Self::from_bytes(bytes)?)
+impl<'a> DecodeValue<'a> for ObjectIdentifier {
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
+        Ok(Self::from_bytes(
+            ByteSlice::decode_value(reader, header)?.as_ref(),
+        )?)
     }
 }
 

--- a/der/src/asn1/optional.rs
+++ b/der/src/asn1/optional.rs
@@ -1,16 +1,16 @@
 //! ASN.1 `OPTIONAL` as mapped to Rust's `Option` type
 
-use crate::{Choice, Decode, Decoder, DerOrd, Encode, Length, Reader, Result, Tag, Writer};
+use crate::{Choice, Decode, DerOrd, Encode, Length, Reader, Result, Tag, Writer};
 use core::cmp::Ordering;
 
 impl<'a, T> Decode<'a> for Option<T>
 where
     T: Choice<'a>, // NOTE: all `Decode + Tagged` types receive a blanket `Choice` impl
 {
-    fn decode(decoder: &mut Decoder<'a>) -> Result<Option<T>> {
-        if let Some(byte) = decoder.peek_byte() {
+    fn decode<R: Reader<'a>>(reader: &mut R) -> Result<Option<T>> {
+        if let Some(byte) = reader.peek_byte() {
             if T::can_decode(Tag::try_from(byte)?) {
-                return T::decode(decoder).map(Some);
+                return T::decode(reader).map(Some);
             }
         }
 

--- a/der/src/asn1/printable_string.rs
+++ b/der/src/asn1/printable_string.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `PrintableString` support.
 
 use crate::{
-    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, Decoder, EncodeValue, Error, FixedTag,
-    Header, Length, Result, StrSlice, Tag, Writer,
+    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, EncodeValue, Error, FixedTag, Header,
+    Length, Reader, Result, StrSlice, Tag, Writer,
 };
 use core::{fmt, str};
 
@@ -107,8 +107,8 @@ impl AsRef<[u8]> for PrintableString<'_> {
 }
 
 impl<'a> DecodeValue<'a> for PrintableString<'a> {
-    fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> Result<Self> {
-        Self::new(ByteSlice::decode_value(decoder, header)?.as_slice())
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
+        Self::new(ByteSlice::decode_value(reader, header)?.as_slice())
     }
 }
 

--- a/der/src/asn1/sequence.rs
+++ b/der/src/asn1/sequence.rs
@@ -2,8 +2,8 @@
 //! `SEQUENCE`s to Rust structs.
 
 use crate::{
-    ByteSlice, Decode, DecodeValue, Decoder, Encode, EncodeValue, FixedTag, Header, Length, Reader,
-    Result, Tag, Writer,
+    ByteSlice, Decode, DecodeValue, Encode, EncodeValue, FixedTag, Header, Length, Reader, Result,
+    Tag, Writer,
 };
 
 /// ASN.1 `SEQUENCE` trait.
@@ -57,28 +57,13 @@ where
 pub struct SequenceRef<'a> {
     /// Body of the `SEQUENCE`.
     body: ByteSlice<'a>,
-
-    /// Offset location in the outer document where this `SEQUENCE` begins.
-    offset: Length,
-}
-
-impl<'a> SequenceRef<'a> {
-    /// Decode the body of this sequence.
-    pub fn decode_body<F, T>(&self, f: F) -> Result<T>
-    where
-        F: FnOnce(&mut Decoder<'a>) -> Result<T>,
-    {
-        let mut nested_decoder = Decoder::new_with_offset(self.body, self.offset);
-        let result = f(&mut nested_decoder)?;
-        nested_decoder.finish(result)
-    }
 }
 
 impl<'a> DecodeValue<'a> for SequenceRef<'a> {
-    fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> Result<Self> {
-        let offset = decoder.position();
-        let body = ByteSlice::decode_value(decoder, header)?;
-        Ok(Self { body, offset })
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
+        Ok(Self {
+            body: ByteSlice::decode_value(reader, header)?,
+        })
     }
 }
 

--- a/der/src/asn1/utc_time.rs
+++ b/der/src/asn1/utc_time.rs
@@ -4,7 +4,7 @@ use crate::{
     asn1::Any,
     datetime::{self, DateTime},
     ord::OrdIsValueOrd,
-    ByteSlice, DecodeValue, Decoder, EncodeValue, Error, ErrorKind, FixedTag, Header, Length,
+    ByteSlice, DecodeValue, EncodeValue, Error, ErrorKind, FixedTag, Header, Length, Reader,
     Result, Tag, Writer,
 };
 use core::time::Duration;
@@ -79,9 +79,9 @@ impl UtcTime {
     }
 }
 
-impl DecodeValue<'_> for UtcTime {
-    fn decode_value(decoder: &mut Decoder<'_>, header: Header) -> Result<Self> {
-        match *ByteSlice::decode_value(decoder, header)?.as_slice() {
+impl<'a> DecodeValue<'a> for UtcTime {
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
+        match *ByteSlice::decode_value(reader, header)?.as_slice() {
             // RFC 5280 requires mandatory seconds and Z-normalized time zone
             [year1, year2, mon1, mon2, day1, day2, hour1, hour2, min1, min2, sec1, sec2, b'Z'] => {
                 let year = u16::from(datetime::decode_decimal(Self::TAG, year1, year2)?);

--- a/der/src/asn1/utf8_string.rs
+++ b/der/src/asn1/utf8_string.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `UTF8String` support.
 
 use crate::{
-    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, Decoder, EncodeValue, Error, FixedTag,
-    Header, Length, Result, StrSlice, Tag, Writer,
+    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, EncodeValue, Error, FixedTag, Header,
+    Length, Reader, Result, StrSlice, Tag, Writer,
 };
 use core::{fmt, str};
 
@@ -70,8 +70,8 @@ impl AsRef<[u8]> for Utf8String<'_> {
 }
 
 impl<'a> DecodeValue<'a> for Utf8String<'a> {
-    fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> Result<Self> {
-        Self::new(ByteSlice::decode_value(decoder, header)?.as_slice())
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
+        Self::new(ByteSlice::decode_value(reader, header)?.as_slice())
     }
 }
 

--- a/der/src/byte_slice.rs
+++ b/der/src/byte_slice.rs
@@ -2,8 +2,8 @@
 //! library-level length limitation i.e. `Length::max()`.
 
 use crate::{
-    str_slice::StrSlice, DecodeValue, Decoder, DerOrd, EncodeValue, Error, Header, Length, Reader,
-    Result, Writer,
+    str_slice::StrSlice, DecodeValue, DerOrd, EncodeValue, Error, Header, Length, Reader, Result,
+    Writer,
 };
 use core::cmp::Ordering;
 
@@ -56,8 +56,8 @@ impl AsRef<[u8]> for ByteSlice<'_> {
 }
 
 impl<'a> DecodeValue<'a> for ByteSlice<'a> {
-    fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> Result<Self> {
-        decoder.read_slice(header.length).and_then(Self::new)
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
+        reader.read_slice(header.length).and_then(Self::new)
     }
 }
 

--- a/der/src/decode.rs
+++ b/der/src/decode.rs
@@ -1,6 +1,6 @@
 //! Trait definition for [`Decode`].
 
-use crate::{Decoder, FixedTag, Header, Result};
+use crate::{Decoder, FixedTag, Header, Reader, Result};
 
 #[cfg(feature = "pem")]
 use {
@@ -15,15 +15,9 @@ use crate::{Length, Tag};
 ///
 /// This trait provides the core abstraction upon which all decoding operations
 /// are based.
-///
-/// # Blanket impl for `TryFrom<Any>`
-///
-/// In almost all cases you do not need to impl this trait yourself, but rather
-/// can instead impl `TryFrom<Any<'a>, Error = Error>` and receive a blanket
-/// impl of this trait.
 pub trait Decode<'a>: Sized {
     /// Attempt to decode this message using the provided decoder.
-    fn decode(decoder: &mut Decoder<'a>) -> Result<Self>;
+    fn decode<R: Reader<'a>>(decoder: &mut R) -> Result<Self>;
 
     /// Parse `Self` from the provided DER-encoded byte slice.
     fn from_der(bytes: &'a [u8]) -> Result<Self> {
@@ -37,10 +31,10 @@ impl<'a, T> Decode<'a> for T
 where
     T: DecodeValue<'a> + FixedTag,
 {
-    fn decode(decoder: &mut Decoder<'a>) -> Result<T> {
-        let header = Header::decode(decoder)?;
+    fn decode<R: Reader<'a>>(reader: &mut R) -> Result<T> {
+        let header = Header::decode(reader)?;
         header.tag.assert_eq(T::TAG)?;
-        T::decode_value(decoder, header)
+        T::decode_value(reader, header)
     }
 }
 
@@ -64,15 +58,15 @@ impl<T> DecodeOwned for T where T: for<'a> Decode<'a> {}
 #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 pub trait DecodePem: DecodeOwned + PemLabel {
     /// Try to decode this type from PEM.
-    fn from_pem(pem: &str) -> Result<Self>;
+    fn from_pem(pem: impl AsRef<[u8]>) -> Result<Self>;
 }
 
 #[cfg(feature = "pem")]
 #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl<T: DecodeOwned + PemLabel> DecodePem for T {
-    fn from_pem(pem: &str) -> Result<Self> {
+    fn from_pem(pem: impl AsRef<[u8]>) -> Result<Self> {
         // TODO(tarcieri): support for decoding directly from PEM (instead of two-pass)
-        let (label, mut der_bytes) = pem::decode_vec(pem.as_bytes())?;
+        let (label, mut der_bytes) = pem::decode_vec(pem.as_ref())?;
         Self::validate_pem_label(label)?;
 
         let result = T::from_der(&der_bytes);
@@ -85,5 +79,5 @@ impl<T: DecodeOwned + PemLabel> DecodePem for T {
 /// and [`Length`].
 pub trait DecodeValue<'a>: Sized {
     /// Attempt to decode this message using the provided [`Decoder`].
-    fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> Result<Self>;
+    fn decode_value<R: Reader<'a>>(decoder: &mut R, header: Header) -> Result<Self>;
 }

--- a/der/src/document.rs
+++ b/der/src/document.rs
@@ -148,11 +148,12 @@ impl Debug for Document {
     }
 }
 
-impl Decode<'_> for Document {
-    fn decode(decoder: &mut Decoder<'_>) -> Result<Document> {
-        let header = decoder.peek_header()?;
+impl<'a> Decode<'a> for Document {
+    fn decode<R: Reader<'a>>(reader: &mut R) -> Result<Document> {
+        let header = reader.peek_header()?;
         let length = (header.encoded_len()? + header.length)?;
-        let bytes = decoder.read_slice(length)?;
+        let bytes = reader.read_slice(length)?;
+
         Ok(Self {
             der_bytes: bytes.into(),
             length,

--- a/der/src/header.rs
+++ b/der/src/header.rs
@@ -1,6 +1,6 @@
 //! ASN.1 DER headers.
 
-use crate::{Decode, Decoder, DerOrd, Encode, ErrorKind, Length, Result, Tag, Writer};
+use crate::{Decode, DerOrd, Encode, ErrorKind, Length, Reader, Result, Tag, Writer};
 use core::cmp::Ordering;
 
 /// ASN.1 DER headers: tag + length component of TLV-encoded values
@@ -23,11 +23,11 @@ impl Header {
     }
 }
 
-impl Decode<'_> for Header {
-    fn decode(decoder: &mut Decoder<'_>) -> Result<Header> {
-        let tag = Tag::decode(decoder)?;
+impl<'a> Decode<'a> for Header {
+    fn decode<R: Reader<'a>>(reader: &mut R) -> Result<Header> {
+        let tag = Tag::decode(reader)?;
 
-        let length = Length::decode(decoder).map_err(|e| {
+        let length = Length::decode(reader).map_err(|e| {
             if e.kind() == ErrorKind::Overlength {
                 ErrorKind::Length { tag }.into()
             } else {

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -98,7 +98,7 @@
 //! // "heapless" usage when the `alloc` feature is disabled.
 //! use der::{
 //!     asn1::{Any, ObjectIdentifier},
-//!     Decode, Decoder, Encode, Sequence
+//!     DecodeValue, Decode, Decoder, Encode, Header, Reader, Sequence
 //! };
 //!
 //! /// X.509 `AlgorithmIdentifier`.
@@ -112,40 +112,35 @@
 //!     pub parameters: Option<Any<'a>>
 //! }
 //!
-//! impl<'a> Decode<'a> for AlgorithmIdentifier<'a> {
-//!     fn decode(decoder: &mut Decoder<'a>) -> der::Result<Self> {
-//!         // The `Decoder::sequence` method decodes an ASN.1 `SEQUENCE` tag
-//!         // and length then calls the provided `FnOnce` with a nested
-//!         // `der::Decoder` which can be used to decode it.
-//!         decoder.sequence(|decoder| {
-//!             // The `der::Decoder::Decode` method can be used to decode any
-//!             // type which impls the `Decode` trait, which is impl'd for
-//!             // all of the ASN.1 built-in types in the `der` crate.
-//!             //
-//!             // Note that if your struct's fields don't contain an ASN.1
-//!             // built-in type specifically, there are also helper methods
-//!             // for all of the built-in types supported by this library
-//!             // which can be used to select a specific type.
-//!             //
-//!             // For example, another way of decoding this particular field,
-//!             // which contains an ASN.1 `OBJECT IDENTIFIER`, is by calling
-//!             // `decoder.oid()`. Similar methods are defined for other
-//!             // ASN.1 built-in types.
-//!             let algorithm = decoder.decode()?;
+//! impl<'a> DecodeValue<'a> for AlgorithmIdentifier<'a> {
+//!     fn decode_value<R: Reader<'a>>(reader: &mut R, _header: Header) -> der::Result<Self> {
+//!        // The `der::Decoder::Decode` method can be used to decode any
+//!        // type which impls the `Decode` trait, which is impl'd for
+//!        // all of the ASN.1 built-in types in the `der` crate.
+//!        //
+//!        // Note that if your struct's fields don't contain an ASN.1
+//!        // built-in type specifically, there are also helper methods
+//!        // for all of the built-in types supported by this library
+//!        // which can be used to select a specific type.
+//!        //
+//!        // For example, another way of decoding this particular field,
+//!        // which contains an ASN.1 `OBJECT IDENTIFIER`, is by calling
+//!        // `decoder.oid()`. Similar methods are defined for other
+//!        // ASN.1 built-in types.
+//!        let algorithm = reader.decode()?;
 //!
-//!             // This field contains an ASN.1 `OPTIONAL` type. The `der` crate
-//!             // maps this directly to Rust's `Option` type and provides
-//!             // impls of the `Decode` and `Encode` traits for `Option`.
-//!             // To explicitly request an `OPTIONAL` type be decoded, use the
-//!             // `decoder.optional()` method.
-//!             let parameters = decoder.decode()?;
+//!        // This field contains an ASN.1 `OPTIONAL` type. The `der` crate
+//!        // maps this directly to Rust's `Option` type and provides
+//!        // impls of the `Decode` and `Encode` traits for `Option`.
+//!        // To explicitly request an `OPTIONAL` type be decoded, use the
+//!        // `decoder.optional()` method.
+//!        let parameters = reader.decode()?;
 //!
-//!             // The value returned from the provided `FnOnce` will be
-//!             // returned from the `any.sequence(...)` call above.
-//!             // Note that the entire sequence body *MUST* be consumed
-//!             // or an error will be returned.
-//!             Ok(Self { algorithm, parameters })
-//!         })
+//!        // The value returned from the provided `FnOnce` will be
+//!        // returned from the `any.sequence(...)` call above.
+//!        // Note that the entire sequence body *MUST* be consumed
+//!        // or an error will be returned.
+//!        Ok(Self { algorithm, parameters })
 //!     }
 //! }
 //!

--- a/der/src/reader.rs
+++ b/der/src/reader.rs
@@ -1,9 +1,16 @@
 //! Reader trait.
 
-use crate::{Error, Header, Length, Result, Tag};
+mod nested;
+
+pub(crate) use nested::NestedReader;
+
+use crate::{
+    asn1::ContextSpecific, Decode, DecodeValue, Encode, Error, ErrorKind, FixedTag, Header, Length,
+    Result, Tag, TagMode, TagNumber,
+};
 
 /// Reader trait which reads DER-encoded input.
-pub trait Reader<'i>: Clone + Sized {
+pub trait Reader<'r>: Sized {
     /// Get the length of the input.
     fn input_len(&self) -> Length;
 
@@ -19,9 +26,65 @@ pub trait Reader<'i>: Clone + Sized {
     /// Get the position within the buffer.
     fn position(&self) -> Length;
 
+    /// Attempt to read data borrowed directly from the input as a slice,
+    /// updating the internal cursor position.
+    ///
+    /// # Returns
+    /// - `Ok(slice)` on success
+    /// - `Err(ErrorKind::Incomplete)` if there is not enough data
+    /// - `Err(ErrorKind::Reader)` if the reader can't borrow from the input
+    fn read_slice(&mut self, len: Length) -> Result<&'r [u8]>;
+
+    /// Attempt to decode an ASN.1 `CONTEXT-SPECIFIC` field with the
+    /// provided [`TagNumber`].
+    fn context_specific<T>(&mut self, tag_number: TagNumber, tag_mode: TagMode) -> Result<Option<T>>
+    where
+        T: DecodeValue<'r> + FixedTag,
+    {
+        Ok(match tag_mode {
+            TagMode::Explicit => ContextSpecific::<T>::decode_explicit(self, tag_number)?,
+            TagMode::Implicit => ContextSpecific::<T>::decode_implicit(self, tag_number)?,
+        }
+        .map(|field| field.value))
+    }
+
+    /// Decode a value which impls the [`Decode`] trait.
+    fn decode<T: Decode<'r>>(&mut self) -> Result<T> {
+        T::decode(self).map_err(|e| e.nested(self.position()))
+    }
+
+    /// Return an error with the given [`ErrorKind`], annotating it with
+    /// context about where the error occurred.
+    fn error(&mut self, kind: ErrorKind) -> Error {
+        kind.at(self.position())
+    }
+
+    /// Finish decoding, returning the given value if there is no
+    /// remaining data, or an error otherwise
+    fn finish<T>(self, value: T) -> Result<T> {
+        if !self.is_finished() {
+            Err(ErrorKind::TrailingData {
+                decoded: self.position(),
+                remaining: self.remaining_len(),
+            }
+            .at(self.position()))
+        } else {
+            Ok(value)
+        }
+    }
+
     /// Have we read all of the input data?
     fn is_finished(&self) -> bool {
         self.remaining_len().is_zero()
+    }
+
+    /// Offset within the original input stream.
+    ///
+    /// This is used for error reporting, and doesn't need to be overridden
+    /// by any reader implementations (except for the built-in `NestedReader`,
+    /// which consumes nested input messages)
+    fn offset(&self) -> Length {
+        self.position()
     }
 
     /// Peek at the next byte in the decoder and attempt to decode it as a
@@ -35,14 +98,12 @@ pub trait Reader<'i>: Clone + Sized {
         }
     }
 
-    /// Attempt to read data borrowed directly from the input as a slice,
-    /// updating the internal cursor position.
-    ///
-    /// # Returns
-    /// - `Ok(slice)` on success
-    /// - `Err(ErrorKind::Incomplete)` if there is not enough data
-    /// - `Err(ErrorKind::Reader)` if the reader can't borrow from the input
-    fn read_slice(&mut self, len: impl TryInto<Length>) -> Result<&'i [u8]>;
+    /// Read a single byte.
+    fn read_byte(&mut self) -> Result<u8> {
+        let mut buf = [0];
+        self.read_into(&mut buf)?;
+        Ok(buf[0])
+    }
 
     /// Attempt to read input data, writing it into the provided buffer, and
     /// returning a slice on success.
@@ -51,21 +112,31 @@ pub trait Reader<'i>: Clone + Sized {
     /// - `Ok(slice)` if there is sufficient data
     /// - `Err(ErrorKind::Incomplete)` if there is not enough data
     fn read_into<'o>(&mut self, buf: &'o mut [u8]) -> Result<&'o [u8]> {
-        let input = self.read_slice(buf.len())?;
+        let input = self.read_slice(buf.len().try_into()?)?;
         buf.copy_from_slice(input);
         Ok(buf)
     }
 
-    /// Read a single byte.
-    fn read_byte(&mut self) -> Result<u8> {
-        let mut buf = [0];
-        self.read_into(&mut buf)?;
-        Ok(buf[0])
+    /// Read nested data of the given length.
+    fn read_nested<'n, T, F>(&'n mut self, len: Length, f: F) -> Result<T>
+    where
+        F: FnOnce(&mut NestedReader<'n, Self>) -> Result<T>,
+    {
+        let mut reader = NestedReader::new(self, len)?;
+        let ret = f(&mut reader)?;
+        reader.finish(ret)
     }
 
     /// Get the number of bytes still remaining in the buffer.
     fn remaining_len(&self) -> Length {
         debug_assert!(self.position() <= self.input_len());
         self.input_len().saturating_sub(self.position())
+    }
+
+    /// Obtain a slice of bytes contain a complete TLV production suitable for parsing later.
+    fn tlv_bytes(&mut self) -> Result<&'r [u8]> {
+        let header = self.peek_header()?;
+        let header_len = header.encoded_len()?;
+        self.read_slice((header_len + header.length)?)
     }
 }

--- a/der/src/reader/nested.rs
+++ b/der/src/reader/nested.rs
@@ -1,0 +1,96 @@
+//! Reader type for consuming nested TLV records within a DER document.
+
+use crate::{reader::Reader, Error, ErrorKind, Header, Length, Result};
+
+/// Reader type used by [`Reader::read_nested`].
+pub struct NestedReader<'i, R> {
+    /// Inner reader type.
+    inner: &'i mut R,
+
+    /// Nested input length.
+    input_len: Length,
+
+    /// Position within the nested input.
+    position: Length,
+}
+
+impl<'i, 'r, R: Reader<'r>> NestedReader<'i, R> {
+    /// Create a new nested reader which can read the given [`Length`].
+    pub(crate) fn new(inner: &'i mut R, len: Length) -> Result<Self> {
+        if len <= inner.remaining_len() {
+            Ok(Self {
+                inner,
+                input_len: len,
+                position: Length::ZERO,
+            })
+        } else {
+            Err(ErrorKind::Incomplete {
+                expected_len: (inner.offset() + len)?,
+                actual_len: (inner.offset() + inner.remaining_len())?,
+            }
+            .at(inner.offset()))
+        }
+    }
+
+    /// Move the position cursor the given length, returning an error if there
+    /// isn't enough remaining data in the nested input.
+    fn advance_position(&mut self, len: Length) -> Result<()> {
+        let new_position = (self.position + len)?;
+
+        if new_position <= self.input_len {
+            self.position = new_position;
+            Ok(())
+        } else {
+            Err(ErrorKind::Incomplete {
+                expected_len: (self.inner.offset() + len)?,
+                actual_len: (self.inner.offset() + self.remaining_len())?,
+            }
+            .at(self.inner.offset()))
+        }
+    }
+}
+
+impl<'i, 'r, R: Reader<'r>> Reader<'r> for NestedReader<'i, R> {
+    fn input_len(&self) -> Length {
+        self.input_len
+    }
+
+    fn peek_byte(&self) -> Option<u8> {
+        if self.is_finished() {
+            None
+        } else {
+            self.inner.peek_byte()
+        }
+    }
+
+    fn peek_header(&self) -> Result<Header> {
+        if self.is_finished() {
+            Err(Error::incomplete(self.offset()))
+        } else {
+            // TODO(tarcieri): handle peeking past nested length
+            self.inner.peek_header()
+        }
+    }
+
+    fn position(&self) -> Length {
+        self.position
+    }
+
+    fn read_slice(&mut self, len: Length) -> Result<&'r [u8]> {
+        self.advance_position(len)?;
+        self.inner.read_slice(len)
+    }
+
+    fn error(&mut self, kind: ErrorKind) -> Error {
+        self.inner.error(kind)
+    }
+
+    fn offset(&self) -> Length {
+        self.inner.offset()
+    }
+
+    fn read_into<'o>(&mut self, out: &'o mut [u8]) -> Result<&'o [u8]> {
+        self.advance_position(Length::try_from(out.len())?)?;
+        self.inner.read_into(out)
+    }
+}

--- a/der/src/str_slice.rs
+++ b/der/src/str_slice.rs
@@ -1,7 +1,7 @@
 //! Common handling for types backed by `str` slices with enforcement of a
 //! library-level length limitation i.e. `Length::max()`.
 
-use crate::{ByteSlice, DecodeValue, Decoder, EncodeValue, Header, Length, Result, Writer};
+use crate::{ByteSlice, DecodeValue, EncodeValue, Header, Length, Reader, Result, Writer};
 use core::str;
 
 /// String slice newtype which respects the [`Length::max`] limit.
@@ -63,8 +63,8 @@ impl AsRef<[u8]> for StrSlice<'_> {
 }
 
 impl<'a> DecodeValue<'a> for StrSlice<'a> {
-    fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> Result<Self> {
-        Self::from_bytes(ByteSlice::decode_value(decoder, header)?.as_slice())
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
+        Self::from_bytes(ByteSlice::decode_value(reader, header)?.as_slice())
     }
 }
 

--- a/der/src/tag.rs
+++ b/der/src/tag.rs
@@ -6,7 +6,7 @@ mod number;
 
 pub use self::{class::Class, mode::TagMode, number::TagNumber};
 
-use crate::{Decode, Decoder, DerOrd, Encode, Error, ErrorKind, Length, Reader, Result, Writer};
+use crate::{Decode, DerOrd, Encode, Error, ErrorKind, Length, Reader, Result, Writer};
 use core::{cmp::Ordering, fmt};
 
 /// Indicator bit for constructed form encoding (i.e. vs primitive form)
@@ -302,9 +302,9 @@ impl From<&Tag> for u8 {
     }
 }
 
-impl Decode<'_> for Tag {
-    fn decode(decoder: &mut Decoder<'_>) -> Result<Self> {
-        decoder.read_byte().and_then(Self::try_from)
+impl<'a> Decode<'a> for Tag {
+    fn decode<R: Reader<'a>>(reader: &mut R) -> Result<Self> {
+        reader.read_byte().and_then(Self::try_from)
     }
 }
 

--- a/der/src/writer.rs
+++ b/der/src/writer.rs
@@ -22,18 +22,18 @@ pub trait Writer {
 /// `Writer` type which outputs PEM-encoded data.
 #[cfg(feature = "pem")]
 #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-pub struct PemWriter<'o>(pem::Encoder<'static, 'o>);
+pub struct PemWriter<'w>(pem::Encoder<'static, 'w>);
 
 #[cfg(feature = "pem")]
 #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-impl<'o> PemWriter<'o> {
+impl<'w> PemWriter<'w> {
     /// Create a new PEM writer which outputs into the provided buffer.
     ///
     /// Uses the default 64-character line wrapping.
     pub fn new(
         type_label: &'static str,
         line_ending: pem::LineEnding,
-        out: &'o mut [u8],
+        out: &'w mut [u8],
     ) -> Result<Self> {
         Ok(Self(pem::Encoder::new(type_label, line_ending, out)?))
     }

--- a/pkcs1/src/private_key/other_prime_info.rs
+++ b/pkcs1/src/private_key/other_prime_info.rs
@@ -1,6 +1,6 @@
 //! PKCS#1 OtherPrimeInfo support.
 
-use der::{asn1::UIntBytes, Decode, Decoder, Encode, Sequence};
+use der::{asn1::UIntBytes, DecodeValue, Encode, Header, Reader, Sequence};
 
 /// PKCS#1 OtherPrimeInfo as defined in [RFC 8017 Appendix 1.2].
 ///
@@ -28,13 +28,13 @@ pub struct OtherPrimeInfo<'a> {
     pub coefficient: UIntBytes<'a>,
 }
 
-impl<'a> Decode<'a> for OtherPrimeInfo<'a> {
-    fn decode(decoder: &mut Decoder<'a>) -> der::Result<Self> {
-        decoder.sequence(|decoder| {
+impl<'a> DecodeValue<'a> for OtherPrimeInfo<'a> {
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> der::Result<Self> {
+        reader.read_nested(header.length, |reader| {
             Ok(Self {
-                prime: decoder.decode()?,
-                exponent: decoder.decode()?,
-                coefficient: decoder.decode()?,
+                prime: reader.decode()?,
+                exponent: reader.decode()?,
+                coefficient: reader.decode()?,
             })
         })
     }

--- a/pkcs1/src/public_key.rs
+++ b/pkcs1/src/public_key.rs
@@ -1,7 +1,7 @@
 //! PKCS#1 RSA Public Keys.
 
 use crate::{Error, Result};
-use der::{asn1::UIntBytes, Decode, Decoder, Encode, Sequence};
+use der::{asn1::UIntBytes, Decode, DecodeValue, Encode, Header, Reader, Sequence};
 
 #[cfg(feature = "alloc")]
 use der::Document;
@@ -30,12 +30,12 @@ pub struct RsaPublicKey<'a> {
     pub public_exponent: UIntBytes<'a>,
 }
 
-impl<'a> Decode<'a> for RsaPublicKey<'a> {
-    fn decode(decoder: &mut Decoder<'a>) -> der::Result<Self> {
-        decoder.sequence(|decoder| {
+impl<'a> DecodeValue<'a> for RsaPublicKey<'a> {
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> der::Result<Self> {
+        reader.read_nested(header.length, |reader| {
             Ok(Self {
-                modulus: decoder.decode()?,
-                public_exponent: decoder.decode()?,
+                modulus: reader.decode()?,
+                public_exponent: reader.decode()?,
             })
         })
     }

--- a/pkcs1/src/version.rs
+++ b/pkcs1/src/version.rs
@@ -1,7 +1,7 @@
 //! PKCS#1 version identifier.
 
 use crate::Error;
-use der::{Decode, Decoder, Encode, FixedTag, Tag, Writer};
+use der::{Decode, Encode, FixedTag, Reader, Tag, Writer};
 
 /// Version identifier for PKCS#1 documents as defined in
 /// [RFC 8017 Appendix 1.2].
@@ -51,8 +51,8 @@ impl TryFrom<u8> for Version {
     }
 }
 
-impl Decode<'_> for Version {
-    fn decode(decoder: &mut Decoder<'_>) -> der::Result<Self> {
+impl<'a> Decode<'a> for Version {
+    fn decode<R: Reader<'a>>(decoder: &mut R) -> der::Result<Self> {
         Version::try_from(u8::decode(decoder)?).map_err(|_| Self::TAG.value_error())
     }
 }

--- a/pkcs5/src/lib.rs
+++ b/pkcs5/src/lib.rs
@@ -29,7 +29,7 @@ pub use crate::error::{Error, Result};
 pub use der::{self, asn1::ObjectIdentifier};
 pub use spki::AlgorithmIdentifier;
 
-use der::{Decode, Decoder, Encode, Sequence, Tag};
+use der::{Decode, DecodeValue, Encode, Header, Reader, Sequence, Tag};
 
 #[cfg(all(feature = "alloc", feature = "pbes2"))]
 use alloc::vec::Vec;
@@ -135,9 +135,9 @@ impl<'a> EncryptionScheme<'a> {
     }
 }
 
-impl<'a> Decode<'a> for EncryptionScheme<'a> {
-    fn decode(decoder: &mut Decoder<'a>) -> der::Result<Self> {
-        AlgorithmIdentifier::decode(decoder)?.try_into()
+impl<'a> DecodeValue<'a> for EncryptionScheme<'a> {
+    fn decode_value<R: Reader<'a>>(decoder: &mut R, header: Header) -> der::Result<Self> {
+        AlgorithmIdentifier::decode_value(decoder, header)?.try_into()
     }
 }
 

--- a/pkcs5/src/pbes2.rs
+++ b/pkcs5/src/pbes2.rs
@@ -15,7 +15,7 @@ pub use self::kdf::{
 use crate::{AlgorithmIdentifier, Error, Result};
 use der::{
     asn1::{Any, ObjectIdentifier, OctetString},
-    Decode, Decoder, Encode, ErrorKind, Length, Sequence, Tag, Writer,
+    Decode, Encode, ErrorKind, Length, Reader, Sequence, Tag, Writer,
 };
 
 #[cfg(all(feature = "alloc", feature = "pbes2"))]
@@ -201,8 +201,8 @@ impl<'a> Parameters<'a> {
 }
 
 impl<'a> Decode<'a> for Parameters<'a> {
-    fn decode(decoder: &mut Decoder<'a>) -> der::Result<Self> {
-        decoder.any()?.try_into()
+    fn decode<R: Reader<'a>>(reader: &mut R) -> der::Result<Self> {
+        Any::decode(reader)?.try_into()
     }
 }
 
@@ -304,8 +304,8 @@ impl<'a> EncryptionScheme<'a> {
 }
 
 impl<'a> Decode<'a> for EncryptionScheme<'a> {
-    fn decode(decoder: &mut Decoder<'a>) -> der::Result<Self> {
-        AlgorithmIdentifier::decode(decoder).and_then(TryInto::try_into)
+    fn decode<R: Reader<'a>>(reader: &mut R) -> der::Result<Self> {
+        AlgorithmIdentifier::decode(reader).and_then(TryInto::try_into)
     }
 }
 

--- a/pkcs7/src/content_type.rs
+++ b/pkcs7/src/content_type.rs
@@ -1,67 +1,73 @@
 use der::asn1::ObjectIdentifier;
-use der::{DecodeValue, Decoder, EncodeValue, ErrorKind, FixedTag, Header, Length, Tag, Writer};
+use der::{DecodeValue, EncodeValue, ErrorKind, FixedTag, Header, Length, Reader, Tag, Writer};
 
 /// Indicates the type of content.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub enum ContentType {
     /// Plain data content type
     Data,
+
     /// Signed-data content type
     SignedData,
+
     /// Enveloped-data content type
     EnvelopedData,
+
     /// Signed-and-enveloped-data content type
     SignedAndEnvelopedData,
+
     /// Digested-data content type
     DigestedData,
+
     /// Encrypted-data content type
     EncryptedData,
 }
 
-impl ContentType {
-    /// return OID for content type
-    pub fn to_oid(&self) -> ObjectIdentifier {
-        match self {
-            Self::Data => crate::PKCS_7_DATA_OID,
-            Self::SignedData => crate::PKCS_7_SIGNED_DATA_OID,
-            Self::EnvelopedData => crate::PKCS_7_ENVELOPED_DATA_OID,
-            Self::SignedAndEnvelopedData => crate::PKCS_7_SIGNED_AND_ENVELOPED_DATA_OID,
-            Self::DigestedData => crate::PKCS_7_DIGESTED_DATA_OID,
-            Self::EncryptedData => crate::PKCS_7_ENCRYPTED_DATA_OID,
-        }
-    }
-
-    /// match content type to given OID
-    pub fn from_oid(oid: ObjectIdentifier) -> Option<Self> {
-        match oid {
-            crate::PKCS_7_DATA_OID => Some(Self::Data),
-            crate::PKCS_7_SIGNED_DATA_OID => Some(Self::SignedData),
-            crate::PKCS_7_ENVELOPED_DATA_OID => Some(Self::EnvelopedData),
-            crate::PKCS_7_SIGNED_AND_ENVELOPED_DATA_OID => Some(Self::SignedAndEnvelopedData),
-            crate::PKCS_7_DIGESTED_DATA_OID => Some(Self::DigestedData),
-            crate::PKCS_7_ENCRYPTED_DATA_OID => Some(Self::EncryptedData),
-            _ => None,
-        }
-    }
-}
-
 impl<'a> DecodeValue<'a> for ContentType {
-    fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> der::Result<ContentType> {
-        let oid = ObjectIdentifier::decode_value(decoder, header)?;
-        ContentType::from_oid(oid).ok_or_else(|| decoder.error(ErrorKind::OidUnknown { oid }))
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> der::Result<ContentType> {
+        ObjectIdentifier::decode_value(reader, header)?.try_into()
     }
 }
 
 impl EncodeValue for ContentType {
     fn value_len(&self) -> der::Result<Length> {
-        self.to_oid().value_len()
+        ObjectIdentifier::from(*self).value_len()
     }
 
     fn encode_value(&self, writer: &mut dyn Writer) -> der::Result<()> {
-        self.to_oid().encode_value(writer)
+        ObjectIdentifier::from(*self).encode_value(writer)
     }
 }
 
 impl FixedTag for ContentType {
     const TAG: Tag = Tag::ObjectIdentifier;
+}
+
+impl From<ContentType> for ObjectIdentifier {
+    fn from(content_type: ContentType) -> ObjectIdentifier {
+        match content_type {
+            ContentType::Data => crate::PKCS_7_DATA_OID,
+            ContentType::SignedData => crate::PKCS_7_SIGNED_DATA_OID,
+            ContentType::EnvelopedData => crate::PKCS_7_ENVELOPED_DATA_OID,
+            ContentType::SignedAndEnvelopedData => crate::PKCS_7_SIGNED_AND_ENVELOPED_DATA_OID,
+            ContentType::DigestedData => crate::PKCS_7_DIGESTED_DATA_OID,
+            ContentType::EncryptedData => crate::PKCS_7_ENCRYPTED_DATA_OID,
+        }
+    }
+}
+
+impl TryFrom<ObjectIdentifier> for ContentType {
+    type Error = der::Error;
+
+    fn try_from(oid: ObjectIdentifier) -> der::Result<Self> {
+        match oid {
+            crate::PKCS_7_DATA_OID => Ok(Self::Data),
+            crate::PKCS_7_SIGNED_DATA_OID => Ok(Self::SignedData),
+            crate::PKCS_7_ENVELOPED_DATA_OID => Ok(Self::EnvelopedData),
+            crate::PKCS_7_SIGNED_AND_ENVELOPED_DATA_OID => Ok(Self::SignedAndEnvelopedData),
+            crate::PKCS_7_DIGESTED_DATA_OID => Ok(Self::DigestedData),
+            crate::PKCS_7_ENCRYPTED_DATA_OID => Ok(Self::EncryptedData),
+            _ => Err(ErrorKind::OidUnknown { oid }.into()),
+        }
+    }
 }

--- a/pkcs7/src/data_content.rs
+++ b/pkcs7/src/data_content.rs
@@ -2,7 +2,7 @@
 
 use core::convert::{From, TryFrom};
 use der::{
-    asn1::OctetString, DecodeValue, Decoder, EncodeValue, FixedTag, Header, Length, Tag, Writer,
+    asn1::OctetString, DecodeValue, EncodeValue, FixedTag, Header, Length, Reader, Tag, Writer,
 };
 
 /// The content that is just an octet string.
@@ -31,10 +31,8 @@ impl<'a> From<DataContent<'a>> for &'a [u8] {
 }
 
 impl<'a> DecodeValue<'a> for DataContent<'a> {
-    fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> der::Result<DataContent<'a>> {
-        Ok(OctetString::decode_value(decoder, header)?
-            .as_bytes()
-            .into())
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> der::Result<DataContent<'a>> {
+        Ok(OctetString::decode_value(reader, header)?.as_bytes().into())
     }
 }
 

--- a/pkcs7/tests/content_tests.rs
+++ b/pkcs7/tests/content_tests.rs
@@ -1,6 +1,9 @@
 //! PKCS#7 example tests
 
-use der::{asn1::ObjectIdentifier, Decode, Encoder};
+use der::{
+    asn1::{ObjectIdentifier, OctetString},
+    Decode, Encoder,
+};
 use hex_literal::hex;
 use pkcs7::{
     encrypted_data_content::EncryptedDataContent, enveloped_data_content::EncryptedContentInfo,
@@ -60,8 +63,8 @@ fn decode_encrypted_key_example() {
 
             let (salt, iter) = any
                 .sequence(|decoder| {
-                    let salt = decoder.octet_string()?;
-                    let iter = decoder.uint16()?;
+                    let salt = OctetString::decode(decoder)?;
+                    let iter = u16::decode(decoder)?;
                     Ok((salt, iter))
                 })
                 .expect("salt and iters parameters");

--- a/pkcs8/src/encrypted_private_key_info.rs
+++ b/pkcs8/src/encrypted_private_key_info.rs
@@ -2,7 +2,7 @@
 
 use crate::{Error, Result};
 use core::fmt;
-use der::{asn1::OctetString, Decode, Decoder, Encode, Sequence};
+use der::{asn1::OctetString, Decode, DecodeValue, Encode, Header, Reader, Sequence};
 use pkcs5::EncryptionScheme;
 
 #[cfg(feature = "alloc")]
@@ -97,12 +97,15 @@ impl<'a> EncryptedPrivateKeyInfo<'a> {
     }
 }
 
-impl<'a> Decode<'a> for EncryptedPrivateKeyInfo<'a> {
-    fn decode(decoder: &mut Decoder<'a>) -> der::Result<EncryptedPrivateKeyInfo<'a>> {
-        decoder.sequence(|decoder| {
+impl<'a> DecodeValue<'a> for EncryptedPrivateKeyInfo<'a> {
+    fn decode_value<R: Reader<'a>>(
+        reader: &mut R,
+        header: Header,
+    ) -> der::Result<EncryptedPrivateKeyInfo<'a>> {
+        reader.read_nested(header.length, |reader| {
             Ok(Self {
-                encryption_algorithm: decoder.decode()?,
-                encrypted_data: decoder.octet_string()?.as_bytes(),
+                encryption_algorithm: reader.decode()?,
+                encrypted_data: OctetString::decode(reader)?.as_bytes(),
             })
         })
     }

--- a/pkcs8/src/version.rs
+++ b/pkcs8/src/version.rs
@@ -1,7 +1,7 @@
 //! PKCS#8 version identifier.
 
 use crate::Error;
-use der::{Decode, Decoder, Encode, FixedTag, Tag, Writer};
+use der::{Decode, Encode, FixedTag, Reader, Tag, Writer};
 
 /// Version identifier for PKCS#8 documents.
 ///
@@ -25,8 +25,8 @@ impl Version {
     }
 }
 
-impl Decode<'_> for Version {
-    fn decode(decoder: &mut Decoder<'_>) -> der::Result<Self> {
+impl<'a> Decode<'a> for Version {
+    fn decode<R: Reader<'a>>(decoder: &mut R) -> der::Result<Self> {
         Version::try_from(u8::decode(decoder)?).map_err(|_| Self::TAG.value_error())
     }
 }

--- a/sec1/src/parameters.rs
+++ b/sec1/src/parameters.rs
@@ -1,6 +1,6 @@
 use der::{
     asn1::{Any, ObjectIdentifier},
-    DecodeValue, Decoder, EncodeValue, FixedTag, Header, Length, Tag, Writer,
+    DecodeValue, EncodeValue, FixedTag, Header, Length, Reader, Tag, Writer,
 };
 
 /// Elliptic curve parameters as described in
@@ -28,8 +28,8 @@ pub enum EcParameters {
     NamedCurve(ObjectIdentifier),
 }
 
-impl DecodeValue<'_> for EcParameters {
-    fn decode_value(decoder: &mut Decoder<'_>, header: Header) -> der::Result<Self> {
+impl<'a> DecodeValue<'a> for EcParameters {
+    fn decode_value<R: Reader<'a>>(decoder: &mut R, header: Header) -> der::Result<Self> {
         ObjectIdentifier::decode_value(decoder, header).map(Self::NamedCurve)
     }
 }

--- a/spki/src/algorithm.rs
+++ b/spki/src/algorithm.rs
@@ -2,8 +2,8 @@
 
 use crate::{Error, Result};
 use core::cmp::Ordering;
-use der::asn1::{Any, ObjectIdentifier, SequenceRef};
-use der::{Decode, DecodeValue, Decoder, DerOrd, Encode, Header, Sequence, ValueOrd};
+use der::asn1::{Any, ObjectIdentifier};
+use der::{Decode, DecodeValue, DerOrd, Encode, Header, Reader, Sequence, ValueOrd};
 
 /// X.509 `AlgorithmIdentifier` as defined in [RFC 5280 Section 4.1.1.2].
 ///
@@ -95,11 +95,12 @@ impl<'a> AlgorithmIdentifier<'a> {
 }
 
 impl<'a> DecodeValue<'a> for AlgorithmIdentifier<'a> {
-    fn decode_value(decoder: &mut Decoder<'a>, header: Header) -> der::Result<Self> {
-        SequenceRef::decode_value(decoder, header)?.decode_body(|decoder| {
-            let oid = decoder.decode()?;
-            let parameters = decoder.decode()?;
-            Ok(Self { oid, parameters })
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> der::Result<Self> {
+        reader.read_nested(header.length, |reader| {
+            Ok(Self {
+                oid: reader.decode()?,
+                parameters: reader.decode()?,
+            })
         })
     }
 }

--- a/ssh-key/src/reader.rs
+++ b/ssh-key/src/reader.rs
@@ -33,10 +33,6 @@ pub(crate) trait Reader: Sized {
     /// Decodes a `uint32` which identifies the length of some encapsulated
     /// data, then calls the given nested reader function with the length of
     /// the remaining data.
-    ///
-    /// As a postcondition, this function checks that the total amount of data
-    /// consumed matches the length prefix.
-    // TODO(tarcieri): enforce that data can't be read past the given length
     fn read_nested<'r, T, F>(&'r mut self, f: F) -> Result<T>
     where
         F: FnOnce(&mut NestedReader<'r, Self>) -> Result<T>,

--- a/x509/src/ext/pkix/name/ediparty.rs
+++ b/x509/src/ext/pkix/name/ediparty.rs
@@ -1,4 +1,4 @@
-use der::{Decode, Sequence};
+use der::Sequence;
 
 use super::DirectoryString;
 

--- a/x509/src/ext/pkix/name/other.rs
+++ b/x509/src/ext/pkix/name/other.rs
@@ -1,4 +1,4 @@
-use der::{asn1::ObjectIdentifier, Any, Decode, Sequence};
+use der::{asn1::ObjectIdentifier, Any, Sequence};
 
 /// OtherName as defined in [RFC 5280 Section 4.2.1.6].
 ///

--- a/x509/src/macros.rs
+++ b/x509/src/macros.rs
@@ -40,8 +40,8 @@ macro_rules! impl_newtype {
         }
 
         impl<'a> ::der::DecodeValue<'a> for $newtype {
-            fn decode_value(
-                decoder: &mut ::der::Decoder<'a>,
+            fn decode_value<R: ::der::Reader<'a>>(
+                decoder: &mut R,
                 header: ::der::Header,
             ) -> ::der::Result<Self> {
                 Ok(Self(<$inner as ::der::DecodeValue>::decode_value(

--- a/x509/tests/pkix_extensions.rs
+++ b/x509/tests/pkix_extensions.rs
@@ -1030,10 +1030,11 @@ fn decode_idp() {
     let idp =
         IssuingDistributionPoint::from_der(&hex!("3067A060A05EA45C305A310B3009060355040613025553311F301D060355040A131654657374204365727469666963617465732032303137311C301A060355040B13136F6E6C79536F6D65526561736F6E7320434133310C300A0603550403130343524C8304079F80"));
     let err = idp.err().unwrap();
+    assert_eq!(err.position().unwrap(), 103u8.into());
     assert_eq!(
         ErrorKind::Incomplete {
-            expected_len: 104u8.into(),
-            actual_len: 103u8.into()
+            expected_len: 106u8.into(),
+            actual_len: 105u8.into()
         },
         err.kind()
     );


### PR DESCRIPTION
Implements decoding generically in terms of the `Reader` trait, similar to what #611 did for encoding.

This approach can enable 1-pass on-the-fly PEM decoding for `DecodeOwned` types (although that will require some additional work beyond what's in this PR).