### PR TITLE
Add sha2-style base64 crypt format

### DIFF
--- a/base64ct/src/alphabet/bcrypt.rs
+++ b/base64ct/src/alphabet/bcrypt.rs
@@ -1,6 +1,6 @@
 //! bcrypt Base64 encoding.
 
-use super::{Alphabet, DecodeStep, EncodeStep};
+use super::{Alphabet, AlphabetEncoding, DecodeStep, EncodeStep};
 
 /// bcrypt Base64 encoding.
 ///
@@ -31,3 +31,5 @@ impl Alphabet for Base64Bcrypt {
 
     type Unpadded = Self;
 }
+
+impl AlphabetEncoding for Base64Bcrypt {}

--- a/base64ct/src/alphabet/shacrypt.rs
+++ b/base64ct/src/alphabet/shacrypt.rs
@@ -1,17 +1,21 @@
-//! `crypt(3)` Base64 encoding.
+//! `crypt(3)` Base64 encoding for sha* family.
 
-use super::{Alphabet, AlphabetEncoding, DecodeStep, EncodeStep};
+use super::{Alphabet, DecodeStep, EncodeStep, LittleEndianAlphabetEncoding};
 
-/// `crypt(3)` Base64 encoding.
+/// `crypt(3)` Base64 encoding for the following schemes.
+///  * sha1_crypt,
+///  * sha256_crypt,
+///  * sha512_crypt,
+///  * md5_crypt
 ///
 /// ```text
 /// [.-9]      [A-Z]      [a-z]
 /// 0x2e-0x39, 0x41-0x5a, 0x61-0x7a
 /// ```
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub struct Base64Crypt;
+pub struct Base64ShaCrypt;
 
