### PR TITLE
x509-cert: support `TeletexString`

### DIFF
--- a/x509-cert/src/attr.rs
+++ b/x509-cert/src/attr.rs
@@ -220,6 +220,7 @@ impl fmt::Display for AttributeTypeAndValue<'_> {
             Tag::PrintableString => self.value.printable_string().ok().map(|s| s.as_str()),
             Tag::Utf8String => self.value.utf8_string().ok().map(|s| s.as_str()),
             Tag::Ia5String => self.value.ia5_string().ok().map(|s| s.as_str()),
+            Tag::TeletexString => self.value.teletex_string().ok().map(|s| s.as_str()),
             _ => None,
         };
 

--- a/x509-cert/src/ext/pkix/name/dirstr.rs
+++ b/x509-cert/src/ext/pkix/name/dirstr.rs
@@ -1,4 +1,4 @@
-use der::asn1::{PrintableStringRef, Utf8StringRef};
+use der::asn1::{PrintableStringRef, TeletexStringRef, Utf8StringRef};
 use der::Choice;
 
 /// DirectoryString as defined in [RFC 5280 Section 4.2.1.4].
@@ -43,6 +43,9 @@ use der::Choice;
 pub enum DirectoryString<'a> {
     #[asn1(type = "PrintableString")]
     PrintableString(PrintableStringRef<'a>),
+
+    #[asn1(type = "TeletexString")]
+    TeletexString(TeletexStringRef<'a>),
 
     #[asn1(type = "UTF8String")]
     Utf8String(Utf8StringRef<'a>),


### PR DESCRIPTION
Enable using TeletexString in several places where it should be enabled.