### PR TITLE
pkcs5 v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -870,7 +870,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs5"
-version = "0.5.0-pre.2"
+version = "0.5.0"
 dependencies = [
  "aes",
  "cbc",

--- a/pkcs5/CHANGELOG.md
+++ b/pkcs5/CHANGELOG.md
@@ -4,13 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [UNRELEASED]
+## 0.5.0 (2022-05-08)
 ### Changed
-- `sha1` feature is renamed to `sha1-insecure` ([#426])
+- Update `hmac`, `pbkdf2`, and `sha2`
+- Update cipher v0.4 crates ([#411])
+- Switch from `sha-1` to `sha1`; `sha1` feature is renamed to `sha1-insecure` ([#426])
 - Bump `scrypt` dependency to v0.9 ([#441])
+- Bump `der` to v0.6 ([#653])
+- Bump `spki` to v0.6 ([#654])
 
+[#411]: https://github.com/RustCrypto/formats/pull/411
 [#426]: https://github.com/RustCrypto/formats/pull/426
 [#441]: https://github.com/RustCrypto/formats/pull/441
+[#653]: https://github.com/RustCrypto/formats/pull/653
+[#654]: https://github.com/RustCrypto/formats/pull/654
 
 ## 0.4.0 (2021-11-15)
 ### Changed

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs5"
-version = "0.5.0-pre.2" # Also update html_root_url in lib.rs when bumping this
+version = "0.5.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #5:
 Password-Based Cryptography Specification Version 2.1 (RFC 8018)

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -21,7 +21,7 @@ spki = { version = "0.6", path = "../spki" }
 
 # optional dependencies
 rand_core = { version = "0.6", optional = true, default-features = false }
-pkcs5 = { version = "=0.5.0-pre.2", optional = true, path = "../pkcs5" }
+pkcs5 = { version = "0.5", optional = true, path = "../pkcs5" }
 subtle = { version = "2", optional = true, default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
### Changed
- Update `hmac`, `pbkdf2`, and `sha2`
- Update cipher v0.4 crates ([#411])
- Switch from `sha-1` to `sha1`; `sha1` feature is renamed to `sha1-insecure` ([#426])
- Bump `scrypt` dependency to v0.9 ([#441])
- Bump `der` to v0.6 ([#653])
- Bump `spki` to v0.6 ([#654])

[#411]: https://github.com/RustCrypto/formats/pull/411
[#426]: https://github.com/RustCrypto/formats/pull/426
[#441]: https://github.com/RustCrypto/formats/pull/441
[#653]: https://github.com/RustCrypto/formats/pull/653
[#654]: https://github.com/RustCrypto/formats/pull/654