### PR TITLE
ssh-key: remove old directory

### DIFF
--- a/ssh-key/README.md
+++ b/ssh-key/README.md
@@ -1,5 +1,0 @@
-# 🚨 MOVED! 🚨
-
-The `ssh-key` crate is now located at:
-
-https://github.com/RustCrypto/SSH/tree/master/ssh-key


### PR DESCRIPTION
The new repo has existed for approximately 1 month.

This commit removes the placeholder directory with information about the repo's new location.