### PR TITLE
base64ct v1.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,7 +71,7 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "base64ct"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "base64",
  "proptest",

--- a/base64ct/CHANGELOG.md
+++ b/base64ct/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.5.3 (2022-10-18)
+### Added
+- `Base64ShaCrypt` alphabet ([#742])
+
+### Changed
+- Use `RangeInclusive` for `DecodeStep` ([#713])
+
+[#713]: https://github.com/RustCrypto/formats/pull/713
+[#742]: https://github.com/RustCrypto/formats/pull/742
+
 ## 1.5.2 (2022-08-22)
 ### Fixed
 - Return `Ok(0)` in `io::Read` impl to signal end of stream ([#704])

--- a/base64ct/Cargo.toml
+++ b/base64ct/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base64ct"
-version = "1.5.2"
+version = "1.5.3"
 description = """
 Pure Rust implementation of Base64 (RFC 4648) which avoids any usages of
 data-dependent branches/LUTs and thereby provides portable "best effort"


### PR DESCRIPTION
### Added
- `Base64ShaCrypt` alphabet ([#742])

### Changed
- Use `RangeInclusive` for `DecodeStep` ([#713])

[#713]: https://github.com/RustCrypto/formats/pull/713
[#742]: https://github.com/RustCrypto/formats/pull/742