### PR TITLE
der: introduce `OwnedtoRef`/`RefToOwned` traits

### DIFF
--- a/.github/workflows/base16ct.yml
+++ b/.github/workflows/base16ct.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/base32ct.yml
+++ b/.github/workflows/base32ct.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/const-oid.yml
+++ b/.github/workflows/const-oid.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/der.yml
+++ b/.github/workflows/der.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -52,7 +52,7 @@ jobs:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
             platform: ubuntu-latest
-            rust: 1.60.0 # MSRV
+            rust: 1.65.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             platform: ubuntu-latest
@@ -62,7 +62,7 @@ jobs:
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
             platform: ubuntu-latest
-            rust: 1.60.0 # MSRV
+            rust: 1.65.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             platform: ubuntu-latest
             rust: stable
@@ -71,7 +71,7 @@ jobs:
           # 64-bit Windows
           #- target: x86_64-pc-windows-msvc
           #  platform: windows-latest
-          #  rust: 1.60.0 # MSRV
+          #  rust: 1.65.0 # MSRV
           #- target: x86_64-pc-windows-msvc
           #  platform: windows-latest
           #  rust: stable
@@ -93,7 +93,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pem-rfc7468.yml
+++ b/.github/workflows/pem-rfc7468.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pkcs1.yml
+++ b/.github/workflows/pkcs1.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pkcs5.yml
+++ b/.github/workflows/pkcs5.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pkcs7.yml
+++ b/.github/workflows/pkcs7.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pkcs8.yml
+++ b/.github/workflows/pkcs8.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -54,7 +54,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/sec1.yml
+++ b/.github/workflows/sec1.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/serdect.yml
+++ b/.github/workflows/serdect.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/spki.yml
+++ b/.github/workflows/spki.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tai64.yml
+++ b/.github/workflows/tai64.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tls_codec.yml
+++ b/.github/workflows/tls_codec.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - wasm32-unknown-unknown
@@ -52,7 +52,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.60.0 # MSRV
+            rust: 1.65.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -60,7 +60,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.60.0 # MSRV
+            rust: 1.65.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
     steps:

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.60.0
+          toolchain: 1.65.0
           components: clippy
           override: true
           profile: minimal

--- a/.github/workflows/x509-cert.yml
+++ b/.github/workflows/x509-cert.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,6 @@ dependencies = [
  "hex-literal",
  "pem-rfc7468",
  "proptest",
- "rustversion",
  "time",
  "zeroize",
 ]
@@ -1000,12 +999,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
-
-[[package]]
 name = "rusty-fork"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1175,7 +1168,6 @@ dependencies = [
  "base64ct",
  "der",
  "hex-literal",
- "rustversion",
  "sha2",
  "tempfile",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,6 +321,7 @@ dependencies = [
  "hex-literal",
  "pem-rfc7468",
  "proptest",
+ "rustversion",
  "time",
  "zeroize",
 ]
@@ -999,6 +1000,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
+
+[[package]]
 name = "rusty-fork"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1168,6 +1175,7 @@ dependencies = [
  "base64ct",
  "der",
  "hex-literal",
+ "rustversion",
  "sha2",
  "tempfile",
 ]

--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -294,3 +294,26 @@ where
         }
     }
 }
+
+#[cfg(feature = "alloc")]
+mod feature_alloc {
+    use super::*;
+    use crate::referenced::*;
+
+    impl<'a> RefToOwned<'a> for AnyRef<'a> {
+        type Owned = Any;
+        fn to_owned(&self) -> Self::Owned {
+            Any {
+                tag: self.tag(),
+                value: Bytes::from(self.value),
+            }
+        }
+    }
+
+    impl OwnedToRef for Any {
+        type Borrowed<'a> = AnyRef<'a>;
+        fn to_ref<'a>(&'a self) -> Self::Borrowed<'a> {
+            self.into()
+        }
+    }
+}

