### PR TITLE
x509-cert: make name an owned type

### DIFF
--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -94,11 +94,6 @@ impl<'a> AnyRef<'a> {
         self.try_into()
     }
 
-    /// Attempt to decode an ASN.1 `IA5String`.
-    pub fn ia5_string(self) -> Result<Ia5StringRef<'a>> {
-        self.try_into()
-    }
-
     /// Attempt to decode an ASN.1 `OCTET STRING`.
     pub fn octet_string(self) -> Result<OctetStringRef<'a>> {
         self.try_into()
@@ -123,21 +118,6 @@ impl<'a> AnyRef<'a> {
         }
     }
 
-    /// Attempt to decode an ASN.1 `PrintableString`.
-    pub fn printable_string(self) -> Result<PrintableStringRef<'a>> {
-        self.try_into()
-    }
-
-    /// Attempt to decode an ASN.1 `TeletexString`.
-    pub fn teletex_string(self) -> Result<TeletexStringRef<'a>> {
-        self.try_into()
-    }
-
-    /// Attempt to decode an ASN.1 `VideotexString`.
-    pub fn videotex_string(self) -> Result<VideotexStringRef<'a>> {
-        self.try_into()
-    }
-
     /// Attempt to decode this value an ASN.1 `SEQUENCE`, creating a new
     /// nested reader and calling the provided argument with it.
     pub fn sequence<F, T>(self, f: F) -> Result<T>
@@ -152,11 +132,6 @@ impl<'a> AnyRef<'a> {
 
     /// Attempt to decode an ASN.1 `UTCTime`.
     pub fn utc_time(self) -> Result<UtcTime> {
-        self.try_into()
-    }
-
-    /// Attempt to decode an ASN.1 `UTF8String`.
-    pub fn utf8_string(self) -> Result<Utf8StringRef<'a>> {
         self.try_into()
     }
 }
@@ -303,5 +278,19 @@ impl<'a> From<&'a Any> for AnyRef<'a> {
 impl Tagged for Any {
     fn tag(&self) -> Tag {
         self.tag
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a, T> From<T> for Any
+where
+    T: Into<AnyRef<'a>>,
+{
+    fn from(input: T) -> Any {
+        let anyref: AnyRef<'a> = input.into();
+        Self {
+            tag: anyref.tag(),
+            value: ByteVec::new(anyref.value()).expect("invalid ANY"),
+        }
     }
 }

--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -194,6 +194,13 @@ impl Tagged for AnyRef<'_> {
     }
 }
 
+#[cfg(feature = "alloc")]
+impl ValueOrd for Any {
+    fn value_cmp(&self, other: &Self) -> Result<Ordering> {
+        self.value.der_cmp(&other.value)
+    }
+}
+
 impl ValueOrd for AnyRef<'_> {
     fn value_cmp(&self, other: &Self) -> Result<Ordering> {
         self.value.der_cmp(&other.value)

--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -290,7 +290,7 @@ where
         let anyref: AnyRef<'a> = input.into();
         Self {
             tag: anyref.tag(),
-            value: Bytes::new(anyref.value()).expect("invalid ANY"),
+            value: Bytes::from(anyref.value),
         }
     }
 }

