### PR TITLE
der v0.6.0-pre.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.6.0-pre.3"
+version = "0.6.0-pre.4"
 dependencies = [
  "const-oid 0.9.0",
  "der_derive",
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "der_derive"
-version = "0.6.0-pre.3"
+version = "0.6.0-pre.4"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -861,7 +861,7 @@ dependencies = [
 name = "pkcs1"
 version = "0.4.0-pre"
 dependencies = [
- "der 0.6.0-pre.3",
+ "der 0.6.0-pre.4",
  "hex-literal",
  "pkcs8 0.9.0-pre.1",
  "tempfile",
@@ -874,7 +874,7 @@ version = "0.5.0-pre.1"
 dependencies = [
  "aes",
  "cbc",
- "der 0.6.0-pre.3",
+ "der 0.6.0-pre.4",
  "des",
  "hex-literal",
  "hmac 0.12.1",
@@ -889,7 +889,7 @@ dependencies = [
 name = "pkcs7"
 version = "0.4.0-pre"
 dependencies = [
- "der 0.6.0-pre.3",
+ "der 0.6.0-pre.4",
  "hex-literal",
  "spki 0.6.0-pre.2",
 ]
@@ -909,7 +909,7 @@ dependencies = [
 name = "pkcs8"
 version = "0.9.0-pre.1"
 dependencies = [
- "der 0.6.0-pre.3",
+ "der 0.6.0-pre.4",
  "hex-literal",
  "pkcs5",
  "rand_core 0.6.3",
@@ -1258,7 +1258,7 @@ dependencies = [
 name = "sec1"
 version = "0.3.0-pre.1"
 dependencies = [
- "der 0.6.0-pre.3",
+ "der 0.6.0-pre.4",
  "generic-array",
  "hex-literal",
  "pkcs8 0.9.0-pre.1",
@@ -1413,7 +1413,7 @@ name = "spki"
 version = "0.6.0-pre.2"
 dependencies = [
  "base64ct 1.5.0",
- "der 0.6.0-pre.3",
+ "der 0.6.0-pre.4",
  "hex-literal",
  "sha2 0.10.2",
  "tempfile",
@@ -1703,7 +1703,7 @@ name = "x509-cert"
 version = "0.0.2"
 dependencies = [
  "const-oid 0.9.0",
- "der 0.6.0-pre.3",
+ "der 0.6.0-pre.4",
  "flagset",
  "hex-literal",
  "rstest",

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der"
-version = "0.6.0-pre.3" # Also update html_root_url in lib.rs when bumping this
+version = "0.6.0-pre.4" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust embedded-friendly implementation of the Distinguished Encoding Rules
 (DER) for Abstract Syntax Notation One (ASN.1) as described in ITU X.690 with
@@ -17,7 +17,7 @@ rust-version = "1.57"
 
 [dependencies]
 const-oid = { version = "0.9", optional = true, path = "../const-oid" }
-der_derive = { version = "=0.6.0-pre.3", optional = true, path = "derive" }
+der_derive = { version = "=0.6.0-pre.4", optional = true, path = "derive" }
 flagset = { version = "0.4.3", optional = true }
 pem-rfc7468 = { version = "0.6", optional = true, path = "../pem-rfc7468" }
 time = { version = "0.3.4", optional = true, default-features = false }

--- a/der/derive/Cargo.toml
+++ b/der/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der_derive"
-version = "0.6.0-pre.3" # Also update html_root_url in lib.rs when bumping this
+version = "0.6.0-pre.4" # Also update html_root_url in lib.rs when bumping this
 description = "Custom derive support for the `der` crate's `Choice` and `Sequence` traits"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"

--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-der = { version = "=0.6.0-pre.3", features = ["oid"], path = "../der" }
+der = { version = "=0.6.0-pre.4", features = ["oid"], path = "../der" }
 
 # optional dependencies
 pkcs8 = { version = "=0.9.0-pre.1", optional = true, default-features = false, path = "../pkcs8" }

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-der = { version = "=0.6.0-pre.3", features = ["oid"], path = "../der" }
+der = { version = "=0.6.0-pre.4", features = ["oid"], path = "../der" }
 spki = { version = "=0.6.0-pre.2", path = "../spki" }
 
 # optional dependencies

--- a/pkcs7/Cargo.toml
+++ b/pkcs7/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-der = { version = "=0.6.0-pre.3", features = ["oid"], path = "../der" }
+der = { version = "=0.6.0-pre.4", features = ["oid"], path = "../der" }
 spki = { version = "=0.6.0-pre.2", path = "../spki" }
 
 [dev-dependencies]

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-der = { version = "=0.6.0-pre.3", features = ["oid"], path = "../der" }
+der = { version = "=0.6.0-pre.4", features = ["oid"], path = "../der" }
 spki = { version = "=0.6.0-pre.2", path = "../spki" }
 
 # optional dependencies

--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-der = { version = "=0.6.0-pre.3", optional = true, features = ["oid"], path = "../der" }
+der = { version = "=0.6.0-pre.4", optional = true, features = ["oid"], path = "../der" }
 generic-array = { version = "0.14.4", optional = true, default-features = false }
 pkcs8 = { version = "=0.9.0-pre.1", optional = true, default-features = false, path = "../pkcs8" }
 serde = { version = "1.0.16", optional = true, default-features = false }

--- a/spki/Cargo.toml
+++ b/spki/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-der = { version = "=0.6.0-pre.3", features = ["oid"], path = "../der" }
+der = { version = "=0.6.0-pre.4", features = ["oid"], path = "../der" }
 
 # Optional dependencies
 sha2 = { version = "0.10", optional = true, default-features = false }

--- a/x509/Cargo.toml
+++ b/x509/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.56"
 
 [dependencies]
 const-oid = { version = "0.9", features = ["db"], path = "../const-oid" }
-der = { version = "=0.6.0-pre.3", features = ["derive", "alloc", "flagset"], path = "../der" }
+der = { version = "=0.6.0-pre.4", features = ["derive", "alloc", "flagset"], path = "../der" }
 flagset = { version = "0.4.3" }
 spki = { version = "=0.6.0-pre.2", path = "../spki" }
 


### PR DESCRIPTION
Also includes a release bump for `der_derive` v0.6.0-pre.4