### PR TITLE
Implement ValueOrd in more places

### DIFF
--- a/der/src/asn1/bit_string.rs
+++ b/der/src/asn1/bit_string.rs
@@ -376,6 +376,17 @@ impl<T: flagset::Flags> FixedTag for flagset::FlagSet<T> {
 }
 
 #[cfg(feature = "flagset")]
+impl<T> ValueOrd for flagset::FlagSet<T>
+where
+    T: flagset::Flags,
+    T::Type: Ord,
+{
+    fn value_cmp(&self, other: &Self) -> Result<Ordering> {
+        Ok(self.bits().cmp(&other.bits()))
+    }
+}
+
+#[cfg(feature = "flagset")]
 #[allow(clippy::integer_arithmetic)]
 impl<'a, T> DecodeValue<'a> for flagset::FlagSet<T>
 where

--- a/der/src/asn1/integer/bigint.rs
+++ b/der/src/asn1/integer/bigint.rs
@@ -2,8 +2,8 @@
 
 use super::uint;
 use crate::{
-    asn1::AnyRef, ByteSlice, DecodeValue, EncodeValue, Error, ErrorKind, FixedTag, Header, Length,
-    Reader, Result, Tag, Writer,
+    asn1::AnyRef, ord::OrdIsValueOrd, ByteSlice, DecodeValue, EncodeValue, Error, ErrorKind,
+    FixedTag, Header, Length, Reader, Result, Tag, Writer,
 };
 
 /// "Big" unsigned ASN.1 `INTEGER` type.
