### PR TITLE
x509: `countryName` should always be `PrintableString`

### DIFF
--- a/x509-cert/src/attr.rs
+++ b/x509-cert/src/attr.rs
@@ -1,6 +1,7 @@
 //! Attribute-related definitions as defined in X.501 (and updated by RFC 5280).
 
 use alloc::vec::Vec;
+use const_oid::db::rfc4519::COUNTRY_NAME;
 use core::fmt::{self, Write};
 
 use const_oid::db::DB;
@@ -181,8 +182,13 @@ impl AttributeTypeAndValue<'_> {
             parser.add(c)?;
         }
 
+        let tag = match oid {
+            COUNTRY_NAME => Tag::PrintableString,
+            _ => Tag::Utf8String,
+        };
+
         // Serialize.
-        let value = AnyRef::new(Tag::Utf8String, parser.as_bytes())?;
+        let value = AnyRef::new(tag, parser.as_bytes())?;
         let atv = AttributeTypeAndValue { oid, value };
         atv.to_vec()
     }

--- a/x509-cert/src/attr.rs
+++ b/x509-cert/src/attr.rs
@@ -1,7 +1,7 @@
 //! Attribute-related definitions as defined in X.501 (and updated by RFC 5280).
 
 use alloc::vec::Vec;
-use const_oid::db::rfc4519::COUNTRY_NAME;
+use const_oid::db::rfc4519::{COUNTRY_NAME, DOMAIN_COMPONENT};
 use core::fmt::{self, Write};
 
 use const_oid::db::DB;
@@ -184,6 +184,7 @@ impl AttributeTypeAndValue<'_> {
 
         let tag = match oid {
             COUNTRY_NAME => Tag::PrintableString,
+            DOMAIN_COMPONENT => Tag::Ia5String,
             _ => Tag::Utf8String,
         };
 

--- a/x509-cert/tests/name.rs
+++ b/x509-cert/tests/name.rs
@@ -1,7 +1,7 @@
 //! Name tests
 
 use const_oid::ObjectIdentifier;
-use der::asn1::{OctetStringRef, SetOfVec, Utf8StringRef};
+use der::asn1::{OctetStringRef, PrintableStringRef, SetOfVec, Utf8StringRef};
 use der::{AnyRef, Decode, Encode, Tag, Tagged};
 use hex_literal::hex;
 use x509_cert::attr::AttributeTypeAndValue;
@@ -207,7 +207,7 @@ fn rdns_serde() {
                 &[
                     AttributeTypeAndValue {
                         oid: const_oid::db::rfc4519::C,
-                        value: AnyRef::from(Utf8StringRef::new("baz").unwrap()),
+                        value: AnyRef::from(PrintableStringRef::new("baz").unwrap()),
                     },
                     AttributeTypeAndValue {
                         oid: const_oid::db::rfc4519::L,

--- a/x509-cert/tests/name.rs
+++ b/x509-cert/tests/name.rs
@@ -1,7 +1,7 @@
 //! Name tests
 
 use const_oid::ObjectIdentifier;
-use der::asn1::{OctetStringRef, PrintableStringRef, SetOfVec, Utf8StringRef};
+use der::asn1::{Ia5StringRef, OctetStringRef, PrintableStringRef, SetOfVec, Utf8StringRef};
 use der::{AnyRef, Decode, Encode, Tag, Tagged};
 use hex_literal::hex;
 use x509_cert::attr::AttributeTypeAndValue;
@@ -226,11 +226,11 @@ fn rdns_serde() {
                 }],
                 &[AttributeTypeAndValue {
                     oid: const_oid::db::rfc4519::DC,
-                    value: AnyRef::from(Utf8StringRef::new("example").unwrap()),
+                    value: AnyRef::from(Ia5StringRef::new("example").unwrap()),
                 }],
                 &[AttributeTypeAndValue {
                     oid: const_oid::db::rfc4519::DC,
-                    value: AnyRef::from(Utf8StringRef::new("net").unwrap()),
+                    value: AnyRef::from(Ia5StringRef::new("net").unwrap()),
                 }],
             ],
         ),
@@ -250,11 +250,11 @@ fn rdns_serde() {
                 ],
                 &[AttributeTypeAndValue {
                     oid: const_oid::db::rfc4519::DC,
-                    value: AnyRef::from(Utf8StringRef::new("example").unwrap()),
+                    value: AnyRef::from(Ia5StringRef::new("example").unwrap()),
                 }],
                 &[AttributeTypeAndValue {
                     oid: const_oid::db::rfc4519::DC,
-                    value: AnyRef::from(Utf8StringRef::new("net").unwrap()),
+                    value: AnyRef::from(Ia5StringRef::new("net").unwrap()),
                 }],
             ],
         ),
@@ -268,11 +268,11 @@ fn rdns_serde() {
                 }],
                 &[AttributeTypeAndValue {
                     oid: const_oid::db::rfc4519::DC,
-                    value: AnyRef::from(Utf8StringRef::new("example").unwrap()),
+                    value: AnyRef::from(Ia5StringRef::new("example").unwrap()),
                 }],
                 &[AttributeTypeAndValue {
                     oid: const_oid::db::rfc4519::DC,
-                    value: AnyRef::from(Utf8StringRef::new("net").unwrap()),
+                    value: AnyRef::from(Ia5StringRef::new("net").unwrap()),
                 }],
             ],
         ),
@@ -286,11 +286,11 @@ fn rdns_serde() {
                 }],
                 &[AttributeTypeAndValue {
                     oid: const_oid::db::rfc4519::DC,
-                    value: AnyRef::from(Utf8StringRef::new("example").unwrap()),
+                    value: AnyRef::from(Ia5StringRef::new("example").unwrap()),
                 }],
                 &[AttributeTypeAndValue {
                     oid: const_oid::db::rfc4519::DC,
-                    value: AnyRef::from(Utf8StringRef::new("net").unwrap()),
+                    value: AnyRef::from(Ia5StringRef::new("net").unwrap()),
                 }],
             ],
         ),


### PR DESCRIPTION
I was doing some testing and came across the fact that creating a CSR / Certificate with countryName set in the DN leads to a different output. I narrowed it down to formats producing UTF8String for countryName and OpenSSL 3.0 producing PrintableString. 

I also came across this stack overflow post on the subject. The countryName field is required to be PrintableString according to X.502. https://stackoverflow.com/questions/17215598/country-name-field-in-ca-generated-by-openssl-is-encoded-as-printablestring-whil

If this isn't the right place to put this logic please let me know, thanks!