### PR TITLE
pkcs8 v0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,7 +863,7 @@ version = "0.4.0-pre.2"
 dependencies = [
  "der 0.6.0",
  "hex-literal",
- "pkcs8 0.9.0-pre.3",
+ "pkcs8 0.9.0",
  "tempfile",
  "zeroize",
 ]
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.9.0-pre.3"
+version = "0.9.0"
 dependencies = [
  "der 0.6.0",
  "hex-literal",
@@ -1262,7 +1262,7 @@ dependencies = [
  "der 0.6.0",
  "generic-array",
  "hex-literal",
- "pkcs8 0.9.0-pre.3",
+ "pkcs8 0.9.0",
  "serdect",
  "subtle",
  "tempfile",

--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.57"
 der = { version = "0.6", features = ["oid"], path = "../der" }
 
 # optional dependencies
-pkcs8 = { version = "=0.9.0-pre.3", optional = true, default-features = false, path = "../pkcs8" }
+pkcs8 = { version = "0.9", optional = true, default-features = false, path = "../pkcs8" }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/pkcs8/CHANGELOG.md
+++ b/pkcs8/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.0 (2022-05-08)
+### Added
+- Error conversion support to `pkcs8::spki::Error` ([#335])
+- Re-export `AssociatedOid` ([#645])
+
+### Changed
+- Use `finish_non_exhaustive` in `Debug` impls ([#245])
+- Replace `PrivateKeyDocument` with `der::SecretDocument` ([#571])
+- Bump `der` to v0.6 ([#653])
+- Bump `spki` to v0.6 ([#654])
+- Bump `pkcs5` to v0.5 ([#655])
+
+### Removed
+- `PrivateKeyDocument` ([#571])
+
+[#245]: https://github.com/RustCrypto/formats/pull/245
+[#335]: https://github.com/RustCrypto/formats/pull/335
+[#571]: https://github.com/RustCrypto/formats/pull/571
+[#645]: https://github.com/RustCrypto/formats/pull/645
+[#653]: https://github.com/RustCrypto/formats/pull/653
+[#654]: https://github.com/RustCrypto/formats/pull/654
+[#655]: https://github.com/RustCrypto/formats/pull/655
+
 ## 0.8.0 (2021-11-16)
 ### Added
 - Re-export `spki` crate ([#210])

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs8"
-version = "0.9.0-pre.3" # Also update html_root_url in lib.rs when bumping this
+version = "0.9.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #8:
 Private-Key Information Syntax Specification (RFC 5208), with additional

--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.57"
 base16ct = { version = "0.1.1", optional = true, default-features = false, path = "../base16ct" }
 der = { version = "0.6", optional = true, features = ["oid"], path = "../der" }
 generic-array = { version = "0.14.4", optional = true, default-features = false }
-pkcs8 = { version = "=0.9.0-pre.3", optional = true, default-features = false, path = "../pkcs8" }
+pkcs8 = { version = "0.9", optional = true, default-features = false, path = "../pkcs8" }
 serdect = { version = "0.1", optional = true, default-features = false, features = ["alloc"], path = "../serdect" }
 subtle = { version = "2", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }


### PR DESCRIPTION
### Added
- Error conversion support to `pkcs8::spki::Error` ([#335])
- Re-export `AssociatedOid` ([#645])

### Changed
- Use `finish_non_exhaustive` in `Debug` impls ([#245])
- Replace `PrivateKeyDocument` with `der::SecretDocument` ([#571])
- Bump `der` to v0.6 ([#653])
- Bump `spki` to v0.6 ([#654])
- Bump `pkcs5` to v0.5 ([#655])

### Removed
- `PrivateKeyDocument` ([#571])

[#245]: https://github.com/RustCrypto/formats/pull/245
[#335]: https://github.com/RustCrypto/formats/pull/335
[#571]: https://github.com/RustCrypto/formats/pull/571
[#645]: https://github.com/RustCrypto/formats/pull/645
[#653]: https://github.com/RustCrypto/formats/pull/653
[#654]: https://github.com/RustCrypto/formats/pull/654
[#655]: https://github.com/RustCrypto/formats/pull/655