### PR TITLE
spki: don't auto-activate base64ct for alloc

### DIFF
--- a/spki/Cargo.toml
+++ b/spki/Cargo.toml
@@ -26,7 +26,7 @@ hex-literal = "0.3"
 tempfile = "3"
 
 [features]
-alloc = ["base64ct/alloc", "der/alloc"]
+alloc = ["base64ct?/alloc", "der/alloc"]
 fingerprint = ["sha2"]
 pem = ["alloc", "der/pem"]
 std = ["der/std", "alloc"]


### PR DESCRIPTION
Change the dependency specification so that activating the `alloc` feature need not also activate the `base64ct` optional dependency.

https://rust-lang.github.io/rfcs/3143-cargo-weak-namespaced-features.html#dependency-features-in-the-features-table