--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -313,7 +313,7 @@ mod feature_alloc {
 
     impl OwnedToRef for Any {
         type Borrowed<'a> = AnyRef<'a>;
-        fn to_ref<'a>(&'a self) -> Self::Borrowed<'a> {
+        fn to_ref(&self) -> Self::Borrowed<'_> {
             self.into()
         }
     }

--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -295,6 +295,7 @@ where
     }
 }
 
+#[rustversion::since(1.65)] // Generic associated types support is required
 #[cfg(feature = "alloc")]
 mod feature_alloc {
     use super::*;

--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -295,7 +295,6 @@ where
     }
 }
 
-#[rustversion::since(1.65)] // Generic associated types support is required
 #[cfg(feature = "alloc")]
 mod feature_alloc {
     use super::*;

--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -296,7 +296,7 @@ where
 }
 
 #[cfg(feature = "alloc")]
-mod feature_alloc {
+mod allocating {
     use super::*;
     use crate::referenced::*;
 

--- a/der/src/asn1/bit_string.rs
+++ b/der/src/asn1/bit_string.rs
@@ -337,6 +337,7 @@ impl ValueOrd for BitString {
     }
 }
 
+#[rustversion::since(1.65)] // Generic associated types support is required
 #[cfg(feature = "alloc")]
 mod feature_alloc {
     use super::*;

--- a/der/src/asn1/bit_string.rs
+++ b/der/src/asn1/bit_string.rs
@@ -338,7 +338,7 @@ impl ValueOrd for BitString {
 }
 
 #[cfg(feature = "alloc")]
-mod feature_alloc {
+mod allocating {
     use super::*;
     use crate::referenced::*;
     use alloc::vec::Vec;

--- a/der/src/asn1/bit_string.rs
+++ b/der/src/asn1/bit_string.rs
@@ -180,7 +180,7 @@ impl<'a> TryFrom<&&'a [u8]> for BitStringRef<'a> {
     type Error = Error;
 
     fn try_from(bytes: &&'a [u8]) -> Result<BitStringRef<'a>> {
-        BitStringRef::from_bytes(*bytes)
+        BitStringRef::from_bytes(bytes)
     }
 }
 

--- a/der/src/asn1/bit_string.rs
+++ b/der/src/asn1/bit_string.rs
@@ -357,7 +357,7 @@ mod feature_alloc {
 
     impl OwnedToRef for BitString {
         type Borrowed<'a> = BitStringRef<'a>;
-        fn to_ref<'a>(&'a self) -> Self::Borrowed<'a> {
+        fn to_ref(&self) -> Self::Borrowed<'_> {
             self.into()
         }
     }

--- a/der/src/asn1/bit_string.rs
+++ b/der/src/asn1/bit_string.rs
@@ -337,7 +337,6 @@ impl ValueOrd for BitString {
     }
 }
 
-#[rustversion::since(1.65)] // Generic associated types support is required
 #[cfg(feature = "alloc")]
 mod feature_alloc {
     use super::*;

--- a/der/src/asn1/bit_string.rs
+++ b/der/src/asn1/bit_string.rs
@@ -337,6 +337,31 @@ impl ValueOrd for BitString {
     }
 }
 
+#[cfg(feature = "alloc")]
+mod feature_alloc {
+    use super::*;
+    use crate::referenced::*;
+    use alloc::vec::Vec;
+
+    impl<'a> RefToOwned<'a> for BitStringRef<'a> {
+        type Owned = BitString;
+        fn to_owned(&self) -> Self::Owned {
+            BitString {
+                unused_bits: self.unused_bits,
+                bit_length: self.bit_length,
+                inner: Vec::from(self.inner.as_slice()),
+            }
+        }
+    }
+
+    impl OwnedToRef for BitString {
+        type Borrowed<'a> = BitStringRef<'a>;
+        fn to_ref<'a>(&'a self) -> Self::Borrowed<'a> {
+            self.into()
+        }
+    }
+}
+
 /// Iterator over the bits of a [`BitString`].
 pub struct BitStringIter<'a> {
     /// [`BitString`] being iterated over.

