### PR TITLE
tls_codec: remove debug asserts from quic vec when fuzzing

### DIFF
--- a/tls_codec/src/lib.rs
+++ b/tls_codec/src/lib.rs
@@ -51,7 +51,7 @@ pub use quic_vec::{VLByteSlice, VLBytes};
 pub use tls_codec_derive::{TlsDeserialize, TlsSerialize, TlsSize};
 
 /// Errors that are thrown by this crate.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub enum Error {
     /// An error occurred during encoding.
     EncodingError(String),
@@ -70,6 +70,9 @@ pub enum Error {
 
     /// Reached the end of a byte stream.
     EndOfStream,
+
+    /// An internal library error that indicates a bug.
+    LibraryError,
 }
 
 #[cfg(feature = "std")]

--- a/tls_codec/tests/decode.rs
+++ b/tls_codec/tests/decode.rs
@@ -161,3 +161,9 @@ fn deserialize_tls_vl_bytes() {
     assert_eq!(long_vector.len(), deserialized_long_vec.as_slice().len());
     assert_eq!(long_vector.as_slice(), deserialized_long_vec.as_slice());
 }
+
+#[test]
+fn deserialize_empty_vl_bytes() {
+    let mut b: &[u8] = &[];
+    VLBytes::tls_deserialize(&mut b).expect("Error parsing empty bytes");
+}


### PR DESCRIPTION
When fuzzing we don't want to assert all the things.