### PR TITLE
der: missing ValueOrd for `OctetString`

### DIFF
--- a/der/src/asn1/octet_string.rs
+++ b/der/src/asn1/octet_string.rs
@@ -177,3 +177,6 @@ impl<'a> From<&'a OctetString> for OctetStringRef<'a> {
         OctetStringRef::new(&octet_string.inner).expect("invalid OCTET STRING")
     }
 }
+
+#[cfg(feature = "alloc")]
+impl OrdIsValueOrd for OctetString {}


### PR DESCRIPTION
The `ValueOrd` is implemented for the zero copy but it was missing for the owned version