### PR TITLE
pkcs1: implement support for OAEP Params structure

### DIFF
--- a/pkcs1/src/lib.rs
+++ b/pkcs1/src/lib.rs
@@ -27,7 +27,7 @@ pub use der::{
 
 pub use crate::{
     error::{Error, Result},
-    params::{RsaPssParams, TrailerField},
+    params::{RsaOaepParams, RsaPssParams, TrailerField},
     private_key::RsaPrivateKey,
     public_key::RsaPublicKey,
     traits::{DecodeRsaPrivateKey, DecodeRsaPublicKey},

--- a/pkcs1/src/params.rs
+++ b/pkcs1/src/params.rs
@@ -10,6 +10,7 @@ use spki::AlgorithmIdentifier;
 
 const OID_SHA_1: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.14.3.2.26");
 const OID_MGF_1: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.8");
+const OID_PSPECIFIED: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.9");
 
 // TODO(tarcieri): make `AlgorithmIdentifier` generic around params; use `OID_SHA_1`
 const SEQ_OID_SHA_1_DER: &[u8] = &[0x06, 0x05, 0x2b, 0x0e, 0x03, 0x02, 0x1a];
@@ -185,6 +186,116 @@ fn default_mgf1_sha1<'a>() -> AlgorithmIdentifier<'a> {
         parameters: Some(
             AnyRef::new(Tag::Sequence, SEQ_OID_SHA_1_DER)
                 .expect("error creating default MGF1 params"),
+        ),
+    }
+}
+
+/// PKCS#1 RSAES-OAEP parameters as defined in [RFC 8017 Appendix 2.1]
+///
+/// ASN.1 structure containing a serialized RSAES-OAEP parameters:
+/// ```text
+/// RSAES-OAEP-params ::= SEQUENCE {
+///     hashAlgorithm      [0] HashAlgorithm     DEFAULT sha1,
+///     maskGenAlgorithm   [1] MaskGenAlgorithm  DEFAULT mgf1SHA1,
+///     pSourceAlgorithm   [2] PSourceAlgorithm  DEFAULT pSpecifiedEmpty
+/// }
+/// HashAlgorithm ::= AlgorithmIdentifier
+/// MaskGenAlgorithm ::= AlgorithmIdentifier
+/// PSourceAlgorithm ::= AlgorithmIdentifier
+/// ```
+///
+/// [RFC 8017 Appendix 2.1]: https://datatracker.ietf.org/doc/html/rfc8017#appendix-A.2.1
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RsaOaepParams<'a> {
+    /// Hash Algorithm
+    pub hash: AlgorithmIdentifier<'a>,
+
+    /// Mask Generation Function (MGF)
+    pub mask_gen: AlgorithmIdentifier<'a>,
+
+    /// The source (and possibly the value) of the label L
+    pub p_source: AlgorithmIdentifier<'a>,
+}
+
+impl<'a> Default for RsaOaepParams<'a> {
+    fn default() -> Self {
+        Self {
+            hash: SHA_1_AI,
+            mask_gen: default_mgf1_sha1(),
+            p_source: default_pempty_string(),
+        }
+    }
+}
+
+impl<'a> DecodeValue<'a> for RsaOaepParams<'a> {
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: der::Header) -> der::Result<Self> {
+        reader.read_nested(header.length, |reader| {
+            Ok(Self {
+                hash: reader
+                    .context_specific(TagNumber::N0, TagMode::Explicit)?
+                    .unwrap_or(SHA_1_AI),
+                mask_gen: reader
+                    .context_specific(TagNumber::N1, TagMode::Explicit)?
+                    .unwrap_or_else(default_mgf1_sha1),
+                p_source: reader
+                    .context_specific(TagNumber::N2, TagMode::Explicit)?
+                    .unwrap_or_else(default_pempty_string),
+            })
+        })
+    }
+}
+
+impl<'a> Sequence<'a> for RsaOaepParams<'a> {
+    fn fields<F, T>(&self, f: F) -> der::Result<T>
+    where
+        F: FnOnce(&[&dyn Encode]) -> der::Result<T>,
+    {
+        f(&[
+            &if self.hash == SHA_1_AI {
+                None
+            } else {
+                Some(ContextSpecificRef {
+                    tag_number: TagNumber::N0,
+                    tag_mode: TagMode::Explicit,
+                    value: &self.hash,
+                })
+            },
+            &if self.mask_gen == default_mgf1_sha1() {
+                None
+            } else {
+                Some(ContextSpecificRef {
+                    tag_number: TagNumber::N1,
+                    tag_mode: TagMode::Explicit,
+                    value: &self.mask_gen,
+                })
+            },
+            &if self.p_source == default_pempty_string() {
+                None
+            } else {
+                Some(ContextSpecificRef {
+                    tag_number: TagNumber::N2,
+                    tag_mode: TagMode::Explicit,
+                    value: &self.p_source,
+                })
+            },
+        ])
+    }
+}
+
+impl<'a> TryFrom<&'a [u8]> for RsaOaepParams<'a> {
+    type Error = Error;
+
+    fn try_from(bytes: &'a [u8]) -> Result<Self> {
+        Ok(Self::from_der(bytes)?)
+    }
+}
+
+/// Default Source Algorithm, empty string
+fn default_pempty_string<'a>() -> AlgorithmIdentifier<'a> {
+    AlgorithmIdentifier {
+        oid: OID_PSPECIFIED,
+        parameters: Some(
+            AnyRef::new(Tag::OctetString, &[]).expect("error creating default OAEP params"),
         ),
     }
 }

