### PR TITLE
spki: make `AlgorithmIdentifier` generic around `Params`

### DIFF
--- a/pkcs1/src/lib.rs
+++ b/pkcs1/src/lib.rs
@@ -52,7 +52,7 @@ pub const ALGORITHM_OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.84
 /// `AlgorithmIdentifier` for RSA.
 #[cfg(feature = "pkcs8")]
 #[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
-pub const ALGORITHM_ID: pkcs8::AlgorithmIdentifier<'static> = pkcs8::AlgorithmIdentifier {
+pub const ALGORITHM_ID: pkcs8::AlgorithmIdentifierRef<'static> = pkcs8::AlgorithmIdentifierRef {
     oid: ALGORITHM_OID,
     parameters: Some(der::asn1::AnyRef::NULL),
 };

--- a/pkcs1/src/params.rs
+++ b/pkcs1/src/params.rs
@@ -6,7 +6,7 @@ use der::{
     asn1::ContextSpecificRef, Decode, DecodeValue, Encode, EncodeValue, FixedTag, Reader, Sequence,
     Tag, TagMode, TagNumber, Writer,
 };
-use spki::AlgorithmIdentifier;
+use spki::AlgorithmIdentifierRef;
 
 const OID_SHA_1: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.14.3.2.26");
 const OID_MGF_1: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.8");
@@ -15,7 +15,7 @@ const OID_PSPECIFIED: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.1
 // TODO(tarcieri): make `AlgorithmIdentifier` generic around params; use `OID_SHA_1`
 const SEQ_OID_SHA_1_DER: &[u8] = &[0x06, 0x05, 0x2b, 0x0e, 0x03, 0x02, 0x1a];
 
-const SHA_1_AI: AlgorithmIdentifier<'_> = AlgorithmIdentifier {
+const SHA_1_AI: AlgorithmIdentifierRef<'_> = AlgorithmIdentifierRef {
     oid: OID_SHA_1,
     parameters: None,
 };
@@ -81,10 +81,10 @@ impl FixedTag for TrailerField {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RsaPssParams<'a> {
     /// Hash Algorithm
-    pub hash: AlgorithmIdentifier<'a>,
+    pub hash: AlgorithmIdentifierRef<'a>,
 
     /// Mask Generation Function (MGF)
-    pub mask_gen: AlgorithmIdentifier<'a>,
+    pub mask_gen: AlgorithmIdentifierRef<'a>,
 
     /// Salt length
     pub salt_len: u8,
@@ -180,8 +180,8 @@ impl<'a> TryFrom<&'a [u8]> for RsaPssParams<'a> {
 }
 
 /// Default Mask Generation Function (MGF): SHA-1.
