### PR TITLE
der: add `*Ref` to reference types in `asn1` module

### DIFF
--- a/der/derive/src/asn1_type.rs
+++ b/der/derive/src/asn1_type.rs
@@ -47,13 +47,13 @@ impl Asn1Type {
     /// Get a `der::Decoder` object for a particular ASN.1 type
     pub fn decoder(self) -> TokenStream {
         match self {
-            Asn1Type::BitString => quote!(::der::asn1::BitString::decode(reader)?),
-            Asn1Type::Ia5String => quote!(::der::asn1::Ia5String::decode(reader)?),
+            Asn1Type::BitString => quote!(::der::asn1::BitStringRef::decode(reader)?),
+            Asn1Type::Ia5String => quote!(::der::asn1::Ia5StringRef::decode(reader)?),
             Asn1Type::GeneralizedTime => quote!(::der::asn1::GeneralizedTime::decode(reader)?),
-            Asn1Type::OctetString => quote!(::der::asn1::OctetString::decode(reader)?),
-            Asn1Type::PrintableString => quote!(::der::asn1::PrintableString::decode(reader)?),
+            Asn1Type::OctetString => quote!(::der::asn1::OctetStringRef::decode(reader)?),
+            Asn1Type::PrintableString => quote!(::der::asn1::PrintableStringRef::decode(reader)?),
             Asn1Type::UtcTime => quote!(::der::asn1::UtcTime::decode(reader)?),
-            Asn1Type::Utf8String => quote!(::der::asn1::Utf8String::decode(reader)?),
+            Asn1Type::Utf8String => quote!(::der::asn1::Utf8StringRef::decode(reader)?),
         }
     }
 
@@ -74,13 +74,13 @@ impl Asn1Type {
     /// Get a `der::Encoder` object for a particular ASN.1 type
     pub fn type_path(self) -> TokenStream {
         match self {
-            Asn1Type::BitString => quote!(::der::asn1::BitString),
-            Asn1Type::Ia5String => quote!(::der::asn1::Ia5String),
+            Asn1Type::BitString => quote!(::der::asn1::BitStringRef),
+            Asn1Type::Ia5String => quote!(::der::asn1::Ia5StringRef),
             Asn1Type::GeneralizedTime => quote!(::der::asn1::GeneralizedTime),
-            Asn1Type::OctetString => quote!(::der::asn1::OctetString),
-            Asn1Type::PrintableString => quote!(::der::asn1::PrintableString),
+            Asn1Type::OctetString => quote!(::der::asn1::OctetStringRef),
+            Asn1Type::PrintableString => quote!(::der::asn1::PrintableStringRef),
             Asn1Type::UtcTime => quote!(::der::asn1::UtcTime),
-            Asn1Type::Utf8String => quote!(::der::asn1::Utf8String),
+            Asn1Type::Utf8String => quote!(::der::asn1::Utf8StringRef),
         }
     }
 }

--- a/der/derive/src/choice/variant.rs
+++ b/der/derive/src/choice/variant.rs
@@ -214,7 +214,7 @@ mod tests {
             variant.to_decode_tokens().to_string(),
             quote! {
                 ::der::Tag::Utf8String => Ok(Self::ExampleVariant(
-                    ::der::asn1::Utf8String::decode(reader)?
+                    ::der::asn1::Utf8StringRef::decode(reader)?
                     .try_into()?
                 )),
             }
@@ -224,7 +224,7 @@ mod tests {
         assert_eq!(
             variant.to_encode_value_tokens().to_string(),
             quote! {
-                Self::ExampleVariant(variant) => ::der::asn1::Utf8String::new(variant)?.encode_value(encoder),
+                Self::ExampleVariant(variant) => ::der::asn1::Utf8StringRef::new(variant)?.encode_value(encoder),
             }
             .to_string()
         );

--- a/der/src/asn1.rs
+++ b/der/src/asn1.rs
@@ -24,26 +24,26 @@ mod utc_time;
 mod utf8_string;
 
 pub use self::{
-    any::Any,
-    bit_string::{BitString, BitStringIter},
+    any::AnyRef,
+    bit_string::{BitStringIter, BitStringRef},
     choice::Choice,
     context_specific::{ContextSpecific, ContextSpecificRef},
     generalized_time::GeneralizedTime,
-    ia5_string::Ia5String,
-    integer::bigint::UIntBytes,
+    ia5_string::Ia5StringRef,
+    integer::bigint::UIntRef,
     null::Null,
-    octet_string::OctetString,
-    printable_string::PrintableString,
+    octet_string::OctetStringRef,
+    printable_string::PrintableStringRef,
     sequence::{Sequence, SequenceRef},
     sequence_of::{SequenceOf, SequenceOfIter},
     set_of::{SetOf, SetOfIter},
     utc_time::UtcTime,
-    utf8_string::Utf8String,
+    utf8_string::Utf8StringRef,
 };
 
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-pub use self::{bit_string::BitStringOwned, set_of::SetOfVec};
+pub use self::{bit_string::BitString, set_of::SetOfVec};
 
 #[cfg(feature = "oid")]
 #[cfg_attr(docsrs, doc(cfg(feature = "oid")))]

--- a/der/src/asn1/boolean.rs
+++ b/der/src/asn1/boolean.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `BOOLEAN` support.
 
 use crate::{
-    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, EncodeValue, Error, ErrorKind, FixedTag,
-    Header, Length, Reader, Result, Tag, Writer,
+    asn1::AnyRef, ord::OrdIsValueOrd, ByteSlice, DecodeValue, EncodeValue, Error, ErrorKind,
+    FixedTag, Header, Length, Reader, Result, Tag, Writer,
 };
 
 /// Byte used to encode `true` in ASN.1 DER. From X.690 Section 11.1:
@@ -44,21 +44,21 @@ impl FixedTag for bool {
 
 impl OrdIsValueOrd for bool {}
 
-impl From<bool> for Any<'static> {
-    fn from(value: bool) -> Any<'static> {
+impl From<bool> for AnyRef<'static> {
+    fn from(value: bool) -> AnyRef<'static> {
         let value = ByteSlice::from(match value {
             false => &[FALSE_OCTET],
             true => &[TRUE_OCTET],
         });
 
-        Any::from_tag_and_value(Tag::Boolean, value)
+        AnyRef::from_tag_and_value(Tag::Boolean, value)
     }
 }
 
-impl TryFrom<Any<'_>> for bool {
+impl TryFrom<AnyRef<'_>> for bool {
     type Error = Error;
 
-    fn try_from(any: Any<'_>) -> Result<bool> {
+    fn try_from(any: AnyRef<'_>) -> Result<bool> {
         any.try_into()
     }
 }

--- a/der/src/asn1/context_specific.rs
+++ b/der/src/asn1/context_specific.rs
@@ -1,7 +1,7 @@
 //! Context-specific field.
 
 use crate::{
-    asn1::Any, Choice, Decode, DecodeValue, DerOrd, Encode, EncodeValue, EncodeValueRef, Error,
+    asn1::AnyRef, Choice, Decode, DecodeValue, DerOrd, Encode, EncodeValue, EncodeValueRef, Error,
     Header, Length, Reader, Result, Tag, TagMode, TagNumber, Tagged, ValueOrd, Writer,
 };
 use core::cmp::Ordering;
@@ -96,7 +96,7 @@ impl<T> ContextSpecific<T> {
             } else if tag.number() == tag_number {
                 return Some(f(reader)).transpose();
             } else {
-                Any::decode(reader)?;
+                AnyRef::decode(reader)?;
             }
         }
 
@@ -170,13 +170,13 @@ where
     }
 }
 