--- a/pkcs1/tests/params.rs
+++ b/pkcs1/tests/params.rs
@@ -1,15 +1,22 @@
 //! PKCS#1 algorithm params tests
 
 use const_oid::db;
-use der::{asn1::ObjectIdentifier, Decode, Encode};
+use der::{
+    asn1::{ObjectIdentifier, OctetStringRef},
+    Decode, Encode,
+};
 use hex_literal::hex;
-use pkcs1::RsaPssParams;
-use pkcs1::TrailerField;
+use pkcs1::{RsaOaepParams, RsaPssParams, TrailerField};
 
 /// Default PSS parameters using all default values (SHA1, MGF1)
 const RSA_PSS_PARAMETERS_DEFAULTS: &[u8] = &hex!("3000");
 /// Example PSS parameters using SHA256 instead of SHA1
 const RSA_PSS_PARAMETERS_SHA2_256: &[u8] = &hex!("3030a00d300b0609608648016503040201a11a301806092a864886f70d010108300b0609608648016503040201a203020120");
+
+/// Default OAEP parameters using all default values (SHA1, MGF1, Empty)
+const RSA_OAEP_PARAMETERS_DEFAULTS: &[u8] = &hex!("3000");
+/// Example OAEP parameters using SHA256 instead of SHA1 and 'abc' as label
+const RSA_OAEP_PARAMETERS_SHA2_256: &[u8] = &hex!("303fa00d300b0609608648016503040201a11a301806092a864886f70d010108300b0609608648016503040201a212301006092a864886f70d0101090403abcdef");
 
 #[test]
 fn decode_pss_param() {
@@ -80,5 +87,92 @@ fn encode_pss_param_default() {
     assert_eq!(
         RsaPssParams::default().encode_to_slice(&mut buf).unwrap(),
         RSA_PSS_PARAMETERS_DEFAULTS
+    );
+}
+
+#[test]
+fn decode_oaep_param() {
+    let param = RsaOaepParams::try_from(RSA_OAEP_PARAMETERS_SHA2_256).unwrap();
+
+    assert!(param
+        .hash
+        .assert_algorithm_oid(db::rfc5912::ID_SHA_256)
+        .is_ok());
+    assert_eq!(param.hash.parameters, None);
+    assert!(param
+        .mask_gen
+        .assert_algorithm_oid(db::rfc5912::ID_MGF_1)
+        .is_ok());
+    assert_eq!(
+        param
+            .mask_gen
+            .parameters_any()
+            .unwrap()
+            .sequence(|reader| Ok(ObjectIdentifier::decode(reader)?))
+            .unwrap(),
+        db::rfc5912::ID_SHA_256
+    );
+    assert!(param
+        .p_source
+        .assert_algorithm_oid(db::rfc5912::ID_P_SPECIFIED)
+        .is_ok());
+    assert_eq!(
+        param.p_source.parameters_any().unwrap().octet_string(),
+        OctetStringRef::new(&[0xab, 0xcd, 0xef])
+    );
+}
+
+#[test]
+fn encode_oaep_param() {
+    let mut buf = [0_u8; 256];
+    let param = RsaOaepParams::try_from(RSA_OAEP_PARAMETERS_SHA2_256).unwrap();
+    assert_eq!(
+        param.encode_to_slice(&mut buf).unwrap(),
+        RSA_OAEP_PARAMETERS_SHA2_256
+    );
+}
+
+#[test]
+fn decode_oaep_param_default() {
+    let param = RsaOaepParams::try_from(RSA_OAEP_PARAMETERS_DEFAULTS).unwrap();
+
+    assert!(param
+        .hash
+        .assert_algorithm_oid(db::rfc5912::ID_SHA_1)
+        .is_ok());
+    assert_eq!(param.hash.parameters, None);
+    assert!(param
+        .mask_gen
+        .assert_algorithm_oid(db::rfc5912::ID_MGF_1)
+        .is_ok());
+    assert_eq!(
+        param
+            .mask_gen
+            .parameters_any()
+            .unwrap()
+            .sequence(|reader| Ok(ObjectIdentifier::decode(reader)?))
+            .unwrap(),
+        db::rfc5912::ID_SHA_1
+    );
+    assert!(param
+        .p_source
+        .assert_algorithm_oid(db::rfc5912::ID_P_SPECIFIED)
+        .is_ok());
+    assert!(param
+        .p_source
+        .parameters_any()
+        .unwrap()
+        .octet_string()
+        .unwrap()
+        .is_empty(),);
+    assert_eq!(param, Default::default())
+}
+
+#[test]
+fn encode_oaep_param_default() {
+    let mut buf = [0_u8; 256];
+    assert_eq!(
+        RsaOaepParams::default().encode_to_slice(&mut buf).unwrap(),
+        RSA_OAEP_PARAMETERS_DEFAULTS
     );
 }


### PR DESCRIPTION
Add support for parsing and generatign RSA OAEP params.

Note: I was not sure regarding the `pSpecifiedEmpty.parameters`, but RFC3560 clearly defines it as `OCTET STRING (SIZE(0))`.