-impl Alphabet for Base64Crypt {
+impl Alphabet for Base64ShaCrypt {
     const BASE: u8 = b'.';
 
     const DECODER: &'static [DecodeStep] = &[
@@ -28,4 +32,4 @@ impl Alphabet for Base64Crypt {
     type Unpadded = Self;
 }
 
-impl AlphabetEncoding for Base64Crypt {}
+impl LittleEndianAlphabetEncoding for Base64ShaCrypt {}

--- a/base64ct/src/alphabet/standard.rs
+++ b/base64ct/src/alphabet/standard.rs
@@ -1,6 +1,6 @@
 //! Standard Base64 encoding.
 
-use super::{Alphabet, DecodeStep, EncodeStep};
+use super::{Alphabet, AlphabetEncoding, DecodeStep, EncodeStep};
 
 /// Standard Base64 encoding with `=` padding.
 ///
@@ -18,6 +18,7 @@ impl Alphabet for Base64 {
     const PADDED: bool = true;
     type Unpadded = Base64Unpadded;
 }
+impl AlphabetEncoding for Base64 {}
 
 /// Standard Base64 encoding *without* padding.
 ///
@@ -52,3 +53,5 @@ const ENCODER: &[EncodeStep] = &[
     EncodeStep::Diff(61, -(b'+' as i16 - 0x1c)),
     EncodeStep::Diff(62, b'/' as i16 - b'+' as i16 - 1),
 ];
+
+impl AlphabetEncoding for Base64Unpadded {}

--- a/base64ct/src/alphabet/url.rs
+++ b/base64ct/src/alphabet/url.rs
@@ -1,6 +1,6 @@
 //! URL-safe Base64 encoding.
 
-use super::{Alphabet, DecodeStep, EncodeStep};
+use super::{Alphabet, AlphabetEncoding, DecodeStep, EncodeStep};
 
 /// URL-safe Base64 encoding with `=` padding.
 ///
@@ -18,6 +18,8 @@ impl Alphabet for Base64Url {
     const PADDED: bool = true;
     type Unpadded = Base64UrlUnpadded;
 }
+
+impl AlphabetEncoding for Base64Url {}
 
 /// URL-safe Base64 encoding *without* padding.
 ///
@@ -52,3 +54,5 @@ const ENCODER: &[EncodeStep] = &[
     EncodeStep::Diff(61, -(b'-' as i16 - 0x20)),
     EncodeStep::Diff(62, b'_' as i16 - b'-' as i16 - 1),
 ];
+
+impl AlphabetEncoding for Base64UrlUnpadded {}

--- a/base64ct/src/decoder.rs
+++ b/base64ct/src/decoder.rs
@@ -546,7 +546,7 @@ impl<'i> Iterator for LineReader<'i> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{alphabet::Alphabet, test_vectors::*, Base64, Base64Unpadded, Decoder};
+    use crate::{alphabet::AlphabetEncoding, test_vectors::*, Base64, Base64Unpadded, Decoder};
 
     #[cfg(feature = "std")]
     use {alloc::vec::Vec, std::io::Read};
@@ -597,7 +597,7 @@ mod tests {
     fn decode_test<'a, F, V>(expected: &[u8], f: F)
     where
         F: Fn() -> Decoder<'a, V>,
-        V: Alphabet,
+        V: AlphabetEncoding,
     {
         for chunk_size in 1..expected.len() {
             let mut decoder = f();

--- a/base64ct/src/encoder.rs
+++ b/base64ct/src/encoder.rs
@@ -306,7 +306,9 @@ impl LineWrapper {
 
 #[cfg(test)]
 mod tests {
-    use crate::{alphabet::Alphabet, test_vectors::*, Base64, Base64Unpadded, Encoder, LineEnding};
+    use crate::{
+        alphabet::AlphabetEncoding, test_vectors::*, Base64, Base64Unpadded, Encoder, LineEnding,
+    };
 
     #[test]
     fn encode_padded() {
@@ -342,7 +344,7 @@ mod tests {
     }
 
     /// Core functionality of an encoding test.
-    fn encode_test<V: Alphabet>(input: &[u8], expected: &str, wrapped: Option<usize>) {
+    fn encode_test<V: AlphabetEncoding>(input: &[u8], expected: &str, wrapped: Option<usize>) {
         let mut buffer = [0u8; 1024];
 
         for chunk_size in 1..input.len() {

--- a/base64ct/src/lib.rs
+++ b/base64ct/src/lib.rs
@@ -89,6 +89,7 @@ pub use crate::{
     alphabet::{
         bcrypt::Base64Bcrypt,
         crypt::Base64Crypt,
+        shacrypt::Base64ShaCrypt,
         standard::{Base64, Base64Unpadded},
         url::{Base64Url, Base64UrlUnpadded},
     },

--- a/base64ct/tests/shacrypt.rs
+++ b/base64ct/tests/shacrypt.rs
@@ -1,0 +1,98 @@
+//! `crypt(3)` Base64 tests
+
+#[macro_use]
+mod common;
+
+use crate::common::*;
+use base64ct::Base64ShaCrypt;
+
+const TEST_VECTORS: &[TestVector] = &[
+    TestVector { raw: b"", b64: "" },
+    TestVector {
+        raw: b"\x55",
+        b64: "J/",
+    },
+    TestVector {
+        raw: b"\x55\xaa",
+        b64: "Jd8",
+    },
+    TestVector {
+        raw: b"\x55\xaa\x55",
+        b64: "JdOJ",
+    },
+    TestVector {
+        raw: b"\x55\xaa\x55\xaa",
+        b64: "JdOJe0",
+    },
+    TestVector {
+        raw: b"\x55\xaa\x55\xaa\x55",
+        b64: "JdOJeK3",
+    },
+    TestVector {
+        raw: b"\x55\xaa\x55\xaa\x55\xaa",
+        b64: "JdOJeKZe",
+    },
+    TestVector {
+        raw: b"\x55\xaa\x55\xaf",
+        b64: "JdOJj0",
+    },
+    TestVector {
+        raw: b"\x55\xaa\x55\xaa\x5f",
+        b64: "JdOJey3",
+    },
+    TestVector {
+        raw: b"\0",
+        b64: "..",
+    },
+    TestVector {
+        raw: b"***",
+        b64: "ecW8",
+    },
+    TestVector {
+        raw: b"\x01\x02\x03\x04",
+        b64: "/6k.2.",
+    },
+    TestVector {
+        raw: b"\xAD\xAD\xAD\xAD\xAD",
+        b64: "hqOfhq8",
+    },
+    TestVector {
+        raw: b"\xFF\xEF\xFE\xFF\xEF\xFE",
+        b64: "zzizzziz",
+    },
+    TestVector {
+        raw: b"\xFF\xFF\xFF\xFF\xFF",
+        b64: "zzzzzzD",
+    },
+    TestVector {
+        raw: b"\x40\xC1\x3F\xBD\x05\x4C\x72\x2A\xA3\xC2\xF2\x11\x73\xC0\x69\xEA\
+               \x49\x7D\x35\x29\x6B\xCC\x24\x65\xF6\xF9\xD0\x41\x08\x7B\xD7\xA9",
+        b64: ".3wDxK.Hmdmc09T2n/QOebITpYmOAHGNqbDo/VkSLb8",
+    },
+    TestVector {
+        raw: b"@ \x0cDa\x1cH\xa2,L\xe3<P$MTe]X\xa6m\\\xe7}`(\x8edi\x9eh\xaa\xael\xeb\xbep,\xcf\xfe\x0f\x00",
+        b64: "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnyz..",
+    },
+];
+
+impl_tests!(Base64ShaCrypt);
+
+#[test]
+fn reject_trailing_whitespace() {
+    let input = "OKC9tOTKagohutGPa6/n4ij7LQjpxAPj7tlOOOf5z4i\n";
+    let mut buf = [0u8; 1024];
+    assert_eq!(
+        Base64ShaCrypt::decode(input, &mut buf),
+        Err(Error::InvalidEncoding)
+    );
+}
+
+#[test]
+fn unpadded_reject_trailing_equals() {
+    let input = "OKC9tOTKagohutGPa6/n4ij7LQjpxAPj7tlOOOf5z4i=";
+    let mut buf = [0u8; 1024];
+    assert_eq!(
+        Base64ShaCrypt::decode(input, &mut buf),
+        Err(Error::InvalidEncoding)
+    );
+}


### PR DESCRIPTION
This format is also known as Hash64 by python's passlib.

It is used e.g. by the `crypt(3)` schemes sha1_crypt, sha256_crypt, sha512_crypt and md5_crypt, but notably not `des_crypt`.

This also refactors Alphabet into two traits.
The translation part stays in `Alphabet`, the en- and decoding part get's its own trait `AlphabetEncoding`.

The default Encoding is the usual big endian encoding. To opt in to little endian, an `Alphabet` struct has to (blankly) implement `LittleEndianAlphabetEncoding` instead of `AlphabetEncoding`.