### PR TITLE
der_derive v0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "der_derive"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/der/derive/CHANGELOG.md
+++ b/der/derive/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.1 (2022-12-05)
+### Added
+- Support for deriving `ValueOrd` on `Choice` enums ([#723])
+
+[#723]: https://github.com/RustCrypto/formats/pull/723
+
 ## 0.6.0 (2022-05-08)
 ### Added
 - Support for Context-Specific fields with default values ([#246])

--- a/der/derive/Cargo.toml
+++ b/der/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der_derive"
-version = "0.6.0"
+version = "0.6.1"
 description = "Custom derive support for the `der` crate's `Choice` and `Sequence` traits"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
### Added
- Support for deriving `ValueOrd` on `Choice` enums ([#723])

[#723]: https://github.com/RustCrypto/formats/pull/723