### PR TITLE
x509-cert: re-export spki

### DIFF
--- a/x509-cert/src/lib.rs
+++ b/x509-cert/src/lib.rs
@@ -32,3 +32,4 @@ pub mod time;
 
 pub use certificate::{Certificate, PkiPath, TbsCertificate, Version};
 pub use der;
+pub use spki;


### PR DESCRIPTION
SubjectPublicKeyInfo is required in order to create a CertReqInfo and was not currently exported