--- a/der/src/asn1/integer.rs
+++ b/der/src/asn1/integer.rs
@@ -126,7 +126,7 @@ impl_uint_encoding!(u8, u16, u32, u64, u128);
 #[inline]
 fn is_highest_bit_set(bytes: &[u8]) -> bool {
     bytes
-        .get(0)
+        .first()
         .map(|byte| byte & 0b10000000 != 0)
         .unwrap_or(false)
 }

--- a/der/src/asn1/integer/uint.rs
+++ b/der/src/asn1/integer/uint.rs
@@ -75,7 +75,7 @@ pub(crate) fn strip_leading_zeroes(mut bytes: &[u8]) -> &[u8] {
 
 /// Does the given integer need a leading zero?
 fn needs_leading_zero(bytes: &[u8]) -> bool {
-    matches!(bytes.get(0), Some(byte) if *byte >= 0x80)
+    matches!(bytes.first(), Some(byte) if *byte >= 0x80)
 }
 
 #[cfg(test)]

--- a/der/src/asn1/real.rs
+++ b/der/src/asn1/real.rs
@@ -23,7 +23,7 @@ impl<'a> DecodeValue<'a> for f64 {
             Ok(0.0)
         } else if is_nth_bit_one::<7>(bytes) {
             // Binary encoding from section 8.5.7 applies
-            let sign: u64 = if is_nth_bit_one::<6>(bytes) { 1 } else { 0 };
+            let sign: u64 = u64::from(is_nth_bit_one::<6>(bytes));
 
             // Section 8.5.7.2: Check the base -- the DER specs say that only base 2 should be supported in DER
             let base = mnth_bits_to_u8::<5, 4>(bytes);
@@ -204,7 +204,7 @@ impl FixedTag for f64 {
 pub(crate) fn is_nth_bit_one<const N: usize>(bytes: &[u8]) -> bool {
     if N < 8 {
         bytes
-            .get(0)
+            .first()
             .map(|byte| byte & (1 << N) != 0)
             .unwrap_or(false)
     } else {

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -340,6 +340,7 @@ extern crate alloc;
 extern crate std;
 
 pub mod asn1;
+pub mod referenced;
 
 pub(crate) mod arrayvec;
 mod byte_slice;

--- a/der/src/reader/slice.rs
+++ b/der/src/reader/slice.rs
@@ -64,7 +64,7 @@ impl<'a> Reader<'a> for SliceReader<'a> {
     fn peek_byte(&self) -> Option<u8> {
         self.remaining()
             .ok()
-            .and_then(|bytes| bytes.get(0).cloned())
+            .and_then(|bytes| bytes.first().cloned())
     }
 
     fn peek_header(&self) -> Result<Header> {

--- a/der/src/referenced.rs
+++ b/der/src/referenced.rs
@@ -1,6 +1,7 @@
 //! A module for working with referenced data.
 
 /// A trait for borrowing data from an owned struct
+#[rustversion::since(1.65)] // Generic associated types support is required
 pub trait OwnedToRef {
     /// The resulting type referencing back to Self
     type Borrowed<'a>
@@ -14,6 +15,7 @@ pub trait OwnedToRef {
 /// A trait for cloning a referenced structure and getting owned objects
 ///
 /// This is the pendant to [`OwnedToRef`]
+#[rustversion::since(1.65)] // Generic associated types support is required
 pub trait RefToOwned<'a> {
     /// The resulting type after obtaining ownership.
     type Owned: OwnedToRef<Borrowed<'a> = Self>
@@ -24,6 +26,7 @@ pub trait RefToOwned<'a> {
     fn to_owned(&self) -> Self::Owned;
 }
 
+#[rustversion::since(1.65)] // Generic associated types support is required
 impl<T> OwnedToRef for Option<T>
 where
     T: OwnedToRef,
@@ -35,6 +38,7 @@ where
     }
 }
 
+#[rustversion::since(1.65)] // Generic associated types support is required
 impl<'a, T> RefToOwned<'a> for Option<T>
 where
     T: RefToOwned<'a> + 'a,

--- a/der/src/referenced.rs
+++ b/der/src/referenced.rs
@@ -1,0 +1,47 @@
+//! A module for working with referenced data.
+
+/// A trait for borrowing data from an owned struct
+pub trait OwnedToRef {
+    /// The resulting type referencing back to Self
+    type Borrowed<'a>
+    where
+        Self: 'a;
+
+    /// Creates a new object referencing back to the self for storage
+    fn to_ref<'a>(&'a self) -> Self::Borrowed<'a>;
+}
+
+/// A trait for cloning a referenced structure and getting owned objects
+///
+/// This is the pendant to [`OwnedToRef`]
+pub trait RefToOwned<'a> {
+    /// The resulting type after obtaining ownership.
+    type Owned: OwnedToRef<Borrowed<'a> = Self>
+    where
+        Self: 'a;
+
+    /// Creates a new object taking ownership of the data
+    fn to_owned(&self) -> Self::Owned;
+}
+
+impl<T> OwnedToRef for Option<T>
+where
+    T: OwnedToRef,
+{
+    type Borrowed<'a> = Option<T::Borrowed<'a>> where T: 'a;
+
+    fn to_ref<'a>(&'a self) -> Self::Borrowed<'a> {
+        self.as_ref().map(|o| o.to_ref())
+    }
+}
+
+impl<'a, T> RefToOwned<'a> for Option<T>
+where
+    T: RefToOwned<'a> + 'a,
+    T::Owned: OwnedToRef,
+{
+    type Owned = Option<T::Owned>;
+    fn to_owned(&self) -> Self::Owned {
+        self.as_ref().map(|o| o.to_owned())
+    }
+}

--- a/der/src/referenced.rs
+++ b/der/src/referenced.rs
@@ -9,7 +9,7 @@ pub trait OwnedToRef {
         Self: 'a;
 
     /// Creates a new object referencing back to the self for storage
-    fn to_ref<'a>(&'a self) -> Self::Borrowed<'a>;
+    fn to_ref(&self) -> Self::Borrowed<'_>;
 }
 
 /// A trait for cloning a referenced structure and getting owned objects
