### PR TITLE
der: add owned `Any` and `OctetString` types

### DIFF
--- a/der/src/asn1.rs
+++ b/der/src/asn1.rs
@@ -43,7 +43,7 @@ pub use self::{
 
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-pub use self::{bit_string::BitString, set_of::SetOfVec};
+pub use self::{any::Any, bit_string::BitString, octet_string::OctetString, set_of::SetOfVec};
 
 #[cfg(feature = "oid")]
 #[cfg_attr(docsrs, doc(cfg(feature = "oid")))]

--- a/der/src/asn1/bit_string.rs
+++ b/der/src/asn1/bit_string.rs
@@ -198,6 +198,145 @@ impl<'a> FixedTag for BitStringRef<'a> {
     const TAG: Tag = Tag::BitString;
 }
 
+/// Owned form of ASN.1 `BIT STRING` type.
+///
+/// This type provides the same functionality as [`BitStringRef`] but owns the
+/// backing data.
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct BitString {
+    /// Number of unused bits in the final octet.
+    unused_bits: u8,
+
+    /// Length of this `BIT STRING` in bits.
+    bit_length: usize,
+
+    /// Bitstring represented as a slice of bytes.
+    inner: Vec<u8>,
+}
+
+#[cfg(feature = "alloc")]
+impl BitString {
+    /// Maximum number of unused bits allowed.
+    pub const MAX_UNUSED_BITS: u8 = 7;
+
+    /// Create a new ASN.1 `BIT STRING` from a byte slice.
+    ///
+    /// Accepts an optional number of "unused bits" (0-7) which are omitted
+    /// from the final octet. This number is 0 if the value is octet-aligned.
+    pub fn new(unused_bits: u8, bytes: impl Into<Vec<u8>>) -> Result<Self> {
+        let inner = bytes.into();
+
+        // Ensure parameters parse successfully as a `BitStringRef`.
+        let bit_length = BitStringRef::new(unused_bits, &inner)?.bit_length;
+
+        Ok(BitString {
+            unused_bits,
+            bit_length,
+            inner,
+        })
+    }
+
+    /// Create a new ASN.1 `BIT STRING` from the given bytes.
+    ///
+    /// The "unused bits" are set to 0.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
+        Self::new(0, bytes)
+    }
+
+    /// Get the number of unused bits in the octet serialization of this
+    /// `BIT STRING`.
+    pub fn unused_bits(&self) -> u8 {
+        self.unused_bits
+    }
+
+    /// Is the number of unused bits a value other than 0?
+    pub fn has_unused_bits(&self) -> bool {
+        self.unused_bits != 0
+    }
+
+    /// Get the length of this `BIT STRING` in bits.
+    pub fn bit_len(&self) -> usize {
+        self.bit_length
+    }
+
+    /// Is the inner byte slice empty?
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Borrow the inner byte slice.
+    ///
+    /// Returns `None` if the number of unused bits is *not* equal to zero,
+    /// i.e. if the `BIT STRING` is not octet aligned.
+    ///
+    /// Use [`BitString::raw_bytes`] to obtain access to the raw value
+    /// regardless of the presence of unused bits.
+    pub fn as_bytes(&self) -> Option<&[u8]> {
+        if self.has_unused_bits() {
+            None
+        } else {
+            Some(self.raw_bytes())
+        }
+    }
+
+    /// Borrow the raw bytes of this `BIT STRING`.
+    pub fn raw_bytes(&self) -> &[u8] {
+        self.inner.as_slice()
+    }
+
+    /// Iterator over the bits of this `BIT STRING`.
+    pub fn bits(&self) -> BitStringIter<'_> {
+        BitStringRef::from(self).bits()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a> DecodeValue<'a> for BitString {
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
+        let inner_len = (header.length - Length::ONE)?;
+        let unused_bits = reader.read_byte()?;
+        let inner = reader.read_vec(inner_len)?;
+        Self::new(unused_bits, inner)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl EncodeValue for BitString {
+    fn value_len(&self) -> Result<Length> {
+        Length::ONE + Length::try_from(self.inner.len())?
+    }
+
+    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+        writer.write_byte(self.unused_bits)?;
+        writer.write(&self.inner)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl FixedTag for BitString {
+    const TAG: Tag = Tag::BitString;
+}
+
+#[cfg(feature = "alloc")]
+impl<'a> From<&'a BitString> for BitStringRef<'a> {
+    fn from(bit_string: &'a BitString) -> BitStringRef<'a> {
+        // Ensured to parse successfully in constructor
+        BitStringRef::new(bit_string.unused_bits, &bit_string.inner).expect("invalid BIT STRING")
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl ValueOrd for BitString {
+    fn value_cmp(&self, other: &Self) -> Result<Ordering> {
+        match self.unused_bits.cmp(&other.unused_bits) {
+            Ordering::Equal => self.inner.der_cmp(&other.inner),
+            ordering => Ok(ordering),
+        }
+    }
+}
+
 /// Iterator over the bits of a [`BitString`].
 pub struct BitStringIter<'a> {
     /// [`BitString`] being iterated over.
@@ -299,95 +438,6 @@ where
         let (lead, buff) = encode_flagset(self);
         let buff = &buff[..buff.len() - lead / 8];
         BitStringRef::new((lead % 8) as u8, buff)?.encode_value(writer)
-    }
-}
-
-/// Owned form of ASN.1 `BIT STRING` type.
-///
-/// This type provides the same functionality as [`BitString`] but owns the
-/// backing data.
-#[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
-pub struct BitString {
-    /// Number of unused bits in the final octet.
-    unused_bits: u8,
-
-    /// Length of this `BIT STRING` in bits.
-    bit_length: usize,
-
-    /// Bitstring represented as a slice of bytes.
-    inner: Vec<u8>,
-}
-
-#[cfg(feature = "alloc")]
-impl BitString {
-    /// Get the number of unused bits in the octet serialization of this
-    /// `BIT STRING`.
-    pub fn unused_bits(&self) -> u8 {
-        self.unused_bits
-    }
-
-    /// Borrow the raw bytes of this `BIT STRING`.
-    pub fn raw_bytes(&self) -> &[u8] {
-        self.inner.as_slice()
-    }
-}
-
-#[cfg(feature = "alloc")]
-impl<'a> DecodeValue<'a> for BitString {
-    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
-        let unused_bits = reader.read_byte()?;
-        let inner_len: usize = (header.length - Length::ONE)?.try_into()?;
-
-        if (unused_bits > BitStringRef::MAX_UNUSED_BITS) || (unused_bits != 0 && inner_len == 0) {
-            return Err(Self::TAG.value_error());
-        }
-
-        let bit_length = inner_len
-            .checked_mul(8)
-            .and_then(|n| n.checked_sub(usize::from(unused_bits)))
-            .ok_or(ErrorKind::Overflow)?;
-
-        let mut inner = vec![0u8; inner_len];
-        let actual_len = reader.read_into(&mut inner)?.len();
-
-        if inner_len == actual_len {
-            Ok(Self {
-                unused_bits,
-                bit_length,
-                inner,
-            })
-        } else {
-            Err(Self::TAG.length_error())
-        }
-    }
-}
-
-#[cfg(feature = "alloc")]
-impl EncodeValue for BitString {
-    fn value_len(&self) -> Result<Length> {
-        Length::ONE + Length::try_from(self.inner.len())?
-    }
-
-    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
-        writer.write_byte(self.unused_bits)?;
-        writer.write(&self.inner)
-    }
-}
-
-#[cfg(feature = "alloc")]
-impl FixedTag for BitString {
-    const TAG: Tag = Tag::BitString;
-}
-
-#[cfg(feature = "alloc")]
-impl ValueOrd for BitString {
-    fn value_cmp(&self, other: &Self) -> Result<Ordering> {
-        match self.unused_bits.cmp(&other.unused_bits) {
-            Ordering::Equal => self.inner.der_cmp(&other.inner),
-            ordering => Ok(ordering),
-        }
     }
 }
 

