### PR TITLE
der/asn1: remove bolerplate code by using Deref (#693)

### DIFF
--- a/der/src/asn1/ia5_string.rs
+++ b/der/src/asn1/ia5_string.rs
@@ -4,7 +4,7 @@ use crate::{
     asn1::AnyRef, ord::OrdIsValueOrd, ByteSlice, DecodeValue, EncodeValue, Error, FixedTag, Header,
     Length, Reader, Result, StrSlice, Tag, Writer,
 };
-use core::{fmt, str};
+use core::{fmt, ops::Deref, str};
 
 /// ASN.1 `IA5String` type.
 ///
@@ -41,25 +41,13 @@ impl<'a> Ia5StringRef<'a> {
             .map(|inner| Self { inner })
             .map_err(|_| Self::TAG.value_error())
     }
+}
 
-    /// Borrow the string as a `str`.
-    pub fn as_str(&self) -> &'a str {
-        self.inner.as_str()
-    }
+impl<'a> Deref for Ia5StringRef<'a> {
+    type Target = StrSlice<'a>;
 
-    /// Borrow the string as bytes.
-    pub fn as_bytes(&self) -> &'a [u8] {
-        self.inner.as_bytes()
-    }
-
-    /// Get the length of the inner byte slice.
-    pub fn len(&self) -> Length {
-        self.inner.len()
-    }
-
-    /// Is the inner string empty?
-    pub fn is_empty(&self) -> bool {
-        self.inner.is_empty()
+    fn deref(&self) -> &Self::Target {
+        &self.inner
     }
 }
 
@@ -114,12 +102,6 @@ impl<'a> TryFrom<AnyRef<'a>> for Ia5StringRef<'a> {
 impl<'a> From<Ia5StringRef<'a>> for AnyRef<'a> {
     fn from(printable_string: Ia5StringRef<'a>) -> AnyRef<'a> {
         AnyRef::from_tag_and_value(Tag::Ia5String, printable_string.inner.into())
-    }
-}
-
-impl<'a> From<Ia5StringRef<'a>> for &'a [u8] {
-    fn from(printable_string: Ia5StringRef<'a>) -> &'a [u8] {
-        printable_string.as_bytes()
     }
 }
 

--- a/der/src/asn1/printable_string.rs
+++ b/der/src/asn1/printable_string.rs
@@ -4,7 +4,7 @@ use crate::{
     asn1::AnyRef, ord::OrdIsValueOrd, ByteSlice, DecodeValue, EncodeValue, Error, FixedTag, Header,
     Length, Reader, Result, StrSlice, Tag, Writer,
 };
-use core::{fmt, str};
+use core::{fmt, ops::Deref, str};
 
 /// ASN.1 `PrintableString` type.
 ///
@@ -75,25 +75,13 @@ impl<'a> PrintableStringRef<'a> {
             .map(|inner| Self { inner })
             .map_err(|_| Self::TAG.value_error())
     }
+}
 
-    /// Borrow the string as a `str`.
-    pub fn as_str(&self) -> &'a str {
-        self.inner.as_str()
-    }
+impl<'a> Deref for PrintableStringRef<'a> {
+    type Target = StrSlice<'a>;
 
-    /// Borrow the string as bytes.
-    pub fn as_bytes(&self) -> &'a [u8] {
-        self.inner.as_bytes()
-    }
-
-    /// Get the length of the inner byte slice.
-    pub fn len(&self) -> Length {
-        self.inner.len()
-    }
-
-    /// Is the inner string empty?
-    pub fn is_empty(&self) -> bool {
-        self.inner.is_empty()
+    fn deref(&self) -> &Self::Target {
+        &self.inner
     }
 }
 
@@ -148,12 +136,6 @@ impl<'a> TryFrom<AnyRef<'a>> for PrintableStringRef<'a> {
 impl<'a> From<PrintableStringRef<'a>> for AnyRef<'a> {
     fn from(printable_string: PrintableStringRef<'a>) -> AnyRef<'a> {
         AnyRef::from_tag_and_value(Tag::PrintableString, printable_string.inner.into())
-    }
-}
-
-impl<'a> From<PrintableStringRef<'a>> for &'a [u8] {
-    fn from(printable_string: PrintableStringRef<'a>) -> &'a [u8] {
-        printable_string.as_bytes()
     }
 }
 

--- a/der/src/asn1/teletex_string.rs
+++ b/der/src/asn1/teletex_string.rs
@@ -4,7 +4,7 @@ use crate::{
     asn1::AnyRef, ord::OrdIsValueOrd, ByteSlice, DecodeValue, EncodeValue, Error, FixedTag, Header,
     Length, Reader, Result, StrSlice, Tag, Writer,
 };
-use core::{fmt, str};
+use core::{fmt, ops::Deref, str};
 
 /// ASN.1 `TeletexString` type.
 ///
@@ -45,25 +45,13 @@ impl<'a> TeletexStringRef<'a> {
             .map(|inner| Self { inner })
             .map_err(|_| Self::TAG.value_error())
     }
+}
 