@@ -36,7 +36,7 @@ where
         T: 'a,
     = Option<T::Borrowed<'a>>;
 
-    fn to_ref<'a>(&'a self) -> Self::Borrowed<'a> {
+    fn to_ref(&self) -> Self::Borrowed<'_> {
         self.as_ref().map(|o| o.to_ref())
     }
 }

--- a/der/src/referenced.rs
+++ b/der/src/referenced.rs
@@ -31,6 +31,9 @@ impl<T> OwnedToRef for Option<T>
 where
     T: OwnedToRef,
 {
+    // TODO: when upgrading to rust 1.65, we can use the new syntax
+    //       MSRV 1.60 requires us to use the old syntax
+    #[allow(deprecated_where_clause_location)]
     type Borrowed<'a>
     where
         T: 'a,

--- a/der/src/referenced.rs
+++ b/der/src/referenced.rs
@@ -33,6 +33,7 @@ where
 {
     // TODO: when upgrading to rust 1.65, we can use the new syntax
     //       MSRV 1.60 requires us to use the old syntax
+    #[allow(unknown_lints)]
     #[allow(deprecated_where_clause_location)]
     type Borrowed<'a>
     where

--- a/der/src/referenced.rs
+++ b/der/src/referenced.rs
@@ -1,7 +1,6 @@
 //! A module for working with referenced data.
 
 /// A trait for borrowing data from an owned struct
-#[rustversion::since(1.65)] // Generic associated types support is required
 pub trait OwnedToRef {
     /// The resulting type referencing back to Self
     type Borrowed<'a>
@@ -15,7 +14,6 @@ pub trait OwnedToRef {
 /// A trait for cloning a referenced structure and getting owned objects
 ///
 /// This is the pendant to [`OwnedToRef`]
-#[rustversion::since(1.65)] // Generic associated types support is required
 pub trait RefToOwned<'a> {
     /// The resulting type after obtaining ownership.
     type Owned: OwnedToRef<Borrowed<'a> = Self>
@@ -26,26 +24,17 @@ pub trait RefToOwned<'a> {
     fn to_owned(&self) -> Self::Owned;
 }
 
-#[rustversion::since(1.65)] // Generic associated types support is required
 impl<T> OwnedToRef for Option<T>
 where
     T: OwnedToRef,
 {
-    // TODO: when upgrading to rust 1.65, we can use the new syntax
-    //       MSRV 1.60 requires us to use the old syntax
-    #[allow(unknown_lints)]
-    #[allow(deprecated_where_clause_location)]
-    type Borrowed<'a>
-    where
-        T: 'a,
-    = Option<T::Borrowed<'a>>;
+    type Borrowed<'a> = Option<T::Borrowed<'a>> where T: 'a;
 
     fn to_ref(&self) -> Self::Borrowed<'_> {
         self.as_ref().map(|o| o.to_ref())
     }
 }
 
-#[rustversion::since(1.65)] // Generic associated types support is required
 impl<'a, T> RefToOwned<'a> for Option<T>
 where
     T: RefToOwned<'a> + 'a,

--- a/der/src/referenced.rs
+++ b/der/src/referenced.rs
@@ -31,7 +31,10 @@ impl<T> OwnedToRef for Option<T>
 where
     T: OwnedToRef,
 {
-    type Borrowed<'a> = Option<T::Borrowed<'a>> where T: 'a;
+    type Borrowed<'a>
+    where
+        T: 'a,
+    = Option<T::Borrowed<'a>>;
 
     fn to_ref<'a>(&'a self) -> Self::Borrowed<'a> {
         self.as_ref().map(|o| o.to_ref())

--- a/pkcs8/src/version.rs
+++ b/pkcs8/src/version.rs
@@ -6,7 +6,7 @@ use der::{Decode, Encode, FixedTag, Reader, Tag, Writer};
 /// Version identifier for PKCS#8 documents.
 ///
 /// (RFC 5958 designates `0` and `1` as the only valid versions for PKCS#8 documents)
-#[derive(Clone, Debug, Copy, PartialEq)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq)]
 pub enum Version {
     /// Denotes PKCS#8 v1: no public key field.
     V1 = 0,

--- a/spki/Cargo.toml
+++ b/spki/Cargo.toml
@@ -16,6 +16,7 @@ rust-version = "1.57"
 
 [dependencies]
 der = { version = "=0.7.0-pre", features = ["oid"], path = "../der" }
+rustversion = "1.0"
 
 # Optional dependencies
 sha2 = { version = "0.10", optional = true, default-features = false }

--- a/spki/Cargo.toml
+++ b/spki/Cargo.toml
@@ -16,7 +16,6 @@ rust-version = "1.57"
 
 [dependencies]
 der = { version = "=0.7.0-pre", features = ["oid"], path = "../der" }
-rustversion = "1.0"
 
 # Optional dependencies
 sha2 = { version = "0.10", optional = true, default-features = false }

--- a/spki/src/algorithm.rs
+++ b/spki/src/algorithm.rs
@@ -157,7 +157,6 @@ impl<'a> AlgorithmIdentifierRef<'a> {
     }
 }
 
-#[rustversion::since(1.65)] // Generic associated types support is required
 #[cfg(feature = "alloc")]
 mod feature_alloc {
     use super::*;

--- a/spki/src/algorithm.rs
+++ b/spki/src/algorithm.rs
@@ -175,7 +175,7 @@ mod feature_alloc {
 
     impl OwnedToRef for AlgorithmIdentifierOwned {
         type Borrowed<'a> = AlgorithmIdentifierRef<'a>;
-        fn to_ref<'a>(&'a self) -> Self::Borrowed<'a> {
+        fn to_ref(&self) -> Self::Borrowed<'_> {
             AlgorithmIdentifier {
                 oid: self.oid,
                 parameters: self.parameters.to_ref(),

--- a/spki/src/algorithm.rs
+++ b/spki/src/algorithm.rs
@@ -158,7 +158,7 @@ impl<'a> AlgorithmIdentifierRef<'a> {
 }
 
 #[cfg(feature = "alloc")]
-mod feature_alloc {
+mod allocating {
     use super::*;
     use der::referenced::*;
 

--- a/spki/src/algorithm.rs
+++ b/spki/src/algorithm.rs
@@ -7,6 +7,9 @@ use der::{
     Decode, DecodeValue, DerOrd, Encode, Header, Reader, Sequence, ValueOrd,
 };
 
+#[cfg(feature = "alloc")]
+use der::asn1::Any;
+
 /// X.509 `AlgorithmIdentifier` as defined in [RFC 5280 Section 4.1.1.2].
 ///
 /// ```text
@@ -78,6 +81,10 @@ where
 /// `AlgorithmIdentifier` reference which has `AnyRef` parameters.
 pub type AlgorithmIdentifierRef<'a> = AlgorithmIdentifier<AnyRef<'a>>;
 
+/// `AlgorithmIdentifier` reference which has `Any` parameters.
+#[cfg(feature = "alloc")]
+pub type AlgorithmIdentifierOwned = AlgorithmIdentifier<Any>;
+
 impl<Params> AlgorithmIdentifier<Params> {
     /// Assert the `algorithm` OID is an expected value.
     pub fn assert_algorithm_oid(&self, expected_oid: ObjectIdentifier) -> Result<ObjectIdentifier> {
@@ -147,5 +154,31 @@ impl<'a> AlgorithmIdentifierRef<'a> {
                 },
             },
         ))
+    }
+}
+
+#[cfg(feature = "alloc")]
+mod feature_alloc {
+    use super::*;
+    use der::referenced::*;
+
+    impl<'a> RefToOwned<'a> for AlgorithmIdentifierRef<'a> {
+        type Owned = AlgorithmIdentifierOwned;
+        fn to_owned(&self) -> Self::Owned {
+            AlgorithmIdentifier {
+                oid: self.oid,
+                parameters: self.parameters.to_owned(),
+            }
+        }
+    }
+
+    impl OwnedToRef for AlgorithmIdentifierOwned {
+        type Borrowed<'a> = AlgorithmIdentifierRef<'a>;
+        fn to_ref<'a>(&'a self) -> Self::Borrowed<'a> {
+            AlgorithmIdentifier {
+                oid: self.oid,
+                parameters: self.parameters.to_ref(),
+            }
+        }
     }
 }

--- a/spki/src/algorithm.rs
+++ b/spki/src/algorithm.rs
@@ -157,6 +157,7 @@ impl<'a> AlgorithmIdentifierRef<'a> {
     }
 }
 
