### PR TITLE
feat(base64ct): add support for output streaming

### DIFF
--- a/base64ct/src/lib.rs
+++ b/base64ct/src/lib.rs
@@ -75,6 +75,8 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
+pub mod stream;
+
 mod alphabet;
 mod decoder;
 mod encoder;

--- a/base64ct/src/stream/dec.rs
+++ b/base64ct/src/stream/dec.rs
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use core::marker::PhantomData;
+
+use super::{Error, Update};
+use crate::{Base64UrlUnpadded, Encoding};
+
+/// A streaming decoder.
+///
+/// NOTE WELL: DO NOT use this type for decoding secrets. This decoder uses an
+/// internal buffer which is not zeroed. It also reports decoding errors
+/// immediately after each block, rather than at the end of the stream. These
+/// properties make it unsuitable for decoding secrets.
+pub struct Decoder<T, E = Base64UrlUnpadded> {
+    decoded: [u8; 3],
+    encoded: [u8; 4],
+    config: PhantomData<E>,
+    used: usize,
+    next: T,
+}
+
+impl<T: Default, E> Default for Decoder<T, E> {
+    fn default() -> Self {
+        Self::from(T::default())
+    }
+}
+
+impl<T, E> From<T> for Decoder<T, E> {
+    fn from(next: T) -> Self {
+        Self {
+            decoded: Default::default(),
+            encoded: Default::default(),
+            config: Default::default(),
+            used: Default::default(),
+            next,
+        }
+    }
+}
+
+impl<T: Update, E: Encoding> Update for Decoder<T, E> {
+    type Error = Error<T::Error>;
+
+    // Integer arithmetic is fine here since we only have values `0..4`.
+    #[allow(clippy::integer_arithmetic)]
+    fn update(&mut self, chunk: impl AsRef<[u8]>) -> Result<(), Self::Error> {
+        for byte in chunk.as_ref() {
+            if self.used == 4 {
+                if E::decode_3bytes(&self.encoded[..], &mut self.decoded[..]) != 0 {
+                    return Err(Error::Value);
+                }
+
+                self.next.update(&self.decoded).map_err(Error::Inner)?;
+                self.used = 0;
+            }
+
+            self.encoded[self.used] = *byte;
+            self.used += 1;
+        }
+
+        Ok(())
+    }
+}
+
+impl<T: Update, E: Encoding> Decoder<T, E> {
+    /// Finish base64 decoding and return the inner type.
+    pub fn finish(mut self) -> Result<T, Error<T::Error>> {
+        let encoded = &self.encoded[..self.used];
+        let decoded = E::decode(encoded, &mut self.decoded[..]).map_err(|e| match e {
+            crate::Error::InvalidEncoding => Error::Value,
+            crate::Error::InvalidLength => Error::Length,
+        })?;
+        self.next.update(decoded).map_err(Error::Inner)?;
+        Ok(self.next)
+    }
+}

--- a/base64ct/src/stream/either.rs
+++ b/base64ct/src/stream/either.rs
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use super::Update;
+
+/// A runtime choice between updaters.
+pub enum Either<A, B> {
+    #[allow(missing_docs)]
+    A(A),
+
+    #[allow(missing_docs)]
+    B(B),
+}
+
+impl<A: Update, B: Update> Update for Either<A, B>
+where
+    A::Error: From<B::Error>,
+{
+    type Error = A::Error;
+
+    fn update(&mut self, chunk: impl AsRef<[u8]>) -> Result<(), Self::Error> {
+        match self {
+            Self::A(x) => x.update(chunk)?,
+            Self::B(x) => x.update(chunk)?,
+        }
+
+        Ok(())
+    }
+}

