### PR TITLE
base64ct: rename `Variant` trait to `Alphabet`

### DIFF
--- a/base64ct/README.md
+++ b/base64ct/README.md
@@ -9,7 +9,7 @@
 
 Pure Rust implementation of Base64 ([RFC 4648]).
 
-Implements multiple Base64 variants without data-dependent branches or lookup
+Implements multiple Base64 alphabets without data-dependent branches or lookup
 tables, thereby providing portable "best effort" constant-time operation.
 
 Supports `no_std` environments and avoids heap allocations in the core API
@@ -19,9 +19,9 @@ Supports `no_std` environments and avoids heap allocations in the core API
 
 ## About
 
-This crate implements several Base64 variants in constant-time for sidechannel
+This crate implements several Base64 alphabets in constant-time for sidechannel
 resistance, aimed at purposes like encoding/decoding the "PEM" format used to
-store things like cryptographic private keys.
+store things like cryptographic private keys (i.e. in the [`pem-rfc7468`] crate).
 
 The paper [Util::Lookup: Exploiting key decoding in cryptographic libraries][Util::Lookup]
 demonstrates how the leakage from non-constant-time Base64 parsers can be used
@@ -30,7 +30,9 @@ to practically extract RSA private keys from SGX enclaves.
 The padded variants require (`=`) padding. Unpadded variants expressly
 reject such padding.
 
-Whitespace is expressly disallowed.
+Whitespace is expressly disallowed, with the exception of the
+[`Decoder::new_wrapped`] and [`Encoder::new_wrapped`] modes which provide
+fixed-width line wrapping.
 
 ## Supported Base64 variants
 
@@ -78,4 +80,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [RustCrypto]: https://github.com/rustcrypto
 [RFC 4648]: https://tools.ietf.org/html/rfc4648
+[`pem-rfc7468`]: https://github.com/RustCrypto/formats/tree/master/pem-rfc7468
 [Util::Lookup]: https://arxiv.org/pdf/2108.04600.pdf
+[`Decoder::new_wrapped`]: https://docs.rs/base64ct/latest/base64ct/struct.Decoder.html#method.new_wrapped
+[`Encoder::new_wrapped`]: https://docs.rs/base64ct/latest/base64ct/struct.Encoder.html#method.new_wrapped

--- a/base64ct/src/alphabet.rs
+++ b/base64ct/src/alphabet.rs
@@ -1,4 +1,4 @@
-//! Base64 variants
+//! Base64 alphabets.
 
 // TODO(tarcieri): explicitly checked/wrapped arithmetic
 #![allow(clippy::integer_arithmetic)]
@@ -10,12 +10,12 @@ pub mod crypt;
 pub mod standard;
 pub mod url;
 
-/// Core encoder/decoder functions for a particular Base64 variant
-pub trait Variant: 'static + Copy + Debug + Eq + Send + Sized + Sync {
-    /// Unpadded equivalent of this variant.
+/// Core encoder/decoder functions for a particular Base64 alphabet.
+pub trait Alphabet: 'static + Copy + Debug + Eq + Send + Sized + Sync {
+    /// Unpadded equivalent of this alphabet.
     ///
-    /// For variants that are unpadded to begin with, this should be `Self`.
-    type Unpadded: Variant;
+    /// For alphabets that are unpadded to begin with, this should be `Self`.
+    type Unpadded: Alphabet;
 
     /// Is this encoding padded?
     const PADDED: bool;
@@ -47,7 +47,7 @@ pub trait Variant: 'static + Copy + Debug + Eq + Send + Sized + Sync {
         ((c0 | c1 | c2 | c3) >> 8) & 1
     }
 
-    /// Decode 6-bits of a Base64 message
+    /// Decode 6-bits of a Base64 message.
     fn decode_6bits(src: u8) -> i16 {
         let mut res: i16 = -1;
 
@@ -70,7 +70,7 @@ pub trait Variant: 'static + Copy + Debug + Eq + Send + Sized + Sync {
         res
     }
 
-    /// Encode 3-bytes of a Base64 message
+    /// Encode 3-bytes of a Base64 message.
     #[inline(always)]
     fn encode_3bytes(src: &[u8], dst: &mut [u8]) {
         debug_assert_eq!(src.len(), 3);
@@ -86,7 +86,7 @@ pub trait Variant: 'static + Copy + Debug + Eq + Send + Sized + Sync {
         dst[3] = Self::encode_6bits(b2 & 63);
     }
 
-    /// Encode 6-bits of a Base64 message
+    /// Encode 6-bits of a Base64 message.
     #[inline(always)]
     fn encode_6bits(src: i16) -> u8 {
         let mut diff = src + Self::BASE as i16;
@@ -102,22 +102,22 @@ pub trait Variant: 'static + Copy + Debug + Eq + Send + Sized + Sync {
     }
 }
 
