### PR TITLE
base64ct: fix last block validation

### DIFF
--- a/base64ct/tests/standard.rs
+++ b/base64ct/tests/standard.rs
@@ -129,4 +129,14 @@ mod unpadded {
             Err(Error::InvalidEncoding)
         );
     }
+
+    #[test]
+    fn reject_non_canonical_encoding() {
+        let input = "Mi";
+        let mut buf = [0u8; 8];
+        assert_eq!(
+            Base64Unpadded::decode(input, &mut buf),
+            Err(Error::InvalidEncoding)
+        );
+    }
 }


### PR DESCRIPTION
Generalizes the internal `validate_padding` function into a `validate_last_block` function which can work on unpadded variants as well.

The function performs round-trip re-encoding the decoded last block, ensuring that it matches the provided input, or otherwise returns an `InvalidEncodingError`.

Closes #679