### PR TITLE
base32ct: add `Base32Upper`

### DIFF
--- a/base32ct/src/lib.rs
+++ b/base32ct/src/lib.rs
@@ -54,7 +54,7 @@ pub use crate::{
     error::{Error, Result},
 };
 
-/// Standard Base32 encoding with `=` padding.
+/// RFC4648 lower case Base32 encoding with `=` padding.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Base32;
 
@@ -70,7 +70,23 @@ impl Encoding for Base32 {
     }
 }
 
-/// Standard Base32 encoding *without* padding.
+/// RFC4648 upper case Base32 encoding with `=` padding.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct Base32Upper;
+
+impl Encoding for Base32Upper {
+    const PADDED: bool = true;
+
+    fn decode_5bits(byte: u8) -> i16 {
+        decode_5bits_upper(byte)
+    }
+
+    fn encode_5bits(src: u8) -> u8 {
+        encode_5bits_upper(src)
+    }
+}
+
+/// RFC4648 lower case Base32 encoding *without* padding.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Base32Unpadded;
 
@@ -92,15 +108,29 @@ fn decode_5bits_lower(byte: u8) -> i16 {
     let mut ret: i16 = -1;
 
     // if (src > 96 && src < 123) ret += src - 97 + 1; // -64
-    ret += (((0x60i16 - src) & (src - 0x7bi16)) >> 8) & (src - 96i16);
+    ret += (((0x60 - src) & (src - 0x7b)) >> 8) & (src - 96);
 
     // if (src > 0x31 && src < 0x38) ret += src - 24 + 1; // -23
-    ret += (((0x31i16 - src) & (src - 0x38i16)) >> 8) & (src - 23i16);
+    ret += (((0x31 - src) & (src - 0x38)) >> 8) & (src - 23);
 
-    ret as i16
+    ret
 }
 
-/// Encode 5-bits of upper-case Base32.
+/// Decode 5-bits of upper-case Base32.
+fn decode_5bits_upper(byte: u8) -> i16 {
+    let src = byte as i16;
+    let mut ret: i16 = -1;
+
+    // if (src > 64 && src < 91) ret += src - 65 + 1; // -64
+    ret += (((0x40 - src) & (src - 0x5b)) >> 8) & (src - 64);
+
+    // if ($src > 0x31 && $src < 0x38) $ret += $src - 24 + 1; // -23
+    ret += (((0x31 - src) & (src - 0x38)) >> 8) & (src - 23);
+
+    ret
+}
+
+/// Encode 5-bits of lower-case Base32.
 fn encode_5bits_lower(src: u8) -> u8 {
     let mut diff: i16 = 0x61;
 
@@ -110,9 +140,19 @@ fn encode_5bits_lower(src: u8) -> u8 {
     (src as i16 + diff) as u8
 }
 
+/// Encode 5-bits of upper-case Base32.
+fn encode_5bits_upper(src: u8) -> u8 {
+    let mut diff: i16 = 0x41;
+
+    // if ($src > 25) $ret -= 40;
+    diff -= ((25 - src as i16) >> 8) & 41;
+
+    (src as i16 + diff) as u8
+}
+
 #[cfg(all(test, feature = "alloc"))]
 mod tests {
-    use crate::{Base32, Base32Unpadded, Encoding, Error};
+    use crate::{Base32, Base32Unpadded, Base32Upper, Encoding, Error};
 
     #[derive(Debug)]
     struct TestVector {
@@ -120,7 +160,7 @@ mod tests {
         encoded: &'static str,
     }
 
-    const PADDED_VECTORS: &[TestVector] = &[
+    const LOWER_PADDED_VECTORS: &[TestVector] = &[
         TestVector {
             decoded: &[0],
             encoded: "aa======",
@@ -135,7 +175,7 @@ mod tests {
         },
     ];
 
-    const UNPADDED_VECTORS: &[TestVector] = &[
+    const LOWER_UNPADDED_VECTORS: &[TestVector] = &[
         TestVector {
             decoded: &[0],
             encoded: "aa",
@@ -150,15 +190,37 @@ mod tests {
         },
     ];
 
+    const UPPER_PADDED_VECTORS: &[TestVector] = &[
+        TestVector {
+            decoded: &[0],
+            encoded: "AA======",
+        },
+        TestVector {
+            decoded: &[1, 2, 3, 5, 9, 17, 33, 65, 129],
+            encoded: "AEBAGBIJCEQUDAI=",
+        },
+        TestVector {
+            decoded: &[32, 7],
+            encoded: "EADQ====",
+        },
+    ];
+
     #[test]
     fn decode_valid_base32() {
-        for vector in PADDED_VECTORS {
+        for vector in LOWER_PADDED_VECTORS {
             assert_eq!(&Base32::decode_vec(vector.encoded).unwrap(), vector.decoded);
         }
 
-        for vector in UNPADDED_VECTORS {
+        for vector in LOWER_UNPADDED_VECTORS {
             assert_eq!(
                 &Base32Unpadded::decode_vec(vector.encoded).unwrap(),
+                vector.decoded
+            );
+        }
+
+        for vector in UPPER_PADDED_VECTORS {
+            assert_eq!(
+                &Base32Upper::decode_vec(vector.encoded).unwrap(),
                 vector.decoded
             );
         }
@@ -166,7 +228,8 @@ mod tests {
 
     #[test]
     fn decode_padding_error() {
-        let truncated = &PADDED_VECTORS[0].encoded[..(&PADDED_VECTORS[0].encoded.len() - 1)];
+        let truncated =
+            &LOWER_PADDED_VECTORS[0].encoded[..(&LOWER_PADDED_VECTORS[0].encoded.len() - 1)];
         assert_eq!(Base32::decode_vec(truncated), Err(Error::InvalidEncoding));
     }
 
@@ -180,15 +243,19 @@ mod tests {
 
     #[test]
     fn encode_base32() {
-        for vector in PADDED_VECTORS {
+        for vector in LOWER_PADDED_VECTORS {
             assert_eq!(&Base32::encode_string(vector.decoded), vector.encoded);
         }
 
-        for vector in UNPADDED_VECTORS {
+        for vector in LOWER_UNPADDED_VECTORS {
             assert_eq!(
                 &Base32Unpadded::encode_string(vector.decoded),
                 vector.encoded
             );
+        }
+
+        for vector in UPPER_PADDED_VECTORS {
+            assert_eq!(&Base32Upper::encode_string(vector.decoded), vector.encoded);
         }
     }
 }


### PR DESCRIPTION
Support for decoding/encoding upper case Base32.