-/// Constant-time decoder step
+/// Constant-time decoder step.
 #[derive(Debug)]
 pub enum Decode {
-    /// Match the given range, offsetting the input on match
+    /// Match the given range, offsetting the input on match.
     Range(Range<u8>, i16),
 
-    /// Match the given value, returning the associated offset on match
+    /// Match the given value, returning the associated offset on match.
     Eq(u8, i16),
 }
 
-/// Constant-time encoder step
+/// Constant-time encoder step.
 #[derive(Copy, Clone, Debug)]
 pub enum Encode {
-    /// Apply the given offset to the cumulative result on match
+    /// Apply the given offset to the cumulative result on match.
     Apply(u8, i16),
 
-    /// Compute a difference using the given offset on match
+    /// Compute a difference using the given offset on match.
     Diff(u8, i16),
 }

--- a/base64ct/src/alphabet/bcrypt.rs
+++ b/base64ct/src/alphabet/bcrypt.rs
@@ -1,6 +1,6 @@
 //! bcrypt Base64 encoding.
 
-use super::{Decode, Encode, Variant};
+use super::{Alphabet, Decode, Encode};
 
 /// bcrypt Base64 encoding.
 ///
@@ -11,7 +11,7 @@ use super::{Decode, Encode, Variant};
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Base64Bcrypt;
 