--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -7,7 +7,7 @@ use crate::{
 use core::cmp::Ordering;
 
 #[cfg(feature = "alloc")]
-use crate::ByteVec;
+use crate::Bytes;
 
 #[cfg(feature = "oid")]
 use crate::asn1::ObjectIdentifier;
@@ -208,14 +208,14 @@ pub struct Any {
     tag: Tag,
 
     /// Inner value encoded as bytes.
-    value: ByteVec,
+    value: Bytes,
 }
 
 #[cfg(feature = "alloc")]
 impl Any {
     /// Create a new [`Any`] from the provided [`Tag`] and DER bytes.
     pub fn new(tag: Tag, bytes: &[u8]) -> Result<Self> {
-        let value = ByteVec::new(bytes)?;
+        let value = Bytes::new(bytes)?;
 
         // Ensure the tag and value are a valid `AnyRef`.
         AnyRef::new(tag, value.as_slice())?;
@@ -290,7 +290,7 @@ where
         let anyref: AnyRef<'a> = input.into();
         Self {
             tag: anyref.tag(),
-            value: ByteVec::new(anyref.value()).expect("invalid ANY"),
+            value: Bytes::new(anyref.value()).expect("invalid ANY"),
         }
     }
 }

--- a/der/src/asn1/ia5_string.rs
+++ b/der/src/asn1/ia5_string.rs
@@ -6,6 +6,9 @@ use crate::{
 };
 use core::{fmt, ops::Deref, str};
 
+#[cfg(feature = "alloc")]
+use crate::asn1::Any;
+
 /// ASN.1 `IA5String` type.
 ///
 /// Supports the [International Alphabet No. 5 (IA5)] character encoding, i.e.
@@ -95,6 +98,15 @@ impl<'a> TryFrom<AnyRef<'a>> for Ia5StringRef<'a> {
     type Error = Error;
 
     fn try_from(any: AnyRef<'a>) -> Result<Ia5StringRef<'a>> {
+        any.decode_into()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a> TryFrom<&'a Any> for Ia5StringRef<'a> {
+    type Error = Error;
+
+    fn try_from(any: &'a Any) -> Result<Ia5StringRef<'a>> {
         any.decode_into()
     }
 }

--- a/der/src/asn1/printable_string.rs
+++ b/der/src/asn1/printable_string.rs
@@ -6,6 +6,9 @@ use crate::{
 };
 use core::{fmt, ops::Deref, str};
 
+#[cfg(feature = "alloc")]
+use crate::asn1::Any;
+
 /// ASN.1 `PrintableString` type.
 ///
 /// Supports a subset the ASCII character set (described below).
@@ -129,6 +132,15 @@ impl<'a> TryFrom<AnyRef<'a>> for PrintableStringRef<'a> {
     type Error = Error;
 
     fn try_from(any: AnyRef<'a>) -> Result<PrintableStringRef<'a>> {
+        any.decode_into()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a> TryFrom<&'a Any> for PrintableStringRef<'a> {
+    type Error = Error;
+
+    fn try_from(any: &'a Any) -> Result<PrintableStringRef<'a>> {
         any.decode_into()
     }
 }

--- a/der/src/asn1/teletex_string.rs
+++ b/der/src/asn1/teletex_string.rs
@@ -6,6 +6,9 @@ use crate::{
 };
 use core::{fmt, ops::Deref, str};
 
+#[cfg(feature = "alloc")]
+use crate::asn1::Any;
+
 /// ASN.1 `TeletexString` type.
 ///
 /// Supports a subset the ASCII character set (described below).
@@ -99,6 +102,15 @@ impl<'a> TryFrom<AnyRef<'a>> for TeletexStringRef<'a> {
     type Error = Error;
 
     fn try_from(any: AnyRef<'a>) -> Result<TeletexStringRef<'a>> {
+        any.decode_into()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a> TryFrom<&'a Any> for TeletexStringRef<'a> {
+    type Error = Error;
+
+    fn try_from(any: &'a Any) -> Result<TeletexStringRef<'a>> {
         any.decode_into()
     }
 }

--- a/der/src/asn1/utf8_string.rs
+++ b/der/src/asn1/utf8_string.rs
@@ -7,7 +7,10 @@ use crate::{
 use core::{fmt, ops::Deref, str};
 
 #[cfg(feature = "alloc")]
-use alloc::{borrow::ToOwned, string::String};
+use {
+    crate::asn1::Any,
+    alloc::{borrow::ToOwned, string::String},
+};
 
 /// ASN.1 `UTF8String` type.
 ///
@@ -95,9 +98,18 @@ impl<'a> TryFrom<AnyRef<'a>> for Utf8StringRef<'a> {
     }
 }
 
+#[cfg(feature = "alloc")]
+impl<'a> TryFrom<&'a Any> for Utf8StringRef<'a> {
+    type Error = Error;
+
+    fn try_from(any: &'a Any) -> Result<Utf8StringRef<'a>> {
+        any.decode_into()
+    }
+}
+
 impl<'a> From<Utf8StringRef<'a>> for AnyRef<'a> {
-    fn from(printable_string: Utf8StringRef<'a>) -> AnyRef<'a> {
-        AnyRef::from_tag_and_value(Tag::Utf8String, printable_string.inner.into())
+    fn from(utf_string: Utf8StringRef<'a>) -> AnyRef<'a> {
+        AnyRef::from_tag_and_value(Tag::Utf8String, utf_string.inner.into())
     }
 }
 

--- a/der/src/asn1/videotex_string.rs
+++ b/der/src/asn1/videotex_string.rs
@@ -6,6 +6,9 @@ use crate::{
 };
 use core::{fmt, ops::Deref, str};
 
+#[cfg(feature = "alloc")]
+use crate::asn1::Any;
+
 /// ASN.1 `VideotexString` type.
 ///
 /// Supports a subset the ASCII character set (described below).
@@ -98,6 +101,15 @@ impl<'a> TryFrom<AnyRef<'a>> for VideotexStringRef<'a> {
     type Error = Error;
 
     fn try_from(any: AnyRef<'a>) -> Result<VideotexStringRef<'a>> {
+        any.decode_into()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a> TryFrom<&'a Any> for VideotexStringRef<'a> {
+    type Error = Error;
+
+    fn try_from(any: &'a Any) -> Result<VideotexStringRef<'a>> {
         any.decode_into()
     }
 }

--- a/der/src/byte_slice.rs
+++ b/der/src/byte_slice.rs
@@ -11,10 +11,10 @@ use core::cmp::Ordering;
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub(crate) struct ByteSlice<'a> {
     /// Precomputed `Length` (avoids possible panicking conversions)
-    length: Length,
+    pub length: Length,
 
     /// Inner value
-    inner: &'a [u8],
+    pub inner: &'a [u8],
 }
 
 impl<'a> ByteSlice<'a> {

--- a/der/src/byte_vec.rs
+++ b/der/src/byte_vec.rs
@@ -1,0 +1,106 @@
+//! Common handling for types backed by byte slices with enforcement of a
+//! library-level length limitation i.e. `Length::max()`.
+
+use crate::{
+    str_slice::StrSlice, DecodeValue, DerOrd, EncodeValue, Error, Header, Length, Reader, Result,
+    Writer,
+};
+use alloc::vec::Vec;
+use core::cmp::Ordering;
+
+/// Byte slice newtype which respects the `Length::max()` limit.
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub(crate) struct ByteVec {
+    /// Precomputed `Length` (avoids possible panicking conversions)
+    length: Length,
+
+    /// Inner value
+    inner: Vec<u8>,
+}
+
+impl ByteVec {
+    /// Create a new [`ByteVec`], ensuring that the provided `slice` value
+    /// is shorter than `Length::max()`.
+    pub fn new(slice: &[u8]) -> Result<Self> {
+        Ok(Self {
+            length: Length::try_from(slice.len())?,
+            inner: Vec::from(slice),
+        })
+    }
+
+    /// Borrow the inner byte slice
+    pub fn as_slice(&self) -> &[u8] {
+        &self.inner
+    }
+
+    /// Get the [`Length`] of this [`ByteSlice`]
+    pub fn len(&self) -> Length {
+        self.length
+    }
+}
+
+impl AsRef<[u8]> for ByteVec {
+    fn as_ref(&self) -> &[u8] {
+        self.as_slice()
+    }
+}
+
+impl<'a> DecodeValue<'a> for ByteVec {
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
+        reader.read_slice(header.length).and_then(Self::new)
+    }
+}
+
+impl EncodeValue for ByteVec {
+    fn value_len(&self) -> Result<Length> {
+        Ok(self.length)
+    }
+
+    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+        writer.write(self.as_ref())
+    }
+}
+
+impl Default for ByteVec {
+    fn default() -> Self {
+        Self {
+            length: Length::ZERO,
+            inner: Vec::new(),
+        }
+    }
+}
+
+impl DerOrd for ByteVec {
+    fn der_cmp(&self, other: &Self) -> Result<Ordering> {
+        Ok(self.as_slice().cmp(other.as_slice()))
+    }
+}
+
+impl From<&[u8; 1]> for ByteVec {
+    fn from(byte: &[u8; 1]) -> ByteVec {
+        Self {
+            length: Length::ONE,
+            inner: vec![byte[0]],
+        }
+    }
+}
+
+impl From<StrSlice<'_>> for ByteVec {
+    fn from(s: StrSlice<'_>) -> ByteVec {
+        let bytes = s.as_bytes();
+        debug_assert_eq!(bytes.len(), usize::try_from(s.length).expect("overflow"));
+
+        ByteVec {
+            inner: Vec::from(bytes),
+            length: s.length,
+        }
+    }
+}
+
+impl TryFrom<&[u8]> for ByteVec {
+    type Error = Error;
+
+    fn try_from(slice: &[u8]) -> Result<Self> {
+        Self::new(slice)
+    }
+}

--- a/der/src/bytes.rs
+++ b/der/src/bytes.rs
@@ -1,30 +1,30 @@
-//! Common handling for types backed by byte slices with enforcement of a
+//! Common handling for types backed by byte allocation with enforcement of a
 //! library-level length limitation i.e. `Length::max()`.
 
 use crate::{
     str_slice::StrSlice, DecodeValue, DerOrd, EncodeValue, Error, Header, Length, Reader, Result,
     Writer,
 };
-use alloc::vec::Vec;
+use alloc::boxed::Box;
 use core::cmp::Ordering;
 
 /// Byte slice newtype which respects the `Length::max()` limit.
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
-pub(crate) struct ByteVec {
+pub(crate) struct Bytes {
     /// Precomputed `Length` (avoids possible panicking conversions)
     length: Length,
 
     /// Inner value
-    inner: Vec<u8>,
+    inner: Box<[u8]>,
 }
 
-impl ByteVec {
-    /// Create a new [`ByteVec`], ensuring that the provided `slice` value
+impl Bytes {
+    /// Create a new [`Bytes`], ensuring that the provided `slice` value
     /// is shorter than `Length::max()`.
     pub fn new(slice: &[u8]) -> Result<Self> {
         Ok(Self {
             length: Length::try_from(slice.len())?,
-            inner: Vec::from(slice),
+            inner: Box::from(slice),
         })
     }
 
@@ -39,19 +39,19 @@ impl ByteVec {
     }
 }
 
-impl AsRef<[u8]> for ByteVec {
+impl AsRef<[u8]> for Bytes {
     fn as_ref(&self) -> &[u8] {
         self.as_slice()
     }
 }
 
-impl<'a> DecodeValue<'a> for ByteVec {
+impl<'a> DecodeValue<'a> for Bytes {
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         reader.read_slice(header.length).and_then(Self::new)
     }
 }
 
-impl EncodeValue for ByteVec {
+impl EncodeValue for Bytes {
     fn value_len(&self) -> Result<Length> {
         Ok(self.length)
     }
@@ -61,43 +61,43 @@ impl EncodeValue for ByteVec {
     }
 }
 
-impl Default for ByteVec {
+impl Default for Bytes {
     fn default() -> Self {
         Self {
             length: Length::ZERO,
-            inner: Vec::new(),
+            inner: Box::new([]),
         }
     }
 }
 
-impl DerOrd for ByteVec {
+impl DerOrd for Bytes {
     fn der_cmp(&self, other: &Self) -> Result<Ordering> {
         Ok(self.as_slice().cmp(other.as_slice()))
     }
 }
 
-impl From<&[u8; 1]> for ByteVec {
-    fn from(byte: &[u8; 1]) -> ByteVec {
+impl From<&[u8; 1]> for Bytes {
+    fn from(byte: &[u8; 1]) -> Bytes {
         Self {
             length: Length::ONE,
-            inner: vec![byte[0]],
+            inner: Box::new([byte[0]]),
         }
     }
 }
 
-impl From<StrSlice<'_>> for ByteVec {
-    fn from(s: StrSlice<'_>) -> ByteVec {
+impl From<StrSlice<'_>> for Bytes {
+    fn from(s: StrSlice<'_>) -> Bytes {
         let bytes = s.as_bytes();
         debug_assert_eq!(bytes.len(), usize::try_from(s.length).expect("overflow"));
 
-        ByteVec {
-            inner: Vec::from(bytes),
+        Bytes {
+            inner: Box::from(bytes),
             length: s.length,
         }
     }
 }
 
-impl TryFrom<&[u8]> for ByteVec {
+impl TryFrom<&[u8]> for Bytes {
     type Error = Error;
 
     fn try_from(slice: &[u8]) -> Result<Self> {

--- a/der/src/bytes.rs
+++ b/der/src/bytes.rs
@@ -2,8 +2,8 @@
 //! library-level length limitation i.e. `Length::max()`.
 
 use crate::{
-    str_slice::StrSlice, DecodeValue, DerOrd, EncodeValue, Error, Header, Length, Reader, Result,
-    Writer,
+    str_slice::StrSlice, ByteSlice, DecodeValue, DerOrd, EncodeValue, Error, Header, Length,
+    Reader, Result, Writer,
 };
 use alloc::boxed::Box;
 use core::cmp::Ordering;
@@ -93,6 +93,15 @@ impl From<StrSlice<'_>> for Bytes {
         Bytes {
             inner: Box::from(bytes),
             length: s.length,
+        }
+    }
+}
+
+impl From<ByteSlice<'_>> for Bytes {
+    fn from(s: ByteSlice<'_>) -> Bytes {
+        Bytes {
+            length: s.length,
+            inner: Box::from(s.inner),
         }
     }
 }

--- a/der/src/bytes.rs
+++ b/der/src/bytes.rs
@@ -21,10 +21,12 @@ pub(crate) struct Bytes {
 impl Bytes {
     /// Create a new [`Bytes`], ensuring that the provided `slice` value
     /// is shorter than `Length::max()`.
-    pub fn new(slice: &[u8]) -> Result<Self> {
+    pub fn new(data: impl Into<Box<[u8]>>) -> Result<Self> {
+        let inner: Box<[u8]> = data.into();
+
         Ok(Self {
-            length: Length::try_from(slice.len())?,
-            inner: Box::from(slice),
+            length: Length::try_from(inner.len())?,
+            inner,
         })
     }
 
@@ -47,7 +49,7 @@ impl AsRef<[u8]> for Bytes {
 
 impl<'a> DecodeValue<'a> for Bytes {
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
-        reader.read_slice(header.length).and_then(Self::new)
+        reader.read_vec(header.length).and_then(Self::new)
     }
 }
 

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -357,6 +357,8 @@ mod tag;
 mod writer;
 
 #[cfg(feature = "alloc")]
+mod byte_vec;
+#[cfg(feature = "alloc")]
 mod document;
 
 pub use crate::{
@@ -406,4 +408,6 @@ pub use zeroize;
 #[cfg(all(feature = "alloc", feature = "zeroize"))]
 pub use crate::document::SecretDocument;
 
+#[cfg(feature = "alloc")]
+pub(crate) use crate::byte_vec::ByteVec;
 pub(crate) use crate::{arrayvec::ArrayVec, byte_slice::ByteSlice, str_slice::StrSlice};

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -357,7 +357,7 @@ mod tag;
 mod writer;
 
 #[cfg(feature = "alloc")]
-mod byte_vec;
+mod bytes;
 #[cfg(feature = "alloc")]
 mod document;
 
@@ -409,5 +409,5 @@ pub use zeroize;
 pub use crate::document::SecretDocument;
 
 #[cfg(feature = "alloc")]
-pub(crate) use crate::byte_vec::ByteVec;
+pub(crate) use crate::bytes::Bytes;
 pub(crate) use crate::{arrayvec::ArrayVec, byte_slice::ByteSlice, str_slice::StrSlice};

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -377,7 +377,7 @@ pub use crate::{
 };
 
 #[cfg(feature = "alloc")]
-pub use crate::document::Document;
+pub use crate::{asn1::Any, document::Document};
 
 #[cfg(feature = "bigint")]
 #[cfg_attr(docsrs, doc(cfg(feature = "bigint")))]

--- a/x509-cert/src/anchor.rs
+++ b/x509-cert/src/anchor.rs
@@ -75,7 +75,7 @@ pub struct TrustAnchorInfo<'a> {
 #[derive(Clone, Debug, Eq, PartialEq, Sequence)]
 #[allow(missing_docs)]
 pub struct CertPathControls<'a> {
-    pub ta_name: Name<'a>,
+    pub ta_name: Name,
 
     #[asn1(context_specific = "0", tag_mode = "IMPLICIT", optional = "true")]
     pub certificate: Option<Certificate<'a>>,

--- a/x509-cert/src/attr.rs
+++ b/x509-cert/src/attr.rs
@@ -5,7 +5,10 @@ use const_oid::db::rfc4519::{COUNTRY_NAME, DOMAIN_COMPONENT, SERIAL_NUMBER};
 use core::fmt::{self, Write};
 
 use const_oid::db::DB;
-use der::asn1::{AnyRef, ObjectIdentifier, SetOfVec};
+use der::asn1::{
+    AnyRef, Ia5StringRef, ObjectIdentifier, PrintableStringRef, SetOfVec, TeletexStringRef,
+    Utf8StringRef,
+};
 use der::{Decode, Encode, Error, ErrorKind, Sequence, Tag, Tagged, ValueOrd};
 
 /// X.501 `AttributeType` as defined in [RFC 5280 Appendix A.1].
@@ -227,10 +230,16 @@ impl AttributeTypeAndValue<'_> {
 impl fmt::Display for AttributeTypeAndValue<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let val = match self.value.tag() {
-            Tag::PrintableString => self.value.printable_string().ok().map(|s| s.as_str()),
-            Tag::Utf8String => self.value.utf8_string().ok().map(|s| s.as_str()),
-            Tag::Ia5String => self.value.ia5_string().ok().map(|s| s.as_str()),
-            Tag::TeletexString => self.value.teletex_string().ok().map(|s| s.as_str()),
+            Tag::PrintableString => PrintableStringRef::try_from(&self.value)
+                .ok()
+                .map(|s| s.as_str()),
+            Tag::Utf8String => Utf8StringRef::try_from(&self.value)
+                .ok()
+                .map(|s| s.as_str()),
+            Tag::Ia5String => Ia5StringRef::try_from(&self.value).ok().map(|s| s.as_str()),
+            Tag::TeletexString => TeletexStringRef::try_from(&self.value)
+                .ok()
+                .map(|s| s.as_str()),
             _ => None,
         };
 

--- a/x509-cert/src/attr.rs
+++ b/x509-cert/src/attr.rs
@@ -6,7 +6,7 @@ use core::fmt::{self, Write};
 
 use const_oid::db::DB;
 use der::asn1::{
-    AnyRef, Ia5StringRef, ObjectIdentifier, PrintableStringRef, SetOfVec, TeletexStringRef,
+    Any, Ia5StringRef, ObjectIdentifier, PrintableStringRef, SetOfVec, TeletexStringRef,
     Utf8StringRef,
 };
 use der::{Decode, Encode, Error, ErrorKind, Sequence, Tag, Tagged, ValueOrd};
@@ -27,7 +27,7 @@ pub type AttributeType = ObjectIdentifier;
 /// ```
 ///
 /// [RFC 5280 Appendix A.1]: https://datatracker.ietf.org/doc/html/rfc5280#appendix-A.1
-pub type AttributeValue<'a> = AnyRef<'a>;
+pub type AttributeValue = Any;
 
 /// X.501 `Attribute` as defined in [RFC 5280 Appendix A.1].
 ///
@@ -53,15 +53,15 @@ pub type AttributeValue<'a> = AnyRef<'a>;
 /// [RFC 5280 Appendix A.1]: https://datatracker.ietf.org/doc/html/rfc5280#appendix-A.1
 #[derive(Clone, Debug, PartialEq, Eq, Sequence, ValueOrd)]
 #[allow(missing_docs)]
-pub struct Attribute<'a> {
+pub struct Attribute {
     pub oid: AttributeType,
-    pub values: SetOfVec<AttributeValue<'a>>,
+    pub values: SetOfVec<AttributeValue>,
 }
 
-impl<'a> TryFrom<&'a [u8]> for Attribute<'a> {
+impl TryFrom<&[u8]> for Attribute {
     type Error = Error;
 
-    fn try_from(bytes: &'a [u8]) -> Result<Self, Self::Error> {
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
         Self::from_der(bytes)
     }
 }
@@ -73,7 +73,7 @@ impl<'a> TryFrom<&'a [u8]> for Attribute<'a> {
 /// ```
 ///
 /// [RFC 2986 Section 4]: https://datatracker.ietf.org/doc/html/rfc2986#section-4
-pub type Attributes<'a> = SetOfVec<Attribute<'a>>;
+pub type Attributes = SetOfVec<Attribute>;
 
 /// X.501 `AttributeTypeAndValue` as defined in [RFC 5280 Appendix A.1].
 ///
@@ -85,11 +85,11 @@ pub type Attributes<'a> = SetOfVec<Attribute<'a>>;
 /// ```
 ///
 /// [RFC 5280 Appendix A.1]: https://datatracker.ietf.org/doc/html/rfc5280#appendix-A.1
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Sequence, ValueOrd)]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Sequence, ValueOrd)]
 #[allow(missing_docs)]
-pub struct AttributeTypeAndValue<'a> {
+pub struct AttributeTypeAndValue {
     pub oid: AttributeType,
-    pub value: AnyRef<'a>,
+    pub value: AttributeValue,
 }
 
 #[derive(Copy, Clone)]
@@ -144,7 +144,7 @@ impl Parser {
     }
 }
 
-impl AttributeTypeAndValue<'_> {
+impl AttributeTypeAndValue {
     /// Parses the hex value in the `OID=#HEX` format.
     fn encode_hex(oid: ObjectIdentifier, val: &str) -> Result<Vec<u8>, Error> {
         // Ensure an even number of hex bytes.
@@ -172,7 +172,7 @@ impl AttributeTypeAndValue<'_> {
         }
 
         // Serialize.
-        let value = AnyRef::from_der(&bytes)?;
+        let value = Any::from_der(&bytes)?;
         let atv = AttributeTypeAndValue { oid, value };
         atv.to_vec()
     }
@@ -195,7 +195,7 @@ impl AttributeTypeAndValue<'_> {
         };
 
         // Serialize.
-        let value = AnyRef::new(tag, parser.as_bytes())?;
+        let value = Any::new(tag, parser.as_bytes())?;
         let atv = AttributeTypeAndValue { oid, value };
         atv.to_vec()
     }
@@ -227,7 +227,7 @@ impl AttributeTypeAndValue<'_> {
 /// Serializes the structure according to the rules in [RFC 4514].
 ///
 /// [RFC 4514]: https://datatracker.ietf.org/doc/html/rfc4514
-impl fmt::Display for AttributeTypeAndValue<'_> {
+impl fmt::Display for AttributeTypeAndValue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let val = match self.value.tag() {
             Tag::PrintableString => PrintableStringRef::try_from(&self.value)

--- a/x509-cert/src/certificate.rs
+++ b/x509-cert/src/certificate.rs
@@ -85,9 +85,9 @@ pub struct TbsCertificate<'a> {
 
     pub serial_number: UintRef<'a>,
     pub signature: AlgorithmIdentifierRef<'a>,
-    pub issuer: Name<'a>,
+    pub issuer: Name,
     pub validity: Validity,
-    pub subject: Name<'a>,
+    pub subject: Name,
     pub subject_public_key_info: SubjectPublicKeyInfoRef<'a>,
 
     #[asn1(context_specific = "1", tag_mode = "IMPLICIT", optional = "true")]

--- a/x509-cert/src/crl.rs
+++ b/x509-cert/src/crl.rs
@@ -76,7 +76,7 @@ pub struct RevokedCert<'a> {
 pub struct TbsCertList<'a> {
     pub version: Version,
     pub signature: AlgorithmIdentifierRef<'a>,
-    pub issuer: Name<'a>,
+    pub issuer: Name,
     pub this_update: Time,
     pub next_update: Option<Time>,
     pub revoked_certificates: Option<Vec<RevokedCert<'a>>>,

--- a/x509-cert/src/ext/pkix.rs
+++ b/x509-cert/src/ext/pkix.rs
@@ -89,16 +89,13 @@ impl_newtype!(IssuerAltName<'a>, name::GeneralNames<'a>);
 ///
 /// [RFC 5280 Section 4.2.1.8]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.8
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct SubjectDirectoryAttributes<'a>(pub Vec<AttributeTypeAndValue<'a>>);
+pub struct SubjectDirectoryAttributes(pub Vec<AttributeTypeAndValue>);
 
-impl<'a> AssociatedOid for SubjectDirectoryAttributes<'a> {
+impl AssociatedOid for SubjectDirectoryAttributes {
     const OID: ObjectIdentifier = ID_CE_SUBJECT_DIRECTORY_ATTRIBUTES;
 }
 
-impl_newtype!(
-    SubjectDirectoryAttributes<'a>,
-    Vec<AttributeTypeAndValue<'a>>
-);
+impl_newtype!(SubjectDirectoryAttributes, Vec<AttributeTypeAndValue>);
 
 /// InhibitAnyPolicy as defined in [RFC 5280 Section 4.2.1.14].
 ///

--- a/x509-cert/src/ext/pkix/name/dp.rs
+++ b/x509-cert/src/ext/pkix/name/dp.rs
@@ -20,5 +20,5 @@ pub enum DistributionPointName<'a> {
     FullName(GeneralNames<'a>),
 
     #[asn1(context_specific = "1", tag_mode = "IMPLICIT", constructed = "true")]
-    NameRelativeToCRLIssuer(RelativeDistinguishedName<'a>),
+    NameRelativeToCRLIssuer(RelativeDistinguishedName),
 }

--- a/x509-cert/src/ext/pkix/name/general.rs
+++ b/x509-cert/src/ext/pkix/name/general.rs
@@ -47,7 +47,7 @@ pub enum GeneralName<'a> {
     DnsName(Ia5StringRef<'a>),
 
     #[asn1(context_specific = "4", tag_mode = "EXPLICIT", constructed = "true")]
-    DirectoryName(Name<'a>),
+    DirectoryName(Name),
 
     #[asn1(context_specific = "5", tag_mode = "IMPLICIT", constructed = "true")]
     EdiPartyName(EdiPartyName<'a>),

--- a/x509-cert/src/ext/pkix/name/other.rs
+++ b/x509-cert/src/ext/pkix/name/other.rs
@@ -23,13 +23,13 @@ pub struct OtherName<'a> {
 #[cfg(test)]
 fn test() {
     use alloc::string::ToString;
-    use der::{Decode, Encode};
+    use der::{asn1::Utf8StringRef, Decode, Encode};
     use hex_literal::hex;
 
     let input = hex!("3021060A2B060104018237140203A0130C1155706E5F323134393530313330406D696C");
     let decoded = OtherName::from_der(&input).unwrap();
 
-    let onval = decoded.value.utf8_string().unwrap();
+    let onval = Utf8StringRef::try_from(decoded.value).unwrap();
     assert_eq!(onval.to_string(), "Upn_214950130@mil");
 
     let encoded = decoded.to_vec().unwrap();

--- a/x509-cert/src/name.rs
+++ b/x509-cert/src/name.rs
@@ -12,7 +12,7 @@ use der::{asn1::SetOfVec, Decode, Encode};
 /// ```
 ///
 /// [RFC 5280 Section 4.1.2.4]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.4
-pub type Name<'a> = RdnSequence<'a>;
+pub type Name = RdnSequence;
 
 /// X.501 RDNSequence as defined in [RFC 5280 Section 4.1.2.4].
 ///
@@ -22,9 +22,9 @@ pub type Name<'a> = RdnSequence<'a>;
 ///
 /// [RFC 5280 Section 4.1.2.4]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.4
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct RdnSequence<'a>(pub Vec<RelativeDistinguishedName<'a>>);
+pub struct RdnSequence(pub Vec<RelativeDistinguishedName>);
 
-impl RdnSequence<'_> {
+impl RdnSequence {
     /// Converts an RDNSequence string into an encoded RDNSequence
     ///
     /// This function follows the rules in [RFC 4514].
@@ -47,7 +47,7 @@ impl RdnSequence<'_> {
 /// Serializes the structure according to the rules in [RFC 4514].
 ///
 /// [RFC 4514]: https://datatracker.ietf.org/doc/html/rfc4514
-impl fmt::Display for RdnSequence<'_> {
+impl fmt::Display for RdnSequence {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for (i, atv) in self.0.iter().enumerate() {
             match i {
@@ -60,7 +60,7 @@ impl fmt::Display for RdnSequence<'_> {
     }
 }
 
-impl_newtype!(RdnSequence<'a>, Vec<RelativeDistinguishedName<'a>>);
+impl_newtype!(RdnSequence, Vec<RelativeDistinguishedName>);
 
 /// Find the indices of all non-escaped separators.
 fn find(s: &str, b: u8) -> impl '_ + Iterator<Item = usize> {
@@ -98,7 +98,7 @@ fn split(s: &str, b: u8) -> impl '_ + Iterator<Item = &'_ str> {
 /// ```
 ///
 /// [RFC 5280 Section 4.1.2.4]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.4
-pub type DistinguishedName<'a> = RdnSequence<'a>;
+pub type DistinguishedName = RdnSequence;
 
 /// RelativeDistinguishedName as defined in [RFC 5280 Section 4.1.2.4].
 ///
@@ -125,9 +125,9 @@ pub type DistinguishedName<'a> = RdnSequence<'a>;
 ///
 /// [RFC 5280 Section 4.1.2.4]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.4
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct RelativeDistinguishedName<'a>(pub SetOfVec<AttributeTypeAndValue<'a>>);
+pub struct RelativeDistinguishedName(pub SetOfVec<AttributeTypeAndValue>);
 
-impl RelativeDistinguishedName<'_> {
+impl RelativeDistinguishedName {
     /// Converts an RelativeDistinguishedName string into an encoded RelativeDistinguishedName
     ///
     /// This function follows the rules in [RFC 4514].
@@ -150,7 +150,7 @@ impl RelativeDistinguishedName<'_> {
 /// Serializes the structure according to the rules in [RFC 4514].
 ///
 /// [RFC 4514]: https://datatracker.ietf.org/doc/html/rfc4514
-impl fmt::Display for RelativeDistinguishedName<'_> {
+impl fmt::Display for RelativeDistinguishedName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for (i, atv) in self.0.iter().enumerate() {
             match i {
@@ -163,7 +163,4 @@ impl fmt::Display for RelativeDistinguishedName<'_> {
     }
 }
 
-impl_newtype!(
-    RelativeDistinguishedName<'a>,
-    SetOfVec<AttributeTypeAndValue<'a>>
-);
+impl_newtype!(RelativeDistinguishedName, SetOfVec<AttributeTypeAndValue>);

--- a/x509-cert/src/request.rs
+++ b/x509-cert/src/request.rs
@@ -40,14 +40,14 @@ pub struct CertReqInfo<'a> {
     pub version: Version,
 
     /// Subject name.
-    pub subject: Name<'a>,
+    pub subject: Name,
 
     /// Subject public key info.
     pub public_key: SubjectPublicKeyInfoRef<'a>,
 
     /// Request attributes.
     #[asn1(context_specific = "0", tag_mode = "IMPLICIT")]
-    pub attributes: Attributes<'a>,
+    pub attributes: Attributes,
 }
 
 impl<'a> TryFrom<&'a [u8]> for CertReqInfo<'a> {

--- a/x509-cert/tests/certificate.rs
+++ b/x509-cert/tests/certificate.rs
@@ -2,7 +2,7 @@
 
 use der::{
     asn1::{
-        BitStringRef, ContextSpecific, ObjectIdentifier, PrintableStringRef, UIntRef, Utf8StringRef,
+        BitStringRef, ContextSpecific, ObjectIdentifier, PrintableStringRef, UintRef, Utf8StringRef,
     },
     Decode, DecodeValue, Encode, FixedTag, Header, Reader, Tag, Tagged,
 };

--- a/x509-cert/tests/certificate.rs
+++ b/x509-cert/tests/certificate.rs
@@ -1,7 +1,9 @@
 //! Certificate tests
 
 use der::{
-    asn1::{BitStringRef, ContextSpecific, ObjectIdentifier, UintRef},
+    asn1::{
+        BitStringRef, ContextSpecific, ObjectIdentifier, PrintableStringRef, UIntRef, Utf8StringRef,
+    },
     Decode, DecodeValue, Encode, FixedTag, Header, Reader, Tag, Tagged,
 };
 use hex_literal::hex;
@@ -229,20 +231,30 @@ fn decode_cert() {
         for atav in i1 {
             if 0 == counter {
                 assert_eq!(atav.oid.to_string(), "2.5.4.6");
-                assert_eq!(atav.value.printable_string().unwrap().to_string(), "US");
+                assert_eq!(
+                    PrintableStringRef::try_from(&atav.value)
+                        .unwrap()
+                        .to_string(),
+                    "US"
+                );
             } else if 1 == counter {
                 assert_eq!(atav.oid.to_string(), "2.5.4.10");
-                assert_eq!(atav.value.printable_string().unwrap().to_string(), "Mock");
+                assert_eq!(
+                    PrintableStringRef::try_from(&atav.value)
+                        .unwrap()
+                        .to_string(),
+                    "Mock"
+                );
             } else if 2 == counter {
                 assert_eq!(atav.oid.to_string(), "2.5.4.10");
                 assert_eq!(
-                    atav.value.utf8_string().unwrap().to_string(),
+                    Utf8StringRef::try_from(&atav.value).unwrap().to_string(),
                     "IdenTrust Services LLC"
                 );
             } else if 3 == counter {
                 assert_eq!(atav.oid.to_string(), "2.5.4.3");
                 assert_eq!(
-                    atav.value.utf8_string().unwrap().to_string(),
+                    Utf8StringRef::try_from(&atav.value).unwrap().to_string(),
                     "PTE IdenTrust Global Common Root CA 1"
                 );
             }
@@ -276,24 +288,35 @@ fn decode_cert() {
             if 0 == counter {
                 assert_eq!(atav.oid.to_string(), "2.5.4.3");
                 assert_eq!(
-                    atav.value.printable_string().unwrap().to_string(),
+                    PrintableStringRef::try_from(&atav.value)
+                        .unwrap()
+                        .to_string(),
                     "Test Federal Bridge CA"
                 );
             } else if 1 == counter {
                 assert_eq!(atav.oid.to_string(), "2.5.4.11");
                 assert_eq!(
-                    atav.value.printable_string().unwrap().to_string(),
+                    PrintableStringRef::try_from(&atav.value)
+                        .unwrap()
+                        .to_string(),
                     "TestFPKI"
                 );
             } else if 2 == counter {
                 assert_eq!(atav.oid.to_string(), "2.5.4.10");
                 assert_eq!(
-                    atav.value.printable_string().unwrap().to_string(),
+                    PrintableStringRef::try_from(&atav.value)
+                        .unwrap()
+                        .to_string(),
                     "U.S. Government"
                 );
             } else if 3 == counter {
                 assert_eq!(atav.oid.to_string(), "2.5.4.6");
-                assert_eq!(atav.value.printable_string().unwrap().to_string(), "US");
+                assert_eq!(
+                    PrintableStringRef::try_from(&atav.value)
+                        .unwrap()
+                        .to_string(),
+                    "US"
+                );
             }
             counter += 1;
         }

--- a/x509-cert/tests/certreq.rs
+++ b/x509-cert/tests/certreq.rs
@@ -1,6 +1,9 @@
 //! Certification request (`CertReq`) tests
 
-use der::{Encode, Tag, Tagged};
+use der::{
+    asn1::{PrintableStringRef, Utf8StringRef},
+    Encode, Tag, Tagged,
+};
 use hex_literal::hex;
 use x509_cert::request::{CertReq, Version};
 
@@ -38,8 +41,8 @@ fn decode_rsa_2048_der() {
     for (name, (oid, val)) in cr.info.subject.0.iter().zip(NAMES) {
         let kind = name.0.get(0).unwrap();
         let value = match kind.value.tag() {
-            Tag::Utf8String => kind.value.utf8_string().unwrap().as_str(),
-            Tag::PrintableString => kind.value.printable_string().unwrap().as_str(),
+            Tag::Utf8String => Utf8StringRef::try_from(&kind.value).unwrap().as_str(),
+            Tag::PrintableString => PrintableStringRef::try_from(&kind.value).unwrap().as_str(),
             _ => panic!("unexpected tag"),
         };
 

--- a/x509-cert/tests/name.rs
+++ b/x509-cert/tests/name.rs
@@ -2,7 +2,7 @@
 
 use const_oid::ObjectIdentifier;
 use der::asn1::{Ia5StringRef, OctetStringRef, PrintableStringRef, SetOfVec, Utf8StringRef};
-use der::{AnyRef, Decode, Encode, Tag, Tagged};
+use der::{Any, Decode, Encode, Tag, Tagged};
 use hex_literal::hex;
 use x509_cert::attr::AttributeTypeAndValue;
 use x509_cert::name::{Name, RdnSequence, RelativeDistinguishedName};
@@ -82,7 +82,7 @@ fn decode_rdn() {
     for atav in i {
         let oid = atav.oid;
         assert_eq!(oid.to_string(), "2.5.4.6");
-        let value = atav.value;
+        let value = &atav.value;
         assert_eq!(value.tag(), Tag::PrintableString);
         let ps = PrintableStringRef::try_from(value).unwrap();
         assert_eq!(ps.to_string(), "US");
@@ -108,7 +108,7 @@ fn decode_rdn() {
     let atav1a = i.next().unwrap();
     let oid2 = atav1a.oid;
     assert_eq!(oid2.to_string(), "2.5.4.10");
-    let value2 = atav1a.value;
+    let value2 = &atav1a.value;
     assert_eq!(value2.tag(), Tag::Utf8String);
     let utf8b = Utf8StringRef::try_from(value2).unwrap();
     assert_eq!(utf8b.to_string(), "123");
@@ -116,14 +116,14 @@ fn decode_rdn() {
     let atav2a = i.next().unwrap();
     let oid1 = atav2a.oid;
     assert_eq!(oid1.to_string(), "2.5.4.3");
-    let value1 = atav2a.value;
+    let value1 = &atav2a.value;
     assert_eq!(value1.tag(), Tag::Utf8String);
     let utf8a = Utf8StringRef::try_from(value1).unwrap();
     assert_eq!(utf8a.to_string(), "JOHN SMITH");
 
     let mut from_scratch = RelativeDistinguishedName::default();
-    assert!(from_scratch.0.add(*atav1a).is_ok());
-    assert!(from_scratch.0.add(*atav2a).is_ok());
+    assert!(from_scratch.0.add(atav1a.clone()).is_ok());
+    assert!(from_scratch.0.add(atav2a.clone()).is_ok());
     let reencoded = from_scratch.to_vec().unwrap();
     assert_eq!(
         reencoded,
@@ -131,9 +131,9 @@ fn decode_rdn() {
     );
 
     let mut from_scratch2 = RelativeDistinguishedName::default();
-    assert!(from_scratch2.0.add(*atav2a).is_ok());
+    assert!(from_scratch2.0.add(atav2a.clone()).is_ok());
     // fails when caller adds items not in DER lexicographical order
-    assert!(from_scratch2.0.add(*atav1a).is_err());
+    assert!(from_scratch2.0.add(atav1a.clone()).is_err());
 
     // allow out-of-order RDNs (see: RustCrypto/formats#625)
     assert!(RelativeDistinguishedName::from_der(
@@ -207,20 +207,20 @@ fn rdns_serde() {
             &[
                 &[AttributeTypeAndValue {
                     oid: const_oid::db::rfc4519::CN,
-                    value: AnyRef::from(Utf8StringRef::new("foo").unwrap()),
+                    value: Any::from(Utf8StringRef::new("foo").unwrap()),
                 }],
                 &[AttributeTypeAndValue {
                     oid: const_oid::db::rfc4519::SN,
-                    value: AnyRef::from(Utf8StringRef::new("bar").unwrap()),
+                    value: Any::from(Utf8StringRef::new("bar").unwrap()),
                 }],
                 &[
                     AttributeTypeAndValue {
                         oid: const_oid::db::rfc4519::C,
-                        value: AnyRef::from(PrintableStringRef::new("baz").unwrap()),
+                        value: Any::from(PrintableStringRef::new("baz").unwrap()),
                     },
                     AttributeTypeAndValue {
                         oid: const_oid::db::rfc4519::L,
-                        value: AnyRef::from(Utf8StringRef::new("bat").unwrap()),
+                        value: Any::from(Utf8StringRef::new("bat").unwrap()),
                     },
                 ],
             ],
@@ -231,15 +231,15 @@ fn rdns_serde() {
             &[
                 &[AttributeTypeAndValue {
                     oid: const_oid::db::rfc4519::UID,
-                    value: AnyRef::from(Utf8StringRef::new("jsmith").unwrap()),
+                    value: Any::from(Utf8StringRef::new("jsmith").unwrap()),
                 }],
                 &[AttributeTypeAndValue {
                     oid: const_oid::db::rfc4519::DC,
-                    value: AnyRef::from(Ia5StringRef::new("example").unwrap()),
+                    value: Any::from(Ia5StringRef::new("example").unwrap()),
                 }],
                 &[AttributeTypeAndValue {
                     oid: const_oid::db::rfc4519::DC,
-                    value: AnyRef::from(Ia5StringRef::new("net").unwrap()),
+                    value: Any::from(Ia5StringRef::new("net").unwrap()),
                 }],
             ],
         ),
@@ -250,20 +250,20 @@ fn rdns_serde() {
                 &[
                     AttributeTypeAndValue {
                         oid: const_oid::db::rfc4519::OU,
-                        value: AnyRef::from(Utf8StringRef::new("Sales").unwrap()),
+                        value: Any::from(Utf8StringRef::new("Sales").unwrap()),
                     },
                     AttributeTypeAndValue {
                         oid: const_oid::db::rfc4519::CN,
-                        value: AnyRef::from(Utf8StringRef::new("J.  Smith").unwrap()),
+                        value: Any::from(Utf8StringRef::new("J.  Smith").unwrap()),
                     },
                 ],
                 &[AttributeTypeAndValue {
                     oid: const_oid::db::rfc4519::DC,
-                    value: AnyRef::from(Ia5StringRef::new("example").unwrap()),
+                    value: Any::from(Ia5StringRef::new("example").unwrap()),
                 }],
                 &[AttributeTypeAndValue {
                     oid: const_oid::db::rfc4519::DC,
-                    value: AnyRef::from(Ia5StringRef::new("net").unwrap()),
+                    value: Any::from(Ia5StringRef::new("net").unwrap()),
                 }],
             ],
         ),
@@ -273,15 +273,15 @@ fn rdns_serde() {
             &[
                 &[AttributeTypeAndValue {
                     oid: const_oid::db::rfc4519::CN,
-                    value: AnyRef::from(Utf8StringRef::new(r#"James "Jim" Smith, III"#).unwrap()),
+                    value: Any::from(Utf8StringRef::new(r#"James "Jim" Smith, III"#).unwrap()),
                 }],
                 &[AttributeTypeAndValue {
                     oid: const_oid::db::rfc4519::DC,
-                    value: AnyRef::from(Ia5StringRef::new("example").unwrap()),
+                    value: Any::from(Ia5StringRef::new("example").unwrap()),
                 }],
                 &[AttributeTypeAndValue {
                     oid: const_oid::db::rfc4519::DC,
-                    value: AnyRef::from(Ia5StringRef::new("net").unwrap()),
+                    value: Any::from(Ia5StringRef::new("net").unwrap()),
                 }],
             ],
         ),
@@ -291,15 +291,15 @@ fn rdns_serde() {
             &[
                 &[AttributeTypeAndValue {
                     oid: const_oid::db::rfc4519::CN,
-                    value: AnyRef::from(Utf8StringRef::new("Before\rAfter").unwrap()),
+                    value: Any::from(Utf8StringRef::new("Before\rAfter").unwrap()),
                 }],
                 &[AttributeTypeAndValue {
                     oid: const_oid::db::rfc4519::DC,
-                    value: AnyRef::from(Ia5StringRef::new("example").unwrap()),
+                    value: Any::from(Ia5StringRef::new("example").unwrap()),
                 }],
                 &[AttributeTypeAndValue {
                     oid: const_oid::db::rfc4519::DC,
-                    value: AnyRef::from(Ia5StringRef::new("net").unwrap()),
+                    value: Any::from(Ia5StringRef::new("net").unwrap()),
                 }],
             ],
         ),
@@ -308,7 +308,7 @@ fn rdns_serde() {
             "1.3.6.1.4.1.1466.0=#04024869",
             &[&[AttributeTypeAndValue {
                 oid: ObjectIdentifier::new("1.3.6.1.4.1.1466.0").unwrap(),
-                value: AnyRef::from(OctetStringRef::new(&[b'H', b'i']).unwrap()),
+                value: Any::from(OctetStringRef::new(&[b'H', b'i']).unwrap()),
             }]],
         ),
     ];

--- a/x509-cert/tests/name.rs
+++ b/x509-cert/tests/name.rs
@@ -40,17 +40,26 @@ fn decode_name() {
         for atav in i1 {
             if 0 == counter {
                 assert_eq!(atav.oid.to_string(), "2.5.4.6");
-                assert_eq!(atav.value.printable_string().unwrap().to_string(), "US");
+                assert_eq!(
+                    PrintableStringRef::try_from(&atav.value)
+                        .unwrap()
+                        .to_string(),
+                    "US"
+                );
             } else if 1 == counter {
                 assert_eq!(atav.oid.to_string(), "2.5.4.10");
                 assert_eq!(
-                    atav.value.printable_string().unwrap().to_string(),
+                    PrintableStringRef::try_from(&atav.value)
+                        .unwrap()
+                        .to_string(),
                     "Test Certificates 2011"
                 );
             } else if 2 == counter {
                 assert_eq!(atav.oid.to_string(), "2.5.4.3");
                 assert_eq!(
-                    atav.value.printable_string().unwrap().to_string(),
+                    PrintableStringRef::try_from(&atav.value)
+                        .unwrap()
+                        .to_string(),
                     "Good CA"
                 );
             }
@@ -75,7 +84,7 @@ fn decode_rdn() {
         assert_eq!(oid.to_string(), "2.5.4.6");
         let value = atav.value;
         assert_eq!(value.tag(), Tag::PrintableString);
-        let ps = value.printable_string().unwrap();
+        let ps = PrintableStringRef::try_from(value).unwrap();
         assert_eq!(ps.to_string(), "US");
     }
 
@@ -101,7 +110,7 @@ fn decode_rdn() {
     assert_eq!(oid2.to_string(), "2.5.4.10");
     let value2 = atav1a.value;
     assert_eq!(value2.tag(), Tag::Utf8String);
-    let utf8b = value2.utf8_string().unwrap();
+    let utf8b = Utf8StringRef::try_from(value2).unwrap();
     assert_eq!(utf8b.to_string(), "123");
 
     let atav2a = i.next().unwrap();
@@ -109,7 +118,7 @@ fn decode_rdn() {
     assert_eq!(oid1.to_string(), "2.5.4.3");
     let value1 = atav2a.value;
     assert_eq!(value1.tag(), Tag::Utf8String);
-    let utf8a = value1.utf8_string().unwrap();
+    let utf8a = Utf8StringRef::try_from(value1).unwrap();
     assert_eq!(utf8a.to_string(), "JOHN SMITH");
 
     let mut from_scratch = RelativeDistinguishedName::default();

--- a/x509-cert/tests/pkix_extensions.rs
+++ b/x509-cert/tests/pkix_extensions.rs
@@ -1,6 +1,6 @@
 //! Certificate tests
 use const_oid::AssociatedOid;
-use der::asn1::UintRef;
+use der::asn1::{Ia5StringRef, PrintableStringRef, UIntRef, Utf8StringRef};
 use der::{Decode, Encode, ErrorKind, Length, Tag, Tagged};
 use hex_literal::hex;
 use x509_cert::ext::pkix::crl::dp::{DistributionPoint, ReasonFlags, Reasons};
@@ -138,7 +138,7 @@ fn decode_general_name() {
     let bytes = hex!("A021060A2B060104018237140203A0130C1155706E5F323134393530313330406D696C");
     match GeneralName::from_der(&bytes).unwrap() {
         GeneralName::OtherName(other_name) => {
-            let onval = other_name.value.utf8_string().unwrap();
+            let onval = Utf8StringRef::try_from(other_name.value).unwrap();
             assert_eq!(onval.to_string(), "Upn_214950130@mil");
         }
         _ => panic!("Failed to parse OtherName from GeneralName"),
@@ -285,7 +285,7 @@ fn decode_cert() {
                     for pqi in pq.iter() {
                         if 0 == counter_pq {
                             assert_eq!("1.3.6.1.5.5.7.2.1", pqi.policy_qualifier_id.to_string());
-                            let cpsval = pqi.qualifier.unwrap().ia5_string().unwrap();
+                            let cpsval = Ia5StringRef::try_from(pqi.qualifier.unwrap()).unwrap();
                             assert_eq!(
                                 "https://secure.identrust.com/certificates/policy/IGC/index.html",
                                 cpsval.to_string()
@@ -508,17 +508,26 @@ fn decode_cert() {
         for atav in i1 {
             if 0 == counter {
                 assert_eq!(atav.oid.to_string(), "2.5.4.6");
-                assert_eq!(atav.value.printable_string().unwrap().to_string(), "US");
+                assert_eq!(
+                    PrintableStringRef::try_from(&atav.value)
+                        .unwrap()
+                        .to_string(),
+                    "US"
+                );
             } else if 1 == counter {
                 assert_eq!(atav.oid.to_string(), "2.5.4.10");
                 assert_eq!(
-                    atav.value.printable_string().unwrap().to_string(),
+                    PrintableStringRef::try_from(&atav.value)
+                        .unwrap()
+                        .to_string(),
                     "Test Certificates 2011"
                 );
             } else if 2 == counter {
                 assert_eq!(atav.oid.to_string(), "2.5.4.3");
                 assert_eq!(
-                    atav.value.printable_string().unwrap().to_string(),
+                    PrintableStringRef::try_from(&atav.value)
+                        .unwrap()
+                        .to_string(),
                     "Trust Anchor"
                 );
             }
@@ -550,17 +559,26 @@ fn decode_cert() {
         for atav in i1 {
             if 0 == counter {
                 assert_eq!(atav.oid.to_string(), "2.5.4.6");
-                assert_eq!(atav.value.printable_string().unwrap().to_string(), "US");
+                assert_eq!(
+                    PrintableStringRef::try_from(&atav.value)
+                        .unwrap()
+                        .to_string(),
+                    "US"
+                );
             } else if 1 == counter {
                 assert_eq!(atav.oid.to_string(), "2.5.4.10");
                 assert_eq!(
-                    atav.value.printable_string().unwrap().to_string(),
+                    PrintableStringRef::try_from(&atav.value)
+                        .unwrap()
+                        .to_string(),
                     "Test Certificates 2011"
                 );
             } else if 2 == counter {
                 assert_eq!(atav.oid.to_string(), "2.5.4.3");
                 assert_eq!(
-                    atav.value.printable_string().unwrap().to_string(),
+                    PrintableStringRef::try_from(&atav.value)
+                        .unwrap()
+                        .to_string(),
                     "Good CA"
                 );
             }

--- a/x509-cert/tests/pkix_extensions.rs
+++ b/x509-cert/tests/pkix_extensions.rs
@@ -1,6 +1,6 @@
 //! Certificate tests
 use const_oid::AssociatedOid;
-use der::asn1::{Ia5StringRef, PrintableStringRef, UIntRef, Utf8StringRef};
+use der::asn1::{Ia5StringRef, PrintableStringRef, UintRef, Utf8StringRef};
 use der::{Decode, Encode, ErrorKind, Length, Tag, Tagged};
 use hex_literal::hex;
 use x509_cert::ext::pkix::crl::dp::{DistributionPoint, ReasonFlags, Reasons};

--- a/x509-cert/tests/trust_anchor_format.rs
+++ b/x509-cert/tests/trust_anchor_format.rs
@@ -1,4 +1,7 @@
-use der::{Decode, Encode, SliceReader};
+use der::{
+    asn1::{Ia5StringRef, PrintableStringRef},
+    Decode, Encode, SliceReader,
+};
 use hex_literal::hex;
 use x509_cert::anchor::{CertPolicies, TrustAnchorChoice};
 use x509_cert::ext::pkix::name::GeneralName;
@@ -90,20 +93,34 @@ fn decode_ta1() {
                 for atav in i1 {
                     if 0 == counter {
                         assert_eq!(atav.oid.to_string(), "2.5.4.6");
-                        assert_eq!(atav.value.printable_string().unwrap().to_string(), "US");
+                        assert_eq!(
+                            PrintableStringRef::try_from(&atav.value)
+                                .unwrap()
+                                .to_string(),
+                            "US"
+                        );
                     } else if 1 == counter {
                         assert_eq!(atav.oid.to_string(), "2.5.4.10");
                         assert_eq!(
-                            atav.value.printable_string().unwrap().to_string(),
+                            PrintableStringRef::try_from(&atav.value)
+                                .unwrap()
+                                .to_string(),
                             "U.S. Government"
                         );
                     } else if 2 == counter {
                         assert_eq!(atav.oid.to_string(), "2.5.4.11");
-                        assert_eq!(atav.value.printable_string().unwrap().to_string(), "ECA");
+                        assert_eq!(
+                            PrintableStringRef::try_from(&atav.value)
+                                .unwrap()
+                                .to_string(),
+                            "ECA"
+                        );
                     } else if 3 == counter {
                         assert_eq!(atav.oid.to_string(), "2.5.4.3");
                         assert_eq!(
-                            atav.value.printable_string().unwrap().to_string(),
+                            PrintableStringRef::try_from(&atav.value)
+                                .unwrap()
+                                .to_string(),
                             "ECA Root CA 4"
                         );
                     }
@@ -153,23 +170,34 @@ fn decode_ta2() {
                 for atav in i1 {
                     if 0 == counter {
                         assert_eq!(atav.oid.to_string(), "2.5.4.6");
-                        assert_eq!(atav.value.printable_string().unwrap().to_string(), "US");
+                        assert_eq!(
+                            PrintableStringRef::try_from(&atav.value)
+                                .unwrap()
+                                .to_string(),
+                            "US"
+                        );
                     } else if 1 == counter {
                         assert_eq!(atav.oid.to_string(), "2.5.4.10");
                         assert_eq!(
-                            atav.value.printable_string().unwrap().to_string(),
+                            PrintableStringRef::try_from(&atav.value)
+                                .unwrap()
+                                .to_string(),
                             "Entrust"
                         );
                     } else if 2 == counter {
                         assert_eq!(atav.oid.to_string(), "2.5.4.11");
                         assert_eq!(
-                            atav.value.printable_string().unwrap().to_string(),
+                            PrintableStringRef::try_from(&atav.value)
+                                .unwrap()
+                                .to_string(),
                             "Certification Authorities"
                         );
                     } else if 3 == counter {
                         assert_eq!(atav.oid.to_string(), "2.5.4.11");
                         assert_eq!(
-                            atav.value.printable_string().unwrap().to_string(),
+                            PrintableStringRef::try_from(&atav.value)
+                                .unwrap()
+                                .to_string(),
                             "Entrust Managed Services NFI Root CA"
                         );
                     }
@@ -190,19 +218,25 @@ fn decode_ta2() {
                                 if 0 == counter {
                                     assert_eq!(atav.oid.to_string(), "2.5.4.6");
                                     assert_eq!(
-                                        atav.value.printable_string().unwrap().to_string(),
+                                        PrintableStringRef::try_from(&atav.value)
+                                            .unwrap()
+                                            .to_string(),
                                         "US"
                                     );
                                 } else if 1 == counter {
                                     assert_eq!(atav.oid.to_string(), "2.5.4.10");
                                     assert_eq!(
-                                        atav.value.printable_string().unwrap().to_string(),
+                                        PrintableStringRef::try_from(&atav.value)
+                                            .unwrap()
+                                            .to_string(),
                                         "U.S. Government"
                                     );
                                 } else if 2 == counter {
                                     assert_eq!(atav.oid.to_string(), "2.5.4.11");
                                     assert_eq!(
-                                        atav.value.printable_string().unwrap().to_string(),
+                                        PrintableStringRef::try_from(&atav.value)
+                                            .unwrap()
+                                            .to_string(),
                                         "DoD"
                                     );
                                 }
@@ -263,23 +297,34 @@ fn decode_ta3() {
                 for atav in i1 {
                     if 0 == counter {
                         assert_eq!(atav.oid.to_string(), "2.5.4.6");
-                        assert_eq!(atav.value.printable_string().unwrap().to_string(), "US");
+                        assert_eq!(
+                            PrintableStringRef::try_from(&atav.value)
+                                .unwrap()
+                                .to_string(),
+                            "US"
+                        );
                     } else if 1 == counter {
                         assert_eq!(atav.oid.to_string(), "2.5.4.10");
                         assert_eq!(
-                            atav.value.printable_string().unwrap().to_string(),
+                            PrintableStringRef::try_from(&atav.value)
+                                .unwrap()
+                                .to_string(),
                             "Exostar LLC"
                         );
                     } else if 2 == counter {
                         assert_eq!(atav.oid.to_string(), "2.5.4.11");
                         assert_eq!(
-                            atav.value.printable_string().unwrap().to_string(),
+                            PrintableStringRef::try_from(&atav.value)
+                                .unwrap()
+                                .to_string(),
                             "Certification Authorities"
                         );
                     } else if 3 == counter {
                         assert_eq!(atav.oid.to_string(), "2.5.4.3");
                         assert_eq!(
-                            atav.value.printable_string().unwrap().to_string(),
+                            PrintableStringRef::try_from(&atav.value)
+                                .unwrap()
+                                .to_string(),
                             "Exostar Federated Identity Service Root CA 1"
                         );
                     }
@@ -300,19 +345,25 @@ fn decode_ta3() {
                                 if 0 == counter {
                                     assert_eq!(atav.oid.to_string(), "2.5.4.6");
                                     assert_eq!(
-                                        atav.value.printable_string().unwrap().to_string(),
+                                        PrintableStringRef::try_from(&atav.value)
+                                            .unwrap()
+                                            .to_string(),
                                         "US"
                                     );
                                 } else if 1 == counter {
                                     assert_eq!(atav.oid.to_string(), "2.5.4.10");
                                     assert_eq!(
-                                        atav.value.printable_string().unwrap().to_string(),
+                                        PrintableStringRef::try_from(&atav.value)
+                                            .unwrap()
+                                            .to_string(),
                                         "U.S. Government"
                                     );
                                 } else if 2 == counter {
                                     assert_eq!(atav.oid.to_string(), "2.5.4.11");
                                     assert_eq!(
-                                        atav.value.printable_string().unwrap().to_string(),
+                                        PrintableStringRef::try_from(&atav.value)
+                                            .unwrap()
+                                            .to_string(),
                                         "DoD"
                                     );
                                 }
@@ -366,17 +417,30 @@ fn decode_ta4() {
                 for atav in i1 {
                     if 0 == counter {
                         assert_eq!(atav.oid.to_string(), "0.9.2342.19200300.100.1.25");
-                        assert_eq!(atav.value.ia5_string().unwrap().to_string(), "com");
+                        assert_eq!(
+                            Ia5StringRef::try_from(&atav.value).unwrap().to_string(),
+                            "com"
+                        );
                     } else if 1 == counter {
                         assert_eq!(atav.oid.to_string(), "0.9.2342.19200300.100.1.25");
-                        assert_eq!(atav.value.ia5_string().unwrap().to_string(), "raytheon");
+                        assert_eq!(
+                            Ia5StringRef::try_from(&atav.value).unwrap().to_string(),
+                            "raytheon"
+                        );
                     } else if 2 == counter {
                         assert_eq!(atav.oid.to_string(), "2.5.4.10");
-                        assert_eq!(atav.value.printable_string().unwrap().to_string(), "CAs");
+                        assert_eq!(
+                            PrintableStringRef::try_from(&atav.value)
+                                .unwrap()
+                                .to_string(),
+                            "CAs"
+                        );
                     } else if 3 == counter {
                         assert_eq!(atav.oid.to_string(), "2.5.4.11");
                         assert_eq!(
-                            atav.value.printable_string().unwrap().to_string(),
+                            PrintableStringRef::try_from(&atav.value)
+                                .unwrap()
+                                .to_string(),
                             "RaytheonRoot"
                         );
                     }

--- a/x509-ocsp/src/lib.rs
+++ b/x509-ocsp/src/lib.rs
@@ -280,7 +280,7 @@ pub struct ResponseData<'a> {
 #[allow(missing_docs)]
 pub enum ResponderId<'a> {
     #[asn1(context_specific = "1", tag_mode = "EXPLICIT", constructed = "true")]
-    ByName(Name<'a>),
+    ByName(Name),
 
     #[asn1(context_specific = "2", tag_mode = "EXPLICIT", constructed = "true")]
     ByKey(KeyHash<'a>),
@@ -405,7 +405,7 @@ pub type AcceptableResponses = Vec<ObjectIdentifier>;
 #[derive(Clone, Debug, Eq, PartialEq, Sequence)]
 #[allow(missing_docs)]
 pub struct ServiceLocator<'a> {
-    pub issuer: Name<'a>,
+    pub issuer: Name,
     pub locator: AuthorityInfoAccessSyntax<'a>,
 }
 


### PR DESCRIPTION
NOTE: breaking change.

This changes x509 from a zero copy type to an owned type.
This brings along a rewrite of `der::Any` and a new `der::ByteVec` to come closer to `der::ByteSlice` backing `der::AnyRef`