### PR TITLE
base32ct+base64ct: use `RangeInclusive` for `DecodeStep`

### DIFF
--- a/base32ct/src/alphabet.rs
+++ b/base32ct/src/alphabet.rs
@@ -2,7 +2,7 @@
 
 pub(crate) mod rfc4648;
 
-use core::{fmt::Debug, ops::Range};
+use core::{fmt::Debug, ops::RangeInclusive};
 
 /// Core encoder/decoder functions for a particular Base64 alphabet
 pub trait Alphabet: 'static + Copy + Debug + Eq + Send + Sized + Sync {
@@ -26,8 +26,8 @@ pub trait Alphabet: 'static + Copy + Debug + Eq + Send + Sized + Sync {
 
         for DecodeStep(range, offset) in Self::DECODER {
             // Compute exclusive range from inclusive one
-            let start = range.start as i16 - 1;
-            let end = range.end as i16 + 1;
+            let start = *range.start() as i16 - 1;
+            let end = *range.end() as i16 + 1;
             ret += (((start - src as i16) & (src as i16 - end)) >> 8) & (src as i16 + *offset);
         }
 
@@ -50,7 +50,7 @@ pub trait Alphabet: 'static + Copy + Debug + Eq + Send + Sized + Sync {
 
 /// Constant-time decoder step.
 #[derive(Debug)]
-pub struct DecodeStep(Range<u8>, i16);
+pub struct DecodeStep(RangeInclusive<u8>, i16);
 
 /// Compute a difference using the given offset on match.
 #[derive(Copy, Clone, Debug)]

--- a/base32ct/src/alphabet/rfc4648.rs
+++ b/base32ct/src/alphabet/rfc4648.rs
@@ -35,7 +35,7 @@ impl Alphabet for Base32Unpadded {
 }
 
 /// Lower-case Base32 decoder.
-const DECODE_LOWER: &[DecodeStep] = &[DecodeStep(b'a'..b'z', -96), DecodeStep(b'2'..b'7', -23)];
+const DECODE_LOWER: &[DecodeStep] = &[DecodeStep(b'a'..=b'z', -96), DecodeStep(b'2'..=b'7', -23)];
 
 /// Standard Base64 encoder
 const ENCODE_LOWER: &[EncodeStep] = &[EncodeStep(25, 73)];
@@ -52,7 +52,7 @@ pub struct Base32Upper;
 impl Alphabet for Base32Upper {
     const BASE: u8 = b'A';
     const DECODER: &'static [DecodeStep] =
-        &[DecodeStep(b'A'..b'Z', -64), DecodeStep(b'2'..b'7', -23)];
+        &[DecodeStep(b'A'..=b'Z', -64), DecodeStep(b'2'..=b'7', -23)];
     const ENCODER: &'static [EncodeStep] = &[EncodeStep(25, 41)];
     const PADDED: bool = true;
 }

--- a/base64ct/src/alphabet.rs
+++ b/base64ct/src/alphabet.rs
@@ -3,7 +3,7 @@
 // TODO(tarcieri): explicitly checked/wrapped arithmetic
 #![allow(clippy::integer_arithmetic)]
 
-use core::{fmt::Debug, ops::Range};
+use core::{fmt::Debug, ops::RangeInclusive};
 
 pub mod bcrypt;
 pub mod crypt;
