### PR TITLE
Bump versions to prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.1"
+version = "0.10.0-pre"
 dependencies = [
  "hex-literal",
 ]
@@ -325,7 +325,7 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.6.1"
+version = "0.7.0-pre"
 dependencies = [
  "const-oid",
  "der_derive",
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "der_derive"
-version = "0.6.1"
+version = "0.7.0-pre"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs1"
-version = "0.4.1"
+version = "0.5.0-pre"
 dependencies = [
  "const-oid",
  "der",
@@ -627,7 +627,7 @@ version = "0.0.0"
 
 [[package]]
 name = "pkcs5"
-version = "0.5.0"
+version = "0.6.0-pre"
 dependencies = [
  "aes",
  "cbc",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.9.0"
+version = "0.10.0-pre"
 dependencies = [
  "der",
  "hex-literal",
@@ -948,7 +948,7 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.3.0"
+version = "0.4.0-pre"
 dependencies = [
  "base16ct",
  "der",
@@ -1048,7 +1048,7 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.6.0"
+version = "0.7.0-pre"
 dependencies = [
  "base64ct",
  "der",
@@ -1318,7 +1318,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "x509-cert"
-version = "0.1.1"
+version = "0.2.0-pre"
 dependencies = [
  "const-oid",
  "der",

--- a/const-oid/Cargo.toml
+++ b/const-oid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "const-oid"
-version = "0.9.1"
+version = "0.10.0-pre"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der"
-version = "0.6.1"
+version = "0.7.0-pre"
 description = """
 Pure Rust embedded-friendly implementation of the Distinguished Encoding Rules
 (DER) for Abstract Syntax Notation One (ASN.1) as described in ITU X.690 with
@@ -16,8 +16,8 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-const-oid = { version = "0.9", optional = true, path = "../const-oid" }
-der_derive = { version = "0.6", optional = true, path = "derive" }
+const-oid = { version = "=0.10.0-pre", optional = true, path = "../const-oid" }
+der_derive = { version = "=0.7.0-pre", optional = true, path = "derive" }
 flagset = { version = "0.4.3", optional = true }
 pem-rfc7468 = { version = "0.6", optional = true, path = "../pem-rfc7468" }
 time = { version = "0.3.4", optional = true, default-features = false }

--- a/der/derive/Cargo.toml
+++ b/der/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der_derive"
-version = "0.6.1"
+version = "0.7.0-pre"
 description = "Custom derive support for the `der` crate's `Choice` and `Sequence` traits"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"

--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs1"
-version = "0.4.1"
+version = "0.5.0-pre"
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #1:
 RSA Cryptography Specifications Version 2.2 (RFC 8017)
@@ -15,17 +15,17 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-der = { version = "0.6", features = ["oid"], path = "../der" }
-spki = { version = "0.6", path = "../spki" }
+der = { version = "=0.7.0-pre", features = ["oid"], path = "../der" }
+spki = { version = "=0.7.0-pre", path = "../spki" }
 
 # optional dependencies
-pkcs8 = { version = "0.9", optional = true, default-features = false, path = "../pkcs8" }
+pkcs8 = { version = "=0.10.0-pre", optional = true, default-features = false, path = "../pkcs8" }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.3"
 tempfile = "3"
-const-oid = { version = "0.9", path = "../const-oid", features = ["db"] }
+const-oid = { version = "0.10.0-pre", path = "../const-oid", features = ["db"] }
 
 [features]
 alloc = ["der/alloc", "pkcs8/alloc", "zeroize/alloc"]

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs5"
-version = "0.5.0"
+version = "0.6.0-pre"
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #5:
 Password-Based Cryptography Specification Version 2.1 (RFC 8018)
@@ -15,8 +15,8 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-der = { version = "0.6", features = ["oid"], path = "../der" }
-spki = { version = "0.6", path = "../spki" }
+der = { version = "=0.7.0-pre", features = ["oid"], path = "../der" }
+spki = { version = "=0.7.0-pre", path = "../spki" }
 
 # optional dependencies
 cbc = { version = "0.1.2", optional = true }

--- a/pkcs7/Cargo.toml
+++ b/pkcs7/Cargo.toml
@@ -15,8 +15,8 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-der = { version = "0.6", features = ["oid"], path = "../der" }
-spki = { version = "0.6", path = "../spki" }
+der = { version = "=0.7.0-pre", features = ["oid"], path = "../der" }
+spki = { version = "=0.7.0-pre", path = "../spki" }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs8"
-version = "0.9.0"
+version = "0.10.0-pre"
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #8:
 Private-Key Information Syntax Specification (RFC 5208), with additional
@@ -16,12 +16,12 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-der = { version = "0.6", features = ["oid"], path = "../der" }
-spki = { version = "0.6", path = "../spki" }
+der = { version = "=0.7.0-pre", features = ["oid"], path = "../der" }
+spki = { version = "=0.7.0-pre", path = "../spki" }
 
 # optional dependencies
 rand_core = { version = "0.6", optional = true, default-features = false }
-pkcs5 = { version = "0.5", optional = true, path = "../pkcs5" }
+pkcs5 = { version = "=0.6.0-pre", optional = true, path = "../pkcs5" }
 subtle = { version = "2", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sec1"
-version = "0.3.0"
+version = "0.4.0-pre"
 description = """
 Pure Rust implementation of SEC1: Elliptic Curve Cryptography encoding formats
 including ASN.1 DER-serialized private keys as well as the
@@ -17,9 +17,9 @@ rust-version = "1.57"
 
 [dependencies]
 base16ct = { version = "0.1.1", optional = true, default-features = false, path = "../base16ct" }
-der = { version = "0.6", optional = true, features = ["oid"], path = "../der" }
+der = { version = "=0.7.0-pre", optional = true, features = ["oid"], path = "../der" }
 generic-array = { version = "0.14.6", optional = true, default-features = false }
-pkcs8 = { version = "0.9", optional = true, default-features = false, path = "../pkcs8" }
+pkcs8 = { version = "=0.10.0-pre", optional = true, default-features = false, path = "../pkcs8" }
 serdect = { version = "0.1", optional = true, default-features = false, features = ["alloc"], path = "../serdect" }
 subtle = { version = "2", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }

--- a/spki/Cargo.toml
+++ b/spki/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spki"
-version = "0.6.0"
+version = "0.7.0-pre"
 description = """
 X.509 Subject Public Key Info (RFC5280) describing public keys as well as their
 associated AlgorithmIdentifiers (i.e. OIDs)
@@ -15,7 +15,7 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-der = { version = "0.6", features = ["oid"], path = "../der" }
+der = { version = "=0.7.0-pre", features = ["oid"], path = "../der" }
 
 # Optional dependencies
 sha2 = { version = "0.10", optional = true, default-features = false }

--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x509-cert"
-version = "0.1.1"
+version = "0.2.0-pre"
 description = """
 Pure Rust implementation of the X.509 Public Key Infrastructure Certificate
 format as described in RFC 5280
@@ -15,10 +15,10 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-const-oid = { version = "0.9", features = ["db"], path = "../const-oid" }
-der = { version = "0.6", features = ["derive", "alloc", "flagset"], path = "../der" }
+const-oid = { version = "=0.10.0-pre", features = ["db"], path = "../const-oid" }
+der = { version = "=0.7.0-pre", features = ["derive", "alloc", "flagset"], path = "../der" }
 flagset = { version = "0.4.3" }
-spki = { version = "0.6", path = "../spki" }
+spki = { version = "=0.7.0-pre", path = "../spki" }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/x509-ocsp/Cargo.toml
+++ b/x509-ocsp/Cargo.toml
@@ -15,10 +15,10 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-der = { version = "0.6", features = ["oid", "derive", "alloc"], path = "../der" }
-x509-cert = { version = "0.1", path = "../x509-cert" }
-const-oid = { version = "0.9", path = "../const-oid" }
-spki = { version = "0.6", path = "../spki" }
+der = { version = "=0.7.0-pre", features = ["oid", "derive", "alloc"], path = "../der" }
+x509-cert = { version = "=0.2.0-pre", path = "../x509-cert" }
+const-oid = { version = "=0.10.0-pre", path = "../const-oid" }
+spki = { version = "=0.7.0-pre", path = "../spki" }
 
 [dev-dependencies]
 hex-literal = "0.3"


### PR DESCRIPTION
Begins the next cycle of breaking changes for all `const-oid`/`der`-dependent crates in this repository:

- `const-oid` v0.10.0-pre
- `der`/`der_derive` v0.7.0-pre
- `pkcs1` v0.5.0-pre
- `pkcs5` v0.6.0-pre
- `pkcs8` v0.10.0-pre
- `sec1` v0.4.0-pre
- `spki` v0.7.0-pre
- `x509-cert` v0.2.0-pre