### PR TITLE
const-oid: add `DynAssociatedOid` trait

### DIFF
--- a/const-oid/src/lib.rs
+++ b/const-oid/src/lib.rs
@@ -46,6 +46,22 @@ pub trait AssociatedOid {
     const OID: ObjectIdentifier;
 }
 
+/// A trait which associates a dynamic, `&self`-dependent OID with a type,
+/// which may change depending on the type's value.
+///
+/// This trait is object safe and auto-impl'd for any types which impl
+/// [`AssociatedOid`].
+pub trait DynAssociatedOid {
+    /// Get the OID associated with this value.
+    fn oid(&self) -> ObjectIdentifier;
+}
+
+impl<T: AssociatedOid> DynAssociatedOid for T {
+    fn oid(&self) -> ObjectIdentifier {
+        T::OID
+    }
+}
+
 /// Object identifier (OID).
 ///
 /// OIDs are hierarchical structures consisting of "arcs", i.e. integer


### PR DESCRIPTION
Adds an object safe value-dependent trait which returns an `ObjectIdentifier` dynamically, with a blanket impl for types which impl `AssociatedOid`.