+#[rustversion::since(1.65)] // Generic associated types support is required
 #[cfg(feature = "alloc")]
 mod feature_alloc {
     use super::*;

--- a/spki/src/lib.rs
+++ b/spki/src/lib.rs
@@ -50,7 +50,10 @@ pub use der::{self, asn1::ObjectIdentifier};
 
 #[cfg(feature = "alloc")]
 pub use {
-    crate::{spki::SubjectPublicKeyInfoOwned, traits::EncodePublicKey},
+    crate::{
+        algorithm::AlgorithmIdentifierOwned, spki::SubjectPublicKeyInfoOwned,
+        traits::EncodePublicKey,
+    },
     der::Document,
 };
 

--- a/spki/src/spki.rs
+++ b/spki/src/spki.rs
@@ -174,7 +174,6 @@ impl<Params, Key> PemLabel for SubjectPublicKeyInfo<Params, Key> {
     const PEM_LABEL: &'static str = "PUBLIC KEY";
 }
 
-#[rustversion::since(1.65)] // Generic associated types support is required
 #[cfg(feature = "alloc")]
 mod feature_alloc {
     use super::*;

--- a/spki/src/spki.rs
+++ b/spki/src/spki.rs
@@ -174,6 +174,7 @@ impl<Params, Key> PemLabel for SubjectPublicKeyInfo<Params, Key> {
     const PEM_LABEL: &'static str = "PUBLIC KEY";
 }
 
+#[rustversion::since(1.65)] // Generic associated types support is required
 #[cfg(feature = "alloc")]
 mod feature_alloc {
     use super::*;

--- a/spki/src/spki.rs
+++ b/spki/src/spki.rs
@@ -192,7 +192,7 @@ mod feature_alloc {
 
     impl OwnedToRef for SubjectPublicKeyInfoOwned {
         type Borrowed<'a> = SubjectPublicKeyInfoRef<'a>;
-        fn to_ref<'a>(&'a self) -> Self::Borrowed<'a> {
+        fn to_ref(&self) -> Self::Borrowed<'_> {
             SubjectPublicKeyInfo {
                 algorithm: self.algorithm.to_ref(),
                 subject_public_key: self.subject_public_key.to_ref(),

--- a/spki/src/spki.rs
+++ b/spki/src/spki.rs
@@ -173,3 +173,29 @@ where
 impl<Params, Key> PemLabel for SubjectPublicKeyInfo<Params, Key> {
     const PEM_LABEL: &'static str = "PUBLIC KEY";
 }
+
+#[cfg(feature = "alloc")]
+mod feature_alloc {
+    use super::*;
+    use der::referenced::*;
+
+    impl<'a> RefToOwned<'a> for SubjectPublicKeyInfoRef<'a> {
+        type Owned = SubjectPublicKeyInfoOwned;
+        fn to_owned(&self) -> Self::Owned {
+            SubjectPublicKeyInfo {
+                algorithm: self.algorithm.to_owned(),
+                subject_public_key: self.subject_public_key.to_owned(),
+            }
+        }
+    }
+
+    impl OwnedToRef for SubjectPublicKeyInfoOwned {
+        type Borrowed<'a> = SubjectPublicKeyInfoRef<'a>;
+        fn to_ref<'a>(&'a self) -> Self::Borrowed<'a> {
+            SubjectPublicKeyInfo {
+                algorithm: self.algorithm.to_ref(),
+                subject_public_key: self.subject_public_key.to_ref(),
+            }
+        }
+    }
+}

--- a/spki/src/spki.rs
+++ b/spki/src/spki.rs
@@ -175,7 +175,7 @@ impl<Params, Key> PemLabel for SubjectPublicKeyInfo<Params, Key> {
 }
 
 #[cfg(feature = "alloc")]
-mod feature_alloc {
+mod allocating {
     use super::*;
     use der::referenced::*;
 

--- a/x509-cert/src/certificate.rs
+++ b/x509-cert/src/certificate.rs
@@ -36,7 +36,7 @@ pub enum Version {
 
 impl ValueOrd for Version {
     fn value_cmp(&self, other: &Self) -> der::Result<Ordering> {
-        (&(*self as u8)).value_cmp(&(*other as u8))
+        (*self as u8).value_cmp(&(*other as u8))
     }
 }
 


### PR DESCRIPTION
This introduces the two new traits to go from a ref object to an owned object as discussed in #796

closes #796 
