### PR TITLE
der v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.6.0-pre.4"
+version = "0.6.0"
 dependencies = [
  "const-oid 0.9.0",
  "der_derive",
@@ -861,7 +861,7 @@ dependencies = [
 name = "pkcs1"
 version = "0.4.0-pre.2"
 dependencies = [
- "der 0.6.0-pre.4",
+ "der 0.6.0",
  "hex-literal",
  "pkcs8 0.9.0-pre.3",
  "tempfile",
@@ -874,7 +874,7 @@ version = "0.5.0-pre.2"
 dependencies = [
  "aes",
  "cbc",
- "der 0.6.0-pre.4",
+ "der 0.6.0",
  "des",
  "hex-literal",
  "hmac 0.12.1",
@@ -889,7 +889,7 @@ dependencies = [
 name = "pkcs7"
 version = "0.4.0-pre"
 dependencies = [
- "der 0.6.0-pre.4",
+ "der 0.6.0",
  "hex-literal",
  "spki 0.6.0-pre.3",
 ]
@@ -909,7 +909,7 @@ dependencies = [
 name = "pkcs8"
 version = "0.9.0-pre.3"
 dependencies = [
- "der 0.6.0-pre.4",
+ "der 0.6.0",
  "hex-literal",
  "pkcs5",
  "rand_core 0.6.3",
@@ -1259,7 +1259,7 @@ name = "sec1"
 version = "0.3.0-pre.4"
 dependencies = [
  "base16ct 0.1.1",
- "der 0.6.0-pre.4",
+ "der 0.6.0",
  "generic-array",
  "hex-literal",
  "pkcs8 0.9.0-pre.3",
@@ -1414,7 +1414,7 @@ name = "spki"
 version = "0.6.0-pre.3"
 dependencies = [
  "base64ct 1.5.0",
- "der 0.6.0-pre.4",
+ "der 0.6.0",
  "hex-literal",
  "sha2 0.10.2",
  "tempfile",
@@ -1704,7 +1704,7 @@ name = "x509-cert"
 version = "0.0.2"
 dependencies = [
  "const-oid 0.9.0",
- "der 0.6.0-pre.4",
+ "der 0.6.0",
  "flagset",
  "hex-literal",
  "rstest",
@@ -1716,7 +1716,7 @@ name = "x509-ocsp"
 version = "0.0.1"
 dependencies = [
  "const-oid 0.9.0",
- "der 0.6.0-pre.4",
+ "der 0.6.0",
  "hex-literal",
  "spki 0.6.0-pre.3",
  "x509-cert",

--- a/der/CHANGELOG.md
+++ b/der/CHANGELOG.md
@@ -4,6 +4,79 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2022-05-08)
+### Added
+- Impl `ValueOrd` for `SetOf` and `SetOfVec` ([#362])
+- `SequenceRef` type ([#374])
+- Support for `SetOf` sorting on heapless `no_std` targets ([#401])
+- Support for mapping `BitString` to/from a `FlagSet` ([#412])
+- `DecodeOwned` marker trait ([#529])
+- Support for the ASN.1 `REAL` type ([#346])
+- `DecodePem` and `EncodePem` traits ([#571])
+- `Document` and `SecretDocument` types ([#571])
+- `EncodeRef`/`EncodeValueRef` wrapper types ([#604])
+- `Writer` trait ([#605])
+- `Reader` trait ([#606])
+- Streaming on-the-fly `PemReader` and `PemWriter` ([#618], [#636])
+- Owned `BitString` ([#636])
+- Owned `Any` and `OctetString` types ([#640])
+
+### Changed
+- Pass `Header` to `DecodeValue` ([#392])
+- Bump `const-oid` dependency to v0.9 ([#507])
+- Renamed `Decodable`/`Encodable` => `Decode`/`Encode` ([#523])
+- Enable arithmetic, casting, and panic `clippy` lints ([#556], [#579])
+- Use `&mut dyn Writer` as output for `Encode::encode` and `EncodeValue::encode_value` ([#611])
+- Bump `pem-rfc7468` dependency to v0.6 ([#620])
+- Use `Reader<'a>` as input for `Decode::decode` and `DecodeValue::decode_value` ([#633])
+- Renamed `Any` => `AnyRef` ([#637])
+- Renamed `BitString` => `BitStringRef` ([#637])
+- Renamed `Ia5String` => `Ia5StringRef` ([#637])
+- Renamed `OctetString` => `OctetStringRef` ([#637])
+- Renamed `PrintableString` => `PrintableStringRef` ([#637])
+- Renamed `Utf8String` => `Utf8StringRef` ([#637])
+- Renamed `UIntBytes` => `UIntRef` ([#637])
+- Renamed `Decoder` => `SliceReader` ([#651])
+- Renamed `Encoder` => `SliceWriter` ([#651])
+
+### Fixed
+- Handling of oversized unsigned `INTEGER` inputs ([#447])
+
+### Removed
+- `bigint` feature ([#344])
+- `OrdIsValueOrd` trait ([#359])
+- `Document` trait ([#571])
+- `OptionalRef` ([#604])
+- Decode-time SET OF ordering checks ([#625])
+
+[#344]: https://github.com/RustCrypto/formats/pull/344
+[#346]: https://github.com/RustCrypto/formats/pull/346
+[#359]: https://github.com/RustCrypto/formats/pull/359
+[#362]: https://github.com/RustCrypto/formats/pull/362
+[#374]: https://github.com/RustCrypto/formats/pull/374
+[#392]: https://github.com/RustCrypto/formats/pull/392
+[#401]: https://github.com/RustCrypto/formats/pull/401
+[#412]: https://github.com/RustCrypto/formats/pull/412
+[#447]: https://github.com/RustCrypto/formats/pull/447
+[#507]: https://github.com/RustCrypto/formats/pull/507
+[#523]: https://github.com/RustCrypto/formats/pull/523
+[#529]: https://github.com/RustCrypto/formats/pull/529
+[#556]: https://github.com/RustCrypto/formats/pull/556
+[#571]: https://github.com/RustCrypto/formats/pull/571
+[#579]: https://github.com/RustCrypto/formats/pull/579
+[#604]: https://github.com/RustCrypto/formats/pull/604
+[#605]: https://github.com/RustCrypto/formats/pull/605
+[#606]: https://github.com/RustCrypto/formats/pull/606
+[#611]: https://github.com/RustCrypto/formats/pull/611
+[#618]: https://github.com/RustCrypto/formats/pull/618
+[#620]: https://github.com/RustCrypto/formats/pull/620
+[#625]: https://github.com/RustCrypto/formats/pull/625
+[#633]: https://github.com/RustCrypto/formats/pull/633
+[#636]: https://github.com/RustCrypto/formats/pull/636
+[#637]: https://github.com/RustCrypto/formats/pull/637
+[#640]: https://github.com/RustCrypto/formats/pull/640
+[#651]: https://github.com/RustCrypto/formats/pull/651
+
 ## 0.5.1 (2021-11-17)
 ### Added
 - `Any::NULL` constant ([#226])

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der"
-version = "0.6.0-pre.4" # Also update html_root_url in lib.rs when bumping this
+version = "0.6.0"
 description = """
 Pure Rust embedded-friendly implementation of the Distinguished Encoding Rules
 (DER) for Abstract Syntax Notation One (ASN.1) as described in ITU X.690 with

--- a/der/LICENSE-MIT
+++ b/der/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2020-2021 The RustCrypto Project Developers
+Copyright (c) 2020-2022 The RustCrypto Project Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/der/derive/LICENSE-MIT
+++ b/der/derive/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2020-2021 The RustCrypto Project Developers
+Copyright (c) 2020-2022 The RustCrypto Project Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -3,8 +3,7 @@
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/der/0.6.0-pre.2"
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
 #![forbid(unsafe_code)]
 #![warn(

--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-der = { version = "=0.6.0-pre.4", features = ["oid"], path = "../der" }
+der = { version = "0.6", features = ["oid"], path = "../der" }
 
 # optional dependencies
 pkcs8 = { version = "=0.9.0-pre.3", optional = true, default-features = false, path = "../pkcs8" }

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-der = { version = "=0.6.0-pre.4", features = ["oid"], path = "../der" }
+der = { version = "0.6", features = ["oid"], path = "../der" }
 spki = { version = "=0.6.0-pre.3", path = "../spki" }
 
 # optional dependencies

--- a/pkcs7/Cargo.toml
+++ b/pkcs7/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-der = { version = "=0.6.0-pre.4", features = ["oid"], path = "../der" }
+der = { version = "0.6", features = ["oid"], path = "../der" }
 spki = { version = "=0.6.0-pre.3", path = "../spki" }
 
 [dev-dependencies]

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-der = { version = "=0.6.0-pre.4", features = ["oid"], path = "../der" }
+der = { version = "0.6", features = ["oid"], path = "../der" }
 spki = { version = "=0.6.0-pre.3", path = "../spki" }
 
 # optional dependencies

--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.57"
 
 [dependencies]
 base16ct = { version = "0.1.1", optional = true, default-features = false, path = "../base16ct" }
-der = { version = "=0.6.0-pre.4", optional = true, features = ["oid"], path = "../der" }
+der = { version = "0.6", optional = true, features = ["oid"], path = "../der" }
 generic-array = { version = "0.14.4", optional = true, default-features = false }
 pkcs8 = { version = "=0.9.0-pre.3", optional = true, default-features = false, path = "../pkcs8" }
 serdect = { version = "0.1", optional = true, default-features = false, features = ["alloc"], path = "../serdect" }

--- a/spki/Cargo.toml
+++ b/spki/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-der = { version = "=0.6.0-pre.4", features = ["oid"], path = "../der" }
+der = { version = "0.6", features = ["oid"], path = "../der" }
 
 # Optional dependencies
 sha2 = { version = "0.10", optional = true, default-features = false }

--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.56"
 
 [dependencies]
 const-oid = { version = "0.9", features = ["db"], path = "../const-oid" }
-der = { version = "=0.6.0-pre.4", features = ["derive", "alloc", "flagset"], path = "../der" }
+der = { version = "0.6", features = ["derive", "alloc", "flagset"], path = "../der" }
 flagset = { version = "0.4.3" }
 spki = { version = "=0.6.0-pre.3", path = "../spki" }
 

--- a/x509-ocsp/Cargo.toml
+++ b/x509-ocsp/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.57"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-der = { version = "0.6.0-pre.3", features = ["oid", "derive", "alloc"], path = "../der" }
+der = { version = "0.6", features = ["oid", "derive", "alloc"], path = "../der" }
 x509-cert = { version = "0.0.2", path = "../x509-cert" }
 const-oid = { version = "0.9", path = "../const-oid" }
 spki = { version = "=0.6.0-pre.3", path = "../spki" }


### PR DESCRIPTION
### Added
- Impl `ValueOrd` for `SetOf` and `SetOfVec` ([#362])
- `SequenceRef` type ([#374])
- Support for `SetOf` sorting on heapless `no_std` targets ([#401])
- Support for mapping `BitString` to/from a `FlagSet` ([#412])
- `DecodeOwned` marker trait ([#529])
- Support for the ASN.1 `REAL` type ([#346])
- `DecodePem` and `EncodePem` traits ([#571])
- `Document` and `SecretDocument` types ([#571])
- `EncodeRef`/`EncodeValueRef` wrapper types ([#604])
- `Writer` trait ([#605])
- `Reader` trait ([#606])
- Streaming on-the-fly `PemReader` and `PemWriter` ([#618], [#636])
- Owned `BitString` ([#636])
- Owned `Any` and `OctetString` types ([#640])

### Changed
- Pass `Header` to `DecodeValue` ([#392])
- Bump `const-oid` dependency to v0.9 ([#507])
- Renamed `Decodable`/`Encodable` => `Decode`/`Encode` ([#523])
- Enable arithmetic, casting, and panic `clippy` lints ([#556], [#579])
- Use `&mut dyn Writer` as output for `Encode::encode` and `EncodeValue::encode_value` ([#611])
- Bump `pem-rfc7468` dependency to v0.6 ([#620])
- Use `Reader<'a>` as input for `Decode::decode` and `DecodeValue::decode_value` ([#633])
- Renamed `Any` => `AnyRef` ([#637])
- Renamed `BitString` => `BitStringRef` ([#637])
- Renamed `Ia5String` => `Ia5StringRef` ([#637])
- Renamed `OctetString` => `OctetStringRef` ([#637])
- Renamed `PrintableString` => `PrintableStringRef` ([#637])
- Renamed `Utf8String` => `Utf8StringRef` ([#637])
- Renamed `UIntBytes` => `UIntRef` ([#637])
- Renamed `Decoder` => `SliceReader` ([#651])
- Renamed `Encoder` => `SliceWriter` ([#651])

### Fixed
- Handling of oversized unsigned `INTEGER` inputs ([#447])

### Removed
- `bigint` feature ([#344])
- `OrdIsValueOrd` trait ([#359])
- `Document` trait ([#571])
- `OptionalRef` ([#604])
- Decode-time SET OF ordering checks ([#625])

[#344]: https://github.com/RustCrypto/formats/pull/344
[#346]: https://github.com/RustCrypto/formats/pull/346
[#359]: https://github.com/RustCrypto/formats/pull/359
[#362]: https://github.com/RustCrypto/formats/pull/362
[#374]: https://github.com/RustCrypto/formats/pull/374
[#392]: https://github.com/RustCrypto/formats/pull/392
[#401]: https://github.com/RustCrypto/formats/pull/401
[#412]: https://github.com/RustCrypto/formats/pull/412
[#447]: https://github.com/RustCrypto/formats/pull/447
[#507]: https://github.com/RustCrypto/formats/pull/507
[#523]: https://github.com/RustCrypto/formats/pull/523
[#529]: https://github.com/RustCrypto/formats/pull/529
[#556]: https://github.com/RustCrypto/formats/pull/556
[#571]: https://github.com/RustCrypto/formats/pull/571
[#579]: https://github.com/RustCrypto/formats/pull/579
[#604]: https://github.com/RustCrypto/formats/pull/604
[#605]: https://github.com/RustCrypto/formats/pull/605
[#606]: https://github.com/RustCrypto/formats/pull/606
[#611]: https://github.com/RustCrypto/formats/pull/611
[#618]: https://github.com/RustCrypto/formats/pull/618
[#620]: https://github.com/RustCrypto/formats/pull/620
[#625]: https://github.com/RustCrypto/formats/pull/625
[#633]: https://github.com/RustCrypto/formats/pull/633
[#636]: https://github.com/RustCrypto/formats/pull/636
[#637]: https://github.com/RustCrypto/formats/pull/637
[#640]: https://github.com/RustCrypto/formats/pull/640
[#651]: https://github.com/RustCrypto/formats/pull/651