@@ -13,7 +13,7 @@ use crate::{
 ///
 /// Intended for use cases like very large integers that are used in
 /// cryptographic applications (e.g. keys, signatures).
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct UIntRef<'a> {
     /// Inner value
     inner: ByteSlice<'a>,
@@ -91,6 +91,8 @@ impl<'a> TryFrom<AnyRef<'a>> for UIntRef<'a> {
 impl<'a> FixedTag for UIntRef<'a> {
     const TAG: Tag = Tag::Integer;
 }
+
+impl<'a> OrdIsValueOrd for UIntRef<'a> {}
 
 #[cfg(test)]
 mod tests {

--- a/x509-cert/src/certificate.rs
+++ b/x509-cert/src/certificate.rs
@@ -3,10 +3,11 @@
 use crate::{name::Name, time::Validity};
 
 use alloc::vec::Vec;
+use core::cmp::Ordering;
 
 use const_oid::AssociatedOid;
 use der::asn1::{BitStringRef, UIntRef};
-use der::{Decode, Enumerated, Error, ErrorKind, Sequence};
+use der::{Decode, Enumerated, Error, ErrorKind, Sequence, ValueOrd};
 use spki::{AlgorithmIdentifier, SubjectPublicKeyInfo};
 
 /// Certificate `Version` as defined in [RFC 5280 Section 4.1].
@@ -28,6 +29,12 @@ pub enum Version {
 
     /// Version 3
     V3 = 2,
+}
+
+impl ValueOrd for Version {
+    fn value_cmp(&self, other: &Self) -> der::Result<Ordering> {
+        (&(*self as u8)).value_cmp(&(*other as u8))
+    }
 }
 
 impl Default for Version {
@@ -61,7 +68,7 @@ impl Default for Version {
 /// ```
 ///
 /// [RFC 5280 Section 4.1]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1
-#[derive(Clone, Debug, Eq, PartialEq, Sequence)]
+#[derive(Clone, Debug, Eq, PartialEq, Sequence, ValueOrd)]
 #[allow(missing_docs)]
 pub struct TbsCertificate<'a> {
     /// The certificate version
@@ -135,7 +142,7 @@ impl<'a> TbsCertificate<'a> {
 /// ```
 ///
 /// [RFC 5280 Section 4.1]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1
-#[derive(Clone, Debug, Eq, PartialEq, Sequence)]
+#[derive(Clone, Debug, Eq, PartialEq, Sequence, ValueOrd)]
 #[allow(missing_docs)]
 pub struct Certificate<'a> {
     pub tbs_certificate: TbsCertificate<'a>,

--- a/x509-cert/src/crl.rs
+++ b/x509-cert/src/crl.rs
@@ -8,7 +8,7 @@ use crate::Version;
 use alloc::vec::Vec;
 
 use der::asn1::{BitStringRef, UIntRef};
-use der::Sequence;
+use der::{Sequence, ValueOrd};
 use spki::AlgorithmIdentifier;
 
 /// `CertificateList` as defined in [RFC 5280 Section 5.1].
@@ -22,7 +22,7 @@ use spki::AlgorithmIdentifier;
 /// ```
 ///
 /// [RFC 5280 Section 5.1]: https://datatracker.ietf.org/doc/html/rfc5280#section-5.1
-#[derive(Clone, Debug, Eq, PartialEq, Sequence)]
+#[derive(Clone, Debug, Eq, PartialEq, Sequence, ValueOrd)]
 #[allow(missing_docs)]
 pub struct CertificateList<'a> {
     pub tbs_cert_list: TbsCertList<'a>,
@@ -44,7 +44,7 @@ pub struct CertificateList<'a> {
 /// ```
 ///
 /// [RFC 5280 Section 5.1]: https://datatracker.ietf.org/doc/html/rfc5280#section-5.1
-#[derive(Clone, Debug, Eq, PartialEq, Sequence)]
+#[derive(Clone, Debug, Eq, PartialEq, Sequence, ValueOrd)]
 #[allow(missing_docs)]
 pub struct RevokedCert<'a> {
     pub serial_number: UIntRef<'a>,
@@ -71,7 +71,7 @@ pub struct RevokedCert<'a> {
 /// ```
 ///
 /// [RFC 5280 Section 5.1]: https://datatracker.ietf.org/doc/html/rfc5280#section-5.1
-#[derive(Clone, Debug, Eq, PartialEq, Sequence)]
+#[derive(Clone, Debug, Eq, PartialEq, Sequence, ValueOrd)]
 #[allow(missing_docs)]
 pub struct TbsCertList<'a> {
     pub version: Version,

--- a/x509-cert/src/ext.rs
+++ b/x509-cert/src/ext.rs
@@ -1,6 +1,6 @@
 //! Standardized X.509 Certificate Extensions
 
-use der::Sequence;
+use der::{Sequence, ValueOrd};
 use spki::ObjectIdentifier;
 
 pub mod pkix;
@@ -22,7 +22,7 @@ pub mod pkix;
 /// ```
 ///
 /// [RFC 5280 Section 4.1.2.9]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.9
-#[derive(Clone, Debug, Eq, PartialEq, Sequence)]
+#[derive(Clone, Debug, Eq, PartialEq, Sequence, ValueOrd)]
 #[allow(missing_docs)]
 pub struct Extension<'a> {
     pub extn_id: ObjectIdentifier,

--- a/x509-cert/src/ext/pkix/access.rs
+++ b/x509-cert/src/ext/pkix/access.rs
@@ -6,7 +6,7 @@ use const_oid::{
     db::rfc5280::{ID_PE_AUTHORITY_INFO_ACCESS, ID_PE_SUBJECT_INFO_ACCESS},
     AssociatedOid,
 };
-use der::{asn1::ObjectIdentifier, Sequence};
+use der::{asn1::ObjectIdentifier, Sequence, ValueOrd};
 
 /// AuthorityInfoAccessSyntax as defined in [RFC 5280 Section 4.2.2.1].
 ///
@@ -50,7 +50,7 @@ impl_newtype!(SubjectInfoAccessSyntax<'a>, Vec<AccessDescription<'a>>);
 /// ```
 ///
 /// [RFC 5280 Section 4.2.2.1]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.2.1
-#[derive(Clone, Debug, Eq, PartialEq, Sequence)]
+#[derive(Clone, Debug, Eq, PartialEq, Sequence, ValueOrd)]
 #[allow(missing_docs)]
 pub struct AccessDescription<'a> {
     pub access_method: ObjectIdentifier,

--- a/x509-cert/src/ext/pkix/certpolicy.rs
+++ b/x509-cert/src/ext/pkix/certpolicy.rs
@@ -5,7 +5,7 @@ use alloc::vec::Vec;
 use const_oid::db::rfc5912::ID_CE_CERTIFICATE_POLICIES;
 use const_oid::AssociatedOid;
 use der::asn1::{GeneralizedTime, Ia5StringRef, ObjectIdentifier, UIntRef, Utf8StringRef};
-use der::{AnyRef, Choice, Sequence};
+use der::{AnyRef, Choice, Sequence, ValueOrd};
 
 /// CertificatePolicies as defined in [RFC 5280 Section 4.2.1.4].
 ///
@@ -35,7 +35,7 @@ impl_newtype!(CertificatePolicies<'a>, Vec<PolicyInformation<'a>>);
 /// ```
 ///
 /// [RFC 5280 Section 4.2.1.4]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.4
-#[derive(Clone, Debug, Eq, PartialEq, Sequence)]
+#[derive(Clone, Debug, Eq, PartialEq, Sequence, ValueOrd)]
 #[allow(missing_docs)]
 pub struct PolicyInformation<'a> {
     pub policy_identifier: ObjectIdentifier,
@@ -52,7 +52,7 @@ pub struct PolicyInformation<'a> {
 /// ```
 ///
 /// [RFC 5280 Section 4.2.1.4]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.4
-#[derive(Clone, Debug, Eq, PartialEq, Sequence)]
+#[derive(Clone, Debug, Eq, PartialEq, Sequence, ValueOrd)]
 #[allow(missing_docs)]
 pub struct PolicyQualifierInfo<'a> {
     pub policy_qualifier_id: ObjectIdentifier,

--- a/x509-cert/src/ext/pkix/crl/dp.rs
+++ b/x509-cert/src/ext/pkix/crl/dp.rs
@@ -1,7 +1,7 @@
 //! PKIX distribution point types
 
 use const_oid::{db::rfc5280::ID_PE_SUBJECT_INFO_ACCESS, AssociatedOid, ObjectIdentifier};
-use der::Sequence;
+use der::{Sequence, ValueOrd};
 use flagset::{flags, FlagSet};
 
 use crate::ext::pkix::name::{DistributionPointName, GeneralNames};
@@ -74,7 +74,7 @@ impl<'a> AssociatedOid for IssuingDistributionPoint<'a> {
 /// ```
 ///
 /// [RFC 5280 Section 4.2.1.13]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.13
-#[derive(Clone, Debug, PartialEq, Eq, Sequence)]
+#[derive(Clone, Debug, PartialEq, Eq, Sequence, ValueOrd)]
 #[allow(missing_docs)]
 pub struct DistributionPoint<'a> {
     #[asn1(context_specific = "0", tag_mode = "EXPLICIT", optional = "true")]

--- a/x509-cert/src/ext/pkix/name/dirstr.rs
+++ b/x509-cert/src/ext/pkix/name/dirstr.rs
@@ -1,5 +1,5 @@
 use der::asn1::{PrintableStringRef, TeletexStringRef, Utf8StringRef};
-use der::Choice;
+use der::{Choice, ValueOrd};
 
 /// DirectoryString as defined in [RFC 5280 Section 4.2.1.4].
 ///
@@ -38,7 +38,7 @@ use der::Choice;
 /// the need arises, we only support `PrintableString` and `UTF8String`.
 ///
 /// [RFC 5280 Section 4.2.1.4]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.4
-#[derive(Clone, Debug, Eq, PartialEq, Choice)]
+#[derive(Clone, Debug, Eq, PartialEq, Choice, ValueOrd)]
 #[allow(missing_docs)]
 pub enum DirectoryString<'a> {
     #[asn1(type = "PrintableString")]

--- a/x509-cert/src/ext/pkix/name/dp.rs
+++ b/x509-cert/src/ext/pkix/name/dp.rs
@@ -1,7 +1,7 @@
 use super::GeneralNames;
 use crate::name::RelativeDistinguishedName;
 
-use der::Choice;
+use der::{Choice, ValueOrd};
 
 /// DistributionPointName as defined in [RFC 5280 Section 4.2.1.13].
 ///
@@ -13,7 +13,7 @@ use der::Choice;
 /// ```
 ///
 /// [RFC 5280 Section 4.2.1.13]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.13
-#[derive(Clone, Debug, Eq, PartialEq, Choice)]
+#[derive(Clone, Debug, Eq, PartialEq, Choice, ValueOrd)]
 #[allow(missing_docs)]
 pub enum DistributionPointName<'a> {
     #[asn1(context_specific = "0", tag_mode = "IMPLICIT", constructed = "true")]

--- a/x509-cert/src/ext/pkix/name/ediparty.rs
+++ b/x509-cert/src/ext/pkix/name/ediparty.rs
@@ -1,4 +1,4 @@
-use der::Sequence;
+use der::{Sequence, ValueOrd};
 
 use super::DirectoryString;
 
@@ -25,7 +25,7 @@ use super::DirectoryString;
 ///
 /// [this OpenSSL bug]: https://github.com/openssl/openssl/issues/6859
 /// [RFC 5280 Section 4.2.1.6]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.6
-#[derive(Clone, Debug, Eq, PartialEq, Sequence)]
+#[derive(Clone, Debug, Eq, PartialEq, Sequence, ValueOrd)]
 #[allow(missing_docs)]
 pub struct EdiPartyName<'a> {
     #[asn1(context_specific = "0", tag_mode = "EXPLICIT", optional = "true")]

--- a/x509-cert/src/ext/pkix/name/general.rs
+++ b/x509-cert/src/ext/pkix/name/general.rs
@@ -4,7 +4,7 @@ use super::{EdiPartyName, OtherName};
 use crate::name::Name;
 
 use der::asn1::{Ia5StringRef, ObjectIdentifier, OctetStringRef};
-use der::Choice;
+use der::{Choice, ValueOrd};
 
 /// GeneralNames as defined in [RFC 5280 Section 4.2.1.6].
 ///
@@ -34,7 +34,7 @@ pub type GeneralNames<'a> = alloc::vec::Vec<GeneralName<'a>>;
 /// This implementation does not currently support the `x400Address` choice.
 ///
 /// [RFC 5280 Section 4.2.1.6]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.6
-#[derive(Clone, Debug, Eq, PartialEq, Choice)]
+#[derive(Clone, Debug, Eq, PartialEq, Choice, ValueOrd)]
 #[allow(missing_docs)]
 pub enum GeneralName<'a> {
     #[asn1(context_specific = "0", tag_mode = "IMPLICIT", constructed = "true")]

--- a/x509-cert/src/ext/pkix/name/other.rs
+++ b/x509-cert/src/ext/pkix/name/other.rs
@@ -1,4 +1,4 @@
-use der::{asn1::ObjectIdentifier, AnyRef, Sequence};
+use der::{asn1::ObjectIdentifier, AnyRef, Sequence, ValueOrd};
 
 /// OtherName as defined in [RFC 5280 Section 4.2.1.6].
 ///
@@ -10,7 +10,7 @@ use der::{asn1::ObjectIdentifier, AnyRef, Sequence};
 /// ```
 ///
 /// [RFC 5280 Section 4.2.1.6]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.6
-#[derive(Clone, Debug, Eq, PartialEq, Sequence)]
+#[derive(Clone, Debug, Eq, PartialEq, Sequence, ValueOrd)]
 #[allow(missing_docs)]
 pub struct OtherName<'a> {
     pub type_id: ObjectIdentifier,

--- a/x509-cert/src/ext/pkix/policymap.rs
+++ b/x509-cert/src/ext/pkix/policymap.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 use const_oid::db::rfc5280::ID_CE_POLICY_MAPPINGS;
 use const_oid::AssociatedOid;
 use der::asn1::ObjectIdentifier;
-use der::Sequence;
+use der::{Sequence, ValueOrd};
 
 /// PolicyMappings as defined in [RFC 5280 Section 4.2.1.5].
 ///
@@ -31,7 +31,7 @@ impl_newtype!(PolicyMappings, Vec<PolicyMapping>);
 /// ```
 ///
 /// [RFC 5280 Section 4.2.1.5]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.5
-#[derive(Clone, Debug, Eq, PartialEq, Sequence)]
+#[derive(Clone, Debug, Eq, PartialEq, Sequence, ValueOrd)]
 #[allow(missing_docs)]
 pub struct PolicyMapping {
     pub issuer_domain_policy: ObjectIdentifier,

--- a/x509-cert/src/macros.rs
+++ b/x509-cert/src/macros.rs
@@ -69,5 +69,12 @@ macro_rules! impl_newtype {
                 self.0.value_len()
             }
         }
+
+        #[allow(unused_lifetimes)]
+        impl<'a> ::der::ValueOrd for $newtype {
+            fn value_cmp(&self, other: &Self) -> ::der::Result<::core::cmp::Ordering> {
+                self.0.value_cmp(&other.0)
+            }
+        }
     };
 }

--- a/x509-cert/src/time.rs
+++ b/x509-cert/src/time.rs
@@ -3,7 +3,7 @@
 use core::fmt;
 use core::time::Duration;
 use der::asn1::{GeneralizedTime, UtcTime};
-use der::{Choice, DateTime, Decode, Error, Result, Sequence};
+use der::{Choice, DateTime, Decode, Error, Result, Sequence, ValueOrd};
 
 #[cfg(feature = "std")]
 use std::time::SystemTime;
@@ -21,7 +21,7 @@ use std::time::SystemTime;
 ///
 /// [RFC 5280 Section 4.1.2.5]: https://tools.ietf.org/html/rfc5280#section-4.1.2.5
 /// [RFC 5280 Appendix A]: https://tools.ietf.org/html/rfc5280#page-117
-#[derive(Choice, Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Choice, Copy, Clone, Debug, Eq, PartialEq, ValueOrd)]
 pub enum Time {
     /// Legacy UTC time (has 2-digit year, valid only through 2050).
     #[asn1(type = "UTCTime")]
@@ -113,7 +113,7 @@ impl TryFrom<SystemTime> for Time {
 /// }
 /// ```
 /// [RFC 5280 Section 4.1.2.5]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.5
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Sequence)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Sequence, ValueOrd)]
 pub struct Validity {
     /// notBefore value
     pub not_before: Time,


### PR DESCRIPTION
I'm currently working on implementing [Authenticode](https://www.symbolcrash.com/wp-content/uploads/2019/02/Authenticode_PE-1.pdf) (microsoft's codesigning system). As part of this, I've had to implement a lot more of PKCS#7, and a problem I've been hitting fairly consistently is how few types implement ValueOrd.

This MR does three things:

1. It adds manual ValueOrd implementations for der's FlagSet, UIntRef, and x509-cert's Version.
2. It allows deriving ValueOrd for Choice enums (note - I'm not 100% sure the implementation is correct, more on this below).
3. It derives ValueOrd on a lot of different types.

---

The biggest improvement here is implementing ValueOrd for Choice enums. It works by generating an implementation that looks roughly like this:

```rust
match (self, other) {
    (Self::A(this), Other::A(other)) => this.value_cmp(other),
    (Self::B(this), Other::B(other)) => this.value_cmp(other),
    _ => unreachable!()
}
```

The idea being that ValueOrd::value_cmp should only be called for enums that share a variants. Enums that don't share a variant should have a different tag, and thus `DerOrd` won't call the `value_cmp` function.