### PR TITLE
pkcs1: implement support for PSS Params structure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -875,9 +875,11 @@ dependencies = [
 name = "pkcs1"
 version = "0.4.0"
 dependencies = [
+ "const-oid 0.9.0",
  "der 0.6.0",
  "hex-literal",
  "pkcs8 0.9.0",
+ "spki 0.6.0",
  "tempfile",
  "zeroize",
 ]

--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -15,7 +15,8 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-der = { version = "0.6", features = ["oid"], path = "../der" }
+der = { version = "0.6", features = ["oid", "derive"], path = "../der" }
+spki = { version = "0.6", path = "../spki" }
 
 # optional dependencies
 pkcs8 = { version = "0.9", optional = true, default-features = false, path = "../pkcs8" }
@@ -24,6 +25,7 @@ zeroize = { version = "1", optional = true, default-features = false }
 [dev-dependencies]
 hex-literal = "0.3"
 tempfile = "3"
+const-oid = { version = "0.9", path = "../const-oid", features = ["db"] }
 
 [features]
 alloc = ["der/alloc", "pkcs8/alloc", "zeroize/alloc"]

--- a/pkcs1/src/lib.rs
+++ b/pkcs1/src/lib.rs
@@ -14,6 +14,7 @@ extern crate alloc;
 extern crate std;
 
 mod error;
+mod params;
 mod private_key;
 mod public_key;
 mod traits;
@@ -26,6 +27,7 @@ pub use der::{
 
 pub use self::{
     error::{Error, Result},
+    params::{RsaPSSParameters, TrailerField},
     private_key::RsaPrivateKey,
     public_key::RsaPublicKey,
     traits::{DecodeRsaPrivateKey, DecodeRsaPublicKey},

--- a/pkcs1/src/params.rs
+++ b/pkcs1/src/params.rs
@@ -1,0 +1,103 @@
+//! PKCS#1 RSA parameters
+
+use crate::{Error, Result};
+use der::asn1::{AnyRef, ObjectIdentifier};
+use der::{Decode, Enumerated, Sequence, Tag};
+use spki::AlgorithmIdentifier;
+
+/// `TrailerField` as defined in [RFC 8017 Appendix 2.3].
+/// ```text
+/// TrailerField ::= INTEGER { trailerFieldBC(1) }
+/// ```
+/// [RFC 8017 Appendix 2.3]: https://datatracker.ietf.org/doc/html/rfc8017#appendix-A.2.3
+#[derive(Clone, Debug, Copy, PartialEq, Eq, Enumerated)]
+#[asn1(type = "INTEGER")]
+#[repr(u8)]
+pub enum TrailerField {
+    /// the only supported value (0xbc, default)
+    BC = 1,
+}
+
+impl Default for TrailerField {
+    fn default() -> Self {
+        Self::BC
+    }
+}
+
+const OID_SHA_1: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.14.3.2.26");
+const OID_MGF_1: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.8");
+
+const SHA_1_AI: AlgorithmIdentifier<'_> = AlgorithmIdentifier {
+    oid: OID_SHA_1,
+    parameters: None,
+};
+
+const SALT_LEN_DEFAULT: u8 = 20;
+
+fn default_sha1<'a>() -> AlgorithmIdentifier<'a> {
+    SHA_1_AI
+}
+
+fn default_mgf1_sha1<'a>() -> AlgorithmIdentifier<'a> {
+    AlgorithmIdentifier {
+        oid: OID_MGF_1,
+        parameters: Some(
+            AnyRef::new(Tag::Sequence, &[0x06, 0x05, 0x2b, 0x0e, 0x03, 0x02, 0x1a])
+                .expect("Internal error inside default generation"),
+        ),
+    }
+}
+
+fn default_salt_len() -> u8 {
+    SALT_LEN_DEFAULT
+}
+
+/// PKCS#1 RSASSA-PSS parameters as defined in [RFC 8017 Appendix 2.3]
+///
+/// ASN.1 structure containing a serialized RSASSA-PSS parameters:
+/// ```text
+/// RSASSA-PSS-params ::= SEQUENCE {
+///     hashAlgorithm      [0] HashAlgorithm      DEFAULT sha1,
+///     maskGenAlgorithm   [1] MaskGenAlgorithm   DEFAULT mgf1SHA1,
+///     saltLength         [2] INTEGER            DEFAULT 20,
+///     trailerField       [3] TrailerField       DEFAULT trailerFieldBC
+/// }
+/// HashAlgorithm ::= AlgorithmIdentifier
+/// MaskGenAlgorithm ::= AlgorithmIdentifier
+/// ```
+///
+/// [RFC 8017 Appendix 2.3]: https://datatracker.ietf.org/doc/html/rfc8017#appendix-A.2.3
+#[derive(Clone, Debug, Eq, PartialEq, Sequence)]
+pub struct RsaPSSParameters<'a> {
+    /// `hash`: Hash Algorithm
+    #[asn1(context_specific = "0", default = "default_sha1")]
+    pub hash: AlgorithmIdentifier<'a>,
+    /// Mask Generation Function Algorithm
+    #[asn1(context_specific = "1", default = "default_mgf1_sha1")]
+    pub mask_gen: AlgorithmIdentifier<'a>,
+    /// used salt length
+    #[asn1(context_specific = "2", default = "default_salt_len")]
+    pub salt_len: u8,
+    /// Trailer field, should be TrailerField::BC
+    #[asn1(context_specific = "3", default = "Default::default")]
+    pub trailer_field: TrailerField,
+}
+
+impl<'a> TryFrom<&'a [u8]> for RsaPSSParameters<'a> {
+    type Error = Error;
+
+    fn try_from(bytes: &'a [u8]) -> Result<Self> {
+        Ok(Self::from_der(bytes)?)
+    }
+}
+
+impl<'a> Default for RsaPSSParameters<'a> {
+    fn default() -> Self {
+        Self {
+            hash: SHA_1_AI,
+            mask_gen: default_mgf1_sha1(),
+            salt_len: SALT_LEN_DEFAULT,
+            trailer_field: Default::default(),
+        }
+    }
+}

