### PR TITLE
x509-cert: note why `rstest` can't easily be upgraded

### DIFF
--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -22,7 +22,11 @@ spki = { version = "0.6", path = "../spki" }
 
 [dev-dependencies]
 hex-literal = "0.3"
-rstest = "0.12.0"
+
+# NOTE: upgrading requires MSRV bumps
+# - rstest v0.13 requires 1.59 (for `async-global-executor`)
+# - rstest v0.14 requires a workspace-wide 1.60 MSRV (for namespaced features)
+rstest = "0.12"
 
 [features]
 alloc = ["der/alloc"]


### PR DESCRIPTION
- `rstest` v0.13 requires MSRV 1.59 for `async-global-executor`
- `rstest` v0.14 and above use namespaced cargo features which require MSRV 1.60. On earlier versions of rustc (for crates anywhere in the same workspace) this causes a confusing failure mode:

https://github.com/RustCrypto/formats/runs/8059634879