### PR TITLE
pkcs1: fix rustdoc warnings

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -37,7 +37,7 @@ jobs:
           toolchain: stable
           override: true
           profile: minimal
-      - run: cargo doc --workspace --exclude ssh-key --all-features
+      - run: cargo doc --workspace --all-features
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/pkcs1/src/traits.rs
+++ b/pkcs1/src/traits.rs
@@ -191,7 +191,7 @@ impl<T: pkcs8::DecodePublicKey> DecodeRsaPublicKey for T {
 }
 
 #[cfg(all(feature = "alloc", feature = "pkcs8"))]
-#[cfg_attr(docsrs, doc(all(feature = "alloc", feature = "pkcs8")))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "alloc", feature = "pkcs8"))))]
 impl<T: pkcs8::EncodePrivateKey> EncodeRsaPrivateKey for T {
     fn to_pkcs1_der(&self) -> Result<SecretDocument> {
         let pkcs8_doc = self.to_pkcs8_der()?;
@@ -202,7 +202,7 @@ impl<T: pkcs8::EncodePrivateKey> EncodeRsaPrivateKey for T {
 }
 
 #[cfg(all(feature = "alloc", feature = "pkcs8"))]
-#[cfg_attr(docsrs, doc(all(feature = "alloc", feature = "pkcs8")))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "alloc", feature = "pkcs8"))))]
 impl<T: pkcs8::EncodePublicKey> EncodeRsaPublicKey for T {
     fn to_pkcs1_der(&self) -> Result<Document> {
         let doc = self.to_public_key_der()?;


### PR DESCRIPTION
The `doc` attribute was missing `cfg`.