### PR TITLE
tls_codec: use serde feature instead of serde_serialize

### DIFF
--- a/tls_codec/src/quic_vec.rs
+++ b/tls_codec/src/quic_vec.rs
@@ -13,7 +13,7 @@
 //! up to 62-bit length values.
 use alloc::vec::Vec;
 
-#[cfg(feature = "serde_serialize")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize as SerdeDeserialize, Serialize as SerdeSerialize};
 
 use crate::{Deserialize, Error, Serialize, Size};
@@ -197,7 +197,7 @@ impl<T: Size> Size for &[T] {
 /// Variable-length encoded byte vectors.
 /// Use this struct if bytes are encoded.
 /// This is faster than the generic version.
-#[cfg_attr(feature = "serde_serialize", derive(SerdeSerialize, SerdeDeserialize))]
+#[cfg_attr(feature = "serde", derive(SerdeSerialize, SerdeDeserialize))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct VLBytes {
     vec: Vec<u8>,

--- a/tls_codec/src/tls_vec.rs
+++ b/tls_codec/src/tls_vec.rs
@@ -7,7 +7,7 @@
 use alloc::vec::Vec;
 use core::ops::Drop;
 
-#[cfg(feature = "serde_serialize")]
+#[cfg(feature = "serde")]
 use serde::ser::SerializeStruct;
 #[cfg(feature = "std")]
 use std::io::{Read, Write};
@@ -444,7 +444,7 @@ macro_rules! impl_tls_vec_generic {
             }
         }
 
-        #[cfg(feature = "serde_serialize")]
+        #[cfg(feature = "serde")]
         impl<T> serde::Serialize for $name<T>
         where
             T: $($bounds + )* serde::Serialize,
@@ -459,7 +459,7 @@ macro_rules! impl_tls_vec_generic {
             }
         }
 
-        #[cfg(feature = "serde_serialize")]
+        #[cfg(feature = "serde")]
         impl<'de, T> serde::de::Deserialize<'de> for $name<T>
         where
             T: $($bounds + )* serde::de::Deserialize<'de>,
@@ -642,7 +642,7 @@ macro_rules! impl_tls_vec {
             }
         }
 
-        #[cfg(feature = "serde_serialize")]
+        #[cfg(feature = "serde")]
         impl serde::Serialize for $name {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where
@@ -654,7 +654,7 @@ macro_rules! impl_tls_vec {
             }
         }
 
-        #[cfg(feature = "serde_serialize")]
+        #[cfg(feature = "serde")]
         impl<'de> serde::de::Deserialize<'de> for $name {
             fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
             where


### PR DESCRIPTION
Followup to #791 to actually use the feature