### PR TITLE
der: rename `UIntRef` => `UintRef`

### DIFF
--- a/der/src/asn1.rs
+++ b/der/src/asn1.rs
@@ -32,7 +32,7 @@ pub use self::{
     context_specific::{ContextSpecific, ContextSpecificRef},
     generalized_time::GeneralizedTime,
     ia5_string::Ia5StringRef,
-    integer::bigint::UIntRef,
+    integer::bigint::UintRef,
     null::Null,
     octet_string::OctetStringRef,
     printable_string::PrintableStringRef,

--- a/der/src/asn1/integer/bigint.rs
+++ b/der/src/asn1/integer/bigint.rs
@@ -14,13 +14,13 @@ use crate::{
 /// Intended for use cases like very large integers that are used in
 /// cryptographic applications (e.g. keys, signatures).
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
-pub struct UIntRef<'a> {
+pub struct UintRef<'a> {
     /// Inner value
     inner: ByteSlice<'a>,
 }
 
-impl<'a> UIntRef<'a> {
-    /// Create a new [`UIntRef`] from a byte slice.
+impl<'a> UintRef<'a> {
+    /// Create a new [`UintRef`] from a byte slice.
     pub fn new(bytes: &'a [u8]) -> Result<Self> {
         let inner = ByteSlice::new(uint::strip_leading_zeroes(bytes))
             .map_err(|_| ErrorKind::Length { tag: Self::TAG })?;
@@ -34,7 +34,7 @@ impl<'a> UIntRef<'a> {
         self.inner.as_slice()
     }
 
-    /// Get the length of this [`UIntRef`] in bytes.
+    /// Get the length of this [`UintRef`] in bytes.
     pub fn len(&self) -> Length {
         self.inner.len()
     }
@@ -45,7 +45,7 @@ impl<'a> UIntRef<'a> {
     }
 }
 
-impl<'a> DecodeValue<'a> for UIntRef<'a> {
+impl<'a> DecodeValue<'a> for UintRef<'a> {
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         let bytes = ByteSlice::decode_value(reader, header)?.as_slice();
         let result = Self::new(uint::decode_to_slice(bytes)?)?;
@@ -59,7 +59,7 @@ impl<'a> DecodeValue<'a> for UIntRef<'a> {
     }
 }
 
-impl<'a> EncodeValue for UIntRef<'a> {
+impl<'a> EncodeValue for UintRef<'a> {
     fn value_len(&self) -> Result<Length> {
         uint::encoded_len(self.inner.as_slice())
     }
@@ -74,29 +74,29 @@ impl<'a> EncodeValue for UIntRef<'a> {
     }
 }
 
-impl<'a> From<&UIntRef<'a>> for UIntRef<'a> {
-    fn from(value: &UIntRef<'a>) -> UIntRef<'a> {
+impl<'a> From<&UintRef<'a>> for UintRef<'a> {
+    fn from(value: &UintRef<'a>) -> UintRef<'a> {
         *value
     }
 }
 
-impl<'a> TryFrom<AnyRef<'a>> for UIntRef<'a> {
+impl<'a> TryFrom<AnyRef<'a>> for UintRef<'a> {
     type Error = Error;
 
-    fn try_from(any: AnyRef<'a>) -> Result<UIntRef<'a>> {
+    fn try_from(any: AnyRef<'a>) -> Result<UintRef<'a>> {
         any.decode_into()
     }
 }
 
-impl<'a> FixedTag for UIntRef<'a> {
+impl<'a> FixedTag for UintRef<'a> {
     const TAG: Tag = Tag::Integer;
 }
 
-impl<'a> OrdIsValueOrd for UIntRef<'a> {}
+impl<'a> OrdIsValueOrd for UintRef<'a> {}
 
 #[cfg(test)]
 mod tests {
-    use super::UIntRef;
+    use super::UintRef;
     use crate::{
         asn1::{integer::tests::*, AnyRef},
         Decode, Encode, ErrorKind, SliceWriter, Tag,
@@ -104,19 +104,19 @@ mod tests {
 
     #[test]
     fn decode_uint_bytes() {
-        assert_eq!(&[0], UIntRef::from_der(I0_BYTES).unwrap().as_bytes());
-        assert_eq!(&[127], UIntRef::from_der(I127_BYTES).unwrap().as_bytes());
-        assert_eq!(&[128], UIntRef::from_der(I128_BYTES).unwrap().as_bytes());
-        assert_eq!(&[255], UIntRef::from_der(I255_BYTES).unwrap().as_bytes());
+        assert_eq!(&[0], UintRef::from_der(I0_BYTES).unwrap().as_bytes());
+        assert_eq!(&[127], UintRef::from_der(I127_BYTES).unwrap().as_bytes());
+        assert_eq!(&[128], UintRef::from_der(I128_BYTES).unwrap().as_bytes());
+        assert_eq!(&[255], UintRef::from_der(I255_BYTES).unwrap().as_bytes());
 
         assert_eq!(
             &[0x01, 0x00],
-            UIntRef::from_der(I256_BYTES).unwrap().as_bytes()
+            UintRef::from_der(I256_BYTES).unwrap().as_bytes()
         );
 
         assert_eq!(
             &[0x7F, 0xFF],
-            UIntRef::from_der(I32767_BYTES).unwrap().as_bytes()
+            UintRef::from_der(I32767_BYTES).unwrap().as_bytes()
         );
     }
 
@@ -130,7 +130,7 @@ mod tests {
             I256_BYTES,
             I32767_BYTES,
         ] {
-            let uint = UIntRef::from_der(example).unwrap();
+            let uint = UintRef::from_der(example).unwrap();
 
             let mut buf = [0u8; 128];
             let mut encoder = SliceWriter::new(&mut buf);
@@ -143,7 +143,7 @@ mod tests {
 
     #[test]
     fn reject_oversize_without_extra_zero() {
-        let err = UIntRef::try_from(AnyRef::new(Tag::Integer, &[0x81]).unwrap())
+        let err = UintRef::try_from(AnyRef::new(Tag::Integer, &[0x81]).unwrap())
             .err()
             .unwrap();
 

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -56,7 +56,7 @@
 //! - [`VideotexStringRef`]: ASN.1 `VideotexString`.
 //! - [`SequenceOf`]: ASN.1 `SEQUENCE OF`.
 //! - [`SetOf`], [`SetOfVec`]: ASN.1 `SET OF`.
-//! - [`UIntRef`]: ASN.1 unsigned `INTEGER` with raw access to encoded bytes.
+//! - [`UintRef`]: ASN.1 unsigned `INTEGER` with raw access to encoded bytes.
 //! - [`UtcTime`]: ASN.1 `UTCTime`.
 //! - [`Utf8StringRef`]: ASN.1 `UTF8String`.
 //!
@@ -328,7 +328,7 @@
 //! [`SequenceOf`]: asn1::SequenceOf
 //! [`SetOf`]: asn1::SetOf
 //! [`SetOfVec`]: asn1::SetOfVec
-//! [`UIntRef`]: asn1::UIntRef
+//! [`UintRef`]: asn1::UintRef
 //! [`UtcTime`]: asn1::UtcTime
 //! [`Utf8StringRef`]: asn1::Utf8StringRef
 

--- a/pkcs1/src/lib.rs
+++ b/pkcs1/src/lib.rs
@@ -22,7 +22,7 @@ mod version;
 
 pub use der::{
     self,
-    asn1::{ObjectIdentifier, UIntRef},
+    asn1::{ObjectIdentifier, UintRef},
 };
 
 pub use crate::{

--- a/pkcs1/src/private_key.rs
+++ b/pkcs1/src/private_key.rs
@@ -5,7 +5,7 @@ pub(crate) mod other_prime_info;
 
 use crate::{Error, Result, RsaPublicKey, Version};
 use core::fmt;
-use der::{asn1::UIntRef, Decode, DecodeValue, Encode, Header, Reader, Sequence, Tag};
+use der::{asn1::UintRef, Decode, DecodeValue, Encode, Header, Reader, Sequence, Tag};
 
 #[cfg(feature = "alloc")]
 use {self::other_prime_info::OtherPrimeInfo, alloc::vec::Vec, der::SecretDocument};
@@ -39,28 +39,28 @@ use der::pem::PemLabel;
 #[derive(Clone)]
 pub struct RsaPrivateKey<'a> {
     /// `n`: RSA modulus.
-    pub modulus: UIntRef<'a>,
+    pub modulus: UintRef<'a>,
 
     /// `e`: RSA public exponent.
-    pub public_exponent: UIntRef<'a>,
+    pub public_exponent: UintRef<'a>,
 
     /// `d`: RSA private exponent.
-    pub private_exponent: UIntRef<'a>,
+    pub private_exponent: UintRef<'a>,
 
     /// `p`: first prime factor of `n`.
-    pub prime1: UIntRef<'a>,
+    pub prime1: UintRef<'a>,
 
     /// `q`: Second prime factor of `n`.
-    pub prime2: UIntRef<'a>,
+    pub prime2: UintRef<'a>,
 
     /// First exponent: `d mod (p-1)`.
-    pub exponent1: UIntRef<'a>,
+    pub exponent1: UintRef<'a>,
 
     /// Second exponent: `d mod (q-1)`.
-    pub exponent2: UIntRef<'a>,
+    pub exponent2: UintRef<'a>,
 
     /// CRT coefficient: `(inverse of q) mod p`.
-    pub coefficient: UIntRef<'a>,
+    pub coefficient: UintRef<'a>,
 
     /// Additional primes `r_3`, ..., `r_u`, in order, if this is a multi-prime
     /// RSA key (i.e. `version` is `multi`).

--- a/pkcs1/src/private_key/other_prime_info.rs
+++ b/pkcs1/src/private_key/other_prime_info.rs
@@ -1,6 +1,6 @@
 //! PKCS#1 OtherPrimeInfo support.
 
-use der::{asn1::UIntRef, DecodeValue, Encode, Header, Reader, Sequence};
+use der::{asn1::UintRef, DecodeValue, Encode, Header, Reader, Sequence};
 
 /// PKCS#1 OtherPrimeInfo as defined in [RFC 8017 Appendix 1.2].
 ///
@@ -19,13 +19,13 @@ use der::{asn1::UIntRef, DecodeValue, Encode, Header, Reader, Sequence};
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub struct OtherPrimeInfo<'a> {
     /// Prime factor `r_i` of `n`, where `i` >= 3.
-    pub prime: UIntRef<'a>,
+    pub prime: UintRef<'a>,
 
     /// Exponent: `d_i = d mod (r_i - 1)`.
-    pub exponent: UIntRef<'a>,
+    pub exponent: UintRef<'a>,
 
     /// CRT coefficient: `t_i = (r_1 * r_2 * ... * r_(i-1))^(-1) mod r_i`.
-    pub coefficient: UIntRef<'a>,
+    pub coefficient: UintRef<'a>,
 }
 
 impl<'a> DecodeValue<'a> for OtherPrimeInfo<'a> {

--- a/pkcs1/src/public_key.rs
+++ b/pkcs1/src/public_key.rs
@@ -1,7 +1,7 @@
 //! PKCS#1 RSA Public Keys.
 
 use crate::{Error, Result};
-use der::{asn1::UIntRef, Decode, DecodeValue, Encode, Header, Reader, Sequence};
+use der::{asn1::UintRef, Decode, DecodeValue, Encode, Header, Reader, Sequence};
 
 #[cfg(feature = "alloc")]
 use der::Document;
@@ -24,10 +24,10 @@ use der::pem::PemLabel;
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct RsaPublicKey<'a> {
     /// `n`: RSA modulus
-    pub modulus: UIntRef<'a>,
+    pub modulus: UintRef<'a>,
 
     /// `e`: RSA public exponent
-    pub public_exponent: UIntRef<'a>,
+    pub public_exponent: UintRef<'a>,
 }
 
 impl<'a> DecodeValue<'a> for RsaPublicKey<'a> {

--- a/x509-cert/src/certificate.rs
+++ b/x509-cert/src/certificate.rs
@@ -6,7 +6,7 @@ use alloc::vec::Vec;
 use core::cmp::Ordering;
 
 use const_oid::AssociatedOid;
-use der::asn1::{BitStringRef, UIntRef};
+use der::asn1::{BitStringRef, UintRef};
 use der::{Decode, Enumerated, Error, ErrorKind, Sequence, ValueOrd};
 use spki::{AlgorithmIdentifier, SubjectPublicKeyInfo};
 
@@ -83,7 +83,7 @@ pub struct TbsCertificate<'a> {
     #[asn1(context_specific = "0", default = "Default::default")]
     pub version: Version,
 
-    pub serial_number: UIntRef<'a>,
+    pub serial_number: UintRef<'a>,
     pub signature: AlgorithmIdentifier<'a>,
     pub issuer: Name<'a>,
     pub validity: Validity,

--- a/x509-cert/src/crl.rs
+++ b/x509-cert/src/crl.rs
@@ -7,7 +7,7 @@ use crate::Version;
 
 use alloc::vec::Vec;
 
-use der::asn1::{BitStringRef, UIntRef};
+use der::asn1::{BitStringRef, UintRef};
 use der::{Sequence, ValueOrd};
 use spki::AlgorithmIdentifier;
 
@@ -47,7 +47,7 @@ pub struct CertificateList<'a> {
 #[derive(Clone, Debug, Eq, PartialEq, Sequence, ValueOrd)]
 #[allow(missing_docs)]
 pub struct RevokedCert<'a> {
-    pub serial_number: UIntRef<'a>,
+    pub serial_number: UintRef<'a>,
     pub revocation_date: Time,
     pub crl_entry_extensions: Option<Extensions<'a>>,
 }

--- a/x509-cert/src/ext/pkix/authkeyid.rs
+++ b/x509-cert/src/ext/pkix/authkeyid.rs
@@ -2,7 +2,7 @@ use super::name::GeneralNames;
 
 use const_oid::db::rfc5280::ID_CE_AUTHORITY_KEY_IDENTIFIER;
 use const_oid::{AssociatedOid, ObjectIdentifier};
-use der::asn1::{OctetStringRef, UIntRef};
+use der::asn1::{OctetStringRef, UintRef};
 use der::Sequence;
 
 /// AuthorityKeyIdentifier as defined in [RFC 5280 Section 4.2.1.1].
@@ -28,7 +28,7 @@ pub struct AuthorityKeyIdentifier<'a> {
     pub authority_cert_issuer: Option<GeneralNames<'a>>,
 
     #[asn1(context_specific = "2", tag_mode = "IMPLICIT", optional = "true")]
-    pub authority_cert_serial_number: Option<UIntRef<'a>>,
+    pub authority_cert_serial_number: Option<UintRef<'a>>,
 }
 
 impl<'a> AssociatedOid for AuthorityKeyIdentifier<'a> {

--- a/x509-cert/src/ext/pkix/certpolicy.rs
+++ b/x509-cert/src/ext/pkix/certpolicy.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 
 use const_oid::db::rfc5912::ID_CE_CERTIFICATE_POLICIES;
 use const_oid::AssociatedOid;
-use der::asn1::{GeneralizedTime, Ia5StringRef, ObjectIdentifier, UIntRef, Utf8StringRef};
+use der::asn1::{GeneralizedTime, Ia5StringRef, ObjectIdentifier, UintRef, Utf8StringRef};
 use der::{AnyRef, Choice, Sequence, ValueOrd};
 
 /// CertificatePolicies as defined in [RFC 5280 Section 4.2.1.4].
@@ -98,7 +98,7 @@ pub struct UserNotice<'a> {
 #[allow(missing_docs)]
 pub struct NoticeReference<'a> {
     pub organization: DisplayText<'a>,
-    pub notice_numbers: Option<Vec<UIntRef<'a>>>,
+    pub notice_numbers: Option<Vec<UintRef<'a>>>,
 }
 
 /// DisplayText as defined in [RFC 5280 Section 4.2.1.4].

--- a/x509-cert/src/ext/pkix/crl.rs
+++ b/x509-cert/src/ext/pkix/crl.rs
@@ -11,7 +11,7 @@ pub use dp::IssuingDistributionPoint;
 
 use alloc::vec::Vec;
 
-use der::{asn1::UIntRef, Enumerated};
+use der::{asn1::UintRef, Enumerated};
 
 /// CrlNumber as defined in [RFC 5280 Section 5.2.3].
 ///
@@ -21,13 +21,13 @@ use der::{asn1::UIntRef, Enumerated};
 ///
 /// [RFC 5280 Section 5.2.3]: https://datatracker.ietf.org/doc/html/rfc5280#section-5.2.3
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct CrlNumber<'a>(pub UIntRef<'a>);
+pub struct CrlNumber<'a>(pub UintRef<'a>);
 
 impl<'a> AssociatedOid for CrlNumber<'a> {
     const OID: ObjectIdentifier = ID_CE_CRL_NUMBER;
 }
 
-impl_newtype!(CrlNumber<'a>, UIntRef<'a>);
+impl_newtype!(CrlNumber<'a>, UintRef<'a>);
 
 /// BaseCRLNumber as defined in [RFC 5280 Section 5.2.4].
 ///
@@ -37,13 +37,13 @@ impl_newtype!(CrlNumber<'a>, UIntRef<'a>);
 ///
 /// [RFC 5280 Section 5.2.4]: https://datatracker.ietf.org/doc/html/rfc5280#section-5.2.4
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct BaseCrlNumber<'a>(pub UIntRef<'a>);
+pub struct BaseCrlNumber<'a>(pub UintRef<'a>);
 
 impl<'a> AssociatedOid for BaseCrlNumber<'a> {
     const OID: ObjectIdentifier = ID_CE_DELTA_CRL_INDICATOR;
 }
 
-impl_newtype!(BaseCrlNumber<'a>, UIntRef<'a>);
+impl_newtype!(BaseCrlNumber<'a>, UintRef<'a>);
 
 /// CrlDistributionPoints as defined in [RFC 5280 Section 4.2.1.13].
 ///

--- a/x509-cert/tests/certificate.rs
+++ b/x509-cert/tests/certificate.rs
@@ -1,7 +1,7 @@
 //! Certificate tests
 
 use der::{
-    asn1::{BitStringRef, ContextSpecific, ObjectIdentifier, UIntRef},
+    asn1::{BitStringRef, ContextSpecific, ObjectIdentifier, UintRef},
     Decode, DecodeValue, Encode, FixedTag, Header, Reader, Tag, Tagged,
 };
 use hex_literal::hex;
@@ -207,7 +207,7 @@ fn decode_cert() {
     ];
     assert_eq!(
         cert.tbs_certificate.serial_number,
-        UIntRef::new(&target_serial).unwrap()
+        UintRef::new(&target_serial).unwrap()
     );
     assert_eq!(
         cert.tbs_certificate.signature.oid.to_string(),

--- a/x509-cert/tests/pkix_extensions.rs
+++ b/x509-cert/tests/pkix_extensions.rs
@@ -1,6 +1,6 @@
 //! Certificate tests
 use const_oid::AssociatedOid;
-use der::asn1::UIntRef;
+use der::asn1::UintRef;
 use der::{Decode, Encode, ErrorKind, Length, Tag, Tagged};
 use hex_literal::hex;
 use x509_cert::ext::pkix::crl::dp::{DistributionPoint, ReasonFlags, Reasons};
@@ -486,7 +486,7 @@ fn decode_cert() {
     let target_serial: [u8; 1] = [2];
     assert_eq!(
         cert.tbs_certificate.serial_number,
-        UIntRef::new(&target_serial).unwrap()
+        UintRef::new(&target_serial).unwrap()
     );
     assert_eq!(
         cert.tbs_certificate.signature.oid.to_string(),

--- a/x509-ocsp/src/lib.rs
+++ b/x509-ocsp/src/lib.rs
@@ -3,7 +3,7 @@
 
 extern crate alloc;
 
-use der::asn1::{BitStringRef, Ia5StringRef, ObjectIdentifier, OctetStringRef, UIntRef};
+use der::asn1::{BitStringRef, Ia5StringRef, ObjectIdentifier, OctetStringRef, UintRef};
 use der::asn1::{GeneralizedTime, Null};
 use der::{AnyRef, Choice, Enumerated, Sequence};
 use spki::AlgorithmIdentifier;
@@ -152,7 +152,7 @@ pub struct CertId<'a> {
     pub hash_algorithm: AlgorithmIdentifier<'a>,
     pub issuer_name_hash: OctetStringRef<'a>,
     pub issuer_key_hash: OctetStringRef<'a>,
-    pub serial_number: UIntRef<'a>,
+    pub serial_number: UintRef<'a>,
 }
 
 /// OCSPResponse structure as defined in [RFC 6960 Section 4.2.1].
@@ -426,7 +426,7 @@ pub struct CrlId<'a> {
     pub crl_url: Option<Ia5StringRef<'a>>,
 
     #[asn1(context_specific = "1", optional = "true", tag_mode = "EXPLICIT")]
-    pub crl_num: Option<UIntRef<'a>>,
+    pub crl_num: Option<UintRef<'a>>,
 
     #[asn1(context_specific = "2", optional = "true", tag_mode = "EXPLICIT")]
     pub crl_time: Option<GeneralizedTime>,


### PR DESCRIPTION
From https://rust-lang.github.io/api-guidelines/naming.html

> In UpperCamelCase, acronyms and contractions of compound words count
> as one word: use Uuid rather than UUID, Usize rather than USize or
> Stdin rather than StdIn.

Based on the `Usize` example, it's pretty clear we should be using `Uint` rather than `UInt`.

This is also consistent with `num-bigint` and `crypto-bigint` as of RustCrypto/crypto-bigint#143