--- a/der/src/asn1/octet_string.rs
+++ b/der/src/asn1/octet_string.rs
@@ -5,7 +5,10 @@ use crate::{
     FixedTag, Header, Length, Reader, Result, Tag, Writer,
 };
 
-/// ASN.1 `OCTET STRING` type.
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
+/// ASN.1 `OCTET STRING` type: borrowed form.
 ///
 /// Octet strings represent contiguous sequences of octets, a.k.a. bytes.
 ///
@@ -92,5 +95,85 @@ impl<'a> From<OctetStringRef<'a>> for AnyRef<'a> {
 impl<'a> From<OctetStringRef<'a>> for &'a [u8] {
     fn from(octet_string: OctetStringRef<'a>) -> &'a [u8] {
         octet_string.as_bytes()
+    }
+}
+
+/// ASN.1 `OCTET STRING` type: owned form..
+///
+/// Octet strings represent contiguous sequences of octets, a.k.a. bytes.
+///
+/// This type provides the same functionality as [`OctetStringRef`] but owns
+/// the backing data.
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct OctetString {
+    /// Bitstring represented as a slice of bytes.
+    inner: Vec<u8>,
+}
+
+#[cfg(feature = "alloc")]
+impl OctetString {
+    /// Create a new ASN.1 `OCTET STRING`.
+    pub fn new(bytes: impl Into<Vec<u8>>) -> Result<Self> {
+        let inner = bytes.into();
+
+        // Ensure the bytes parse successfully as an `OctetStringRef`
+        OctetStringRef::new(&inner)?;
+
+        Ok(Self { inner })
+    }
+
+    /// Borrow the inner byte slice.
+    pub fn as_bytes(&self) -> &[u8] {
+        self.inner.as_slice()
+    }
+
+    /// Get the length of the inner byte slice.
+    pub fn len(&self) -> Length {
+        self.value_len().expect("invalid OCTET STRING length")
+    }
+
+    /// Is the inner byte slice empty?
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl AsRef<[u8]> for OctetString {
+    fn as_ref(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a> DecodeValue<'a> for OctetString {
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
+        Self::new(reader.read_vec(header.length)?)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl EncodeValue for OctetString {
+    fn value_len(&self) -> Result<Length> {
+        self.inner.len().try_into()
+    }
+
+    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+        writer.write(&self.inner)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl FixedTag for OctetString {
+    const TAG: Tag = Tag::OctetString;
+}
+
+#[cfg(feature = "alloc")]
+impl<'a> From<&'a OctetString> for OctetStringRef<'a> {
+    fn from(octet_string: &'a OctetString) -> OctetStringRef<'a> {
+        // Ensured to parse successfully in constructor
+        OctetStringRef::new(&octet_string.inner).expect("invalid OCTET STRING")
     }
 }

--- a/der/src/asn1/utf8_string.rs
+++ b/der/src/asn1/utf8_string.rs
@@ -175,6 +175,14 @@ impl<'a> TryFrom<AnyRef<'a>> for String {
 
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+impl<'a> DecodeValue<'a> for String {
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
+        Ok(String::from_utf8(reader.read_vec(header.length)?)?)
+    }
+}
+
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl EncodeValue for String {
     fn value_len(&self) -> Result<Length> {
         Utf8StringRef::new(self)?.value_len()

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -39,26 +39,25 @@
 //! - [`f64`]: ASN.1 `REAL` (gated on `real` crate feature)
 //! - [`str`], [`String`][`alloc::string::String`]: ASN.1 `UTF8String`.
 //!   `String` requires `alloc` feature. See also [`Utf8StringRef`].
-//!   Requires `alloc` feature. See also [`SetOf`].
 //! - [`Option`]: ASN.1 `OPTIONAL`.
 //! - [`SystemTime`][`std::time::SystemTime`]: ASN.1 `GeneralizedTime`. Requires `std` feature.
 //! - [`Vec`][`alloc::vec::Vec`]: ASN.1 `SEQUENCE OF`. Requires `alloc` feature.
 //! - `[T; N]`: ASN.1 `SEQUENCE OF`. See also [`SequenceOf`].
 //!
 //! The following ASN.1 types provided by this crate also impl these traits:
-//! - [`AnyRef`]: ASN.1 `ANY`
-//! - [`BitStringRef`]: ASN.1 `BIT STRING`
-//! - [`GeneralizedTime`]: ASN.1 `GeneralizedTime`
-//! - [`Ia5StringRef`]: ASN.1 `IA5String`
-//! - [`Null`]: ASN.1 `NULL`
-//! - [`ObjectIdentifier`]: ASN.1 `OBJECT IDENTIFIER`
-//! - [`OctetStringRef`]: ASN.1 `OCTET STRING`
-//! - [`PrintableStringRef`]: ASN.1 `PrintableString` (ASCII subset)
-//! - [`SequenceOf`]: ASN.1 `SEQUENCE OF`
-//! - [`SetOf`], [`SetOfVec`]: ASN.1 `SET OF`
-//! - [`UIntRef`]: ASN.1 unsigned `INTEGER` with raw access to encoded bytes
-//! - [`UtcTime`]: ASN.1 `UTCTime`
-//! - [`Utf8StringRef`]: ASN.1 `UTF8String`
+//! - [`Any`], [`AnyRef`]: ASN.1 `ANY`.
+//! - [`BitString`], [`BitStringRef`]: ASN.1 `BIT STRING`
+//! - [`GeneralizedTime`]: ASN.1 `GeneralizedTime`.
+//! - [`Ia5StringRef`]: ASN.1 `IA5String`.
+//! - [`Null`]: ASN.1 `NULL`.
+//! - [`ObjectIdentifier`]: ASN.1 `OBJECT IDENTIFIER`.
+//! - [`OctetString`], [`OctetStringRef`]: ASN.1 `OCTET STRING`.
+//! - [`PrintableStringRef`]: ASN.1 `PrintableString` (ASCII subset).
+//! - [`SequenceOf`]: ASN.1 `SEQUENCE OF`.
+//! - [`SetOf`], [`SetOfVec`]: ASN.1 `SET OF`.
+//! - [`UIntRef`]: ASN.1 unsigned `INTEGER` with raw access to encoded bytes.
+//! - [`UtcTime`]: ASN.1 `UTCTime`.
+//! - [`Utf8StringRef`]: ASN.1 `UTF8String`.
 //!
 //! Context specific fields can be modeled using these generic types:
 //! - [`ContextSpecific`]: decoder/encoder for owned context-specific fields
@@ -315,14 +314,17 @@
 //! [A Layman's Guide to a Subset of ASN.1, BER, and DER]: https://luca.ntop.org/Teaching/Appunti/asn1.html
 //! [A Warm Welcome to ASN.1 and DER]: https://letsencrypt.org/docs/a-warm-welcome-to-asn1-and-der/
 //!
+//! [`Any`]: asn1::AnyRef
 //! [`AnyRef`]: asn1::AnyRef
 //! [`ContextSpecific`]: asn1::ContextSpecific
 //! [`ContextSpecificRef`]: asn1::ContextSpecificRef
+//! [`BitString`]: asn1::BitStringRef
 //! [`BitStringRef`]: asn1::BitStringRef
 //! [`GeneralizedTime`]: asn1::GeneralizedTime
 //! [`Ia5StringRef`]: asn1::Ia5StringRef
 //! [`Null`]: asn1::Null
 //! [`ObjectIdentifier`]: asn1::ObjectIdentifier
+//! [`OctetString`]: asn1::OctetStringRef
 //! [`OctetStringRef`]: asn1::OctetStringRef
 //! [`PrintableStringRef`]: asn1::PrintableStringRef
 //! [`SequenceOf`]: asn1::SequenceOf

--- a/der/src/reader.rs
+++ b/der/src/reader.rs
@@ -12,6 +12,9 @@ use crate::{
     Result, Tag, TagMode, TagNumber,
 };
 
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
 /// Reader trait which reads DER-encoded input.
 pub trait Reader<'r>: Sized {
     /// Get the length of the input.
@@ -128,6 +131,15 @@ pub trait Reader<'r>: Sized {
         let mut reader = NestedReader::new(self, len)?;
         let ret = f(&mut reader)?;
         reader.finish(ret)
+    }
+
+    /// Read a byte vector of the given length.
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    fn read_vec(&mut self, len: Length) -> Result<Vec<u8>> {
+        let mut bytes = vec![0u8; usize::try_from(len)?];
+        self.read_into(&mut bytes)?;
+        Ok(bytes)
     }
 
     /// Get the number of bytes still remaining in the buffer.


### PR DESCRIPTION
Adds owned forms of these two ASN.1 types, now that the borrowed forms have been renamed to `AnyRef` and `OctetStringRef`.

Includes some refactoring of the owned `BitString` type.

Also adds a `Reader::read_vec` method for reading a byte vector from a reader, and uses it to impl `DecodeValue` for `String`.