### PR TITLE
der_derive v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "der_derive"
-version = "0.6.0-pre.4"
+version = "0.6.0"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.57"
 
 [dependencies]
 const-oid = { version = "0.9", optional = true, path = "../const-oid" }
-der_derive = { version = "=0.6.0-pre.4", optional = true, path = "derive" }
+der_derive = { version = "0.6", optional = true, path = "derive" }
 flagset = { version = "0.4.3", optional = true }
 pem-rfc7468 = { version = "0.6", optional = true, path = "../pem-rfc7468" }
 time = { version = "0.3.4", optional = true, default-features = false }

--- a/der/derive/CHANGELOG.md
+++ b/der/derive/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2022-05-08)
+### Added
+- Support for Context-Specific fields with default values ([#246])
+- Context-Specific tags on `#[derive(Sequence)]` ([#349])
+- `#[asn1(constructed = "true")]` ([#398])
+
+### Changed
+- Have `Sequence` macro derive `DecodeValue` ([#375])
+- Pass `Header` to `DecodeValue` ([#392])
+- Have `Choice` macro derive `EncodeValue` ([#395])
+- Only emit `.try_into()?` when a type is specified ([#397])
+- Use type's tag by default on `derive(Choice)` ([#416])
+
+### Fixed
+- Length calculation for explicit tags ([#400])
+
+### Removed
+- Static lifetime from ENUMERATED's derived `DecodeValue` ([#367])
+
+[#246]: https://github.com/RustCrypto/formats/pull/246
+[#349]: https://github.com/RustCrypto/formats/pull/349
+[#367]: https://github.com/RustCrypto/formats/pull/367
+[#375]: https://github.com/RustCrypto/formats/pull/375
+[#392]: https://github.com/RustCrypto/formats/pull/392
+[#395]: https://github.com/RustCrypto/formats/pull/395
+[#397]: https://github.com/RustCrypto/formats/pull/397
+[#398]: https://github.com/RustCrypto/formats/pull/398
+[#400]: https://github.com/RustCrypto/formats/pull/400
+[#416]: https://github.com/RustCrypto/formats/pull/416
+
 ## 0.5.0 (2021-11-15)
 ### Added
 - `asn1(tag_mode = "...")` derive attribute ([#150])

--- a/der/derive/Cargo.toml
+++ b/der/derive/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "der_derive"
-version = "0.6.0-pre.4" # Also update html_root_url in lib.rs when bumping this
+version = "0.6.0"
 description = "Custom derive support for the `der` crate's `Choice` and `Sequence` traits"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/der"
 repository = "https://github.com/RustCrypto/formats/tree/master/der/derive"
-categories = ["cryptography", "data-structures", "encoding", "no-std"]
+categories = ["cryptography", "data-structures", "encoding", "no-std", "parser-implementations"]
 keywords = ["asn1", "der", "crypto", "itu", "pkcs"]
 readme = "README.md"
 edition = "2021"

--- a/der/derive/src/lib.rs
+++ b/der/derive/src/lib.rs
@@ -113,8 +113,13 @@
 //! [`der::asn1::Utf8String`]: https://docs.rs/der/latest/der/asn1/struct.Utf8String.html
 
 #![crate_type = "proc-macro"]
-#![forbid(unsafe_code, clippy::unwrap_used)]
-#![warn(rust_2018_idioms, trivial_casts, unused_qualifications)]
+#![forbid(unsafe_code)]
+#![warn(
+    clippy::unwrap_used,
+    rust_2018_idioms,
+    trivial_casts,
+    unused_qualifications
+)]
 
 mod asn1_type;
 mod attributes;


### PR DESCRIPTION
### Added
- Support for Context-Specific fields with default values ([#246])
- Context-Specific tags on `#[derive(Sequence)]` ([#349])
- `#[asn1(constructed = "true")]` ([#398])

### Changed
- Have `Sequence` macro derive `DecodeValue` ([#375])
- Pass `Header` to `DecodeValue` ([#392])
- Have `Choice` macro derive `EncodeValue` ([#395])
- Only emit `.try_into()?` when a type is specified ([#397])
- Use type's tag by default on `derive(Choice)` ([#416])

### Fixed
- Length calculation for explicit tags ([#400])

### Removed
- Static lifetime from ENUMERATED's derived `DecodeValue` ([#367])

[#246]: https://github.com/RustCrypto/formats/pull/246
[#349]: https://github.com/RustCrypto/formats/pull/349
[#367]: https://github.com/RustCrypto/formats/pull/367
[#375]: https://github.com/RustCrypto/formats/pull/375
[#392]: https://github.com/RustCrypto/formats/pull/392
[#395]: https://github.com/RustCrypto/formats/pull/395
[#397]: https://github.com/RustCrypto/formats/pull/397
[#398]: https://github.com/RustCrypto/formats/pull/398
[#400]: https://github.com/RustCrypto/formats/pull/400
[#416]: https://github.com/RustCrypto/formats/pull/416