### PR TITLE
spki v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,7 +882,7 @@ dependencies = [
  "scrypt",
  "sha1",
  "sha2 0.10.2",
- "spki 0.6.0-pre.3",
+ "spki 0.6.0",
 ]
 
 [[package]]
@@ -891,7 +891,7 @@ version = "0.4.0-pre"
 dependencies = [
  "der 0.6.0",
  "hex-literal",
- "spki 0.6.0-pre.3",
+ "spki 0.6.0",
 ]
 
 [[package]]
@@ -913,7 +913,7 @@ dependencies = [
  "hex-literal",
  "pkcs5",
  "rand_core 0.6.3",
- "spki 0.6.0-pre.3",
+ "spki 0.6.0",
  "subtle",
  "tempfile",
 ]
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.6.0-pre.3"
+version = "0.6.0"
 dependencies = [
  "base64ct 1.5.0",
  "der 0.6.0",
@@ -1708,7 +1708,7 @@ dependencies = [
  "flagset",
  "hex-literal",
  "rstest",
- "spki 0.6.0-pre.3",
+ "spki 0.6.0",
 ]
 
 [[package]]
@@ -1718,7 +1718,7 @@ dependencies = [
  "const-oid 0.9.0",
  "der 0.6.0",
  "hex-literal",
- "spki 0.6.0-pre.3",
+ "spki 0.6.0",
  "x509-cert",
 ]
 

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.57"
 
 [dependencies]
 der = { version = "0.6", features = ["oid"], path = "../der" }
-spki = { version = "=0.6.0-pre.3", path = "../spki" }
+spki = { version = "0.6", path = "../spki" }
 
 # optional dependencies
 cbc = { version = "0.1.2", optional = true }

--- a/pkcs7/Cargo.toml
+++ b/pkcs7/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.57"
 
 [dependencies]
 der = { version = "0.6", features = ["oid"], path = "../der" }
-spki = { version = "=0.6.0-pre.3", path = "../spki" }
+spki = { version = "0.6", path = "../spki" }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.57"
 
 [dependencies]
 der = { version = "0.6", features = ["oid"], path = "../der" }
-spki = { version = "=0.6.0-pre.3", path = "../spki" }
+spki = { version = "0.6", path = "../spki" }
 
 # optional dependencies
 rand_core = { version = "0.6", optional = true, default-features = false }

--- a/spki/CHANGELOG.md
+++ b/spki/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2022-05-08)
+### Added
+- `AlgorithmIdentifier::oids()` helper function ([#443])
+- Impl `PartialOrd` for `AlgorithmIdentifier` ([#476])
+- Impl `DecodeValue` for `AlgorithmIdentifier` ([#449])
+- Impl `ValueOrd` for `SubjectPublicKeyInfo` ([#522])
+
+### Changed
+- Replace `PublicKeyDocument` with `der` crate's `Document` type ([#571])
+- Streaming fingerprint builder ([#616])
+- Bump `der` crate dependency to v0.6 ([#653])
+
+### Removed
+- `PublicKeyDocument` ([#571])
+
+[#443]: https://github.com/RustCrypto/formats/pull/443
+[#449]: https://github.com/RustCrypto/formats/pull/449
+[#476]: https://github.com/RustCrypto/formats/pull/476
+[#522]: https://github.com/RustCrypto/formats/pull/522
+[#571]: https://github.com/RustCrypto/formats/pull/571
+[#616]: https://github.com/RustCrypto/formats/pull/616
+[#653]: https://github.com/RustCrypto/formats/pull/653
+
 ## 0.5.4 (2022-01-05)
 ### Added
 - `Error::KeyMalformed` variant ([#318])

--- a/spki/Cargo.toml
+++ b/spki/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spki"
-version = "0.6.0-pre.3" # Also update html_root_url in lib.rs when bumping this
+version = "0.6.0"
 description = """
 X.509 Subject Public Key Info (RFC5280) describing public keys as well as their
 associated AlgorithmIdentifiers (i.e. OIDs)

--- a/spki/src/lib.rs
+++ b/spki/src/lib.rs
@@ -3,8 +3,7 @@
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/spki/0.6.0-pre.1"
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]

--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.56"
 const-oid = { version = "0.9", features = ["db"], path = "../const-oid" }
 der = { version = "0.6", features = ["derive", "alloc", "flagset"], path = "../der" }
 flagset = { version = "0.4.3" }
-spki = { version = "=0.6.0-pre.3", path = "../spki" }
+spki = { version = "0.6", path = "../spki" }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/x509-ocsp/Cargo.toml
+++ b/x509-ocsp/Cargo.toml
@@ -20,7 +20,7 @@ rust-version = "1.57"
 der = { version = "0.6", features = ["oid", "derive", "alloc"], path = "../der" }
 x509-cert = { version = "0.0.2", path = "../x509-cert" }
 const-oid = { version = "0.9", path = "../const-oid" }
-spki = { version = "=0.6.0-pre.3", path = "../spki" }
+spki = { version = "0.6", path = "../spki" }
 
 [dev-dependencies]
 hex-literal = "0.3"


### PR DESCRIPTION
### Added
- `AlgorithmIdentifier::oids()` helper function ([#443])
- Impl `PartialOrd` for `AlgorithmIdentifier` ([#476])
- Impl `DecodeValue` for `AlgorithmIdentifier` ([#449])
- Impl `ValueOrd` for `SubjectPublicKeyInfo` ([#522])

### Changed
- Replace `PublicKeyDocument` with `der` crate's `Document` type ([#571])
- Streaming fingerprint builder ([#616])
- Bump `der` crate dependency to v0.6 ([#653])

### Removed
- `PublicKeyDocument` ([#571])

[#443]: https://github.com/RustCrypto/formats/pull/443
[#449]: https://github.com/RustCrypto/formats/pull/449
[#476]: https://github.com/RustCrypto/formats/pull/476
[#522]: https://github.com/RustCrypto/formats/pull/522
[#571]: https://github.com/RustCrypto/formats/pull/571
[#616]: https://github.com/RustCrypto/formats/pull/616
[#653]: https://github.com/RustCrypto/formats/pull/653