### PR TITLE
tls_codec: Implement `Ord/PartialOrd` for VLBytes

### DIFF
--- a/tls_codec/src/quic_vec.rs
+++ b/tls_codec/src/quic_vec.rs
@@ -167,7 +167,7 @@ impl<T: Size> Size for &[T] {
 /// Use this struct if bytes are encoded.
 /// This is faster than the generic version.
 #[cfg_attr(feature = "serde_serialize", derive(SerdeSerialize, SerdeDeserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct VLBytes {
     vec: Vec<u8>,
 }


### PR DESCRIPTION
I am working on switching hash references in OpenMLS to [variable length vectors](https://github.com/openmls/openmls/issues/928#event-7556019970). The references will be stored as `VLBytes`. OpenMLS contains tree operations that depend on an `Ord` implementation for hash references. 