-fn default_mgf1_sha1<'a>() -> AlgorithmIdentifier<'a> {
-    AlgorithmIdentifier {
+fn default_mgf1_sha1<'a>() -> AlgorithmIdentifierRef<'a> {
+    AlgorithmIdentifierRef {
         oid: OID_MGF_1,
         parameters: Some(
             AnyRef::new(Tag::Sequence, SEQ_OID_SHA_1_DER)
@@ -208,13 +208,13 @@ fn default_mgf1_sha1<'a>() -> AlgorithmIdentifier<'a> {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RsaOaepParams<'a> {
     /// Hash Algorithm
-    pub hash: AlgorithmIdentifier<'a>,
+    pub hash: AlgorithmIdentifierRef<'a>,
 
     /// Mask Generation Function (MGF)
-    pub mask_gen: AlgorithmIdentifier<'a>,
+    pub mask_gen: AlgorithmIdentifierRef<'a>,
 
     /// The source (and possibly the value) of the label L
-    pub p_source: AlgorithmIdentifier<'a>,
+    pub p_source: AlgorithmIdentifierRef<'a>,
 }
 
 impl<'a> Default for RsaOaepParams<'a> {
@@ -291,8 +291,8 @@ impl<'a> TryFrom<&'a [u8]> for RsaOaepParams<'a> {
 }
 
 /// Default Source Algorithm, empty string
-fn default_pempty_string<'a>() -> AlgorithmIdentifier<'a> {
-    AlgorithmIdentifier {
+fn default_pempty_string<'a>() -> AlgorithmIdentifierRef<'a> {
+    AlgorithmIdentifierRef {
         oid: OID_PSPECIFIED,
         parameters: Some(
             AnyRef::new(Tag::OctetString, &[]).expect("error creating default OAEP params"),

--- a/pkcs5/src/lib.rs
+++ b/pkcs5/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! The main API for this crate is the [`EncryptionScheme`] enum, which impls
 //! the [`Decode`] and [`Encode`] traits from the [`der`] crate, and can be
-//! used for decoding/encoding PKCS#5 [`AlgorithmIdentifier`] fields.
+//! used for decoding/encoding PKCS#5 `AlgorithmIdentifier` fields.
 //!
 //! [RFC 8018]: https://tools.ietf.org/html/rfc8018
 
@@ -26,7 +26,7 @@ pub mod pbes2;
 
 pub use crate::error::{Error, Result};
 pub use der::{self, asn1::ObjectIdentifier};
-pub use spki::AlgorithmIdentifier;
+pub use spki::AlgorithmIdentifierRef;
 
 use der::{Decode, DecodeValue, Encode, Header, Reader, Sequence, Tag};
 
@@ -136,7 +136,7 @@ impl<'a> EncryptionScheme<'a> {
 
 impl<'a> DecodeValue<'a> for EncryptionScheme<'a> {
     fn decode_value<R: Reader<'a>>(decoder: &mut R, header: Header) -> der::Result<Self> {
-        AlgorithmIdentifier::decode_value(decoder, header)?.try_into()
+        AlgorithmIdentifierRef::decode_value(decoder, header)?.try_into()
     }
 }
 
@@ -164,10 +164,10 @@ impl<'a> From<pbes2::Parameters<'a>> for EncryptionScheme<'a> {
     }
 }
 
-impl<'a> TryFrom<AlgorithmIdentifier<'a>> for EncryptionScheme<'a> {
+impl<'a> TryFrom<AlgorithmIdentifierRef<'a>> for EncryptionScheme<'a> {
     type Error = der::Error;
 
-    fn try_from(alg: AlgorithmIdentifier<'a>) -> der::Result<EncryptionScheme<'_>> {
+    fn try_from(alg: AlgorithmIdentifierRef<'a>) -> der::Result<EncryptionScheme<'_>> {
         if alg.oid == pbes2::PBES2_OID {
             match alg.parameters {
                 Some(params) => pbes2::Parameters::try_from(params).map(Into::into),
@@ -183,6 +183,6 @@ impl<'a> TryFrom<&'a [u8]> for EncryptionScheme<'a> {
     type Error = der::Error;
 
     fn try_from(bytes: &'a [u8]) -> der::Result<EncryptionScheme<'a>> {
-        AlgorithmIdentifier::from_der(bytes)?.try_into()
+        AlgorithmIdentifierRef::from_der(bytes)?.try_into()
     }
 }

--- a/pkcs5/src/pbes1.rs
+++ b/pkcs5/src/pbes1.rs
@@ -2,7 +2,7 @@
 //!
 //! [RFC 8018 Section 6.1]: https://tools.ietf.org/html/rfc8018#section-6.1
 
-use crate::AlgorithmIdentifier;
+use crate::AlgorithmIdentifierRef;
 use der::{
     asn1::{AnyRef, ObjectIdentifier, OctetStringRef},
     Decode, Encode, ErrorKind, Length, Reader, Sequence, Tag, Writer,
@@ -68,7 +68,7 @@ impl Algorithm {
 
 impl<'a> Decode<'a> for Algorithm {
     fn decode<R: Reader<'a>>(decoder: &mut R) -> der::Result<Self> {
-        AlgorithmIdentifier::decode(decoder)?.try_into()
+        AlgorithmIdentifierRef::decode(decoder)?.try_into()
     }
 }
 
@@ -81,10 +81,10 @@ impl Sequence<'_> for Algorithm {
     }
 }
 
-impl<'a> TryFrom<AlgorithmIdentifier<'a>> for Algorithm {
+impl<'a> TryFrom<AlgorithmIdentifierRef<'a>> for Algorithm {
     type Error = der::Error;
 
-    fn try_from(alg: AlgorithmIdentifier<'a>) -> der::Result<Self> {
+    fn try_from(alg: AlgorithmIdentifierRef<'a>) -> der::Result<Self> {
         // Ensure that we have a supported PBES1 algorithm identifier
         let encryption = EncryptionScheme::try_from(alg.oid)
             .map_err(|_| der::Tag::ObjectIdentifier.value_error())?;

--- a/pkcs7/src/enveloped_data_content.rs
+++ b/pkcs7/src/enveloped_data_content.rs
@@ -6,9 +6,9 @@ use der::{
     asn1::{ContextSpecific, OctetStringRef},
     DecodeValue, Encode, Header, Reader, Sequence, TagMode, TagNumber,
 };
-use spki::AlgorithmIdentifier;
+use spki::AlgorithmIdentifierRef;
 
-type ContentEncryptionAlgorithmIdentifier<'a> = AlgorithmIdentifier<'a>;
+type ContentEncryptionAlgorithmIdentifier<'a> = AlgorithmIdentifierRef<'a>;
 
 const ENCRYPTED_CONTENT_TAG: TagNumber = TagNumber::new(0);
 

--- a/pkcs7/tests/content_tests.rs
+++ b/pkcs7/tests/content_tests.rs
@@ -9,7 +9,7 @@ use pkcs7::{
     encrypted_data_content::EncryptedDataContent, enveloped_data_content::EncryptedContentInfo,
     ContentInfo, ContentType,
 };
-use spki::AlgorithmIdentifier;
+use spki::AlgorithmIdentifierRef;
 use std::fs;
 
 fn encode_content_info<'a>(content_info: &ContentInfo<'a>, buf: &'a mut [u8]) -> &'a [u8] {
@@ -52,7 +52,7 @@ fn decode_encrypted_key_example() {
                 EncryptedContentInfo {
                     content_type: ContentType::Data,
                     content_encryption_algorithm:
-                        AlgorithmIdentifier {
+                        AlgorithmIdentifierRef {
                             oid,
                             parameters: Some(any),
                         },

--- a/pkcs8/src/error.rs
+++ b/pkcs8/src/error.rs
@@ -26,7 +26,7 @@ pub enum Error {
     /// or [`SubjectPublicKeyInfo::subject_public_key`][`crate::SubjectPublicKeyInfo::subject_public_key`].
     KeyMalformed,
 
-    /// [`AlgorithmIdentifier::parameters`][`crate::AlgorithmIdentifier::parameters`]
+    /// [`AlgorithmIdentifier::parameters`][`crate::AlgorithmIdentifierRef::parameters`]
     /// is malformed or otherwise encoded in an unexpected manner.
     ParametersMalformed,
 

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -83,7 +83,7 @@ pub use crate::{
     version::Version,
 };
 pub use der::{self, asn1::ObjectIdentifier, oid::AssociatedOid};
-pub use spki::{self, AlgorithmIdentifier, DecodePublicKey, SubjectPublicKeyInfo};
+pub use spki::{self, AlgorithmIdentifierRef, DecodePublicKey, SubjectPublicKeyInfo};
 
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]

--- a/pkcs8/src/private_key_info.rs
+++ b/pkcs8/src/private_key_info.rs
@@ -1,6 +1,6 @@
 //! PKCS#8 `PrivateKeyInfo`.
 
-use crate::{AlgorithmIdentifier, Error, Result, Version};
+use crate::{AlgorithmIdentifierRef, Error, Result, Version};
 use core::fmt;
 use der::{
     asn1::{AnyRef, BitStringRef, ContextSpecific, OctetStringRef},
@@ -29,7 +29,7 @@ const PUBLIC_KEY_TAG: TagNumber = TagNumber::N1;
 
 /// PKCS#8 `PrivateKeyInfo`.
 ///
-/// ASN.1 structure containing an [`AlgorithmIdentifier`], private key
+/// ASN.1 structure containing an `AlgorithmIdentifier`, private key
 /// data in an algorithm specific format, and optional attributes
 /// (ignored by this implementation).
 ///
@@ -90,8 +90,8 @@ const PUBLIC_KEY_TAG: TagNumber = TagNumber::N1;
 /// [RFC 5958 Section 2]: https://datatracker.ietf.org/doc/html/rfc5958#section-2
 #[derive(Clone)]
 pub struct PrivateKeyInfo<'a> {
-    /// X.509 [`AlgorithmIdentifier`] for the private key type.
-    pub algorithm: AlgorithmIdentifier<'a>,
+    /// X.509 `AlgorithmIdentifier` for the private key type.
+    pub algorithm: AlgorithmIdentifierRef<'a>,
 
     /// Private key data.
     pub private_key: &'a [u8],
@@ -105,7 +105,7 @@ impl<'a> PrivateKeyInfo<'a> {
     ///
     /// This is a helper method which initializes `attributes` and `public_key`
     /// to `None`, helpful if you aren't using those.
-    pub fn new(algorithm: AlgorithmIdentifier<'a>, private_key: &'a [u8]) -> Self {
+    pub fn new(algorithm: AlgorithmIdentifierRef<'a>, private_key: &'a [u8]) -> Self {
         Self {
             algorithm,
             private_key,

--- a/sec1/src/traits.rs
+++ b/sec1/src/traits.rs
@@ -106,7 +106,7 @@ where
             .parameters
             .and_then(|params| params.named_curve());
 
-        let algorithm = pkcs8::AlgorithmIdentifier {
+        let algorithm = pkcs8::AlgorithmIdentifierRef {
             oid: ALGORITHM_OID,
             parameters: params_oid.as_ref().map(Into::into),
         };

--- a/spki/src/lib.rs
+++ b/spki/src/lib.rs
@@ -15,14 +15,14 @@
 //! Borrow the [`ObjectIdentifier`] first then use [`der::AnyRef::from`] or `.into()`:
 //!
 //! ```
-//! use spki::{AlgorithmIdentifier, ObjectIdentifier, der::AnyRef};
+//! use spki::{AlgorithmIdentifier, ObjectIdentifier};
 //!
 //! let alg_oid = "1.2.840.10045.2.1".parse::<ObjectIdentifier>().unwrap();
 //! let params_oid = "1.2.840.10045.3.1.7".parse::<ObjectIdentifier>().unwrap();
 //!
 //! let alg_id = AlgorithmIdentifier {
 //!     oid: alg_oid,
-//!     parameters: Some(AnyRef::from(&params_oid))
+//!     parameters: Some(params_oid)
 //! };
 //! ```
 
@@ -41,7 +41,7 @@ mod traits;
 mod fingerprint;
 
 pub use crate::{
-    algorithm::AlgorithmIdentifier,
+    algorithm::{AlgorithmIdentifier, AlgorithmIdentifierRef},
     error::{Error, Result},
     spki::SubjectPublicKeyInfo,
     traits::DecodePublicKey,

--- a/spki/src/spki.rs
+++ b/spki/src/spki.rs
@@ -1,6 +1,6 @@
 //! X.509 `SubjectPublicKeyInfo`
 
-use crate::{AlgorithmIdentifier, Error, Result};
+use crate::{AlgorithmIdentifierRef, Error, Result};
 use core::cmp::Ordering;
 use der::{
     asn1::BitStringRef, Decode, DecodeValue, DerOrd, Encode, Header, Reader, Sequence, ValueOrd,
@@ -21,6 +21,9 @@ use {
 #[cfg(feature = "pem")]
 use der::pem::PemLabel;
 
+#[cfg(doc)]
+use crate::AlgorithmIdentifier;
+
 /// X.509 `SubjectPublicKeyInfo` (SPKI) as defined in [RFC 5280 § 4.1.2.7].
 ///
 /// ASN.1 structure containing an [`AlgorithmIdentifier`] and public key
@@ -36,7 +39,7 @@ use der::pem::PemLabel;
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct SubjectPublicKeyInfo<'a> {
     /// X.509 [`AlgorithmIdentifier`] for the public key type
-    pub algorithm: AlgorithmIdentifier<'a>,
+    pub algorithm: AlgorithmIdentifierRef<'a>,
 
     /// Public key data
     pub subject_public_key: &'a [u8],

--- a/x509-cert/src/certificate.rs
+++ b/x509-cert/src/certificate.rs
@@ -8,7 +8,7 @@ use core::cmp::Ordering;
 use const_oid::AssociatedOid;
 use der::asn1::{BitStringRef, UintRef};
 use der::{Decode, Enumerated, Error, ErrorKind, Sequence, ValueOrd};
-use spki::{AlgorithmIdentifier, SubjectPublicKeyInfo};
+use spki::{AlgorithmIdentifierRef, SubjectPublicKeyInfo};
 
 #[cfg(feature = "pem")]
 use der::pem::PemLabel;
@@ -84,7 +84,7 @@ pub struct TbsCertificate<'a> {
     pub version: Version,
 
     pub serial_number: UintRef<'a>,
-    pub signature: AlgorithmIdentifier<'a>,
+    pub signature: AlgorithmIdentifierRef<'a>,
     pub issuer: Name<'a>,
     pub validity: Validity,
     pub subject: Name<'a>,
@@ -149,7 +149,7 @@ impl<'a> TbsCertificate<'a> {
 #[allow(missing_docs)]
 pub struct Certificate<'a> {
     pub tbs_certificate: TbsCertificate<'a>,
-    pub signature_algorithm: AlgorithmIdentifier<'a>,
+    pub signature_algorithm: AlgorithmIdentifierRef<'a>,
     pub signature: BitStringRef<'a>,
 }
 

--- a/x509-cert/src/crl.rs
+++ b/x509-cert/src/crl.rs
@@ -9,7 +9,7 @@ use alloc::vec::Vec;
 
 use der::asn1::{BitStringRef, UintRef};
 use der::{Sequence, ValueOrd};
-use spki::AlgorithmIdentifier;
+use spki::AlgorithmIdentifierRef;
 
 /// `CertificateList` as defined in [RFC 5280 Section 5.1].
 ///
@@ -26,7 +26,7 @@ use spki::AlgorithmIdentifier;
 #[allow(missing_docs)]
 pub struct CertificateList<'a> {
     pub tbs_cert_list: TbsCertList<'a>,
-    pub signature_algorithm: AlgorithmIdentifier<'a>,
+    pub signature_algorithm: AlgorithmIdentifierRef<'a>,
     pub signature: BitStringRef<'a>,
 }
 
@@ -75,7 +75,7 @@ pub struct RevokedCert<'a> {
 #[allow(missing_docs)]
 pub struct TbsCertList<'a> {
     pub version: Version,
-    pub signature: AlgorithmIdentifier<'a>,
+    pub signature: AlgorithmIdentifierRef<'a>,
     pub issuer: Name<'a>,
     pub this_update: Time,
     pub next_update: Option<Time>,

--- a/x509-cert/src/request.rs
+++ b/x509-cert/src/request.rs
@@ -9,7 +9,7 @@ use const_oid::db::rfc5912::ID_EXTENSION_REQ;
 use const_oid::{AssociatedOid, ObjectIdentifier};
 use der::asn1::BitStringRef;
 use der::{Decode, Enumerated, Sequence};
-use spki::{AlgorithmIdentifier, SubjectPublicKeyInfo};
+use spki::{AlgorithmIdentifierRef, SubjectPublicKeyInfo};
 
 /// Version identifier for certification request information.
 ///
@@ -75,7 +75,7 @@ pub struct CertReq<'a> {
     pub info: CertReqInfo<'a>,
 
     /// Signature algorithm identifier.
-    pub algorithm: AlgorithmIdentifier<'a>,
+    pub algorithm: AlgorithmIdentifierRef<'a>,
 
     /// Signature.
     pub signature: BitStringRef<'a>,

--- a/x509-cert/tests/certificate.rs
+++ b/x509-cert/tests/certificate.rs
@@ -5,7 +5,7 @@ use der::{
     Decode, DecodeValue, Encode, FixedTag, Header, Reader, Tag, Tagged,
 };
 use hex_literal::hex;
-use spki::AlgorithmIdentifier;
+use spki::AlgorithmIdentifierRef;
 use x509_cert::Certificate;
 use x509_cert::*;
 
@@ -116,7 +116,7 @@ fn reencode_cert() {
     let reencoded_tbs = parsed_tbs.to_vec().unwrap();
     assert_eq!(defer_cert.tbs_certificate, reencoded_tbs);
 
-    let parsed_sigalg = AlgorithmIdentifier::from_der(defer_cert.signature_algorithm).unwrap();
+    let parsed_sigalg = AlgorithmIdentifierRef::from_der(defer_cert.signature_algorithm).unwrap();
     let reencoded_sigalg = parsed_sigalg.to_vec().unwrap();
     assert_eq!(defer_cert.signature_algorithm, reencoded_sigalg);
 

--- a/x509-ocsp/src/lib.rs
+++ b/x509-ocsp/src/lib.rs
@@ -6,7 +6,7 @@ extern crate alloc;
 use der::asn1::{BitStringRef, Ia5StringRef, ObjectIdentifier, OctetStringRef, UintRef};
 use der::asn1::{GeneralizedTime, Null};
 use der::{AnyRef, Choice, Enumerated, Sequence};
-use spki::AlgorithmIdentifier;
+use spki::AlgorithmIdentifierRef;
 use x509_cert::ext::pkix::name::GeneralName;
 use x509_cert::ext::pkix::{AuthorityInfoAccessSyntax, CrlReason};
 use x509_cert::ext::Extensions;
@@ -89,7 +89,7 @@ pub struct TbsRequest<'a> {
 #[derive(Clone, Debug, Eq, PartialEq, Sequence)]
 #[allow(missing_docs)]
 pub struct Signature<'a> {
-    pub signature_algorithm: AlgorithmIdentifier<'a>,
+    pub signature_algorithm: AlgorithmIdentifierRef<'a>,
     pub signature: BitStringRef<'a>,
 
     #[asn1(context_specific = "0", optional = "true", tag_mode = "EXPLICIT")]
@@ -149,7 +149,7 @@ pub struct Request<'a> {
 #[derive(Clone, Debug, Eq, PartialEq, Sequence)]
 #[allow(missing_docs)]
 pub struct CertId<'a> {
-    pub hash_algorithm: AlgorithmIdentifier<'a>,
+    pub hash_algorithm: AlgorithmIdentifierRef<'a>,
     pub issuer_name_hash: OctetStringRef<'a>,
     pub issuer_key_hash: OctetStringRef<'a>,
     pub serial_number: UintRef<'a>,
@@ -231,7 +231,7 @@ pub struct ResponseBytes<'a> {
 #[allow(missing_docs)]
 pub struct BasicOcspResponse<'a> {
     pub tbs_response_data: ResponseData<'a>,
-    pub signature_algorithm: AlgorithmIdentifier<'a>,
+    pub signature_algorithm: AlgorithmIdentifierRef<'a>,
     pub signature: BitStringRef<'a>,
 
     #[asn1(context_specific = "0", optional = "true", tag_mode = "EXPLICIT")]
@@ -453,6 +453,6 @@ pub type PreferredSignatureAlgorithms<'a> = Vec<PreferredSignatureAlgorithm<'a>>
 #[derive(Clone, Debug, Eq, PartialEq, Sequence)]
 #[allow(missing_docs)]
 pub struct PreferredSignatureAlgorithm<'a> {
-    pub sig_identifier: AlgorithmIdentifier<'a>,
-    pub cert_identifier: Option<AlgorithmIdentifier<'a>>,
+    pub sig_identifier: AlgorithmIdentifierRef<'a>,
+    pub cert_identifier: Option<AlgorithmIdentifierRef<'a>>,
 }


### PR DESCRIPTION
NOTE: breaking change.

Previously `AlgorithmIdentifier::parameters` were always `AnyRef`. This commit changes them to a generic parameter `Params`.

An alias `AlgorithmIdentifierRef` provides a type identical to the original with `AnyRef` as its `parameters`, which is used in all of the other crates in this repo.

cc @baloo @lumag