### PR TITLE
der: rename `SliceReader`/`SliceWriter`

### DIFF
--- a/der/src/asn1/generalized_time.rs
+++ b/der/src/asn1/generalized_time.rs
@@ -331,7 +331,7 @@ impl TryFrom<GeneralizedTime> for PrimitiveDateTime {
 #[cfg(test)]
 mod tests {
     use super::GeneralizedTime;
-    use crate::{Decode, Encode, Encoder};
+    use crate::{Decode, Encode, SliceWriter};
     use hex_literal::hex;
 
     #[test]
@@ -341,7 +341,7 @@ mod tests {
         assert_eq!(utc_time.to_unix_duration().as_secs(), 673573540);
 
         let mut buf = [0u8; 128];
-        let mut encoder = Encoder::new(&mut buf);
+        let mut encoder = SliceWriter::new(&mut buf);
         utc_time.encode(&mut encoder).unwrap();
         assert_eq!(example_bytes, encoder.finish().unwrap());
     }

--- a/der/src/asn1/integer.rs
+++ b/der/src/asn1/integer.rs
@@ -5,8 +5,8 @@ pub(super) mod int;
 pub(super) mod uint;
 
 use crate::{
-    asn1::AnyRef, ByteSlice, DecodeValue, EncodeValue, Encoder, Error, FixedTag, Header, Length,
-    Reader, Result, Tag, ValueOrd, Writer,
+    asn1::AnyRef, ByteSlice, DecodeValue, EncodeValue, Error, FixedTag, Header, Length, Reader,
+    Result, SliceWriter, Tag, ValueOrd, Writer,
 };
 use core::{cmp::Ordering, mem};
 
@@ -140,11 +140,11 @@ where
     debug_assert!(mem::size_of::<T>() <= MAX_INT_SIZE);
 
     let mut buf1 = [0u8; MAX_INT_SIZE];
-    let mut encoder1 = Encoder::new(&mut buf1);
+    let mut encoder1 = SliceWriter::new(&mut buf1);
     a.encode_value(&mut encoder1)?;
 
     let mut buf2 = [0u8; MAX_INT_SIZE];
-    let mut encoder2 = Encoder::new(&mut buf2);
+    let mut encoder2 = SliceWriter::new(&mut buf2);
     b.encode_value(&mut encoder2)?;
 
     Ok(encoder1.finish()?.cmp(encoder2.finish()?))

--- a/der/src/asn1/integer/bigint.rs
+++ b/der/src/asn1/integer/bigint.rs
@@ -97,7 +97,7 @@ mod tests {
     use super::UIntRef;
     use crate::{
         asn1::{integer::tests::*, AnyRef},
-        Decode, Encode, Encoder, ErrorKind, Tag,
+        Decode, Encode, ErrorKind, SliceWriter, Tag,
     };
 
     #[test]
@@ -131,7 +131,7 @@ mod tests {
             let uint = UIntRef::from_der(example).unwrap();
 
             let mut buf = [0u8; 128];
-            let mut encoder = Encoder::new(&mut buf);
+            let mut encoder = SliceWriter::new(&mut buf);
             uint.encode(&mut encoder).unwrap();
 
             let result = encoder.finish().unwrap();

--- a/der/src/asn1/utc_time.rs
+++ b/der/src/asn1/utc_time.rs
@@ -198,7 +198,7 @@ impl TryFrom<AnyRef<'_>> for UtcTime {
 #[cfg(test)]
 mod tests {
     use super::UtcTime;
-    use crate::{Decode, Encode, Encoder};
+    use crate::{Decode, Encode, SliceWriter};
     use hex_literal::hex;
 
     #[test]
@@ -208,7 +208,7 @@ mod tests {
         assert_eq!(utc_time.to_unix_duration().as_secs(), 673573540);
 
         let mut buf = [0u8; 128];
-        let mut encoder = Encoder::new(&mut buf);
+        let mut encoder = SliceWriter::new(&mut buf);
         utc_time.encode(&mut encoder).unwrap();
         assert_eq!(example_bytes, encoder.finish().unwrap());
     }

--- a/der/src/decode.rs
+++ b/der/src/decode.rs
@@ -1,6 +1,6 @@
 //! Trait definition for [`Decode`].
 
-use crate::{Decoder, FixedTag, Header, Reader, Result};
+use crate::{FixedTag, Header, Reader, Result, SliceReader};
 
 #[cfg(feature = "pem")]
 use crate::{pem::PemLabel, PemReader};
@@ -18,9 +18,9 @@ pub trait Decode<'a>: Sized {
 
     /// Parse `Self` from the provided DER-encoded byte slice.
     fn from_der(bytes: &'a [u8]) -> Result<Self> {
-        let mut decoder = Decoder::new(bytes)?;
-        let result = Self::decode(&mut decoder)?;
-        decoder.finish(result)
+        let mut reader = SliceReader::new(bytes)?;
+        let result = Self::decode(&mut reader)?;
+        reader.finish(result)
     }
 }
 
@@ -71,6 +71,6 @@ impl<T: DecodeOwned + PemLabel> DecodePem for T {
 /// Decode the value part of a Tag-Length-Value encoded field, sans the [`Tag`]
 /// and [`Length`].
 pub trait DecodeValue<'a>: Sized {
-    /// Attempt to decode this message using the provided [`Decoder`].
-    fn decode_value<R: Reader<'a>>(decoder: &mut R, header: Header) -> Result<Self>;
+    /// Attempt to decode this message using the provided [`Reader`].
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self>;
 }

--- a/der/src/document.rs
+++ b/der/src/document.rs
@@ -1,6 +1,6 @@
 //! ASN.1 DER-encoded documents stored on the heap.
 
-use crate::{Decode, Decoder, Encode, Error, FixedTag, Length, Reader, Result, Tag, Writer};
+use crate::{Decode, Encode, Error, FixedTag, Length, Reader, Result, SliceReader, Tag, Writer};
 use alloc::vec::Vec;
 use core::fmt::{self, Debug};
 
@@ -187,7 +187,7 @@ impl TryFrom<Vec<u8>> for Document {
     type Error = Error;
 
     fn try_from(der_bytes: Vec<u8>) -> Result<Self> {
-        let mut decoder = Decoder::new(&der_bytes)?;
+        let mut decoder = SliceReader::new(&der_bytes)?;
         decode_sequence(&mut decoder)?;
         decoder.finish(())?;
 
@@ -331,7 +331,7 @@ impl ZeroizeOnDrop for SecretDocument {}
 
 /// Attempt to decode a ASN.1 `SEQUENCE` from the given decoder, returning the
 /// entire sequence including the header.
-fn decode_sequence<'a>(decoder: &mut Decoder<'a>) -> Result<&'a [u8]> {
+fn decode_sequence<'a>(decoder: &mut SliceReader<'a>) -> Result<&'a [u8]> {
     let header = decoder.peek_header()?;
     header.tag.assert_eq(Tag::Sequence)?;
 

--- a/der/src/length.rs
+++ b/der/src/length.rs
@@ -1,6 +1,6 @@
 //! Length calculations for encoded ASN.1 DER values
 
-use crate::{Decode, DerOrd, Encode, Encoder, Error, ErrorKind, Reader, Result, Writer};
+use crate::{Decode, DerOrd, Encode, Error, ErrorKind, Reader, Result, SliceWriter, Writer};
 use core::{
     cmp::Ordering,
     fmt,
@@ -270,10 +270,10 @@ impl DerOrd for Length {
         let mut buf1 = [0u8; MAX_DER_OCTETS];
         let mut buf2 = [0u8; MAX_DER_OCTETS];
 
-        let mut encoder1 = Encoder::new(&mut buf1);
+        let mut encoder1 = SliceWriter::new(&mut buf1);
         encoder1.encode(self)?;
 
-        let mut encoder2 = Encoder::new(&mut buf2);
+        let mut encoder2 = SliceWriter::new(&mut buf2);
         encoder2.encode(other)?;
 
         Ok(encoder1.finish()?.cmp(encoder2.finish()?))

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -27,9 +27,9 @@
 
 //! # Usage
 //! ## [`Decode`] and [`Encode`] traits
-//! The [`Decode`] and [`Encode`] traits are the core abstractions on
-//! which this crate is built and control what types can be (de)serialized
-//! as ASN.1 DER.
+//! The [`Decode`] and [`Encode`] traits provide the decoding/encoding API
+//! respectively, and are designed to work in conjunction with concrete ASN.1
+//! types, including all types which impl the [`Sequence`] trait.
 //!
 //! The traits are impl'd for the following Rust core types:
 //! - `()`: ASN.1 `NULL`. See also [`Null`].
@@ -81,11 +81,6 @@
 //! of the [`Encode`] trait, so any type which impls [`Sequence`] can be
 //! used for both decoding and encoding.
 //!
-//! The [`Decoder`] and [`Encoder`] types provide the decoding/encoding API
-//! respectively, and are designed to work in conjunction with concrete ASN.1
-//! types which impl the [`Decode`] and [`Encode`] traits, including
-//! all types which impl the [`Sequence`] trait.
-//!
 //! The following code example shows how to define a struct which maps to the
 //! above schema, as well as impl the [`Sequence`] trait for that struct:
 //!
@@ -97,7 +92,7 @@
 //! // "heapless" usage when the `alloc` feature is disabled.
 //! use der::{
 //!     asn1::{AnyRef, ObjectIdentifier},
-//!     DecodeValue, Decode, Decoder, Encode, Header, Reader, Sequence
+//!     DecodeValue, Decode, SliceReader, Encode, Header, Reader, Sequence
 //! };
 //!
 //! /// X.509 `AlgorithmIdentifier`.
@@ -347,10 +342,8 @@ pub(crate) mod arrayvec;
 mod byte_slice;
 mod datetime;
 mod decode;
-mod decoder;
 mod encode;
 mod encode_ref;
-mod encoder;
 mod error;
 mod header;
 mod length;
@@ -367,17 +360,15 @@ pub use crate::{
     asn1::{AnyRef, Choice, Sequence},
     datetime::DateTime,
     decode::{Decode, DecodeOwned, DecodeValue},
-    decoder::Decoder,
     encode::{Encode, EncodeValue},
     encode_ref::{EncodeRef, EncodeValueRef},
-    encoder::Encoder,
     error::{Error, ErrorKind, Result},
     header::Header,
     length::Length,
     ord::{DerOrd, ValueOrd},
-    reader::Reader,
+    reader::{slice::SliceReader, Reader},
     tag::{Class, FixedTag, Tag, TagMode, TagNumber, Tagged},
-    writer::Writer,
+    writer::{slice::SliceWriter, Writer},
 };
 
 #[cfg(feature = "alloc")]

--- a/der/src/reader.rs
+++ b/der/src/reader.rs
@@ -1,9 +1,9 @@
 //! Reader trait.
 
 mod nested;
-
 #[cfg(feature = "pem")]
 pub(crate) mod pem;
+pub(crate) mod slice;
 
 pub(crate) use nested::NestedReader;
 

--- a/der/src/writer.rs
+++ b/der/src/writer.rs
@@ -2,6 +2,7 @@
 
 #[cfg(feature = "pem")]
 pub(crate) mod pem;
+pub(crate) mod slice;
 
 use crate::Result;
 

--- a/der/tests/datetime.rs
+++ b/der/tests/datetime.rs
@@ -31,7 +31,7 @@ proptest! {
         let utc_time1 = UtcTime::try_from(datetime).unwrap();
 
         let mut buf = [0u8; 128];
-        let mut encoder = der::Encoder::new(&mut buf);
+        let mut encoder = der::SliceWriter::new(&mut buf);
         utc_time1.encode(&mut encoder).unwrap();
         let der_bytes = encoder.finish().unwrap();
 

--- a/der/tests/derive.rs
+++ b/der/tests/derive.rs
@@ -15,7 +15,7 @@ mod choice {
     mod explicit {
         use der::{
             asn1::{GeneralizedTime, UtcTime},
-            Choice, Decode, Encode, Encoder,
+            Choice, Decode, Encode, SliceWriter,
         };
         use hex_literal::hex;
         use std::time::Duration;
@@ -67,12 +67,12 @@ mod choice {
             let mut buf = [0u8; 128];
 
             let utc_time = Time::from_der(UTC_TIMESTAMP_DER).unwrap();
-            let mut encoder = Encoder::new(&mut buf);
+            let mut encoder = SliceWriter::new(&mut buf);
             utc_time.encode(&mut encoder).unwrap();
             assert_eq!(UTC_TIMESTAMP_DER, encoder.finish().unwrap());
 
             let general_time = Time::from_der(GENERAL_TIMESTAMP_DER).unwrap();
-            let mut encoder = Encoder::new(&mut buf);
+            let mut encoder = SliceWriter::new(&mut buf);
             general_time.encode(&mut encoder).unwrap();
             assert_eq!(GENERAL_TIMESTAMP_DER, encoder.finish().unwrap());
         }
@@ -82,7 +82,7 @@ mod choice {
     mod implicit {
         use der::{
             asn1::{BitStringRef, GeneralizedTime},
-            Choice, Decode, Encode, Encoder,
+            Choice, Decode, Encode, SliceWriter,
         };
         use hex_literal::hex;
 
@@ -139,12 +139,12 @@ mod choice {
             let mut buf = [0u8; 128];
 
             let cs_bit_string = ImplicitChoice::from_der(BITSTRING_DER).unwrap();
-            let mut encoder = Encoder::new(&mut buf);
+            let mut encoder = SliceWriter::new(&mut buf);
             cs_bit_string.encode(&mut encoder).unwrap();
             assert_eq!(BITSTRING_DER, encoder.finish().unwrap());
 
             let cs_time = ImplicitChoice::from_der(TIME_DER).unwrap();
-            let mut encoder = Encoder::new(&mut buf);
+            let mut encoder = SliceWriter::new(&mut buf);
             cs_time.encode(&mut encoder).unwrap();
             assert_eq!(TIME_DER, encoder.finish().unwrap());
         }
@@ -153,7 +153,7 @@ mod choice {
 
 /// Custom derive test cases for the `Enumerated` macro.
 mod enumerated {
-    use der::{Decode, Encode, Encoder, Enumerated};
+    use der::{Decode, Encode, Enumerated, SliceWriter};
     use hex_literal::hex;
 
     /// X.509 `CRLReason`.
@@ -188,11 +188,11 @@ mod enumerated {
     fn encode() {
         let mut buf = [0u8; 128];
 
-        let mut encoder = Encoder::new(&mut buf);
+        let mut encoder = SliceWriter::new(&mut buf);
         CrlReason::Unspecified.encode(&mut encoder).unwrap();
         assert_eq!(UNSPECIFIED_DER, encoder.finish().unwrap());
 
-        let mut encoder = Encoder::new(&mut buf);
+        let mut encoder = SliceWriter::new(&mut buf);
         CrlReason::KeyCompromise.encode(&mut encoder).unwrap();
         assert_eq!(KEY_COMPROMISE_DER, encoder.finish().unwrap());
     }

--- a/pkcs5/tests/pbes2.rs
+++ b/pkcs5/tests/pbes2.rs
@@ -165,7 +165,7 @@ fn encode_pbes2_pbkdf2_sha1_aes128cbc() {
     let mut buffer = [0u8; 1024];
 
     let scheme = pkcs5::EncryptionScheme::try_from(PBES2_PBKDF2_SHA1_AES128CBC_ALG_ID).unwrap();
-    let mut encoder = der::Encoder::new(&mut buffer);
+    let mut encoder = der::SliceWriter::new(&mut buffer);
     scheme.encode(&mut encoder).unwrap();
 
     let encoded_der = encoder.finish().unwrap();
@@ -178,7 +178,7 @@ fn encode_pbes2_pbkdf2_sha256_aes256cbc() {
     let mut buffer = [0u8; 1024];
 
     let scheme = pkcs5::EncryptionScheme::try_from(PBES2_PBKDF2_SHA256_AES256CBC_ALG_ID).unwrap();
-    let mut encoder = der::Encoder::new(&mut buffer);
+    let mut encoder = der::SliceWriter::new(&mut buffer);
     scheme.encode(&mut encoder).unwrap();
 
     let encoded_der = encoder.finish().unwrap();
@@ -191,7 +191,7 @@ fn encode_pbes2_scrypt_aes256cbc() {
     let mut buffer = [0u8; 1024];
 
     let scheme = pkcs5::EncryptionScheme::try_from(PBES2_SCRYPT_AES256CBC_ALG_ID).unwrap();
-    let mut encoder = der::Encoder::new(&mut buffer);
+    let mut encoder = der::SliceWriter::new(&mut buffer);
     scheme.encode(&mut encoder).unwrap();
 
     let encoded_der = encoder.finish().unwrap();

--- a/pkcs7/src/content_info.rs
+++ b/pkcs7/src/content_info.rs
@@ -124,13 +124,13 @@ impl<'a> Sequence<'a> for ContentInfo<'a> {
 mod tests {
     use super::{ContentInfo, DataContent};
     use core::convert::TryFrom;
-    use der::{asn1::OctetStringRef, Decode, Encode, Encoder, Length, TagMode, TagNumber};
+    use der::{asn1::OctetStringRef, Decode, Encode, Length, SliceWriter, TagMode, TagNumber};
 
     #[test]
     fn empty_data() -> der::Result<()> {
         let mut in_buf = [0u8; 32];
 
-        let mut encoder = Encoder::new(&mut in_buf);
+        let mut encoder = SliceWriter::new(&mut in_buf);
         encoder.sequence(crate::PKCS_7_DATA_OID.encoded_len()?, |encoder| {
             crate::PKCS_7_DATA_OID.encode(encoder)
         })?;
@@ -154,7 +154,7 @@ mod tests {
     fn empty_encrypted_data() -> der::Result<()> {
         let mut in_buf = [0u8; 32];
 
-        let mut encoder = Encoder::new(&mut in_buf);
+        let mut encoder = SliceWriter::new(&mut in_buf);
         encoder.sequence(crate::PKCS_7_ENCRYPTED_DATA_OID.encoded_len()?, |encoder| {
             (crate::PKCS_7_ENCRYPTED_DATA_OID).encode(encoder)
         })?;
@@ -193,7 +193,7 @@ mod tests {
         let inner_len = (oid_len + tagged_hello_len)?;
         assert_eq!(Length::new(20), inner_len);
 
-        let mut encoder = Encoder::new(&mut in_buf);
+        let mut encoder = SliceWriter::new(&mut in_buf);
         encoder.sequence(inner_len, |encoder| {
             crate::PKCS_7_DATA_OID.encode(encoder)?;
             encoder.context_specific(

--- a/pkcs7/tests/content_tests.rs
+++ b/pkcs7/tests/content_tests.rs
@@ -2,7 +2,7 @@
 
 use der::{
     asn1::{ObjectIdentifier, OctetStringRef},
-    Decode, Encoder,
+    Decode, SliceWriter,
 };
 use hex_literal::hex;
 use pkcs7::{
@@ -13,7 +13,7 @@ use spki::AlgorithmIdentifier;
 use std::fs;
 
 fn encode_content_info<'a>(content_info: &ContentInfo<'a>, buf: &'a mut [u8]) -> &'a [u8] {
-    let mut encoder = Encoder::new(buf);
+    let mut encoder = SliceWriter::new(buf);
     encoder.encode(content_info).expect("encoded content info");
     encoder.finish().expect("encoding success")
 }

--- a/x509-cert/tests/trust_anchor_format.rs
+++ b/x509-cert/tests/trust_anchor_format.rs
@@ -1,4 +1,4 @@
-use der::{Decode, Decoder, Encode};
+use der::{Decode, Encode, SliceReader};
 use hex_literal::hex;
 use x509_cert::anchor::{CertPolicies, TrustAnchorChoice};
 use x509_cert::ext::pkix::name::GeneralName;
@@ -10,7 +10,7 @@ fn decode_ta1() {
     let der_encoded_tac = include_bytes!("examples/eca_policies.ta");
     let der_encoded_cert = include_bytes!("examples/eca.der");
 
-    let mut decoder = Decoder::new(der_encoded_tac).unwrap();
+    let mut decoder = SliceReader::new(der_encoded_tac).unwrap();
     let tac = TrustAnchorChoice::decode(&mut decoder).unwrap();
     let reencoded_tac = tac.to_vec().unwrap();
     println!("Original : {:02X?}", der_encoded_cert);
@@ -125,7 +125,7 @@ fn decode_ta2() {
     let der_encoded_tac = include_bytes!("examples/entrust_dnConstraint.ta");
     let der_encoded_cert = include_bytes!("examples/entrust.der");
 
-    let mut decoder = Decoder::new(der_encoded_tac).unwrap();
+    let mut decoder = SliceReader::new(der_encoded_tac).unwrap();
     let tac = TrustAnchorChoice::decode(&mut decoder).unwrap();
     let reencoded_tac = tac.to_vec().unwrap();
     println!("Original : {:02X?}", der_encoded_cert);
@@ -228,7 +228,7 @@ fn decode_ta3() {
     let der_encoded_tac = include_bytes!("examples/exostar_policyFlags.ta");
     let der_encoded_cert = include_bytes!("examples/exostar.der");
 
-    let mut decoder = Decoder::new(der_encoded_tac).unwrap();
+    let mut decoder = SliceReader::new(der_encoded_tac).unwrap();
     let tac = TrustAnchorChoice::decode(&mut decoder).unwrap();
     let reencoded_tac = tac.to_vec().unwrap();
     println!("Original : {:02X?}", der_encoded_cert);
@@ -338,7 +338,7 @@ fn decode_ta4() {
     let der_encoded_tac = include_bytes!("examples/raytheon_pathLenConstraint.ta");
     let der_encoded_cert = include_bytes!("examples/raytheon.der");
 
-    let mut decoder = Decoder::new(der_encoded_tac).unwrap();
+    let mut decoder = SliceReader::new(der_encoded_tac).unwrap();
     let tac = TrustAnchorChoice::decode(&mut decoder).unwrap();
     let reencoded_tac = tac.to_vec().unwrap();
     println!("Original : {:02X?}", der_encoded_cert);


### PR DESCRIPTION
Renames the following types:
- `Decoder` => `SliceReader`
- `Encoder` => `SliceWriter`