### PR TITLE
const-oid: generic backing buffer

### DIFF
--- a/const-oid/src/buffer.rs
+++ b/const-oid/src/buffer.rs
@@ -1,0 +1,52 @@
+//! Array-backed buffer for BER bytes.
+
+/// Array-backed buffer for storing BER computed at compile-time.
+#[derive(Copy, Clone, Eq, Hash, PartialEq, PartialOrd, Ord)]
+pub struct Buffer<const SIZE: usize> {
+    /// Length in bytes
+    pub(crate) length: u8,
+
+    /// Array containing BER/DER-serialized bytes (no header)
+    pub(crate) bytes: [u8; SIZE],
+}
+
+impl<const SIZE: usize> Buffer<SIZE> {
+    /// Borrow the inner byte slice.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes[..self.length as usize]
+    }
+
+    /// Get the length of the BER message.
+    pub const fn len(&self) -> usize {
+        self.length as usize
+    }
+
+    /// Const comparison of two buffers.
+    pub const fn eq(&self, rhs: &Self) -> bool {
+        if self.length != rhs.length {
+            return false;
+        }
+
+        let mut i = 0usize;
+
+        while i < self.len() {
+            if self.bytes[i] != rhs.bytes[i] {
+                return false;
+            }
+
+            // Won't overflow due to `i < self.len()` check above
+            #[allow(clippy::integer_arithmetic)]
+            {
+                i += 1;
+            }
+        }
+
+        true
+    }
+}
+
+impl<const SIZE: usize> AsRef<[u8]> for Buffer<SIZE> {
+    fn as_ref(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}

--- a/const-oid/src/db.rs
+++ b/const-oid/src/db.rs
@@ -17,24 +17,6 @@ pub use gen::*;
 
 use crate::{Error, ObjectIdentifier};
 
-/// A const implementation of byte equals.
-const fn eq(lhs: &[u8], rhs: &[u8]) -> bool {
-    if lhs.len() != rhs.len() {
-        return false;
-    }
-
-    let mut i = 0usize;
-    while i < lhs.len() {
-        if lhs[i] != rhs[i] {
-            return false;
-        }
-
-        i += 1;
-    }
-
-    true
-}
-
 /// A const implementation of case-insensitive ASCII equals.
 const fn eq_case(lhs: &[u8], rhs: &[u8]) -> bool {
     if lhs.len() != rhs.len() {
@@ -74,7 +56,8 @@ impl<'a> Database<'a> {
 
         while i < self.0.len() {
             let lhs = self.0[i].0;
-            if lhs.length == oid.length && eq(&lhs.bytes, &oid.bytes) {
+
+            if lhs.buffer.eq(&oid.buffer) {
                 return Some(self.0[i].1);
             }
 

--- a/const-oid/src/encoder.rs
+++ b/const-oid/src/encoder.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     arcs::{ARC_MAX_FIRST, ARC_MAX_SECOND},
-    Arc, Error, ObjectIdentifier, Result,
+    Arc, Buffer, Error, ObjectIdentifier, Result,
 };
 
 /// BER/DER encoder
@@ -45,8 +45,8 @@ impl Encoder {
     pub(crate) const fn extend(oid: ObjectIdentifier) -> Self {
         Self {
             state: State::Body,
-            bytes: oid.bytes,
-            cursor: oid.length as usize,
+            bytes: oid.buffer.bytes,
+            cursor: oid.buffer.length as usize,
         }
     }
 
@@ -101,10 +101,12 @@ impl Encoder {
     /// Finish encoding an OID.
     pub(crate) const fn finish(self) -> Result<ObjectIdentifier> {
         if self.cursor >= 2 {
-            Ok(ObjectIdentifier {
+            let bytes = Buffer {
                 bytes: self.bytes,
                 length: self.cursor as u8,
-            })
+            };
+
+            Ok(ObjectIdentifier { buffer: bytes })
         } else {
             Err(Error::NotEnoughArcs)
         }


### PR DESCRIPTION
The current buffering approach, with a fixed-sized `ArrayVec`-like backing buffer, is helpful for being able to use `const fn` to be able to parse OID strings at compile time and re-encode them in BER form. This functionality is preserved as a new `Buffer` type, which still supports all current `const fn` functionality.

`ObjectIdentifier` has been changed to be generic around `B: AsRef<[u8]>` which allows a `const fn` constructor that accepts a BER-encoded slice.

This is useful for when there are large numbers of OID constants, as in the `const_oid::db` module. However, while this module has been updated so the code compiles, it has not yet been changed to take advantage of this new approach.