### PR TITLE
pkcs1 v0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -604,7 +604,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs1"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "const-oid",
  "der",

--- a/pkcs1/CHANGELOG.md
+++ b/pkcs1/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.1 (2022-10-10)
+### Added
+- `RsaPssParams` support ([#698])
+- `RsaOaepParams` support ([#733])
+
+[#698]: https://github.com/RustCrypto/formats/pull/698
+[#733]: https://github.com/RustCrypto/formats/pull/733
+
 ## 0.4.0 (2022-05-08)
 ### Changed
 - Replace document types with `doc::{Document, SecretDocument}` types ([#571])

--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs1"
-version = "0.4.0"
+version = "0.4.1"
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #1:
 RSA Cryptography Specifications Version 2.2 (RFC 8017)


### PR DESCRIPTION
### Added
- `RsaPssParams` support ([#698])
- `RsaOaepParams` support ([#733])

[#698]: https://github.com/RustCrypto/formats/pull/698
[#733]: https://github.com/RustCrypto/formats/pull/733