### PR TITLE
tls_codec: fix `serde_serialize` reference in CI

### DIFF
--- a/.github/workflows/tls_codec.yml
+++ b/.github/workflows/tls_codec.yml
@@ -38,7 +38,7 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - uses: RustCrypto/actions/cargo-hack-install@master
-      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features std,default,derive,serde_serialize
+      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features std,default,derive,serde
 
   minimal-versions:
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master


### PR DESCRIPTION
It's been renamed to `serde`.

It's causing these build failures on `master`:

https://github.com/RustCrypto/formats/actions/runs/3721094404/jobs/6311010746