--- a/base64ct/src/stream/enc.rs
+++ b/base64ct/src/stream/enc.rs
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use core::marker::PhantomData;
+
+use super::Update;
+use crate::{Base64UrlUnpadded, Encoding};
+
+/// A streaming encoder.
+///
+/// NOTE WELL: DO NOT use this type for encoding secrets. This encoder uses an
+/// internal buffer which is not zeroed. This property makes it unsuitable for
+/// encoding secrets.
+pub struct Encoder<T, E = Base64UrlUnpadded> {
+    decoded: [u8; 3],
+    encoded: [u8; 4],
+    config: PhantomData<E>,
+    used: usize,
+    next: T,
+}
+
+impl<T: Default, E> Default for Encoder<T, E> {
+    fn default() -> Self {
+        Self::from(T::default())
+    }
+}
+
+impl<T, E> From<T> for Encoder<T, E> {
+    fn from(next: T) -> Self {
+        Self {
+            decoded: Default::default(),
+            encoded: Default::default(),
+            config: Default::default(),
+            used: Default::default(),
+            next,
+        }
+    }
+}
+
+impl<T: Update, E: Encoding> Update for Encoder<T, E> {
+    type Error = T::Error;
+
+    // Integer arithmetic is fine here since we only have values `0..3`.
+    #[allow(clippy::integer_arithmetic)]
+    fn update(&mut self, buf: impl AsRef<[u8]>) -> Result<(), Self::Error> {
+        for byte in buf.as_ref() {
+            self.decoded[self.used] = *byte;
+
+            match self.used {
+                2 => {
+                    E::encode_3bytes(&self.decoded[..], &mut self.encoded[..]);
+                    self.next.update(&self.encoded)?;
+                    self.used = 0
+                }
+
+                _ => self.used += 1,
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl<T: Update, E: Encoding> Encoder<T, E> {
+    /// Finish base64 encoding and return the inner type.
+    pub fn finish(mut self) -> Result<T, T::Error> {
+        let decoded = &self.decoded[..self.used];
+        let encoded = E::encode(decoded, &mut self.encoded[..]).expect("unreachable");
+        self.next.update(encoded.as_bytes())?;
+        Ok(self.next)
+    }
+}

--- a/base64ct/src/stream/mod.rs
+++ b/base64ct/src/stream/mod.rs
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Streamed encoding/decoding types
+//!
+//! NOTE WELL: These types are not suitable for managing secrets. For more
+//! details, see the documentation for each type.
+
+mod dec;
+mod either;
+mod enc;
+mod update;
+
+pub use dec::Decoder;
+pub use either::Either;
+pub use enc::Encoder;
+pub use update::Update;
+
+/// A streaming error.
+#[derive(Debug)]
+pub enum Error<T> {
+    /// An embedded error.
+    Inner(T),
+
+    /// The length is invalid.
+    Length,
+
+    /// An invalid value was found.
+    Value,
+}
+
+impl<T> From<T> for Error<T> {
+    fn from(error: T) -> Self {
+        Self::Inner(error)
+    }
+}
+
+impl Error<core::convert::Infallible> {
+    /// Casts an infallible error to any other kind of error.
+    pub fn cast<T>(&self) -> Error<T> {
+        match self {
+            Self::Inner(..) => unreachable!(),
+            Self::Length => Error::Length,
+            Self::Value => Error::Value,
+        }
+    }
+}

--- a/base64ct/src/stream/update.rs
+++ b/base64ct/src/stream/update.rs
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+/// A type that can be updated with bytes.
+///
+/// This type is similar to `std::io::Write` or `digest::Update`.
+pub trait Update {
+    /// The error that may occur during update.
+    type Error;
+
+    /// Update the instance with the provided bytes.
+    fn update(&mut self, chunk: impl AsRef<[u8]>) -> Result<(), Self::Error>;
+
+    /// Perform a chain update.
+    fn chain(mut self, chunk: impl AsRef<[u8]>) -> Result<Self, Self::Error>
+    where
+        Self: Sized,
+    {
+        self.update(chunk)?;
+        Ok(self)
+    }
+}
+
+impl<T: Update> Update for &mut T {
+    type Error = T::Error;
+
+    fn update(&mut self, chunk: impl AsRef<[u8]>) -> Result<(), Self::Error> {
+        (*self).update(chunk)
+    }
+}
+
+impl<T: Update> Update for [T] {
+    type Error = T::Error;
+
+    fn update(&mut self, chunk: impl AsRef<[u8]>) -> Result<(), Self::Error> {
+        for x in self.iter_mut() {
+            x.update(chunk.as_ref())?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Update> Update for alloc::boxed::Box<[T]> {
+    type Error = T::Error;
+
+    fn update(&mut self, chunk: impl AsRef<[u8]>) -> Result<(), Self::Error> {
+        (**self).update(chunk)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Update> Update for alloc::vec::Vec<T> {
+    type Error = T::Error;
+
+    fn update(&mut self, chunk: impl AsRef<[u8]>) -> Result<(), Self::Error> {
+        (**self).update(chunk)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl Update for alloc::vec::Vec<u8> {
+    type Error = core::convert::Infallible;
+
+    fn update(&mut self, chunk: impl AsRef<[u8]>) -> Result<(), Self::Error> {
+        self.extend(chunk.as_ref());
+        Ok(())
+    }
+}


### PR DESCRIPTION
There are two reasons you might want to reject this PR.

1. Unlike the rest of the crate, output streaming is not secret-safe. I have documented this. But it still may lead to a mismatch of expectations.

2. Unlike the rest of the crate, encoded output is streamed as `&[u8]` rather than `&str`. This allows for the `Update` trait to be reused for both encoding and decoding. It also allows runtime enablement of encoding without changing the types. This is required to implement the JWS `b64` parameter. For example, you can do: `Either<T, Encoder<T>>` and the result still implements `Update`.
