### PR TITLE
Cut prereleases with `der` v0.6 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs7"
-version = "0.4.0-pre"
+version = "0.4.0-pre.0"
 dependencies = [
  "der 0.6.0",
  "hex-literal",
@@ -1701,7 +1701,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "x509-cert"
-version = "0.0.2"
+version = "0.1.0-pre.0"
 dependencies = [
  "const-oid 0.9.0",
  "der 0.6.0",
@@ -1713,7 +1713,7 @@ dependencies = [
 
 [[package]]
 name = "x509-ocsp"
-version = "0.0.1"
+version = "0.1.0-pre.0"
 dependencies = [
  "const-oid 0.9.0",
  "der 0.6.0",

--- a/pkcs7/Cargo.toml
+++ b/pkcs7/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs7"
-version = "0.4.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.4.0-pre.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #7:
 PKCS #7: Cryptographic Message Syntax Version 1.5 (RFC 5652)

--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x509-cert"
-version = "0.0.2" # Also update html_root_url in lib.rs when bumping this
+version = "0.1.0-pre.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of the X.509 Public Key Infrastructure Certificate
 format as described in RFC 5280

--- a/x509-ocsp/Cargo.toml
+++ b/x509-ocsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x509-ocsp"
-version = "0.0.1"
+version = "0.1.0-pre.0"
 description = """
 Pure Rust implementation of the X.509 Internet Public Key Infrastructure
 Online Certificate Status Protocol - OCSP formats as described in RFC 6960
@@ -14,11 +14,9 @@ readme = "README.md"
 edition = "2021"
 rust-version = "1.57"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 der = { version = "0.6", features = ["oid", "derive", "alloc"], path = "../der" }
-x509-cert = { version = "0.0.2", path = "../x509-cert" }
+x509-cert = { version = "=0.1.0-pre.0", path = "../x509-cert" }
 const-oid = { version = "0.9", path = "../const-oid" }
 spki = { version = "0.6", path = "../spki" }
 


### PR DESCRIPTION
The following are the remaining crates which haven't yet received a final release with `der` v0.6, with this commit cutting the following prereleases:

- `pkcs7` v0.4.0-pre.0
- `x509-cert` v0.1.0-pre.0
- `x509-ocsp` v0.1.0-pre.0

The idea is to give one last opportunity to make breaking changes before cutting final releases.

cc @bstrie @carl-wallace @npmccallum 