### PR TITLE
pkcs8: re-export `AssociatedOid`

### DIFF
--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -83,7 +83,7 @@ pub use crate::{
     traits::DecodePrivateKey,
     version::Version,
 };
-pub use der::{self, asn1::ObjectIdentifier};
+pub use der::{self, asn1::ObjectIdentifier, oid::AssociatedOid};
 pub use spki::{self, AlgorithmIdentifier, DecodePublicKey, SubjectPublicKeyInfo};
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
This trait can be used to associate an OID with a particular type