### PR TITLE
pkcs8+spki: use blanket impls for `Decode*` traits

### DIFF
--- a/pkcs1/src/traits.rs
+++ b/pkcs1/src/traits.rs
@@ -169,7 +169,10 @@ pub trait EncodeRsaPublicKey {
 
 #[cfg(feature = "pkcs8")]
 #[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
-impl<T: pkcs8::DecodePrivateKey> DecodeRsaPrivateKey for T {
+impl<T> DecodeRsaPrivateKey for T
+where
+    T: for<'a> TryFrom<pkcs8::PrivateKeyInfo<'a>, Error = pkcs8::Error>,
+{
     fn from_pkcs1_der(private_key: &[u8]) -> Result<Self> {
         Ok(Self::try_from(pkcs8::PrivateKeyInfo {
             algorithm: ALGORITHM_ID,
@@ -181,7 +184,10 @@ impl<T: pkcs8::DecodePrivateKey> DecodeRsaPrivateKey for T {
 
 #[cfg(feature = "pkcs8")]
 #[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
-impl<T: pkcs8::DecodePublicKey> DecodeRsaPublicKey for T {
+impl<T: pkcs8::DecodePublicKey> DecodeRsaPublicKey for T
+where
+    T: for<'a> TryFrom<pkcs8::SubjectPublicKeyInfo<'a>, Error = pkcs8::Error>,
+{
     fn from_pkcs1_der(public_key: &[u8]) -> Result<Self> {
         Ok(Self::try_from(pkcs8::SubjectPublicKeyInfo {
             algorithm: ALGORITHM_ID,

--- a/pkcs8/src/traits.rs
+++ b/pkcs8/src/traits.rs
@@ -21,12 +21,10 @@ use der::pem::PemLabel;
 use std::path::Path;
 
 /// Parse a private key object from a PKCS#8 encoded document.
-pub trait DecodePrivateKey: for<'a> TryFrom<PrivateKeyInfo<'a>, Error = Error> + Sized {
+pub trait DecodePrivateKey: Sized {
     /// Deserialize PKCS#8 private key from ASN.1 DER-encoded data
     /// (binary format).
-    fn from_pkcs8_der(bytes: &[u8]) -> Result<Self> {
-        Self::try_from(PrivateKeyInfo::try_from(bytes)?)
-    }
+    fn from_pkcs8_der(bytes: &[u8]) -> Result<Self>;
 
     /// Deserialize encrypted PKCS#8 private key from ASN.1 DER-encoded data
     /// (binary format) and attempt to decrypt it using the provided password.
@@ -84,6 +82,15 @@ pub trait DecodePrivateKey: for<'a> TryFrom<PrivateKeyInfo<'a>, Error = Error> +
         let (label, doc) = SecretDocument::read_pem_file(path)?;
         PrivateKeyInfo::validate_pem_label(&label)?;
         Self::from_pkcs8_der(doc.as_bytes())
+    }
+}
+
+impl<T> DecodePrivateKey for T
+where
+    T: for<'a> TryFrom<PrivateKeyInfo<'a>, Error = Error>,
+{
+    fn from_pkcs8_der(bytes: &[u8]) -> Result<Self> {
+        Self::try_from(PrivateKeyInfo::try_from(bytes)?)
     }
 }
 

--- a/pkcs8/tests/traits.rs
+++ b/pkcs8/tests/traits.rs
@@ -30,12 +30,6 @@ impl AsRef<[u8]> for MockKey {
     }
 }
 
-impl DecodePrivateKey for MockKey {
-    fn from_pkcs8_der(bytes: &[u8]) -> Result<MockKey> {
-        Ok(MockKey(bytes.to_vec()))
-    }
-}
-
 impl EncodePrivateKey for MockKey {
     fn to_pkcs8_der(&self) -> Result<SecretDocument> {
         Ok(SecretDocument::try_from(self.as_ref())?)

--- a/sec1/src/traits.rs
+++ b/sec1/src/traits.rs
@@ -97,7 +97,10 @@ pub trait EncodeEcPrivateKey {
 
 #[cfg(feature = "pkcs8")]
 #[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
-impl<T: pkcs8::DecodePrivateKey> DecodeEcPrivateKey for T {
+impl<T> DecodeEcPrivateKey for T
+where
+    T: for<'a> TryFrom<pkcs8::PrivateKeyInfo<'a>, Error = pkcs8::Error>,
+{
     fn from_sec1_der(private_key: &[u8]) -> Result<Self> {
         let params_oid = EcPrivateKey::from_der(private_key)?
             .parameters

--- a/spki/src/traits.rs
+++ b/spki/src/traits.rs
@@ -15,14 +15,10 @@ use {
 use std::path::Path;
 
 /// Parse a public key object from an encoded SPKI document.
-pub trait DecodePublicKey:
-    for<'a> TryFrom<SubjectPublicKeyInfo<'a>, Error = Error> + Sized
-{
+pub trait DecodePublicKey: Sized {
     /// Deserialize object from ASN.1 DER-encoded [`SubjectPublicKeyInfo`]
     /// (binary format).
-    fn from_public_key_der(bytes: &[u8]) -> Result<Self> {
-        Self::try_from(SubjectPublicKeyInfo::try_from(bytes)?)
-    }
+    fn from_public_key_der(bytes: &[u8]) -> Result<Self>;
 
     /// Deserialize PEM-encoded [`SubjectPublicKeyInfo`].
     ///
@@ -55,6 +51,15 @@ pub trait DecodePublicKey:
         let (label, doc) = Document::read_pem_file(path)?;
         SubjectPublicKeyInfo::validate_pem_label(&label)?;
         Self::from_public_key_der(doc.as_bytes())
+    }
+}
+
+impl<T> DecodePublicKey for T
+where
+    T: for<'a> TryFrom<SubjectPublicKeyInfo<'a>, Error = Error>,
+{
+    fn from_public_key_der(bytes: &[u8]) -> Result<Self> {
+        Self::try_from(SubjectPublicKeyInfo::try_from(bytes)?)
     }
 }
 

--- a/spki/tests/traits.rs
+++ b/spki/tests/traits.rs
@@ -30,12 +30,6 @@ impl AsRef<[u8]> for MockKey {
     }
 }
 
-impl DecodePublicKey for MockKey {
-    fn from_public_key_der(bytes: &[u8]) -> Result<MockKey> {
-        Ok(MockKey(bytes.to_vec()))
-    }
-}
-
 impl EncodePublicKey for MockKey {
     fn to_public_key_der(&self) -> Result<Document> {
         Ok(Document::from_der(self.as_ref())?)


### PR DESCRIPTION
Previously these traits had `TryFrom` bounds for e.g. `PrivateKeyInfo`, which limits the applicability of these traits.

This commit changes to using blanket impls for `TryFrom`, which allows types to handle parsing raw DER on their own, as in the `ring-compat` crate.