### PR TITLE
sec1 v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,7 +1256,7 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.3.0-pre.4"
+version = "0.3.0"
 dependencies = [
  "base16ct 0.1.1",
  "der 0.6.0",

--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs1"
-version = "0.4.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.4.0"
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #1:
 RSA Cryptography Specifications Version 2.2 (RFC 8017)

--- a/pkcs1/LICENSE-MIT
+++ b/pkcs1/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2021 The RustCrypto Project Developers
+Copyright (c) 2021-2022 The RustCrypto Project Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/pkcs1/src/lib.rs
+++ b/pkcs1/src/lib.rs
@@ -3,8 +3,7 @@
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/pkcs1/0.4.0-pre"
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]

--- a/sec1/CHANGELOG.md
+++ b/sec1/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2022-05-08)
+### Added
+- Make `der` feature optional but on-by-default ([#497])
+- Make `point` feature optional but on-by-default ([#516])
+
+### Changed
+- Use `base16ct` and `serdect` crates ([#648])
+- Bump `der` to v0.6 ([#653])
+- Bump `pkcs8` to v0.9 ([#656])
+
+[#497]: https://github.com/RustCrypto/formats/pull/497
+[#516]: https://github.com/RustCrypto/formats/pull/516
+[#648]: https://github.com/RustCrypto/formats/pull/648
+[#653]: https://github.com/RustCrypto/formats/pull/653
+[#656]: https://github.com/RustCrypto/formats/pull/656
+
 ## 0.2.1 (2021-11-18)
 ### Added
 - `serde` feature ([#248])

--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sec1"
-version = "0.3.0-pre.4" # Also update html_root_url in lib.rs when bumping this
+version = "0.3.0"
 description = """
 Pure Rust implementation of SEC1: Elliptic Curve Cryptography encoding formats
 including ASN.1 DER-serialized private keys as well as the

--- a/sec1/LICENSE-MIT
+++ b/sec1/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2021 The RustCrypto Project Developers
+Copyright (c) 2021-2022 The RustCrypto Project Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/sec1/src/lib.rs
+++ b/sec1/src/lib.rs
@@ -3,8 +3,7 @@
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/sec1/0.3.0-pre"
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Added
- Make `der` feature optional but on-by-default ([#497])
- Make `point` feature optional but on-by-default ([#516])

### Changed
- Use `base16ct` and `serdect` crates ([#648])
- Bump `der` to v0.6 ([#653])
- Bump `pkcs8` to v0.9 ([#656])

[#497]: https://github.com/RustCrypto/formats/pull/497
[#516]: https://github.com/RustCrypto/formats/pull/516
[#648]: https://github.com/RustCrypto/formats/pull/648
[#653]: https://github.com/RustCrypto/formats/pull/653
[#656]: https://github.com/RustCrypto/formats/pull/656