--- a/pkcs1/tests/params.rs
+++ b/pkcs1/tests/params.rs
@@ -1,0 +1,86 @@
+//! PKCS#1 algorithm params tests
+
+use const_oid::db;
+use der::{asn1::ObjectIdentifier, Decode, Encode};
+use hex_literal::hex;
+use pkcs1::RsaPSSParameters;
+use pkcs1::TrailerField;
+
+/// Default PSS parameters using all default values (SHA1, MGF1)
+const RSA_PSS_PARAMETERS_DEFAULTS: &[u8] = &hex!("3000");
+/// Example PSS parameters using SHA256 instead of SHA1
+const RSA_PSS_PARAMETERS_SHA2_256: &[u8] = &hex!("3030a00d300b0609608648016503040201a11a301806092a864886f70d010108300b0609608648016503040201a203020120");
+
+#[test]
+fn decode_pss_param() {
+    let param = RsaPSSParameters::try_from(RSA_PSS_PARAMETERS_SHA2_256).unwrap();
+
+    assert!(param
+        .hash
+        .assert_algorithm_oid(db::rfc5912::ID_SHA_256)
+        .is_ok());
+    assert_eq!(param.hash.parameters, None);
+    assert!(param
+        .mask_gen
+        .assert_algorithm_oid(db::rfc5912::ID_MGF_1)
+        .is_ok());
+    assert_eq!(
+        param
+            .mask_gen
+            .parameters_any()
+            .unwrap()
+            .sequence(|reader| Ok(ObjectIdentifier::decode(reader)?))
+            .unwrap(),
+        db::rfc5912::ID_SHA_256
+    );
+    assert_eq!(param.salt_len, 32);
+    assert_eq!(param.trailer_field, TrailerField::BC);
+}
+
+#[test]
+fn encode_pss_param() {
+    let mut buf = [0_u8; 256];
+    let param = RsaPSSParameters::try_from(RSA_PSS_PARAMETERS_SHA2_256).unwrap();
+    assert_eq!(
+        param.encode_to_slice(&mut buf).unwrap(),
+        RSA_PSS_PARAMETERS_SHA2_256
+    );
+}
+
+#[test]
+fn decode_pss_param_default() {
+    let param = RsaPSSParameters::try_from(RSA_PSS_PARAMETERS_DEFAULTS).unwrap();
+
+    assert!(param
+        .hash
+        .assert_algorithm_oid(db::rfc5912::ID_SHA_1)
+        .is_ok());
+    assert_eq!(param.hash.parameters, None);
+    assert!(param
+        .mask_gen
+        .assert_algorithm_oid(db::rfc5912::ID_MGF_1)
+        .is_ok());
+    assert_eq!(
+        param
+            .mask_gen
+            .parameters_any()
+            .unwrap()
+            .sequence(|reader| Ok(ObjectIdentifier::decode(reader)?))
+            .unwrap(),
+        db::rfc5912::ID_SHA_1
+    );
+    assert_eq!(param.salt_len, 20);
+    assert_eq!(param.trailer_field, TrailerField::BC);
+    assert_eq!(param, Default::default())
+}
+
+#[test]
+fn encode_pss_param_default() {
+    let mut buf = [0_u8; 256];
+    assert_eq!(
+        RsaPSSParameters::default()
+            .encode_to_slice(&mut buf)
+            .unwrap(),
+        RSA_PSS_PARAMETERS_DEFAULTS
+    );
+}


### PR DESCRIPTION
Add support for parsing and generatign RSA PSS params.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>