-    /// Borrow the string as a `str`.
-    pub fn as_str(&self) -> &'a str {
-        self.inner.as_str()
-    }
+impl<'a> Deref for TeletexStringRef<'a> {
+    type Target = StrSlice<'a>;
 
-    /// Borrow the string as bytes.
-    pub fn as_bytes(&self) -> &'a [u8] {
-        self.inner.as_bytes()
-    }
-
-    /// Get the length of the inner byte slice.
-    pub fn len(&self) -> Length {
-        self.inner.len()
-    }
-
-    /// Is the inner string empty?
-    pub fn is_empty(&self) -> bool {
-        self.inner.is_empty()
+    fn deref(&self) -> &Self::Target {
+        &self.inner
     }
 }
 
@@ -118,12 +106,6 @@ impl<'a> TryFrom<AnyRef<'a>> for TeletexStringRef<'a> {
 impl<'a> From<TeletexStringRef<'a>> for AnyRef<'a> {
     fn from(teletex_string: TeletexStringRef<'a>) -> AnyRef<'a> {
         AnyRef::from_tag_and_value(Tag::TeletexString, teletex_string.inner.into())
-    }
-}
-
-impl<'a> From<TeletexStringRef<'a>> for &'a [u8] {
-    fn from(teletex_string: TeletexStringRef<'a>) -> &'a [u8] {
-        teletex_string.as_bytes()
     }
 }
 

--- a/der/src/asn1/utf8_string.rs
+++ b/der/src/asn1/utf8_string.rs
@@ -4,7 +4,7 @@ use crate::{
     asn1::AnyRef, ord::OrdIsValueOrd, ByteSlice, DecodeValue, EncodeValue, Error, FixedTag, Header,
     Length, Reader, Result, StrSlice, Tag, Writer,
 };
-use core::{fmt, str};
+use core::{fmt, ops::Deref, str};
 
 #[cfg(feature = "alloc")]
 use alloc::{borrow::ToOwned, string::String};
@@ -37,25 +37,13 @@ impl<'a> Utf8StringRef<'a> {
     {
         StrSlice::from_bytes(input.as_ref()).map(|inner| Self { inner })
     }
+}
 
-    /// Borrow the string as a `str`.
-    pub fn as_str(&self) -> &'a str {
-        self.inner.as_str()
-    }
+impl<'a> Deref for Utf8StringRef<'a> {
+    type Target = StrSlice<'a>;
 
-    /// Borrow the string as bytes.
-    pub fn as_bytes(&self) -> &'a [u8] {
-        self.inner.as_bytes()
-    }
-
-    /// Get the length of the inner byte slice.
-    pub fn len(&self) -> Length {
-        self.inner.len()
-    }
-
-    /// Is the inner string empty?
-    pub fn is_empty(&self) -> bool {
-        self.inner.is_empty()
+    fn deref(&self) -> &Self::Target {
+        &self.inner
     }
 }
 
@@ -110,12 +98,6 @@ impl<'a> TryFrom<AnyRef<'a>> for Utf8StringRef<'a> {
 impl<'a> From<Utf8StringRef<'a>> for AnyRef<'a> {
     fn from(printable_string: Utf8StringRef<'a>) -> AnyRef<'a> {
         AnyRef::from_tag_and_value(Tag::Utf8String, printable_string.inner.into())
-    }
-}
-
-impl<'a> From<Utf8StringRef<'a>> for &'a [u8] {
-    fn from(utf8_string: Utf8StringRef<'a>) -> &'a [u8] {
-        utf8_string.as_bytes()
     }
 }
 

--- a/der/src/asn1/videotex_string.rs
+++ b/der/src/asn1/videotex_string.rs
@@ -4,7 +4,7 @@ use crate::{
     asn1::AnyRef, ord::OrdIsValueOrd, ByteSlice, DecodeValue, EncodeValue, Error, FixedTag, Header,
     Length, Reader, Result, StrSlice, Tag, Writer,
 };
-use core::{fmt, str};
+use core::{fmt, ops::Deref, str};
 
 /// ASN.1 `VideotexString` type.
 ///
@@ -44,25 +44,13 @@ impl<'a> VideotexStringRef<'a> {
             .map(|inner| Self { inner })
             .map_err(|_| Self::TAG.value_error())
     }
+}
 
-    /// Borrow the string as a `str`.
-    pub fn as_str(&self) -> &'a str {
-        self.inner.as_str()
-    }
+impl<'a> Deref for VideotexStringRef<'a> {
+    type Target = StrSlice<'a>;
 
-    /// Borrow the string as bytes.
-    pub fn as_bytes(&self) -> &'a [u8] {
-        self.inner.as_bytes()
-    }
-
-    /// Get the length of the inner byte slice.
-    pub fn len(&self) -> Length {
-        self.inner.len()
-    }
-
-    /// Is the inner string empty?
-    pub fn is_empty(&self) -> bool {
-        self.inner.is_empty()
+    fn deref(&self) -> &Self::Target {
+        &self.inner
     }
 }
 

--- a/der/src/str_slice.rs
+++ b/der/src/str_slice.rs
@@ -6,7 +6,7 @@ use core::str;
 
 /// String slice newtype which respects the [`Length::max`] limit.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
-pub(crate) struct StrSlice<'a> {
+pub struct StrSlice<'a> {
     /// Inner value
     pub(crate) inner: &'a str,
 


### PR DESCRIPTION
Use Deref<StrSlice> to limit amount of boilerplace code in the
*StringRef implementations.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>