### PR TITLE
pkcs1/5/8 and sec1 pre.2 releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -859,18 +859,18 @@ dependencies = [
 
 [[package]]
 name = "pkcs1"
-version = "0.4.0-pre"
+version = "0.4.0-pre.2"
 dependencies = [
  "der 0.6.0-pre.4",
  "hex-literal",
- "pkcs8 0.9.0-pre.1",
+ "pkcs8 0.9.0-pre.2",
  "tempfile",
  "zeroize",
 ]
 
 [[package]]
 name = "pkcs5"
-version = "0.5.0-pre.1"
+version = "0.5.0-pre.2"
 dependencies = [
  "aes",
  "cbc",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.9.0-pre.1"
+version = "0.9.0-pre.2"
 dependencies = [
  "der 0.6.0-pre.4",
  "hex-literal",
@@ -1256,12 +1256,12 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.3.0-pre.1"
+version = "0.3.0-pre.2"
 dependencies = [
  "der 0.6.0-pre.4",
  "generic-array",
  "hex-literal",
- "pkcs8 0.9.0-pre.1",
+ "pkcs8 0.9.0-pre.2",
  "serde",
  "subtle",
  "tempfile",

--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs1"
-version = "0.4.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.4.0-pre.2" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #1:
 RSA Cryptography Specifications Version 2.2 (RFC 8017)
@@ -18,7 +18,7 @@ rust-version = "1.57"
 der = { version = "=0.6.0-pre.4", features = ["oid"], path = "../der" }
 
 # optional dependencies
-pkcs8 = { version = "=0.9.0-pre.1", optional = true, default-features = false, path = "../pkcs8" }
+pkcs8 = { version = "=0.9.0-pre.2", optional = true, default-features = false, path = "../pkcs8" }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs5"
-version = "0.5.0-pre.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.5.0-pre.2" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #5:
 Password-Based Cryptography Specification Version 2.1 (RFC 8018)

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs8"
-version = "0.9.0-pre.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.9.0-pre.2" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #8:
 Private-Key Information Syntax Specification (RFC 5208), with additional
@@ -21,7 +21,7 @@ spki = { version = "=0.6.0-pre.3", path = "../spki" }
 
 # optional dependencies
 rand_core = { version = "0.6", optional = true, default-features = false }
-pkcs5 = { version = "=0.5.0-pre.1", optional = true, path = "../pkcs5" }
+pkcs5 = { version = "=0.5.0-pre.2", optional = true, path = "../pkcs5" }
 subtle = { version = "2", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sec1"
-version = "0.3.0-pre.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.3.0-pre.2" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of SEC1: Elliptic Curve Cryptography encoding formats
 including ASN.1 DER-serialized private keys as well as the
@@ -18,7 +18,7 @@ rust-version = "1.57"
 [dependencies]
 der = { version = "=0.6.0-pre.4", optional = true, features = ["oid"], path = "../der" }
 generic-array = { version = "0.14.4", optional = true, default-features = false }
-pkcs8 = { version = "=0.9.0-pre.1", optional = true, default-features = false, path = "../pkcs8" }
+pkcs8 = { version = "=0.9.0-pre.2", optional = true, default-features = false, path = "../pkcs8" }
 serde = { version = "1.0.16", optional = true, default-features = false }
 subtle = { version = "2", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }


### PR DESCRIPTION
Releases the following pre.2 versions:

- `pkcs1` v0.4.0-pre.2
- `pkcs5` v0.5.0-pre.2
- `pkcs8` v0.9.0-pre.2
- `sec1` v0.3.0-pre.2