### PR TITLE
der: remove unused impls

### DIFF
--- a/der/src/asn1/boolean.rs
+++ b/der/src/asn1/boolean.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `BOOLEAN` support.
 
 use crate::{
-    asn1::AnyRef, ord::OrdIsValueOrd, ByteSlice, DecodeValue, EncodeValue, Error, ErrorKind,
-    FixedTag, Header, Length, Reader, Result, Tag, Writer,
+    asn1::AnyRef, ord::OrdIsValueOrd, DecodeValue, EncodeValue, Error, ErrorKind, FixedTag, Header,
+    Length, Reader, Result, Tag, Writer,
 };
 
 /// Byte used to encode `true` in ASN.1 DER. From X.690 Section 11.1:
@@ -43,17 +43,6 @@ impl FixedTag for bool {
 }
 
 impl OrdIsValueOrd for bool {}
-
-impl From<bool> for AnyRef<'static> {
-    fn from(value: bool) -> AnyRef<'static> {
-        let value = ByteSlice::from(match value {
-            false => &[FALSE_OCTET],
-            true => &[TRUE_OCTET],
-        });
-
-        AnyRef::from_tag_and_value(Tag::Boolean, value)
-    }
-}
 
 impl TryFrom<AnyRef<'_>> for bool {
     type Error = Error;

--- a/der/src/byte_slice.rs
+++ b/der/src/byte_slice.rs
@@ -86,15 +86,6 @@ impl DerOrd for ByteSlice<'_> {
     }
 }
 
-impl<'a> From<&'a [u8; 1]> for ByteSlice<'a> {
-    fn from(byte: &'a [u8; 1]) -> ByteSlice<'a> {
-        Self {
-            length: Length::ONE,
-            inner: byte,
-        }
-    }
-}
-
 impl<'a> From<StrSlice<'a>> for ByteSlice<'a> {
     fn from(s: StrSlice<'a>) -> ByteSlice<'a> {
         let bytes = s.as_bytes();

--- a/der/src/bytes.rs
+++ b/der/src/bytes.rs
@@ -78,15 +78,6 @@ impl DerOrd for Bytes {
     }
 }
 
-impl From<&[u8; 1]> for Bytes {
-    fn from(byte: &[u8; 1]) -> Bytes {
-        Self {
-            length: Length::ONE,
-            inner: Box::new([byte[0]]),
-        }
-    }
-}
-
 impl From<StrSlice<'_>> for Bytes {
     fn from(s: StrSlice<'_>) -> Bytes {
         let bytes = s.as_bytes();


### PR DESCRIPTION
This is a vestige from when more decoding/encoding was handled by way of `AnyRef` instead of generics/traits.