@@ -55,8 +55,8 @@ pub trait Alphabet: 'static + Copy + Debug + Eq + Send + Sized + Sync {
             ret += match step {
                 DecodeStep::Range(range, offset) => {
                     // Compute exclusive range from inclusive one
-                    let start = range.start as i16 - 1;
-                    let end = range.end as i16 + 1;
+                    let start = *range.start() as i16 - 1;
+                    let end = *range.end() as i16 + 1;
                     (((start - src as i16) & (src as i16 - end)) >> 8) & (src as i16 + *offset)
                 }
                 DecodeStep::Eq(value, offset) => {
@@ -106,7 +106,7 @@ pub trait Alphabet: 'static + Copy + Debug + Eq + Send + Sized + Sync {
 #[derive(Debug)]
 pub enum DecodeStep {
     /// Match the given range, offsetting the input on match.
-    Range(Range<u8>, i16),
+    Range(RangeInclusive<u8>, i16),
 
     /// Match the given value, returning the associated offset on match.
     Eq(u8, i16),

--- a/base64ct/src/alphabet/bcrypt.rs
+++ b/base64ct/src/alphabet/bcrypt.rs
@@ -15,10 +15,10 @@ impl Alphabet for Base64Bcrypt {
     const BASE: u8 = b'.';
 
     const DECODER: &'static [DecodeStep] = &[
-        DecodeStep::Range(b'.'..b'/', -45),
-        DecodeStep::Range(b'A'..b'Z', -62),
-        DecodeStep::Range(b'a'..b'z', -68),
-        DecodeStep::Range(b'0'..b'9', 7),
+        DecodeStep::Range(b'.'..=b'/', -45),
+        DecodeStep::Range(b'A'..=b'Z', -62),
+        DecodeStep::Range(b'a'..=b'z', -68),
+        DecodeStep::Range(b'0'..=b'9', 7),
     ];
 
     const ENCODER: &'static [EncodeStep] = &[

--- a/base64ct/src/alphabet/crypt.rs
+++ b/base64ct/src/alphabet/crypt.rs
@@ -15,9 +15,9 @@ impl Alphabet for Base64Crypt {
     const BASE: u8 = b'.';
 
     const DECODER: &'static [DecodeStep] = &[
-        DecodeStep::Range(b'.'..b'9', -45),
-        DecodeStep::Range(b'A'..b'Z', -52),
-        DecodeStep::Range(b'a'..b'z', -58),
+        DecodeStep::Range(b'.'..=b'9', -45),
+        DecodeStep::Range(b'A'..=b'Z', -52),
+        DecodeStep::Range(b'a'..=b'z', -58),
     ];
 
     const ENCODER: &'static [EncodeStep] =

--- a/base64ct/src/alphabet/standard.rs
+++ b/base64ct/src/alphabet/standard.rs
@@ -38,9 +38,9 @@ impl Alphabet for Base64Unpadded {
 
 /// Standard Base64 decoder
 const DECODER: &[DecodeStep] = &[
-    DecodeStep::Range(b'A'..b'Z', -64),
-    DecodeStep::Range(b'a'..b'z', -70),
-    DecodeStep::Range(b'0'..b'9', 5),
+    DecodeStep::Range(b'A'..=b'Z', -64),
+    DecodeStep::Range(b'a'..=b'z', -70),
+    DecodeStep::Range(b'0'..=b'9', 5),
     DecodeStep::Eq(b'+', 63),
     DecodeStep::Eq(b'/', 64),
 ];

--- a/base64ct/src/alphabet/url.rs
+++ b/base64ct/src/alphabet/url.rs
@@ -38,9 +38,9 @@ impl Alphabet for Base64UrlUnpadded {
 
 /// URL-safe Base64 decoder
 const DECODER: &[DecodeStep] = &[
-    DecodeStep::Range(b'A'..b'Z', -64),
-    DecodeStep::Range(b'a'..b'z', -70),
-    DecodeStep::Range(b'0'..b'9', 5),
+    DecodeStep::Range(b'A'..=b'Z', -64),
+    DecodeStep::Range(b'a'..=b'z', -70),
+    DecodeStep::Range(b'0'..=b'9', 5),
     DecodeStep::Eq(b'-', 63),
     DecodeStep::Eq(b'_', 64),
 ];


### PR DESCRIPTION
This is semantically more correct and avoids triggering the `almost_complete_letter_range` clippy lint.

Note that there was no bug here as the same range is still used behind the scenes.