-impl<'a, T> TryFrom<Any<'a>> for ContextSpecific<T>
+impl<'a, T> TryFrom<AnyRef<'a>> for ContextSpecific<T>
 where
     T: Decode<'a>,
 {
     type Error = Error;
 
-    fn try_from(any: Any<'a>) -> Result<ContextSpecific<T>> {
+    fn try_from(any: AnyRef<'a>) -> Result<ContextSpecific<T>> {
         match any.tag() {
             Tag::ContextSpecific {
                 number,
@@ -256,7 +256,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::ContextSpecific;
-    use crate::{asn1::BitString, Decode, Decoder, Encode, TagMode, TagNumber};
+    use crate::{asn1::BitStringRef, Decode, Decoder, Encode, TagMode, TagNumber};
     use hex_literal::hex;
 
     // Public key data from `pkcs8` crate's `ed25519-pkcs8-v2.der`
@@ -265,11 +265,11 @@ mod tests {
 
     #[test]
     fn round_trip() {
-        let field = ContextSpecific::<BitString<'_>>::from_der(EXAMPLE_BYTES).unwrap();
+        let field = ContextSpecific::<BitStringRef<'_>>::from_der(EXAMPLE_BYTES).unwrap();
         assert_eq!(field.tag_number.value(), 1);
         assert_eq!(
             field.value,
-            BitString::from_bytes(&EXAMPLE_BYTES[5..]).unwrap()
+            BitStringRef::from_bytes(&EXAMPLE_BYTES[5..]).unwrap()
         );
 
         let mut buf = [0u8; 128];
@@ -320,7 +320,7 @@ mod tests {
         let tag_number = TagNumber::new(1);
 
         let mut decoder = Decoder::new(&context_specific_implicit_bytes).unwrap();
-        let field = ContextSpecific::<BitString<'_>>::decode_implicit(&mut decoder, tag_number)
+        let field = ContextSpecific::<BitStringRef<'_>>::decode_implicit(&mut decoder, tag_number)
             .unwrap()
             .unwrap();
 

--- a/der/src/asn1/generalized_time.rs
+++ b/der/src/asn1/generalized_time.rs
@@ -1,7 +1,7 @@
 //! ASN.1 `GeneralizedTime` support.
 
 use crate::{
-    asn1::Any,
+    asn1::AnyRef,
     datetime::{self, DateTime},
     ord::OrdIsValueOrd,
     ByteSlice, DecodeValue, EncodeValue, Error, ErrorKind, FixedTag, Header, Length, Reader,
@@ -155,10 +155,10 @@ impl From<&DateTime> for GeneralizedTime {
     }
 }
 
-impl TryFrom<Any<'_>> for GeneralizedTime {
+impl TryFrom<AnyRef<'_>> for GeneralizedTime {
     type Error = Error;
 
-    fn try_from(any: Any<'_>) -> Result<GeneralizedTime> {
+    fn try_from(any: AnyRef<'_>) -> Result<GeneralizedTime> {
         any.decode_into()
     }
 }
@@ -243,10 +243,10 @@ impl TryFrom<&SystemTime> for GeneralizedTime {
 
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl<'a> TryFrom<Any<'a>> for SystemTime {
+impl<'a> TryFrom<AnyRef<'a>> for SystemTime {
     type Error = Error;
 
-    fn try_from(any: Any<'a>) -> Result<SystemTime> {
+    fn try_from(any: AnyRef<'a>) -> Result<SystemTime> {
         GeneralizedTime::try_from(any).map(|s| s.to_system_time())
     }
 }

--- a/der/src/asn1/ia5_string.rs
+++ b/der/src/asn1/ia5_string.rs
@@ -1,7 +1,7 @@
 //! ASN.1 `IA5String` support.
 
 use crate::{
-    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, EncodeValue, Error, FixedTag, Header,
+    asn1::AnyRef, ord::OrdIsValueOrd, ByteSlice, DecodeValue, EncodeValue, Error, FixedTag, Header,
     Length, Reader, Result, StrSlice, Tag, Writer,
 };
 use core::{fmt, str};
@@ -13,16 +13,18 @@ use core::{fmt, str};
 /// technically known as the International Reference Alphabet or IRA as
 /// specified in the ITU-T's T.50 recommendation).
 ///
-/// For UTF-8, use [`Utf8String`][`crate::asn1::Utf8String`].
+/// For UTF-8, use [`Utf8StringRef`][`crate::asn1::Utf8StringRef`].
+///
+/// This is a zero-copy reference type which borrows from the input data.
 ///
 /// [International Alphabet No. 5 (IA5)]: https://en.wikipedia.org/wiki/T.50_%28standard%29
 #[derive(Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
-pub struct Ia5String<'a> {
+pub struct Ia5StringRef<'a> {
     /// Inner value
     inner: StrSlice<'a>,
 }
 
-impl<'a> Ia5String<'a> {
+impl<'a> Ia5StringRef<'a> {
     /// Create a new `IA5String`.
     pub fn new<T>(input: &'a T) -> Result<Self>
     where
@@ -61,25 +63,25 @@ impl<'a> Ia5String<'a> {
     }
 }
 
-impl AsRef<str> for Ia5String<'_> {
+impl AsRef<str> for Ia5StringRef<'_> {
     fn as_ref(&self) -> &str {
         self.as_str()
     }
 }
 
-impl AsRef<[u8]> for Ia5String<'_> {
+impl AsRef<[u8]> for Ia5StringRef<'_> {
     fn as_ref(&self) -> &[u8] {
         self.as_bytes()
     }
 }
 
-impl<'a> DecodeValue<'a> for Ia5String<'a> {
+impl<'a> DecodeValue<'a> for Ia5StringRef<'a> {
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         Self::new(ByteSlice::decode_value(reader, header)?.as_slice())
     }
 }
 
-impl EncodeValue for Ia5String<'_> {
+impl EncodeValue for Ia5StringRef<'_> {
     fn value_len(&self) -> Result<Length> {
         self.inner.value_len()
     }
@@ -89,45 +91,45 @@ impl EncodeValue for Ia5String<'_> {
     }
 }
 
-impl<'a> FixedTag for Ia5String<'a> {
+impl<'a> FixedTag for Ia5StringRef<'a> {
     const TAG: Tag = Tag::Ia5String;
 }
 
-impl OrdIsValueOrd for Ia5String<'_> {}
+impl OrdIsValueOrd for Ia5StringRef<'_> {}
 
-impl<'a> From<&Ia5String<'a>> for Ia5String<'a> {
-    fn from(value: &Ia5String<'a>) -> Ia5String<'a> {
+impl<'a> From<&Ia5StringRef<'a>> for Ia5StringRef<'a> {
+    fn from(value: &Ia5StringRef<'a>) -> Ia5StringRef<'a> {
         *value
     }
 }
 
-impl<'a> TryFrom<Any<'a>> for Ia5String<'a> {
+impl<'a> TryFrom<AnyRef<'a>> for Ia5StringRef<'a> {
     type Error = Error;
 
-    fn try_from(any: Any<'a>) -> Result<Ia5String<'a>> {
+    fn try_from(any: AnyRef<'a>) -> Result<Ia5StringRef<'a>> {
         any.decode_into()
     }
 }
 
-impl<'a> From<Ia5String<'a>> for Any<'a> {
-    fn from(printable_string: Ia5String<'a>) -> Any<'a> {
-        Any::from_tag_and_value(Tag::Ia5String, printable_string.inner.into())
+impl<'a> From<Ia5StringRef<'a>> for AnyRef<'a> {
+    fn from(printable_string: Ia5StringRef<'a>) -> AnyRef<'a> {
+        AnyRef::from_tag_and_value(Tag::Ia5String, printable_string.inner.into())
     }
 }
 
-impl<'a> From<Ia5String<'a>> for &'a [u8] {
-    fn from(printable_string: Ia5String<'a>) -> &'a [u8] {
+impl<'a> From<Ia5StringRef<'a>> for &'a [u8] {
+    fn from(printable_string: Ia5StringRef<'a>) -> &'a [u8] {
         printable_string.as_bytes()
     }
 }
 
-impl<'a> fmt::Display for Ia5String<'a> {
+impl<'a> fmt::Display for Ia5StringRef<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
     }
 }
 
-impl<'a> fmt::Debug for Ia5String<'a> {
+impl<'a> fmt::Debug for Ia5StringRef<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Ia5String({:?})", self.as_str())
     }
@@ -135,14 +137,14 @@ impl<'a> fmt::Debug for Ia5String<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::Ia5String;
+    use super::Ia5StringRef;
     use crate::Decode;
     use hex_literal::hex;
 
     #[test]
     fn parse_bytes() {
         let example_bytes = hex!("16 0d 74 65 73 74 31 40 72 73 61 2e 63 6f 6d");
-        let printable_string = Ia5String::from_der(&example_bytes).unwrap();
+        let printable_string = Ia5StringRef::from_der(&example_bytes).unwrap();
         assert_eq!(printable_string.as_str(), "test1@rsa.com");
     }
 }

--- a/der/src/asn1/integer.rs
+++ b/der/src/asn1/integer.rs
@@ -5,7 +5,7 @@ pub(super) mod int;
 pub(super) mod uint;
 
 use crate::{
-    asn1::Any, ByteSlice, DecodeValue, EncodeValue, Encoder, Error, FixedTag, Header, Length,
+    asn1::AnyRef, ByteSlice, DecodeValue, EncodeValue, Encoder, Error, FixedTag, Header, Length,
     Reader, Result, Tag, ValueOrd, Writer,
 };
 use core::{cmp::Ordering, mem};
@@ -60,10 +60,10 @@ macro_rules! impl_int_encoding {
                 }
             }
 
-            impl TryFrom<Any<'_>> for $int {
+            impl TryFrom<AnyRef<'_>> for $int {
                 type Error = Error;
 
-                fn try_from(any: Any<'_>) -> Result<Self> {
+                fn try_from(any: AnyRef<'_>) -> Result<Self> {
                     any.decode_into()
                 }
             }
@@ -108,10 +108,10 @@ macro_rules! impl_uint_encoding {
                 }
             }
 
-            impl TryFrom<Any<'_>> for $uint {
+            impl TryFrom<AnyRef<'_>> for $uint {
                 type Error = Error;
 
-                fn try_from(any: Any<'_>) -> Result<Self> {
+                fn try_from(any: AnyRef<'_>) -> Result<Self> {
                     any.decode_into()
                 }
             }

--- a/der/src/asn1/null.rs
+++ b/der/src/asn1/null.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `NULL` support.
 
 use crate::{
-    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, EncodeValue, Error, ErrorKind, FixedTag,
-    Header, Length, Reader, Result, Tag, Writer,
+    asn1::AnyRef, ord::OrdIsValueOrd, ByteSlice, DecodeValue, EncodeValue, Error, ErrorKind,
+    FixedTag, Header, Length, Reader, Result, Tag, Writer,
 };
 
 /// ASN.1 `NULL` type.
@@ -35,30 +35,30 @@ impl FixedTag for Null {
 
 impl OrdIsValueOrd for Null {}
 
-impl<'a> From<Null> for Any<'a> {
-    fn from(_: Null) -> Any<'a> {
-        Any::from_tag_and_value(Tag::Null, ByteSlice::default())
+impl<'a> From<Null> for AnyRef<'a> {
+    fn from(_: Null) -> AnyRef<'a> {
+        AnyRef::from_tag_and_value(Tag::Null, ByteSlice::default())
     }
 }
 
-impl TryFrom<Any<'_>> for Null {
+impl TryFrom<AnyRef<'_>> for Null {
     type Error = Error;
 
-    fn try_from(any: Any<'_>) -> Result<Null> {
+    fn try_from(any: AnyRef<'_>) -> Result<Null> {
         any.decode_into()
     }
 }
 
-impl TryFrom<Any<'_>> for () {
+impl TryFrom<AnyRef<'_>> for () {
     type Error = Error;
 
-    fn try_from(any: Any<'_>) -> Result<()> {
+    fn try_from(any: AnyRef<'_>) -> Result<()> {
         Null::try_from(any).map(|_| ())
     }
 }
 
-impl<'a> From<()> for Any<'a> {
-    fn from(_: ()) -> Any<'a> {
+impl<'a> From<()> for AnyRef<'a> {
+    fn from(_: ()) -> AnyRef<'a> {
         Null.into()
     }
 }

--- a/der/src/asn1/octet_string.rs
+++ b/der/src/asn1/octet_string.rs
@@ -1,18 +1,22 @@
 //! ASN.1 `OCTET STRING` support.
 
 use crate::{
-    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, EncodeValue, Error, ErrorKind, FixedTag,
-    Header, Length, Reader, Result, Tag, Writer,
+    asn1::AnyRef, ord::OrdIsValueOrd, ByteSlice, DecodeValue, EncodeValue, Error, ErrorKind,
+    FixedTag, Header, Length, Reader, Result, Tag, Writer,
 };
 
 /// ASN.1 `OCTET STRING` type.
+///
+/// Octet strings represent contiguous sequences of octets, a.k.a. bytes.
+///
+/// This is a zero-copy reference type which borrows from the input data.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
-pub struct OctetString<'a> {
+pub struct OctetStringRef<'a> {
     /// Inner value
     inner: ByteSlice<'a>,
 }
 
-impl<'a> OctetString<'a> {
+impl<'a> OctetStringRef<'a> {
     /// Create a new ASN.1 `OCTET STRING` from a byte slice.
     pub fn new(slice: &'a [u8]) -> Result<Self> {
         ByteSlice::new(slice)
@@ -36,20 +40,20 @@ impl<'a> OctetString<'a> {
     }
 }
 
-impl AsRef<[u8]> for OctetString<'_> {
+impl AsRef<[u8]> for OctetStringRef<'_> {
     fn as_ref(&self) -> &[u8] {
         self.as_bytes()
     }
 }
 
-impl<'a> DecodeValue<'a> for OctetString<'a> {
+impl<'a> DecodeValue<'a> for OctetStringRef<'a> {
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         let inner = ByteSlice::decode_value(reader, header)?;
         Ok(Self { inner })
     }
 }
 
-impl EncodeValue for OctetString<'_> {
+impl EncodeValue for OctetStringRef<'_> {
     fn value_len(&self) -> Result<Length> {
         self.inner.value_len()
     }
@@ -59,34 +63,34 @@ impl EncodeValue for OctetString<'_> {
     }
 }
 
-impl FixedTag for OctetString<'_> {
+impl FixedTag for OctetStringRef<'_> {
     const TAG: Tag = Tag::OctetString;
 }
 
-impl OrdIsValueOrd for OctetString<'_> {}
+impl OrdIsValueOrd for OctetStringRef<'_> {}
 
-impl<'a> From<&OctetString<'a>> for OctetString<'a> {
-    fn from(value: &OctetString<'a>) -> OctetString<'a> {
+impl<'a> From<&OctetStringRef<'a>> for OctetStringRef<'a> {
+    fn from(value: &OctetStringRef<'a>) -> OctetStringRef<'a> {
         *value
     }
 }
 
-impl<'a> TryFrom<Any<'a>> for OctetString<'a> {
+impl<'a> TryFrom<AnyRef<'a>> for OctetStringRef<'a> {
     type Error = Error;
 
-    fn try_from(any: Any<'a>) -> Result<OctetString<'a>> {
+    fn try_from(any: AnyRef<'a>) -> Result<OctetStringRef<'a>> {
         any.decode_into()
     }
 }
 
-impl<'a> From<OctetString<'a>> for Any<'a> {
-    fn from(octet_string: OctetString<'a>) -> Any<'a> {
-        Any::from_tag_and_value(Tag::OctetString, octet_string.inner)
+impl<'a> From<OctetStringRef<'a>> for AnyRef<'a> {
+    fn from(octet_string: OctetStringRef<'a>) -> AnyRef<'a> {
+        AnyRef::from_tag_and_value(Tag::OctetString, octet_string.inner)
     }
 }
 
-impl<'a> From<OctetString<'a>> for &'a [u8] {
-    fn from(octet_string: OctetString<'a>) -> &'a [u8] {
+impl<'a> From<OctetStringRef<'a>> for &'a [u8] {
+    fn from(octet_string: OctetStringRef<'a>) -> &'a [u8] {
         octet_string.as_bytes()
     }
 }

--- a/der/src/asn1/oid.rs
+++ b/der/src/asn1/oid.rs
@@ -1,7 +1,7 @@
 //! ASN.1 `OBJECT IDENTIFIER`
 
 use crate::{
-    asn1::Any, ord::OrdIsValueOrd, DecodeValue, EncodeValue, Error, FixedTag, Header, Length,
+    asn1::AnyRef, ord::OrdIsValueOrd, DecodeValue, EncodeValue, Error, FixedTag, Header, Length,
     Reader, Result, Tag, Tagged, Writer,
 };
 use const_oid::ObjectIdentifier;
@@ -35,8 +35,8 @@ impl FixedTag for ObjectIdentifier {
 
 impl OrdIsValueOrd for ObjectIdentifier {}
 
-impl<'a> From<&'a ObjectIdentifier> for Any<'a> {
-    fn from(oid: &'a ObjectIdentifier) -> Any<'a> {
+impl<'a> From<&'a ObjectIdentifier> for AnyRef<'a> {
+    fn from(oid: &'a ObjectIdentifier) -> AnyRef<'a> {
         // Note: ensuring an infallible conversion is possible relies on the
         // invariant that `const_oid::MAX_LEN <= Length::max()`.
         //
@@ -46,14 +46,14 @@ impl<'a> From<&'a ObjectIdentifier> for Any<'a> {
             .try_into()
             .expect("OID length invariant violated");
 
-        Any::from_tag_and_value(Tag::ObjectIdentifier, value)
+        AnyRef::from_tag_and_value(Tag::ObjectIdentifier, value)
     }
 }
 
-impl TryFrom<Any<'_>> for ObjectIdentifier {
+impl TryFrom<AnyRef<'_>> for ObjectIdentifier {
     type Error = Error;
 
-    fn try_from(any: Any<'_>) -> Result<ObjectIdentifier> {
+    fn try_from(any: AnyRef<'_>) -> Result<ObjectIdentifier> {
         any.tag().assert_eq(Tag::ObjectIdentifier)?;
         Ok(ObjectIdentifier::from_bytes(any.value())?)
     }

--- a/der/src/asn1/sequence.rs
+++ b/der/src/asn1/sequence.rs
@@ -54,6 +54,8 @@ where
 
 /// The [`SequenceRef`] type provides raw access to the octets which comprise a
 /// DER-encoded `SEQUENCE`.
+///
+/// This is a zero-copy reference type which borrows from the input data.
 pub struct SequenceRef<'a> {
     /// Body of the `SEQUENCE`.
     body: ByteSlice<'a>,

--- a/der/src/asn1/utc_time.rs
+++ b/der/src/asn1/utc_time.rs
@@ -1,7 +1,7 @@
 //! ASN.1 `UTCTime` support.
 
 use crate::{
-    asn1::Any,
+    asn1::AnyRef,
     datetime::{self, DateTime},
     ord::OrdIsValueOrd,
     ByteSlice, DecodeValue, EncodeValue, Error, ErrorKind, FixedTag, Header, Length, Reader,
@@ -180,10 +180,10 @@ impl From<UtcTime> for SystemTime {
     }
 }
 
-impl TryFrom<Any<'_>> for UtcTime {
+impl TryFrom<AnyRef<'_>> for UtcTime {
     type Error = Error;
 
-    fn try_from(any: Any<'_>) -> Result<UtcTime> {
+    fn try_from(any: AnyRef<'_>) -> Result<UtcTime> {
         any.decode_into()
     }
 }

--- a/der/src/asn1/utf8_string.rs
+++ b/der/src/asn1/utf8_string.rs
@@ -1,7 +1,7 @@
 //! ASN.1 `UTF8String` support.
 
 use crate::{
-    asn1::Any, ord::OrdIsValueOrd, ByteSlice, DecodeValue, EncodeValue, Error, FixedTag, Header,
+    asn1::AnyRef, ord::OrdIsValueOrd, ByteSlice, DecodeValue, EncodeValue, Error, FixedTag, Header,
     Length, Reader, Result, StrSlice, Tag, Writer,
 };
 use core::{fmt, str};
@@ -15,19 +15,21 @@ use alloc::{borrow::ToOwned, string::String};
 ///
 /// Note that the [`Decode`][`crate::Decode`] and [`Encode`][`crate::Encode`]
 /// traits are impl'd for Rust's [`str`][`prim@str`] primitive, which
-/// decodes/encodes as a [`Utf8String`].
+/// decodes/encodes as a [`Utf8StringRef`].
 ///
 /// You are free to use [`str`][`prim@str`] instead of this type, however it's
 /// still provided for explicitness in cases where it might be ambiguous with
 /// other ASN.1 string encodings such as
-/// [`PrintableString`][`crate::asn1::PrintableString`].
+/// [`PrintableStringRef`][`crate::asn1::PrintableStringRef`].
+///
+/// This is a zero-copy reference type which borrows from the input data.
 #[derive(Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
-pub struct Utf8String<'a> {
+pub struct Utf8StringRef<'a> {
     /// Inner value
     inner: StrSlice<'a>,
 }
 
-impl<'a> Utf8String<'a> {
+impl<'a> Utf8StringRef<'a> {
     /// Create a new ASN.1 `UTF8String`.
     pub fn new<T>(input: &'a T) -> Result<Self>
     where
@@ -57,25 +59,25 @@ impl<'a> Utf8String<'a> {
     }
 }
 
-impl AsRef<str> for Utf8String<'_> {
+impl AsRef<str> for Utf8StringRef<'_> {
     fn as_ref(&self) -> &str {
         self.as_str()
     }
 }
 
-impl AsRef<[u8]> for Utf8String<'_> {
+impl AsRef<[u8]> for Utf8StringRef<'_> {
     fn as_ref(&self) -> &[u8] {
         self.as_bytes()
     }
 }
 
-impl<'a> DecodeValue<'a> for Utf8String<'a> {
+impl<'a> DecodeValue<'a> for Utf8StringRef<'a> {
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         Self::new(ByteSlice::decode_value(reader, header)?.as_slice())
     }
 }
 
-impl EncodeValue for Utf8String<'_> {
+impl EncodeValue for Utf8StringRef<'_> {
     fn value_len(&self) -> Result<Length> {
         self.inner.value_len()
     }
@@ -85,65 +87,65 @@ impl EncodeValue for Utf8String<'_> {
     }
 }
 
-impl FixedTag for Utf8String<'_> {
+impl FixedTag for Utf8StringRef<'_> {
     const TAG: Tag = Tag::Utf8String;
 }
 
-impl OrdIsValueOrd for Utf8String<'_> {}
+impl OrdIsValueOrd for Utf8StringRef<'_> {}
 
-impl<'a> From<&Utf8String<'a>> for Utf8String<'a> {
-    fn from(value: &Utf8String<'a>) -> Utf8String<'a> {
+impl<'a> From<&Utf8StringRef<'a>> for Utf8StringRef<'a> {
+    fn from(value: &Utf8StringRef<'a>) -> Utf8StringRef<'a> {
         *value
     }
 }
 
-impl<'a> TryFrom<Any<'a>> for Utf8String<'a> {
+impl<'a> TryFrom<AnyRef<'a>> for Utf8StringRef<'a> {
     type Error = Error;
 
-    fn try_from(any: Any<'a>) -> Result<Utf8String<'a>> {
+    fn try_from(any: AnyRef<'a>) -> Result<Utf8StringRef<'a>> {
         any.decode_into()
     }
 }
 
-impl<'a> From<Utf8String<'a>> for Any<'a> {
-    fn from(printable_string: Utf8String<'a>) -> Any<'a> {
-        Any::from_tag_and_value(Tag::Utf8String, printable_string.inner.into())
+impl<'a> From<Utf8StringRef<'a>> for AnyRef<'a> {
+    fn from(printable_string: Utf8StringRef<'a>) -> AnyRef<'a> {
+        AnyRef::from_tag_and_value(Tag::Utf8String, printable_string.inner.into())
     }
 }
 
-impl<'a> From<Utf8String<'a>> for &'a [u8] {
-    fn from(utf8_string: Utf8String<'a>) -> &'a [u8] {
+impl<'a> From<Utf8StringRef<'a>> for &'a [u8] {
+    fn from(utf8_string: Utf8StringRef<'a>) -> &'a [u8] {
         utf8_string.as_bytes()
     }
 }
 
-impl<'a> fmt::Display for Utf8String<'a> {
+impl<'a> fmt::Display for Utf8StringRef<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
     }
 }
 
-impl<'a> fmt::Debug for Utf8String<'a> {
+impl<'a> fmt::Debug for Utf8StringRef<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Utf8String({:?})", self.as_str())
     }
 }
 
-impl<'a> TryFrom<Any<'a>> for &'a str {
+impl<'a> TryFrom<AnyRef<'a>> for &'a str {
     type Error = Error;
 
-    fn try_from(any: Any<'a>) -> Result<&'a str> {
-        Utf8String::try_from(any).map(|s| s.as_str())
+    fn try_from(any: AnyRef<'a>) -> Result<&'a str> {
+        Utf8StringRef::try_from(any).map(|s| s.as_str())
     }
 }
 
 impl EncodeValue for str {
     fn value_len(&self) -> Result<Length> {
-        Utf8String::new(self)?.value_len()
+        Utf8StringRef::new(self)?.value_len()
     }
 
     fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
-        Utf8String::new(self)?.encode_value(writer)
+        Utf8StringRef::new(self)?.encode_value(writer)
     }
 }
 
@@ -155,19 +157,19 @@ impl OrdIsValueOrd for str {}
 
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-impl<'a> From<Utf8String<'a>> for String {
-    fn from(s: Utf8String<'a>) -> String {
+impl<'a> From<Utf8StringRef<'a>> for String {
+    fn from(s: Utf8StringRef<'a>) -> String {
         s.as_str().to_owned()
     }
 }
 
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-impl<'a> TryFrom<Any<'a>> for String {
+impl<'a> TryFrom<AnyRef<'a>> for String {
     type Error = Error;
 
-    fn try_from(any: Any<'a>) -> Result<String> {
-        Utf8String::try_from(any).map(|s| s.as_str().to_owned())
+    fn try_from(any: AnyRef<'a>) -> Result<String> {
+        Utf8StringRef::try_from(any).map(|s| s.as_str().to_owned())
     }
 }
 
@@ -175,11 +177,11 @@ impl<'a> TryFrom<Any<'a>> for String {
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl EncodeValue for String {
     fn value_len(&self) -> Result<Length> {
-        Utf8String::new(self)?.value_len()
+        Utf8StringRef::new(self)?.value_len()
     }
 
     fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
-        Utf8String::new(self)?.encode_value(writer)
+        Utf8StringRef::new(self)?.encode_value(writer)
     }
 }
 
@@ -195,7 +197,7 @@ impl OrdIsValueOrd for String {}
 
 #[cfg(test)]
 mod tests {
-    use super::Utf8String;
+    use super::Utf8StringRef;
     use crate::Decode;
 
     #[test]
@@ -204,14 +206,14 @@ mod tests {
             0x0c, 0x0b, 0x54, 0x65, 0x73, 0x74, 0x20, 0x55, 0x73, 0x65, 0x72, 0x20, 0x31,
         ];
 
-        let utf8_string = Utf8String::from_der(example_bytes).unwrap();
+        let utf8_string = Utf8StringRef::from_der(example_bytes).unwrap();
         assert_eq!(utf8_string.as_str(), "Test User 1");
     }
 
     #[test]
     fn parse_utf8_bytes() {
         let example_bytes = &[0x0c, 0x06, 0x48, 0x65, 0x6c, 0x6c, 0xc3, 0xb3];
-        let utf8_string = Utf8String::from_der(example_bytes).unwrap();
+        let utf8_string = Utf8StringRef::from_der(example_bytes).unwrap();
         assert_eq!(utf8_string.as_str(), "Helló");
     }
 }

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -38,7 +38,7 @@
 //! - [`u8`], [`u16`], [`u32`], [`u64`], [`u128`]: ASN.1 `INTEGER`.
 //! - [`f64`]: ASN.1 `REAL` (gated on `real` crate feature)
 //! - [`str`], [`String`][`alloc::string::String`]: ASN.1 `UTF8String`.
-//!   `String` requires `alloc` feature. See also [`Utf8String`].
+//!   `String` requires `alloc` feature. See also [`Utf8StringRef`].
 //!   Requires `alloc` feature. See also [`SetOf`].
 //! - [`Option`]: ASN.1 `OPTIONAL`.
 //! - [`SystemTime`][`std::time::SystemTime`]: ASN.1 `GeneralizedTime`. Requires `std` feature.
@@ -46,19 +46,19 @@
 //! - `[T; N]`: ASN.1 `SEQUENCE OF`. See also [`SequenceOf`].
 //!
 //! The following ASN.1 types provided by this crate also impl these traits:
-//! - [`Any`]: ASN.1 `ANY`
-//! - [`BitString`]: ASN.1 `BIT STRING`
+//! - [`AnyRef`]: ASN.1 `ANY`
+//! - [`BitStringRef`]: ASN.1 `BIT STRING`
 //! - [`GeneralizedTime`]: ASN.1 `GeneralizedTime`
-//! - [`Ia5String`]: ASN.1 `IA5String`
+//! - [`Ia5StringRef`]: ASN.1 `IA5String`
 //! - [`Null`]: ASN.1 `NULL`
 //! - [`ObjectIdentifier`]: ASN.1 `OBJECT IDENTIFIER`
-//! - [`OctetString`]: ASN.1 `OCTET STRING`
-//! - [`PrintableString`]: ASN.1 `PrintableString` (ASCII subset)
+//! - [`OctetStringRef`]: ASN.1 `OCTET STRING`
+//! - [`PrintableStringRef`]: ASN.1 `PrintableString` (ASCII subset)
 //! - [`SequenceOf`]: ASN.1 `SEQUENCE OF`
 //! - [`SetOf`], [`SetOfVec`]: ASN.1 `SET OF`
-//! - [`UIntBytes`]: ASN.1 unsigned `INTEGER` with raw access to encoded bytes
+//! - [`UIntRef`]: ASN.1 unsigned `INTEGER` with raw access to encoded bytes
 //! - [`UtcTime`]: ASN.1 `UTCTime`
-//! - [`Utf8String`]: ASN.1 `UTF8String`
+//! - [`Utf8StringRef`]: ASN.1 `UTF8String`
 //!
 //! Context specific fields can be modeled using these generic types:
 //! - [`ContextSpecific`]: decoder/encoder for owned context-specific fields
@@ -97,7 +97,7 @@
 //! // It does leverage the `alloc` feature, but also provides instructions for
 //! // "heapless" usage when the `alloc` feature is disabled.
 //! use der::{
-//!     asn1::{Any, ObjectIdentifier},
+//!     asn1::{AnyRef, ObjectIdentifier},
 //!     DecodeValue, Decode, Decoder, Encode, Header, Reader, Sequence
 //! };
 //!
@@ -109,7 +109,7 @@
 //!
 //!     /// This field is `OPTIONAL` and contains the ASN.1 `ANY` type, which
 //!     /// in this example allows arbitrary algorithm-defined parameters.
-//!     pub parameters: Option<Any<'a>>
+//!     pub parameters: Option<AnyRef<'a>>
 //! }
 //!
 //! impl<'a> DecodeValue<'a> for AlgorithmIdentifier<'a> {
@@ -178,7 +178,7 @@
 //! // `&'a [u8]` byte slice.
 //! //
 //! // To do that, we need owned DER-encoded data so that we can have
-//! // `Any` borrow a reference to it, so we have to serialize the OID.
+//! // `AnyRef` borrow a reference to it, so we have to serialize the OID.
 //! //
 //! // When the `alloc` feature of this crate is enabled, any type that impls
 //! // the `Encode` trait including all ASN.1 built-in types and any type
@@ -234,7 +234,7 @@
 //! ```
 //! # #[cfg(all(feature = "alloc", feature = "derive", feature = "oid"))]
 //! # {
-//! use der::{asn1::{Any, ObjectIdentifier}, Encode, Decode, Sequence};
+//! use der::{asn1::{AnyRef, ObjectIdentifier}, Encode, Decode, Sequence};
 //!
 //! /// X.509 `AlgorithmIdentifier` (same as above)
 //! #[derive(Copy, Clone, Debug, Eq, PartialEq, Sequence)] // NOTE: added `Sequence`
@@ -244,7 +244,7 @@
 //!
 //!     /// This field is `OPTIONAL` and contains the ASN.1 `ANY` type, which
 //!     /// in this example allows arbitrary algorithm-defined parameters.
-//!     pub parameters: Option<Any<'a>>
+//!     pub parameters: Option<AnyRef<'a>>
 //! }
 //!
 //! // Example parameters value: OID for the NIST P-256 elliptic curve.
@@ -255,8 +255,8 @@
 //!     algorithm: "1.2.840.10045.2.1".parse().unwrap(),
 //!
 //!     // `Any<'a>` impls `From<&'a ObjectIdentifier>`, allowing OID constants to
-//!     // be directly converted to an `Any` type for this use case.
-//!     parameters: Some(Any::from(&parameters_oid))
+//!     // be directly converted to an `AnyRef` type for this use case.
+//!     parameters: Some(AnyRef::from(&parameters_oid))
 //! };
 //!
 //! // Encode
@@ -286,12 +286,12 @@
 //! ```rust
 //! # #[cfg(all(feature = "alloc", feature = "derive", feature = "oid"))]
 //! # {
-//! # use der::{asn1::{Any, BitString, ObjectIdentifier}, Sequence};
+//! # use der::{asn1::{AnyRef, BitStringRef, ObjectIdentifier}, Sequence};
 //! #
 //! # #[derive(Copy, Clone, Debug, Eq, PartialEq, Sequence)]
 //! # pub struct AlgorithmIdentifier<'a> {
 //! #     pub algorithm: ObjectIdentifier,
-//! #     pub parameters: Option<Any<'a>>
+//! #     pub parameters: Option<AnyRef<'a>>
 //! # }
 //! /// X.509 `SubjectPublicKeyInfo` (SPKI)
 //! #[derive(Copy, Clone, Debug, Eq, PartialEq, Sequence)]
@@ -300,7 +300,7 @@
 //!     pub algorithm: AlgorithmIdentifier<'a>,
 //!
 //!     /// Public key data
-//!     pub subject_public_key: BitString<'a>,
+//!     pub subject_public_key: BitStringRef<'a>,
 //! }
 //! # }
 //! ```
@@ -315,22 +315,22 @@
 //! [A Layman's Guide to a Subset of ASN.1, BER, and DER]: https://luca.ntop.org/Teaching/Appunti/asn1.html
 //! [A Warm Welcome to ASN.1 and DER]: https://letsencrypt.org/docs/a-warm-welcome-to-asn1-and-der/
 //!
-//! [`Any`]: asn1::Any
+//! [`AnyRef`]: asn1::AnyRef
 //! [`ContextSpecific`]: asn1::ContextSpecific
 //! [`ContextSpecificRef`]: asn1::ContextSpecificRef
-//! [`BitString`]: asn1::BitString
+//! [`BitStringRef`]: asn1::BitStringRef
 //! [`GeneralizedTime`]: asn1::GeneralizedTime
-//! [`Ia5String`]: asn1::Ia5String
+//! [`Ia5StringRef`]: asn1::Ia5StringRef
 //! [`Null`]: asn1::Null
 //! [`ObjectIdentifier`]: asn1::ObjectIdentifier
-//! [`OctetString`]: asn1::OctetString
-//! [`PrintableString`]: asn1::PrintableString
+//! [`OctetStringRef`]: asn1::OctetStringRef
+//! [`PrintableStringRef`]: asn1::PrintableStringRef
 //! [`SequenceOf`]: asn1::SequenceOf
 //! [`SetOf`]: asn1::SetOf
 //! [`SetOfVec`]: asn1::SetOfVec
-//! [`UIntBytes`]: asn1::UIntBytes
+//! [`UIntRef`]: asn1::UIntRef
 //! [`UtcTime`]: asn1::UtcTime
-//! [`Utf8String`]: asn1::Utf8String
+//! [`Utf8StringRef`]: asn1::Utf8StringRef
 
 #[cfg(feature = "alloc")]
 #[allow(unused_imports)]
@@ -362,7 +362,7 @@ mod writer;
 mod document;
 
 pub use crate::{
-    asn1::{Any, Choice, Sequence},
+    asn1::{AnyRef, Choice, Sequence},
     datetime::DateTime,
     decode::{Decode, DecodeOwned, DecodeValue},
     decoder::Decoder,

--- a/der/tests/derive.rs
+++ b/der/tests/derive.rs
@@ -81,7 +81,7 @@ mod choice {
     /// `Choice` with `IMPLICIT` tagging.
     mod implicit {
         use der::{
-            asn1::{BitString, GeneralizedTime},
+            asn1::{BitStringRef, GeneralizedTime},
             Choice, Decode, Encode, Encoder,
         };
         use hex_literal::hex;
@@ -91,7 +91,7 @@ mod choice {
         #[asn1(tag_mode = "IMPLICIT")]
         pub enum ImplicitChoice<'a> {
             #[asn1(context_specific = "0", type = "BIT STRING")]
-            BitString(BitString<'a>),
+            BitString(BitStringRef<'a>),
 
             #[asn1(context_specific = "1", type = "GeneralizedTime")]
             Time(GeneralizedTime),
@@ -101,7 +101,7 @@ mod choice {
         }
 
         impl<'a> ImplicitChoice<'a> {
-            pub fn bit_string(&self) -> Option<BitString<'a>> {
+            pub fn bit_string(&self) -> Option<BitStringRef<'a>> {
                 match self {
                     Self::BitString(bs) => Some(*bs),
                     _ => None,
@@ -202,7 +202,7 @@ mod enumerated {
 #[cfg(feature = "oid")]
 mod sequence {
     use der::{
-        asn1::{Any, ObjectIdentifier, SetOf},
+        asn1::{AnyRef, ObjectIdentifier, SetOf},
         Decode, Encode, Sequence, ValueOrd,
     };
     use hex_literal::hex;
@@ -303,7 +303,7 @@ mod sequence {
     #[derive(Copy, Clone, Debug, Eq, PartialEq, Sequence, ValueOrd)]
     pub struct AlgorithmIdentifier<'a> {
         pub algorithm: ObjectIdentifier,
-        pub parameters: Option<Any<'a>>,
+        pub parameters: Option<AnyRef<'a>>,
     }
 
     /// X.509 `SubjectPublicKeyInfo` (SPKI)
@@ -322,7 +322,7 @@ mod sequence {
         #[asn1(type = "OCTET STRING")]
         pub private_key: &'a [u8],
         #[asn1(context_specific = "0", extensible = "true", optional = "true")]
-        pub attributes: Option<SetOf<Any<'a>, 1>>,
+        pub attributes: Option<SetOf<AnyRef<'a>, 1>>,
         #[asn1(
             context_specific = "1",
             extensible = "true",
@@ -448,7 +448,7 @@ mod sequence {
 
         let algorithm_identifier = AlgorithmIdentifier {
             algorithm: ID_EC_PUBLIC_KEY_OID,
-            parameters: Some(Any::from(&parameters_oid)),
+            parameters: Some(AnyRef::from(&parameters_oid)),
         };
 
         assert_eq!(

--- a/der/tests/pem.rs
+++ b/der/tests/pem.rs
@@ -3,7 +3,7 @@
 #![cfg(all(feature = "derive", feature = "oid", feature = "pem"))]
 
 use der::{
-    asn1::{BitStringOwned, ObjectIdentifier},
+    asn1::{BitString, ObjectIdentifier},
     pem::{LineEnding, PemLabel},
     Decode, DecodePem, EncodePem, Sequence,
 };
@@ -37,7 +37,7 @@ impl PemLabel for SpkiBorrowed<'_> {
 #[derive(Clone, Debug, Eq, PartialEq, Sequence)]
 pub struct SpkiOwned {
     pub algorithm: AlgorithmIdentifier,
-    pub subject_public_key: BitStringOwned,
+    pub subject_public_key: BitString,
 }
 
 impl PemLabel for SpkiOwned {

--- a/der/tests/set_of.rs
+++ b/der/tests/set_of.rs
@@ -20,7 +20,7 @@ proptest! {
 #[cfg(all(feature = "derive", feature = "oid"))]
 mod ordering {
     use der::{
-        asn1::{Any, ObjectIdentifier, SetOf, SetOfVec},
+        asn1::{AnyRef, ObjectIdentifier, SetOf, SetOfVec},
         Decode, Sequence, ValueOrd,
     };
     use hex_literal::hex;
@@ -29,7 +29,7 @@ mod ordering {
     #[derive(Copy, Clone, Debug, Eq, PartialEq, Sequence, ValueOrd)]
     pub struct AttributeTypeAndValue<'a> {
         pub oid: ObjectIdentifier,
-        pub value: Any<'a>,
+        pub value: AnyRef<'a>,
     }
 
     const OUT_OF_ORDER_RDN_EXAMPLE: &[u8] =

--- a/pkcs1/src/lib.rs
+++ b/pkcs1/src/lib.rs
@@ -22,7 +22,7 @@ mod version;
 
 pub use der::{
     self,
-    asn1::{ObjectIdentifier, UIntBytes},
+    asn1::{ObjectIdentifier, UIntRef},
 };
 
 pub use self::{
@@ -53,5 +53,5 @@ pub const ALGORITHM_OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.84
 #[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
 pub const ALGORITHM_ID: pkcs8::AlgorithmIdentifier<'static> = pkcs8::AlgorithmIdentifier {
     oid: ALGORITHM_OID,
-    parameters: Some(der::asn1::Any::NULL),
+    parameters: Some(der::asn1::AnyRef::NULL),
 };

--- a/pkcs1/src/private_key.rs
+++ b/pkcs1/src/private_key.rs
@@ -5,7 +5,7 @@ pub(crate) mod other_prime_info;
 
 use crate::{Error, Result, RsaPublicKey, Version};
 use core::fmt;
-use der::{asn1::UIntBytes, Decode, DecodeValue, Encode, Header, Reader, Sequence, Tag};
+use der::{asn1::UIntRef, Decode, DecodeValue, Encode, Header, Reader, Sequence, Tag};
 
 #[cfg(feature = "alloc")]
 use {self::other_prime_info::OtherPrimeInfo, alloc::vec::Vec, der::SecretDocument};
@@ -39,28 +39,28 @@ use der::pem::PemLabel;
 #[derive(Clone)]
 pub struct RsaPrivateKey<'a> {
     /// `n`: RSA modulus.
-    pub modulus: UIntBytes<'a>,
+    pub modulus: UIntRef<'a>,
 
     /// `e`: RSA public exponent.
-    pub public_exponent: UIntBytes<'a>,
+    pub public_exponent: UIntRef<'a>,
 
     /// `d`: RSA private exponent.
-    pub private_exponent: UIntBytes<'a>,
+    pub private_exponent: UIntRef<'a>,
 
     /// `p`: first prime factor of `n`.
-    pub prime1: UIntBytes<'a>,
+    pub prime1: UIntRef<'a>,
 
     /// `q`: Second prime factor of `n`.
-    pub prime2: UIntBytes<'a>,
+    pub prime2: UIntRef<'a>,
 
     /// First exponent: `d mod (p-1)`.
-    pub exponent1: UIntBytes<'a>,
+    pub exponent1: UIntRef<'a>,
 
     /// Second exponent: `d mod (q-1)`.
-    pub exponent2: UIntBytes<'a>,
+    pub exponent2: UIntRef<'a>,
 
     /// CRT coefficient: `(inverse of q) mod p`.
-    pub coefficient: UIntBytes<'a>,
+    pub coefficient: UIntRef<'a>,
 
     /// Additional primes `r_3`, ..., `r_u`, in order, if this is a multi-prime
     /// RSA key (i.e. `version` is `multi`).

--- a/pkcs1/src/private_key/other_prime_info.rs
+++ b/pkcs1/src/private_key/other_prime_info.rs
@@ -1,6 +1,6 @@
 //! PKCS#1 OtherPrimeInfo support.
 
-use der::{asn1::UIntBytes, DecodeValue, Encode, Header, Reader, Sequence};
+use der::{asn1::UIntRef, DecodeValue, Encode, Header, Reader, Sequence};
 
 /// PKCS#1 OtherPrimeInfo as defined in [RFC 8017 Appendix 1.2].
 ///
@@ -19,13 +19,13 @@ use der::{asn1::UIntBytes, DecodeValue, Encode, Header, Reader, Sequence};
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub struct OtherPrimeInfo<'a> {
     /// Prime factor `r_i` of `n`, where `i` >= 3.
-    pub prime: UIntBytes<'a>,
+    pub prime: UIntRef<'a>,
 
     /// Exponent: `d_i = d mod (r_i - 1)`.
-    pub exponent: UIntBytes<'a>,
+    pub exponent: UIntRef<'a>,
 
     /// CRT coefficient: `t_i = (r_1 * r_2 * ... * r_(i-1))^(-1) mod r_i`.
-    pub coefficient: UIntBytes<'a>,
+    pub coefficient: UIntRef<'a>,
 }
 
 impl<'a> DecodeValue<'a> for OtherPrimeInfo<'a> {

--- a/pkcs1/src/public_key.rs
+++ b/pkcs1/src/public_key.rs
@@ -1,7 +1,7 @@
 //! PKCS#1 RSA Public Keys.
 
 use crate::{Error, Result};
-use der::{asn1::UIntBytes, Decode, DecodeValue, Encode, Header, Reader, Sequence};
+use der::{asn1::UIntRef, Decode, DecodeValue, Encode, Header, Reader, Sequence};
 
 #[cfg(feature = "alloc")]
 use der::Document;
@@ -24,10 +24,10 @@ use der::pem::PemLabel;
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct RsaPublicKey<'a> {
     /// `n`: RSA modulus
-    pub modulus: UIntBytes<'a>,
+    pub modulus: UIntRef<'a>,
 
     /// `e`: RSA public exponent
-    pub public_exponent: UIntBytes<'a>,
+    pub public_exponent: UIntRef<'a>,
 }
 
 impl<'a> DecodeValue<'a> for RsaPublicKey<'a> {

--- a/pkcs5/src/pbes1.rs
+++ b/pkcs5/src/pbes1.rs
@@ -4,7 +4,7 @@
 
 use crate::AlgorithmIdentifier;
 use der::{
-    asn1::{Any, ObjectIdentifier, OctetString},
+    asn1::{AnyRef, ObjectIdentifier, OctetStringRef},
     Decode, Encode, ErrorKind, Length, Reader, Sequence, Tag, Writer,
 };
 
@@ -119,7 +119,7 @@ pub struct Parameters {
 
 impl<'a> Decode<'a> for Parameters {
     fn decode<R: Reader<'a>>(decoder: &mut R) -> der::Result<Self> {
-        Any::decode(decoder)?.try_into()
+        AnyRef::decode(decoder)?.try_into()
     }
 }
 
@@ -128,17 +128,17 @@ impl Sequence<'_> for Parameters {
     where
         F: FnOnce(&[&dyn Encode]) -> der::Result<T>,
     {
-        f(&[&OctetString::new(&self.salt)?, &self.iteration_count])
+        f(&[&OctetStringRef::new(&self.salt)?, &self.iteration_count])
     }
 }
 
-impl TryFrom<Any<'_>> for Parameters {
+impl TryFrom<AnyRef<'_>> for Parameters {
     type Error = der::Error;
 
-    fn try_from(any: Any<'_>) -> der::Result<Parameters> {
+    fn try_from(any: AnyRef<'_>) -> der::Result<Parameters> {
         any.sequence(|reader| {
             Ok(Parameters {
-                salt: OctetString::decode(reader)?
+                salt: OctetStringRef::decode(reader)?
                     .as_bytes()
                     .try_into()
                     .map_err(|_| der::Tag::OctetString.value_error())?,

--- a/pkcs5/src/pbes2.rs
+++ b/pkcs5/src/pbes2.rs
@@ -14,7 +14,7 @@ pub use self::kdf::{
 
 use crate::{AlgorithmIdentifier, Error, Result};
 use der::{
-    asn1::{Any, ObjectIdentifier, OctetString},
+    asn1::{AnyRef, ObjectIdentifier, OctetStringRef},
     Decode, Encode, ErrorKind, Length, Reader, Sequence, Tag, Writer,
 };
 
@@ -202,7 +202,7 @@ impl<'a> Parameters<'a> {
 
 impl<'a> Decode<'a> for Parameters<'a> {
     fn decode<R: Reader<'a>>(reader: &mut R) -> der::Result<Self> {
-        Any::decode(reader)?.try_into()
+        AnyRef::decode(reader)?.try_into()
     }
 }
 
@@ -215,10 +215,10 @@ impl<'a> Sequence<'a> for Parameters<'a> {
     }
 }
 
-impl<'a> TryFrom<Any<'a>> for Parameters<'a> {
+impl<'a> TryFrom<AnyRef<'a>> for Parameters<'a> {
     type Error = der::Error;
 
-    fn try_from(any: Any<'a>) -> der::Result<Self> {
+    fn try_from(any: AnyRef<'a>) -> der::Result<Self> {
         any.sequence(|params| {
             let kdf = AlgorithmIdentifier::decode(params)?;
             let encryption = AlgorithmIdentifier::decode(params)?;
@@ -356,7 +356,7 @@ impl<'a> TryFrom<EncryptionScheme<'a>> for AlgorithmIdentifier<'a> {
     type Error = der::Error;
 
     fn try_from(scheme: EncryptionScheme<'a>) -> der::Result<Self> {
-        let parameters = OctetString::new(match scheme {
+        let parameters = OctetStringRef::new(match scheme {
             EncryptionScheme::Aes128Cbc { iv } => iv,
             EncryptionScheme::Aes192Cbc { iv } => iv,
             EncryptionScheme::Aes256Cbc { iv } => iv,

--- a/pkcs5/src/pbes2/kdf.rs
+++ b/pkcs5/src/pbes2/kdf.rs
@@ -2,7 +2,7 @@
 
 use crate::{AlgorithmIdentifier, Error, Result};
 use der::{
-    asn1::{Any, ObjectIdentifier, OctetString},
+    asn1::{AnyRef, ObjectIdentifier, OctetStringRef},
     Decode, Encode, ErrorKind, Length, Reader, Sequence, Tag, Tagged, Writer,
 };
 
@@ -206,7 +206,7 @@ impl<'a> Pbkdf2Params<'a> {
 
 impl<'a> Decode<'a> for Pbkdf2Params<'a> {
     fn decode<R: Reader<'a>>(reader: &mut R) -> der::Result<Self> {
-        Any::decode(reader)?.try_into()
+        AnyRef::decode(reader)?.try_into()
     }
 }
 
@@ -217,13 +217,13 @@ impl<'a> Sequence<'a> for Pbkdf2Params<'a> {
     {
         if self.prf == Pbkdf2Prf::default() {
             f(&[
-                &OctetString::new(self.salt)?,
+                &OctetStringRef::new(self.salt)?,
                 &self.iteration_count,
                 &self.key_length,
             ])
         } else {
             f(&[
-                &OctetString::new(self.salt)?,
+                &OctetStringRef::new(self.salt)?,
                 &self.iteration_count,
                 &self.key_length,
                 &self.prf,
@@ -232,14 +232,14 @@ impl<'a> Sequence<'a> for Pbkdf2Params<'a> {
     }
 }
 
-impl<'a> TryFrom<Any<'a>> for Pbkdf2Params<'a> {
+impl<'a> TryFrom<AnyRef<'a>> for Pbkdf2Params<'a> {
     type Error = der::Error;
 
-    fn try_from(any: Any<'a>) -> der::Result<Self> {
+    fn try_from(any: AnyRef<'a>) -> der::Result<Self> {
         any.sequence(|reader| {
             // TODO(tarcieri): support salt `CHOICE` w\ `AlgorithmIdentifier`
             Ok(Self {
-                salt: OctetString::decode(reader)?.as_bytes(),
+                salt: OctetStringRef::decode(reader)?.as_bytes(),
                 iteration_count: reader.decode()?,
                 key_length: reader.decode()?,
                 prf: Option::<AlgorithmIdentifier<'_>>::decode(reader)?
@@ -397,7 +397,7 @@ impl<'a> ScryptParams<'a> {
 
 impl<'a> Decode<'a> for ScryptParams<'a> {
     fn decode<R: Reader<'a>>(reader: &mut R) -> der::Result<Self> {
-        Any::decode(reader)?.try_into()
+        AnyRef::decode(reader)?.try_into()
     }
 }
 
@@ -407,7 +407,7 @@ impl<'a> Sequence<'a> for ScryptParams<'a> {
         F: FnOnce(&[&dyn Encode]) -> der::Result<T>,
     {
         f(&[
-            &OctetString::new(self.salt)?,
+            &OctetStringRef::new(self.salt)?,
             &self.cost_parameter,
             &self.block_size,
             &self.parallelization,
@@ -416,13 +416,13 @@ impl<'a> Sequence<'a> for ScryptParams<'a> {
     }
 }
 
-impl<'a> TryFrom<Any<'a>> for ScryptParams<'a> {
+impl<'a> TryFrom<AnyRef<'a>> for ScryptParams<'a> {
     type Error = der::Error;
 
-    fn try_from(any: Any<'a>) -> der::Result<Self> {
+    fn try_from(any: AnyRef<'a>) -> der::Result<Self> {
         any.sequence(|reader| {
             Ok(Self {
-                salt: OctetString::decode(reader)?.as_bytes(),
+                salt: OctetStringRef::decode(reader)?.as_bytes(),
                 cost_parameter: reader.decode()?,
                 block_size: reader.decode()?,
                 parallelization: reader.decode()?,

--- a/pkcs7/src/data_content.rs
+++ b/pkcs7/src/data_content.rs
@@ -2,7 +2,7 @@
 
 use core::convert::{From, TryFrom};
 use der::{
-    asn1::OctetString, DecodeValue, EncodeValue, FixedTag, Header, Length, Reader, Tag, Writer,
+    asn1::OctetStringRef, DecodeValue, EncodeValue, FixedTag, Header, Length, Reader, Tag, Writer,
 };
 
 /// The content that is just an octet string.
@@ -32,7 +32,9 @@ impl<'a> From<DataContent<'a>> for &'a [u8] {
 
 impl<'a> DecodeValue<'a> for DataContent<'a> {
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> der::Result<DataContent<'a>> {
-        Ok(OctetString::decode_value(reader, header)?.as_bytes().into())
+        Ok(OctetStringRef::decode_value(reader, header)?
+            .as_bytes()
+            .into())
     }
 }
 
@@ -42,7 +44,7 @@ impl<'a> EncodeValue for DataContent<'a> {
     }
 
     fn encode_value(&self, writer: &mut dyn Writer) -> der::Result<()> {
-        OctetString::new(self.content)?.encode_value(writer)
+        OctetStringRef::new(self.content)?.encode_value(writer)
     }
 }
 

--- a/pkcs7/src/enveloped_data_content.rs
+++ b/pkcs7/src/enveloped_data_content.rs
@@ -3,7 +3,7 @@
 use crate::ContentType;
 
 use der::{
-    asn1::{ContextSpecific, OctetString},
+    asn1::{ContextSpecific, OctetStringRef},
     DecodeValue, Encode, Header, Reader, Sequence, TagMode, TagNumber,
 };
 use spki::AlgorithmIdentifier;
@@ -59,7 +59,10 @@ impl<'a> DecodeValue<'a> for EncryptedContentInfo<'a> {
                 content_type: reader.decode()?,
                 content_encryption_algorithm: reader.decode()?,
                 encrypted_content: reader
-                    .context_specific::<OctetString<'_>>(ENCRYPTED_CONTENT_TAG, TagMode::Implicit)?
+                    .context_specific::<OctetStringRef<'_>>(
+                        ENCRYPTED_CONTENT_TAG,
+                        TagMode::Implicit,
+                    )?
                     .map(|o| o.as_bytes()),
             })
         })
@@ -71,7 +74,10 @@ impl<'a> Sequence<'a> for EncryptedContentInfo<'a> {
     where
         F: FnOnce(&[&dyn Encode]) -> der::Result<T>,
     {
-        let opt_octet = self.encrypted_content.map(OctetString::new).transpose()?;
+        let opt_octet = self
+            .encrypted_content
+            .map(OctetStringRef::new)
+            .transpose()?;
         f(&[
             &self.content_type,
             &self.content_encryption_algorithm,

--- a/pkcs7/tests/content_tests.rs
+++ b/pkcs7/tests/content_tests.rs
@@ -1,7 +1,7 @@
 //! PKCS#7 example tests
 
 use der::{
-    asn1::{ObjectIdentifier, OctetString},
+    asn1::{ObjectIdentifier, OctetStringRef},
     Decode, Encoder,
 };
 use hex_literal::hex;
@@ -63,7 +63,7 @@ fn decode_encrypted_key_example() {
 
             let (salt, iter) = any
                 .sequence(|decoder| {
-                    let salt = OctetString::decode(decoder)?;
+                    let salt = OctetStringRef::decode(decoder)?;
                     let iter = u16::decode(decoder)?;
                     Ok((salt, iter))
                 })

--- a/pkcs8/src/encrypted_private_key_info.rs
+++ b/pkcs8/src/encrypted_private_key_info.rs
@@ -2,7 +2,7 @@
 
 use crate::{Error, Result};
 use core::fmt;
-use der::{asn1::OctetString, Decode, DecodeValue, Encode, Header, Reader, Sequence};
+use der::{asn1::OctetStringRef, Decode, DecodeValue, Encode, Header, Reader, Sequence};
 use pkcs5::EncryptionScheme;
 
 #[cfg(feature = "alloc")]
@@ -105,7 +105,7 @@ impl<'a> DecodeValue<'a> for EncryptedPrivateKeyInfo<'a> {
         reader.read_nested(header.length, |reader| {
             Ok(Self {
                 encryption_algorithm: reader.decode()?,
-                encrypted_data: OctetString::decode(reader)?.as_bytes(),
+                encrypted_data: OctetStringRef::decode(reader)?.as_bytes(),
             })
         })
     }
@@ -118,7 +118,7 @@ impl<'a> Sequence<'a> for EncryptedPrivateKeyInfo<'a> {
     {
         f(&[
             &self.encryption_algorithm,
-            &OctetString::new(self.encrypted_data)?,
+            &OctetStringRef::new(self.encrypted_data)?,
         ])
     }
 }

--- a/pkcs8/src/private_key_info.rs
+++ b/pkcs8/src/private_key_info.rs
@@ -3,7 +3,7 @@
 use crate::{AlgorithmIdentifier, Error, Result, Version};
 use core::fmt;
 use der::{
-    asn1::{Any, BitString, ContextSpecific, OctetString},
+    asn1::{AnyRef, BitStringRef, ContextSpecific, OctetStringRef},
     Decode, DecodeValue, Encode, Header, Reader, Sequence, TagMode, TagNumber,
 };
 
@@ -167,9 +167,9 @@ impl<'a> DecodeValue<'a> for PrivateKeyInfo<'a> {
             // Parse and validate `version` INTEGER.
             let version = Version::decode(reader)?;
             let algorithm = reader.decode()?;
-            let private_key = OctetString::decode(reader)?.into();
+            let private_key = OctetStringRef::decode(reader)?.into();
             let public_key = reader
-                .context_specific::<BitString<'_>>(PUBLIC_KEY_TAG, TagMode::Implicit)?
+                .context_specific::<BitStringRef<'_>>(PUBLIC_KEY_TAG, TagMode::Implicit)?
                 .map(|bs| {
                     bs.as_bytes()
                         .ok_or_else(|| der::Tag::BitString.value_error())
@@ -189,7 +189,7 @@ impl<'a> DecodeValue<'a> for PrivateKeyInfo<'a> {
 
             // Ignore any remaining extension fields
             while !reader.is_finished() {
-                reader.decode::<ContextSpecific<Any<'_>>>()?;
+                reader.decode::<ContextSpecific<AnyRef<'_>>>()?;
             }
 
             Ok(Self {
@@ -209,11 +209,11 @@ impl<'a> Sequence<'a> for PrivateKeyInfo<'a> {
         f(&[
             &u8::from(self.version()),
             &self.algorithm,
-            &OctetString::new(self.private_key)?,
+            &OctetStringRef::new(self.private_key)?,
             &self
                 .public_key
                 .map(|pk| {
-                    BitString::from_bytes(pk).map(|value| ContextSpecific {
+                    BitStringRef::from_bytes(pk).map(|value| ContextSpecific {
                         tag_number: PUBLIC_KEY_TAG,
                         tag_mode: TagMode::Implicit,
                         value,

--- a/sec1/src/parameters.rs
+++ b/sec1/src/parameters.rs
@@ -1,5 +1,5 @@
 use der::{
-    asn1::{Any, ObjectIdentifier},
+    asn1::{AnyRef, ObjectIdentifier},
     DecodeValue, EncodeValue, FixedTag, Header, Length, Reader, Tag, Writer,
 };
 
@@ -57,8 +57,8 @@ impl EcParameters {
     }
 }
 
-impl<'a> From<&'a EcParameters> for Any<'a> {
-    fn from(params: &'a EcParameters) -> Any<'a> {
+impl<'a> From<&'a EcParameters> for AnyRef<'a> {
+    fn from(params: &'a EcParameters) -> AnyRef<'a> {
         match params {
             EcParameters::NamedCurve(oid) => oid.into(),
         }

--- a/sec1/src/private_key.rs
+++ b/sec1/src/private_key.rs
@@ -8,7 +8,7 @@
 use crate::{EcParameters, Error, Result};
 use core::fmt;
 use der::{
-    asn1::{BitString, ContextSpecific, OctetString},
+    asn1::{BitStringRef, ContextSpecific, OctetStringRef},
     Decode, DecodeValue, Encode, Header, Reader, Sequence, Tag, TagMode, TagNumber,
 };
 
@@ -77,10 +77,10 @@ impl<'a> DecodeValue<'a> for EcPrivateKey<'a> {
                 return Err(der::Tag::Integer.value_error());
             }
 
-            let private_key = OctetString::decode(reader)?.as_bytes();
+            let private_key = OctetStringRef::decode(reader)?.as_bytes();
             let parameters = reader.context_specific(EC_PARAMETERS_TAG, TagMode::Explicit)?;
             let public_key = reader
-                .context_specific::<BitString<'_>>(PUBLIC_KEY_TAG, TagMode::Explicit)?
+                .context_specific::<BitStringRef<'_>>(PUBLIC_KEY_TAG, TagMode::Explicit)?
                 .map(|bs| bs.as_bytes().ok_or_else(|| Tag::BitString.value_error()))
                 .transpose()?;
 
@@ -100,7 +100,7 @@ impl<'a> Sequence<'a> for EcPrivateKey<'a> {
     {
         f(&[
             &VERSION,
-            &OctetString::new(self.private_key)?,
+            &OctetStringRef::new(self.private_key)?,
             &self.parameters.as_ref().map(|params| ContextSpecific {
                 tag_number: EC_PARAMETERS_TAG,
                 tag_mode: TagMode::Explicit,
@@ -109,7 +109,7 @@ impl<'a> Sequence<'a> for EcPrivateKey<'a> {
             &self
                 .public_key
                 .map(|pk| {
-                    BitString::from_bytes(pk).map(|value| ContextSpecific {
+                    BitStringRef::from_bytes(pk).map(|value| ContextSpecific {
                         tag_number: PUBLIC_KEY_TAG,
                         tag_mode: TagMode::Explicit,
                         value,

--- a/spki/src/algorithm.rs
+++ b/spki/src/algorithm.rs
@@ -2,7 +2,7 @@
 
 use crate::{Error, Result};
 use core::cmp::Ordering;
-use der::asn1::{Any, ObjectIdentifier};
+use der::asn1::{AnyRef, ObjectIdentifier};
 use der::{Decode, DecodeValue, DerOrd, Encode, Header, Reader, Sequence, ValueOrd};
 
 /// X.509 `AlgorithmIdentifier` as defined in [RFC 5280 Section 4.1.1.2].
@@ -21,7 +21,7 @@ pub struct AlgorithmIdentifier<'a> {
     pub oid: ObjectIdentifier,
 
     /// Algorithm `parameters`.
-    pub parameters: Option<Any<'a>>,
+    pub parameters: Option<AnyRef<'a>>,
 }
 
 impl<'a> AlgorithmIdentifier<'a> {
@@ -59,10 +59,10 @@ impl<'a> AlgorithmIdentifier<'a> {
         Ok(())
     }
 
-    /// Get the `parameters` field as an [`Any`].
+    /// Get the `parameters` field as an [`AnyRef`].
     ///
     /// Returns an error if `parameters` are `None`.
-    pub fn parameters_any(&self) -> Result<Any<'a>> {
+    pub fn parameters_any(&self) -> Result<AnyRef<'a>> {
         self.parameters.ok_or(Error::AlgorithmParametersMissing)
     }
 
@@ -86,7 +86,7 @@ impl<'a> AlgorithmIdentifier<'a> {
             match self.parameters {
                 None => None,
                 Some(p) => match p {
-                    Any::NULL => None,
+                    AnyRef::NULL => None,
                     _ => Some(p.oid()?),
                 },
             },

--- a/spki/src/lib.rs
+++ b/spki/src/lib.rs
@@ -13,17 +13,17 @@
 //! The following example demonstrates how to use an OID as the `parameters`
 //! of an [`AlgorithmIdentifier`].
 //!
-//! Borrow the [`ObjectIdentifier`] first then use [`der::Any::from`] or `.into()`:
+//! Borrow the [`ObjectIdentifier`] first then use [`der::AnyRef::from`] or `.into()`:
 //!
 //! ```
-//! use spki::{AlgorithmIdentifier, ObjectIdentifier, der::Any};
+//! use spki::{AlgorithmIdentifier, ObjectIdentifier, der::AnyRef};
 //!
 //! let alg_oid = "1.2.840.10045.2.1".parse::<ObjectIdentifier>().unwrap();
 //! let params_oid = "1.2.840.10045.3.1.7".parse::<ObjectIdentifier>().unwrap();
 //!
 //! let alg_id = AlgorithmIdentifier {
 //!     oid: alg_oid,
-//!     parameters: Some(Any::from(&params_oid))
+//!     parameters: Some(AnyRef::from(&params_oid))
 //! };
 //! ```
 

--- a/spki/src/spki.rs
+++ b/spki/src/spki.rs
@@ -3,7 +3,7 @@
 use crate::{AlgorithmIdentifier, Error, Result};
 use core::cmp::Ordering;
 use der::{
-    asn1::BitString, Decode, DecodeValue, DerOrd, Encode, Header, Reader, Sequence, ValueOrd,
+    asn1::BitStringRef, Decode, DecodeValue, DerOrd, Encode, Header, Reader, Sequence, ValueOrd,
 };
 
 #[cfg(feature = "alloc")]
@@ -70,8 +70,8 @@ impl<'a> SubjectPublicKeyInfo<'a> {
     }
 
     /// Get a [`BitString`] representing the `subject_public_key`
-    fn bitstring(&self) -> der::Result<BitString<'a>> {
-        BitString::from_bytes(self.subject_public_key)
+    fn bitstring(&self) -> der::Result<BitStringRef<'a>> {
+        BitStringRef::from_bytes(self.subject_public_key)
     }
 }
 
@@ -80,7 +80,7 @@ impl<'a> DecodeValue<'a> for SubjectPublicKeyInfo<'a> {
         reader.read_nested(header.length, |reader| {
             Ok(Self {
                 algorithm: reader.decode()?,
-                subject_public_key: BitString::decode(reader)?
+                subject_public_key: BitStringRef::decode(reader)?
                     .as_bytes()
                     .ok_or_else(|| der::Tag::BitString.value_error())?,
             })

--- a/x509/src/anchor.rs
+++ b/x509/src/anchor.rs
@@ -4,7 +4,7 @@ use crate::ext::pkix::{certpolicy::CertificatePolicies, NameConstraints};
 use crate::{ext::Extensions, name::Name};
 use crate::{Certificate, TbsCertificate};
 
-use der::asn1::{OctetString, Utf8String};
+use der::asn1::{OctetStringRef, Utf8StringRef};
 use der::{Choice, Enumerated, Sequence};
 use flagset::{flags, FlagSet};
 use spki::SubjectPublicKeyInfo;
@@ -47,10 +47,10 @@ pub struct TrustAnchorInfo<'a> {
 
     pub pub_key: SubjectPublicKeyInfo<'a>,
 
-    pub key_id: OctetString<'a>,
+    pub key_id: OctetStringRef<'a>,
 
     #[asn1(optional = "true")]
-    pub ta_title: Option<Utf8String<'a>>,
+    pub ta_title: Option<Utf8StringRef<'a>>,
 
     #[asn1(optional = "true")]
     pub cert_path: Option<CertPathControls<'a>>,
@@ -59,7 +59,7 @@ pub struct TrustAnchorInfo<'a> {
     pub extensions: Option<Extensions<'a>>,
 
     #[asn1(context_specific = "2", tag_mode = "IMPLICIT", optional = "true")]
-    pub ta_title_lang_tag: Option<Utf8String<'a>>,
+    pub ta_title_lang_tag: Option<Utf8StringRef<'a>>,
 }
 
 /// ```text

--- a/x509/src/attr.rs
+++ b/x509/src/attr.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 use core::fmt::{self, Write};
 
 use const_oid::db::DB;
-use der::asn1::{Any, ObjectIdentifier, SetOfVec};
+use der::asn1::{AnyRef, ObjectIdentifier, SetOfVec};
 use der::{Decode, Encode, Error, ErrorKind, Sequence, Tag, Tagged, ValueOrd};
 
 /// X.501 `AttributeType` as defined in [RFC 5280 Appendix A.1].
@@ -23,7 +23,7 @@ pub type AttributeType = ObjectIdentifier;
 /// ```
 ///
 /// [RFC 5280 Appendix A.1]: https://datatracker.ietf.org/doc/html/rfc5280#appendix-A.1
-pub type AttributeValue<'a> = Any<'a>;
+pub type AttributeValue<'a> = AnyRef<'a>;
 
 /// X.501 `Attribute` as defined in [RFC 5280 Appendix A.1].
 ///
@@ -85,7 +85,7 @@ pub type Attributes<'a> = SetOfVec<Attribute<'a>>;
 #[allow(missing_docs)]
 pub struct AttributeTypeAndValue<'a> {
     pub oid: AttributeType,
-    pub value: Any<'a>,
+    pub value: AnyRef<'a>,
 }
 
 #[derive(Copy, Clone)]
@@ -168,7 +168,7 @@ impl AttributeTypeAndValue<'_> {
         }
 
         // Serialize.
-        let value = Any::from_der(&bytes)?;
+        let value = AnyRef::from_der(&bytes)?;
         let atv = AttributeTypeAndValue { oid, value };
         atv.to_vec()
     }
@@ -182,7 +182,7 @@ impl AttributeTypeAndValue<'_> {
         }
 
         // Serialize.
-        let value = Any::new(Tag::Utf8String, parser.as_bytes())?;
+        let value = AnyRef::new(Tag::Utf8String, parser.as_bytes())?;
         let atv = AttributeTypeAndValue { oid, value };
         atv.to_vec()
     }

--- a/x509/src/certificate.rs
+++ b/x509/src/certificate.rs
@@ -5,7 +5,7 @@ use crate::{name::Name, time::Validity};
 use alloc::vec::Vec;
 
 use const_oid::AssociatedOid;
-use der::asn1::{BitString, UIntBytes};
+use der::asn1::{BitStringRef, UIntRef};
 use der::{Decode, Enumerated, Error, ErrorKind, Sequence};
 use spki::{AlgorithmIdentifier, SubjectPublicKeyInfo};
 
@@ -73,7 +73,7 @@ pub struct TbsCertificate<'a> {
     #[asn1(context_specific = "0", default = "Default::default")]
     pub version: Version,
 
-    pub serial_number: UIntBytes<'a>,
+    pub serial_number: UIntRef<'a>,
     pub signature: AlgorithmIdentifier<'a>,
     pub issuer: Name<'a>,
     pub validity: Validity,
@@ -81,10 +81,10 @@ pub struct TbsCertificate<'a> {
     pub subject_public_key_info: SubjectPublicKeyInfo<'a>,
 
     #[asn1(context_specific = "1", tag_mode = "IMPLICIT", optional = "true")]
-    pub issuer_unique_id: Option<BitString<'a>>,
+    pub issuer_unique_id: Option<BitStringRef<'a>>,
 
     #[asn1(context_specific = "2", tag_mode = "IMPLICIT", optional = "true")]
-    pub subject_unique_id: Option<BitString<'a>>,
+    pub subject_unique_id: Option<BitStringRef<'a>>,
 
     #[asn1(context_specific = "3", tag_mode = "EXPLICIT", optional = "true")]
     pub extensions: Option<crate::ext::Extensions<'a>>,
@@ -140,7 +140,7 @@ impl<'a> TbsCertificate<'a> {
 pub struct Certificate<'a> {
     pub tbs_certificate: TbsCertificate<'a>,
     pub signature_algorithm: AlgorithmIdentifier<'a>,
-    pub signature: BitString<'a>,
+    pub signature: BitStringRef<'a>,
 }
 
 /// `PkiPath` as defined by X.509 and referenced by [RFC 6066].

--- a/x509/src/crl.rs
+++ b/x509/src/crl.rs
@@ -7,7 +7,7 @@ use crate::Version;
 
 use alloc::vec::Vec;
 
-use der::asn1::{BitString, UIntBytes};
+use der::asn1::{BitStringRef, UIntRef};
 use der::Sequence;
 use spki::AlgorithmIdentifier;
 
@@ -27,7 +27,7 @@ use spki::AlgorithmIdentifier;
 pub struct CertificateList<'a> {
     pub tbs_cert_list: TbsCertList<'a>,
     pub signature_algorithm: AlgorithmIdentifier<'a>,
-    pub signature: BitString<'a>,
+    pub signature: BitStringRef<'a>,
 }
 
 /// Implicit intermediate structure from the ASN.1 definition of `TBSCertList`.
@@ -47,7 +47,7 @@ pub struct CertificateList<'a> {
 #[derive(Clone, Debug, Eq, PartialEq, Sequence)]
 #[allow(missing_docs)]
 pub struct RevokedCert<'a> {
-    pub serial_number: UIntBytes<'a>,
+    pub serial_number: UIntRef<'a>,
     pub revocation_date: Time,
     pub crl_entry_extensions: Option<Extensions<'a>>,
 }

--- a/x509/src/ext/pkix.rs
+++ b/x509/src/ext/pkix.rs
@@ -31,7 +31,7 @@ pub use const_oid::db::rfc5280::{
 
 use alloc::vec::Vec;
 
-use der::asn1::OctetString;
+use der::asn1::OctetStringRef;
 
 /// SubjectKeyIdentifier as defined in [RFC 5280 Section 4.2.1.2].
 ///
@@ -41,13 +41,13 @@ use der::asn1::OctetString;
 ///
 /// [RFC 5280 Section 4.2.1.2]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.2
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct SubjectKeyIdentifier<'a>(pub OctetString<'a>);
+pub struct SubjectKeyIdentifier<'a>(pub OctetStringRef<'a>);
 
 impl<'a> AssociatedOid for SubjectKeyIdentifier<'a> {
     const OID: ObjectIdentifier = ID_CE_SUBJECT_KEY_IDENTIFIER;
 }
 
-impl_newtype!(SubjectKeyIdentifier<'a>, OctetString<'a>);
+impl_newtype!(SubjectKeyIdentifier<'a>, OctetStringRef<'a>);
 
 /// SubjectAltName as defined in [RFC 5280 Section 4.2.1.6].
 ///

--- a/x509/src/ext/pkix/authkeyid.rs
+++ b/x509/src/ext/pkix/authkeyid.rs
@@ -2,7 +2,7 @@ use super::name::GeneralNames;
 
 use const_oid::db::rfc5280::ID_CE_AUTHORITY_KEY_IDENTIFIER;
 use const_oid::{AssociatedOid, ObjectIdentifier};
-use der::asn1::{OctetString, UIntBytes};
+use der::asn1::{OctetStringRef, UIntRef};
 use der::Sequence;
 
 /// AuthorityKeyIdentifier as defined in [RFC 5280 Section 4.2.1.1].
@@ -22,13 +22,13 @@ use der::Sequence;
 #[allow(missing_docs)]
 pub struct AuthorityKeyIdentifier<'a> {
     #[asn1(context_specific = "0", tag_mode = "IMPLICIT", optional = "true")]
-    pub key_identifier: Option<OctetString<'a>>,
+    pub key_identifier: Option<OctetStringRef<'a>>,
 
     #[asn1(context_specific = "1", tag_mode = "IMPLICIT", optional = "true")]
     pub authority_cert_issuer: Option<GeneralNames<'a>>,
 
     #[asn1(context_specific = "2", tag_mode = "IMPLICIT", optional = "true")]
-    pub authority_cert_serial_number: Option<UIntBytes<'a>>,
+    pub authority_cert_serial_number: Option<UIntRef<'a>>,
 }
 
 impl<'a> AssociatedOid for AuthorityKeyIdentifier<'a> {

--- a/x509/src/ext/pkix/certpolicy.rs
+++ b/x509/src/ext/pkix/certpolicy.rs
@@ -4,8 +4,8 @@ use alloc::vec::Vec;
 
 use const_oid::db::rfc5912::ID_CE_CERTIFICATE_POLICIES;
 use const_oid::AssociatedOid;
-use der::asn1::{GeneralizedTime, Ia5String, ObjectIdentifier, UIntBytes, Utf8String};
-use der::{Any, Choice, Sequence};
+use der::asn1::{GeneralizedTime, Ia5StringRef, ObjectIdentifier, UIntRef, Utf8StringRef};
+use der::{AnyRef, Choice, Sequence};
 
 /// CertificatePolicies as defined in [RFC 5280 Section 4.2.1.4].
 ///
@@ -56,7 +56,7 @@ pub struct PolicyInformation<'a> {
 #[allow(missing_docs)]
 pub struct PolicyQualifierInfo<'a> {
     pub policy_qualifier_id: ObjectIdentifier,
-    pub qualifier: Option<Any<'a>>,
+    pub qualifier: Option<AnyRef<'a>>,
 }
 
 /// CpsUri as defined in [RFC 5280 Section 4.2.1.4].
@@ -66,7 +66,7 @@ pub struct PolicyQualifierInfo<'a> {
 /// ```
 ///
 /// [RFC 5280 Section 4.2.1.4]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.4
-pub type CpsUri<'a> = Ia5String<'a>;
+pub type CpsUri<'a> = Ia5StringRef<'a>;
 
 /// UserNotice as defined in [RFC 5280 Section 4.2.1.4].
 ///
@@ -98,7 +98,7 @@ pub struct UserNotice<'a> {
 #[allow(missing_docs)]
 pub struct NoticeReference<'a> {
     pub organization: DisplayText<'a>,
-    pub notice_numbers: Option<Vec<UIntBytes<'a>>>,
+    pub notice_numbers: Option<Vec<UIntRef<'a>>>,
 }
 
 /// DisplayText as defined in [RFC 5280 Section 4.2.1.4].
@@ -119,8 +119,8 @@ pub struct NoticeReference<'a> {
 #[allow(missing_docs)]
 pub enum DisplayText<'a> {
     #[asn1(type = "IA5String")]
-    Ia5String(Ia5String<'a>),
+    Ia5String(Ia5StringRef<'a>),
 
     #[asn1(type = "UTF8String")]
-    Utf8String(Utf8String<'a>),
+    Utf8String(Utf8StringRef<'a>),
 }

--- a/x509/src/ext/pkix/crl.rs
+++ b/x509/src/ext/pkix/crl.rs
@@ -11,7 +11,7 @@ pub use dp::IssuingDistributionPoint;
 
 use alloc::vec::Vec;
 
-use der::{asn1::UIntBytes, Enumerated};
+use der::{asn1::UIntRef, Enumerated};
 
 /// CrlNumber as defined in [RFC 5280 Section 5.2.3].
 ///
@@ -21,13 +21,13 @@ use der::{asn1::UIntBytes, Enumerated};
 ///
 /// [RFC 5280 Section 5.2.3]: https://datatracker.ietf.org/doc/html/rfc5280#section-5.2.3
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct CrlNumber<'a>(pub UIntBytes<'a>);
+pub struct CrlNumber<'a>(pub UIntRef<'a>);
 
 impl<'a> AssociatedOid for CrlNumber<'a> {
     const OID: ObjectIdentifier = ID_CE_CRL_NUMBER;
 }
 
-impl_newtype!(CrlNumber<'a>, UIntBytes<'a>);
+impl_newtype!(CrlNumber<'a>, UIntRef<'a>);
 
 /// BaseCRLNumber as defined in [RFC 5280 Section 5.2.4].
 ///
@@ -37,13 +37,13 @@ impl_newtype!(CrlNumber<'a>, UIntBytes<'a>);
 ///
 /// [RFC 5280 Section 5.2.4]: https://datatracker.ietf.org/doc/html/rfc5280#section-5.2.4
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct BaseCrlNumber<'a>(pub UIntBytes<'a>);
+pub struct BaseCrlNumber<'a>(pub UIntRef<'a>);
 
 impl<'a> AssociatedOid for BaseCrlNumber<'a> {
     const OID: ObjectIdentifier = ID_CE_DELTA_CRL_INDICATOR;
 }
 
-impl_newtype!(BaseCrlNumber<'a>, UIntBytes<'a>);
+impl_newtype!(BaseCrlNumber<'a>, UIntRef<'a>);
 
 /// CrlDistributionPoints as defined in [RFC 5280 Section 4.2.1.13].
 ///

--- a/x509/src/ext/pkix/name/dirstr.rs
+++ b/x509/src/ext/pkix/name/dirstr.rs
@@ -1,4 +1,4 @@
-use der::asn1::{PrintableString, Utf8String};
+use der::asn1::{PrintableStringRef, Utf8StringRef};
 use der::Choice;
 
 /// DirectoryString as defined in [RFC 5280 Section 4.2.1.4].
@@ -42,8 +42,8 @@ use der::Choice;
 #[allow(missing_docs)]
 pub enum DirectoryString<'a> {
     #[asn1(type = "PrintableString")]
-    PrintableString(PrintableString<'a>),
+    PrintableString(PrintableStringRef<'a>),
 
     #[asn1(type = "UTF8String")]
-    Utf8String(Utf8String<'a>),
+    Utf8String(Utf8StringRef<'a>),
 }

--- a/x509/src/ext/pkix/name/general.rs
+++ b/x509/src/ext/pkix/name/general.rs
@@ -3,7 +3,7 @@
 use super::{EdiPartyName, OtherName};
 use crate::name::Name;
 
-use der::asn1::{Ia5String, ObjectIdentifier, OctetString};
+use der::asn1::{Ia5StringRef, ObjectIdentifier, OctetStringRef};
 use der::Choice;
 
 /// GeneralNames as defined in [RFC 5280 Section 4.2.1.6].
@@ -41,10 +41,10 @@ pub enum GeneralName<'a> {
     OtherName(OtherName<'a>),
 
     #[asn1(context_specific = "1", tag_mode = "IMPLICIT")]
-    Rfc822Name(Ia5String<'a>),
+    Rfc822Name(Ia5StringRef<'a>),
 
     #[asn1(context_specific = "2", tag_mode = "IMPLICIT")]
-    DnsName(Ia5String<'a>),
+    DnsName(Ia5StringRef<'a>),
 
     #[asn1(context_specific = "4", tag_mode = "EXPLICIT", constructed = "true")]
     DirectoryName(Name<'a>),
@@ -53,10 +53,10 @@ pub enum GeneralName<'a> {
     EdiPartyName(EdiPartyName<'a>),
 
     #[asn1(context_specific = "6", tag_mode = "IMPLICIT")]
-    UniformResourceIdentifier(Ia5String<'a>),
+    UniformResourceIdentifier(Ia5StringRef<'a>),
 
     #[asn1(context_specific = "7", tag_mode = "IMPLICIT")]
-    IpAddress(OctetString<'a>),
+    IpAddress(OctetStringRef<'a>),
 
     #[asn1(context_specific = "8", tag_mode = "IMPLICIT")]
     RegisteredId(ObjectIdentifier),

--- a/x509/src/ext/pkix/name/other.rs
+++ b/x509/src/ext/pkix/name/other.rs
@@ -1,4 +1,4 @@
-use der::{asn1::ObjectIdentifier, Any, Sequence};
+use der::{asn1::ObjectIdentifier, AnyRef, Sequence};
 
 /// OtherName as defined in [RFC 5280 Section 4.2.1.6].
 ///
@@ -16,7 +16,7 @@ pub struct OtherName<'a> {
     pub type_id: ObjectIdentifier,
 
     #[asn1(context_specific = "0", tag_mode = "EXPLICIT")]
-    pub value: Any<'a>,
+    pub value: AnyRef<'a>,
 }
 
 #[test]

--- a/x509/src/request.rs
+++ b/x509/src/request.rs
@@ -7,7 +7,7 @@ use alloc::vec::Vec;
 
 use const_oid::db::rfc5912::ID_EXTENSION_REQ;
 use const_oid::{AssociatedOid, ObjectIdentifier};
-use der::asn1::BitString;
+use der::asn1::BitStringRef;
 use der::{Decode, Enumerated, Sequence};
 use spki::{AlgorithmIdentifier, SubjectPublicKeyInfo};
 
@@ -78,7 +78,7 @@ pub struct CertReq<'a> {
     pub algorithm: AlgorithmIdentifier<'a>,
 
     /// Signature.
-    pub signature: BitString<'a>,
+    pub signature: BitStringRef<'a>,
 }
 
 impl<'a> TryFrom<&'a [u8]> for CertReq<'a> {

--- a/x509/tests/certificate.rs
+++ b/x509/tests/certificate.rs
@@ -1,7 +1,7 @@
 //! Certificate tests
 
 use der::{
-    asn1::{BitString, ContextSpecific, ObjectIdentifier, UIntBytes},
+    asn1::{BitStringRef, ContextSpecific, ObjectIdentifier, UIntRef},
     Decode, DecodeValue, Encode, FixedTag, Header, Reader, Tag, Tagged,
 };
 use hex_literal::hex;
@@ -69,9 +69,9 @@ pub struct DeferDecodeTbsCertificate<'a> {
     /// Defer decoded field
     pub subject_public_key_info: &'a [u8],
     /// Decoded field (never present)
-    pub issuer_unique_id: Option<BitString<'a>>,
+    pub issuer_unique_id: Option<BitStringRef<'a>>,
     /// Decoded field (never present)
-    pub subject_unique_id: Option<BitString<'a>>,
+    pub subject_unique_id: Option<BitStringRef<'a>>,
     /// Defer decoded field
     pub extensions: &'a [u8],
 }
@@ -120,7 +120,7 @@ fn reencode_cert() {
     let reencoded_sigalg = parsed_sigalg.to_vec().unwrap();
     assert_eq!(defer_cert.signature_algorithm, reencoded_sigalg);
 
-    let parsed_sig = BitString::from_der(defer_cert.signature).unwrap();
+    let parsed_sig = BitStringRef::from_der(defer_cert.signature).unwrap();
     let reencoded_sig = parsed_sig.to_vec().unwrap();
     assert_eq!(defer_cert.signature, reencoded_sig);
 
@@ -207,7 +207,7 @@ fn decode_cert() {
     ];
     assert_eq!(
         cert.tbs_certificate.serial_number,
-        UIntBytes::new(&target_serial).unwrap()
+        UIntRef::new(&target_serial).unwrap()
     );
     assert_eq!(
         cert.tbs_certificate.signature.oid.to_string(),

--- a/x509/tests/name.rs
+++ b/x509/tests/name.rs
@@ -1,8 +1,8 @@
 //! Name tests
 
 use const_oid::ObjectIdentifier;
-use der::asn1::{OctetString, SetOfVec, Utf8String};
-use der::{Any, Decode, Encode, Tag, Tagged};
+use der::asn1::{OctetStringRef, SetOfVec, Utf8StringRef};
+use der::{AnyRef, Decode, Encode, Tag, Tagged};
 use hex_literal::hex;
 use x509_cert::attr::AttributeTypeAndValue;
 use x509_cert::name::{Name, RdnSequence, RelativeDistinguishedName};
@@ -198,20 +198,20 @@ fn rdns_serde() {
             &[
                 &[AttributeTypeAndValue {
                     oid: const_oid::db::rfc4519::CN,
-                    value: Any::from(Utf8String::new("foo").unwrap()),
+                    value: AnyRef::from(Utf8StringRef::new("foo").unwrap()),
                 }],
                 &[AttributeTypeAndValue {
                     oid: const_oid::db::rfc4519::SN,
-                    value: Any::from(Utf8String::new("bar").unwrap()),
+                    value: AnyRef::from(Utf8StringRef::new("bar").unwrap()),
                 }],
                 &[
                     AttributeTypeAndValue {
                         oid: const_oid::db::rfc4519::C,
-                        value: Any::from(Utf8String::new("baz").unwrap()),
+                        value: AnyRef::from(Utf8StringRef::new("baz").unwrap()),
                     },
                     AttributeTypeAndValue {
                         oid: const_oid::db::rfc4519::L,
-                        value: Any::from(Utf8String::new("bat").unwrap()),
+                        value: AnyRef::from(Utf8StringRef::new("bat").unwrap()),
                     },
                 ],
             ],
@@ -222,15 +222,15 @@ fn rdns_serde() {
             &[
                 &[AttributeTypeAndValue {
                     oid: const_oid::db::rfc4519::UID,
-                    value: Any::from(Utf8String::new("jsmith").unwrap()),
+                    value: AnyRef::from(Utf8StringRef::new("jsmith").unwrap()),
                 }],
                 &[AttributeTypeAndValue {
                     oid: const_oid::db::rfc4519::DC,
-                    value: Any::from(Utf8String::new("example").unwrap()),
+                    value: AnyRef::from(Utf8StringRef::new("example").unwrap()),
                 }],
                 &[AttributeTypeAndValue {
                     oid: const_oid::db::rfc4519::DC,
-                    value: Any::from(Utf8String::new("net").unwrap()),
+                    value: AnyRef::from(Utf8StringRef::new("net").unwrap()),
                 }],
             ],
         ),
@@ -241,20 +241,20 @@ fn rdns_serde() {
                 &[
                     AttributeTypeAndValue {
                         oid: const_oid::db::rfc4519::OU,
-                        value: Any::from(Utf8String::new("Sales").unwrap()),
+                        value: AnyRef::from(Utf8StringRef::new("Sales").unwrap()),
                     },
                     AttributeTypeAndValue {
                         oid: const_oid::db::rfc4519::CN,
-                        value: Any::from(Utf8String::new("J.  Smith").unwrap()),
+                        value: AnyRef::from(Utf8StringRef::new("J.  Smith").unwrap()),
                     },
                 ],
                 &[AttributeTypeAndValue {
                     oid: const_oid::db::rfc4519::DC,
-                    value: Any::from(Utf8String::new("example").unwrap()),
+                    value: AnyRef::from(Utf8StringRef::new("example").unwrap()),
                 }],
                 &[AttributeTypeAndValue {
                     oid: const_oid::db::rfc4519::DC,
-                    value: Any::from(Utf8String::new("net").unwrap()),
+                    value: AnyRef::from(Utf8StringRef::new("net").unwrap()),
                 }],
             ],
         ),
@@ -264,15 +264,15 @@ fn rdns_serde() {
             &[
                 &[AttributeTypeAndValue {
                     oid: const_oid::db::rfc4519::CN,
-                    value: Any::from(Utf8String::new(r#"James "Jim" Smith, III"#).unwrap()),
+                    value: AnyRef::from(Utf8StringRef::new(r#"James "Jim" Smith, III"#).unwrap()),
                 }],
                 &[AttributeTypeAndValue {
                     oid: const_oid::db::rfc4519::DC,
-                    value: Any::from(Utf8String::new("example").unwrap()),
+                    value: AnyRef::from(Utf8StringRef::new("example").unwrap()),
                 }],
                 &[AttributeTypeAndValue {
                     oid: const_oid::db::rfc4519::DC,
-                    value: Any::from(Utf8String::new("net").unwrap()),
+                    value: AnyRef::from(Utf8StringRef::new("net").unwrap()),
                 }],
             ],
         ),
@@ -282,15 +282,15 @@ fn rdns_serde() {
             &[
                 &[AttributeTypeAndValue {
                     oid: const_oid::db::rfc4519::CN,
-                    value: Any::from(Utf8String::new("Before\rAfter").unwrap()),
+                    value: AnyRef::from(Utf8StringRef::new("Before\rAfter").unwrap()),
                 }],
                 &[AttributeTypeAndValue {
                     oid: const_oid::db::rfc4519::DC,
-                    value: Any::from(Utf8String::new("example").unwrap()),
+                    value: AnyRef::from(Utf8StringRef::new("example").unwrap()),
                 }],
                 &[AttributeTypeAndValue {
                     oid: const_oid::db::rfc4519::DC,
-                    value: Any::from(Utf8String::new("net").unwrap()),
+                    value: AnyRef::from(Utf8StringRef::new("net").unwrap()),
                 }],
             ],
         ),
@@ -299,7 +299,7 @@ fn rdns_serde() {
             "1.3.6.1.4.1.1466.0=#04024869",
             &[&[AttributeTypeAndValue {
                 oid: ObjectIdentifier::new("1.3.6.1.4.1.1466.0").unwrap(),
-                value: Any::from(OctetString::new(&[b'H', b'i']).unwrap()),
+                value: AnyRef::from(OctetStringRef::new(&[b'H', b'i']).unwrap()),
             }]],
         ),
     ];

--- a/x509/tests/pkix_extensions.rs
+++ b/x509/tests/pkix_extensions.rs
@@ -1,6 +1,6 @@
 //! Certificate tests
 use const_oid::AssociatedOid;
-use der::asn1::UIntBytes;
+use der::asn1::UIntRef;
 use der::{Decode, Encode, ErrorKind, Length, Tag, Tagged};
 use hex_literal::hex;
 use x509_cert::ext::pkix::crl::dp::{DistributionPoint, ReasonFlags, Reasons};
@@ -486,7 +486,7 @@ fn decode_cert() {
     let target_serial: [u8; 1] = [2];
     assert_eq!(
         cert.tbs_certificate.serial_number,
-        UIntBytes::new(&target_serial).unwrap()
+        UIntRef::new(&target_serial).unwrap()
     );
     assert_eq!(
         cert.tbs_certificate.signature.oid.to_string(),


### PR DESCRIPTION
Now that we have a `DecodeOwned` trait and initial support for on-the-fly PEM decoding, it makes sense to add owned forms of all of the various reference types.

This brings up a question of naming: we can either add `*Owned` to all of the owned types or add a `*Ref` to all of the existing reference types.

This PR chooses to do the latter, renaming all of the reference types to make room for the owned types.

Owned types are easier to work with and probably preferable for anyone who can depend on `alloc` existing, so this PR gives them the shorter name.

The following types are renamed:

- `Any` => `AnyRef`
- `BitString` => `BitStringRef`
- `Ia5String` => `Ia5StringRef`
- `OctetString` => `OctetStringRef`
- `PrintableString` => `PrintableStringRef`
- `Utf8String` => `Utf8StringRef`

Also renames the newly introduced `BitStringOwned` type to `BitString`.