### PR TITLE
x509-cert v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1318,7 +1318,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "x509-cert"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "const-oid",
  "der",

--- a/x509-cert/CHANGELOG.md
+++ b/x509-cert/CHANGELOG.md
@@ -4,5 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.1 (2022-12-10)
+### Added
+- Support `TeletexString` in `DirectoryString` ([#692])
+- Re-export `spki` ([#701])
+- `PemLabel` impl for `Certificate` ([#763])
+- `ValueOrd` impl for `Version` and other derived types ([#723])
+
+### Fixed
+-  `countryName` should always be `PrintableString` ([#760])
+
+[#692]: https://github.com/RustCrypto/formats/pull/692
+[#701]: https://github.com/RustCrypto/formats/pull/701
+[#723]: https://github.com/RustCrypto/formats/pull/723
+[#760]: https://github.com/RustCrypto/formats/pull/760
+[#763]: https://github.com/RustCrypto/formats/pull/763
+
 ## 0.1.0 (2022-07-23)
 - Initial release

--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x509-cert"
-version = "0.1.0"
+version = "0.1.1"
 description = """
 Pure Rust implementation of the X.509 Public Key Infrastructure Certificate
 format as described in RFC 5280


### PR DESCRIPTION
### Added
- Support `TeletexString` in `DirectoryString` ([#692])
- Re-export `spki` ([#701])
- `PemLabel` impl for `Certificate` ([#763])
- `ValueOrd` impl for `Version` and other derived types ([#723])

### Fixed
-  `countryName` should always be `PrintableString` ([#760])

[#692]: https://github.com/RustCrypto/formats/pull/692
[#701]: https://github.com/RustCrypto/formats/pull/701
[#723]: https://github.com/RustCrypto/formats/pull/723
[#760]: https://github.com/RustCrypto/formats/pull/760
[#763]: https://github.com/RustCrypto/formats/pull/763