### PR TITLE
der: move `PemWriter` to its own module

### DIFF
--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -396,7 +396,7 @@ pub use const_oid as oid;
 #[cfg(feature = "pem")]
 #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 pub use {
-    crate::{decode::DecodePem, encode::EncodePem, writer::PemWriter},
+    crate::{decode::DecodePem, encode::EncodePem, writer::pem::PemWriter},
     pem_rfc7468 as pem,
 };
 

--- a/der/src/writer.rs
+++ b/der/src/writer.rs
@@ -1,9 +1,9 @@
 //! Writer trait.
 
-use crate::Result;
-
 #[cfg(feature = "pem")]
-use crate::pem;
+pub(crate) mod pem;
+
+use crate::Result;
 
 #[cfg(feature = "std")]
 use std::io;
@@ -16,48 +16,6 @@ pub trait Writer {
     /// Write a single byte.
     fn write_byte(&mut self, byte: u8) -> Result<()> {
         self.write(&[byte])
-    }
-}
-
-/// `Writer` type which outputs PEM-encoded data.
-#[cfg(feature = "pem")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-pub struct PemWriter<'w>(pem::Encoder<'static, 'w>);
-
-#[cfg(feature = "pem")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-impl<'w> PemWriter<'w> {
-    /// Create a new PEM writer which outputs into the provided buffer.
-    ///
-    /// Uses the default 64-character line wrapping.
-    pub fn new(
-        type_label: &'static str,
-        line_ending: pem::LineEnding,
-        out: &'w mut [u8],
-    ) -> Result<Self> {
-        Ok(Self(pem::Encoder::new(type_label, line_ending, out)?))
-    }
-
-    /// Get the PEM label which will be used in the encapsulation boundaries
-    /// for this document.
-    pub fn type_label(&self) -> &'static str {
-        self.0.type_label()
-    }
-
-    /// Finish encoding PEM, writing the post-encapsulation boundary.
-    ///
-    /// On success, returns the total number of bytes written to the output buffer.
-    pub fn finish(self) -> Result<usize> {
-        Ok(self.0.finish()?)
-    }
-}
-
-#[cfg(feature = "pem")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-impl Writer for PemWriter<'_> {
-    fn write(&mut self, slice: &[u8]) -> Result<()> {
-        self.0.encode(slice)?;
-        Ok(())
     }
 }
 

--- a/der/src/writer/pem.rs
+++ b/der/src/writer/pem.rs
@@ -1,0 +1,42 @@
+//! Streaming PEM writer.
+
+use super::Writer;
+use crate::Result;
+use pem_rfc7468::{Encoder, LineEnding};
+
+/// `Writer` type which outputs PEM-encoded data.
+#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
+pub struct PemWriter<'w>(Encoder<'static, 'w>);
+
+impl<'w> PemWriter<'w> {
+    /// Create a new PEM writer which outputs into the provided buffer.
+    ///
+    /// Uses the default 64-character line wrapping.
+    pub fn new(
+        type_label: &'static str,
+        line_ending: LineEnding,
+        out: &'w mut [u8],
+    ) -> Result<Self> {
+        Ok(Self(Encoder::new(type_label, line_ending, out)?))
+    }
+
+    /// Get the PEM label which will be used in the encapsulation boundaries
+    /// for this document.
+    pub fn type_label(&self) -> &'static str {
+        self.0.type_label()
+    }
+
+    /// Finish encoding PEM, writing the post-encapsulation boundary.
+    ///
+    /// On success, returns the total number of bytes written to the output buffer.
+    pub fn finish(self) -> Result<usize> {
+        Ok(self.0.finish()?)
+    }
+}
+
+impl Writer for PemWriter<'_> {
+    fn write(&mut self, slice: &[u8]) -> Result<()> {
+        self.0.encode(slice)?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
Internal refactor in preparation for adding `PemReader`.