-impl Variant for Base64Bcrypt {
+impl Alphabet for Base64Bcrypt {
     type Unpadded = Self;
     const PADDED: bool = false;
     const BASE: u8 = b'.';

--- a/base64ct/src/alphabet/crypt.rs
+++ b/base64ct/src/alphabet/crypt.rs
@@ -1,6 +1,6 @@
 //! `crypt(3)` Base64 encoding.
 
-use super::{Decode, Encode, Variant};
+use super::{Alphabet, Decode, Encode};
 
 /// `crypt(3)` Base64 encoding.
 ///
@@ -11,7 +11,7 @@ use super::{Decode, Encode, Variant};
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Base64Crypt;
 
-impl Variant for Base64Crypt {
+impl Alphabet for Base64Crypt {
     type Unpadded = Self;
     const PADDED: bool = false;
     const BASE: u8 = b'.';

--- a/base64ct/src/alphabet/standard.rs
+++ b/base64ct/src/alphabet/standard.rs
@@ -1,6 +1,6 @@
 //! Standard Base64 encoding.
 
-use super::{Decode, Encode, Variant};
+use super::{Alphabet, Decode, Encode};
 
 /// Standard Base64 encoding with `=` padding.
 ///
@@ -11,7 +11,7 @@ use super::{Decode, Encode, Variant};
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Base64;
 
-impl Variant for Base64 {
+impl Alphabet for Base64 {
     type Unpadded = Base64Unpadded;
     const PADDED: bool = true;
     const BASE: u8 = b'A';
@@ -28,7 +28,7 @@ impl Variant for Base64 {
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Base64Unpadded;
 
-impl Variant for Base64Unpadded {
+impl Alphabet for Base64Unpadded {
     type Unpadded = Self;
     const PADDED: bool = false;
     const BASE: u8 = b'A';

--- a/base64ct/src/alphabet/url.rs
+++ b/base64ct/src/alphabet/url.rs
@@ -1,6 +1,6 @@
 //! URL-safe Base64 encoding.
 
-use super::{Decode, Encode, Variant};
+use super::{Alphabet, Decode, Encode};
 
 /// URL-safe Base64 encoding with `=` padding.
 ///
@@ -11,7 +11,7 @@ use super::{Decode, Encode, Variant};
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Base64Url;
 
-impl Variant for Base64Url {
+impl Alphabet for Base64Url {
     type Unpadded = Base64UrlUnpadded;
     const PADDED: bool = true;
     const BASE: u8 = b'A';
@@ -28,7 +28,7 @@ impl Variant for Base64Url {
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Base64UrlUnpadded;
 
-impl Variant for Base64UrlUnpadded {
+impl Alphabet for Base64UrlUnpadded {
     type Unpadded = Self;
     const PADDED: bool = false;
     const BASE: u8 = b'A';

--- a/base64ct/src/decoder.rs
+++ b/base64ct/src/decoder.rs
@@ -540,7 +540,7 @@ impl<'i> Iterator for LineReader<'i> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{test_vectors::*, variant::Variant, Base64, Base64Unpadded, Decoder};
+    use crate::{alphabet::Alphabet, test_vectors::*, Base64, Base64Unpadded, Decoder};
 
     #[cfg(feature = "std")]
     use {alloc::vec::Vec, std::io::Read};
@@ -591,7 +591,7 @@ mod tests {
     fn decode_test<'a, F, V>(expected: &[u8], f: F)
     where
         F: Fn() -> Decoder<'a, V>,
-        V: Variant,
+        V: Alphabet,
     {
         for chunk_size in 1..expected.len() {
             let mut decoder = f();

--- a/base64ct/src/encoder.rs
+++ b/base64ct/src/encoder.rs
@@ -306,7 +306,7 @@ impl LineWrapper {
 
 #[cfg(test)]
 mod tests {
-    use crate::{test_vectors::*, variant::Variant, Base64, Base64Unpadded, Encoder, LineEnding};
+    use crate::{alphabet::Alphabet, test_vectors::*, Base64, Base64Unpadded, Encoder, LineEnding};
 
     #[test]
     fn encode_padded() {
@@ -342,7 +342,7 @@ mod tests {
     }
 
     /// Core functionality of an encoding test.
-    fn encode_test<V: Variant>(input: &[u8], expected: &str, wrapped: Option<usize>) {
+    fn encode_test<V: Alphabet>(input: &[u8], expected: &str, wrapped: Option<usize>) {
         let mut buffer = [0u8; 1024];
 
         for chunk_size in 1..input.len() {

--- a/base64ct/src/encoding.rs
+++ b/base64ct/src/encoding.rs
@@ -1,8 +1,8 @@
 //! Base64 encodings
 
 use crate::{
+    alphabet::Alphabet,
     errors::{Error, InvalidEncodingError, InvalidLengthError},
-    variant::Variant,
 };
 use core::str;
 
@@ -17,7 +17,7 @@ const PAD: u8 = b'=';
 
 /// Base64 encoding trait.
 ///
-/// This trait must be imported to make use of any Base64 variant defined
+/// This trait must be imported to make use of any Base64 alphabet defined
 /// in this crate.
 ///
 /// The following encoding types impl this trait:
@@ -28,7 +28,7 @@ const PAD: u8 = b'=';
 /// - [`Base64Unpadded`]: standard Base64 encoding *without* padding.
 /// - [`Base64Url`]: URL-safe Base64 encoding with `=` padding.
 /// - [`Base64UrlUnpadded`]: URL-safe Base64 encoding *without* padding.
-pub trait Encoding: Variant {
+pub trait Encoding: Alphabet {
     /// Decode a Base64 string into the provided destination buffer.
     fn decode(src: impl AsRef<[u8]>, dst: &mut [u8]) -> Result<&[u8], Error>;
 
@@ -63,7 +63,7 @@ pub trait Encoding: Variant {
     fn encoded_len(bytes: &[u8]) -> usize;
 }
 
-impl<T: Variant> Encoding for T {
+impl<T: Alphabet> Encoding for T {
     fn decode(src: impl AsRef<[u8]>, dst: &mut [u8]) -> Result<&[u8], Error> {
         let (src_unpadded, mut err) = if T::PADDED {
             let (unpadded_len, e) = decode_padding(src.as_ref())?;
@@ -300,7 +300,7 @@ pub(crate) fn decode_padding(input: &[u8]) -> Result<(usize, i16), InvalidEncodi
 
 /// Check that the padding of a Base64 encoding string is valid given
 /// the decoded buffer.
-fn validate_padding<T: Variant>(encoded: &[u8], decoded: &[u8]) -> Result<(), Error> {
+fn validate_padding<T: Alphabet>(encoded: &[u8], decoded: &[u8]) -> Result<(), Error> {
     if !T::PADDED || (encoded.is_empty() && decoded.is_empty()) {
         return Ok(());
     }

--- a/base64ct/src/lib.rs
+++ b/base64ct/src/lib.rs
@@ -76,28 +76,28 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
+mod alphabet;
 mod decoder;
 mod encoder;
 mod encoding;
 mod errors;
 mod line_ending;
-mod variant;
 
 #[cfg(test)]
 mod test_vectors;
 
 pub use crate::{
-    decoder::Decoder,
-    encoder::Encoder,
-    encoding::Encoding,
-    errors::{Error, InvalidEncodingError, InvalidLengthError},
-    line_ending::LineEnding,
-    variant::{
+    alphabet::{
         bcrypt::Base64Bcrypt,
         crypt::Base64Crypt,
         standard::{Base64, Base64Unpadded},
         url::{Base64Url, Base64UrlUnpadded},
     },
+    decoder::Decoder,
+    encoder::Encoder,
+    encoding::Encoding,
+    errors::{Error, InvalidEncodingError, InvalidLengthError},
+    line_ending::LineEnding,
 };
 
 /// Minimum supported line width.


### PR DESCRIPTION
Matches the name used in #668.

The trait is sealed, so renaming it is not a breaking change.