### PR TITLE
x509-cert: make key storage a parameter for `Certificate`

### DIFF
--- a/der/derive/src/attributes.rs
+++ b/der/derive/src/attributes.rs
@@ -1,11 +1,11 @@
 //! Attribute-related types used by the proc macro
 
 use crate::{Asn1Type, Tag, TagMode, TagNumber};
-use proc_macro2::TokenStream;
+use proc_macro2::{Span, TokenStream};
 use proc_macro_error::{abort, abort_call_site};
 use quote::quote;
 use std::{fmt::Debug, str::FromStr};
-use syn::{Attribute, Lit, LitStr, Meta, MetaList, MetaNameValue, NestedMeta, Path};
+use syn::{Attribute, Ident, Lit, LitStr, Meta, MetaList, MetaNameValue, NestedMeta, Path};
 
 /// Attribute name.
 pub(crate) const ATTR_NAME: &str = "asn1";
@@ -21,12 +21,19 @@ pub(crate) struct TypeAttrs {
     ///
     /// The default value is `EXPLICIT`.
     pub tag_mode: TagMode,
+
+    /// The type parameters that needs to implement `der::Choice<'_> + der::Encode`
+    pub params: Vec<Ident>,
+    /// The type parameters that needs to implement `der::Decode<'_> + der::Encode + der::FixedTag`
+    pub key: Vec<Ident>,
 }
 
 impl TypeAttrs {
     /// Parse attributes from a struct field or enum variant.
     pub fn parse(attrs: &[Attribute]) -> Self {
         let mut tag_mode = None;
+        let mut params = Vec::new();
+        let mut key = Vec::new();
 
         let mut parsed_attrs = Vec::new();
         AttrNameValue::from_attributes(attrs, &mut parsed_attrs);
@@ -39,6 +46,10 @@ impl TypeAttrs {
                 }
 
                 tag_mode = Some(mode);
+            } else if let Some(ident) = attr.parse_value::<String>("params") {
+                params.push(Ident::new(&ident, Span::call_site()));
+            } else if let Some(ident) = attr.parse_value::<String>("key") {
+                key.push(Ident::new(&ident, Span::call_site()));
             } else {
                 abort!(
                     attr.name,
@@ -49,6 +60,8 @@ impl TypeAttrs {
 
         Self {
             tag_mode: tag_mode.unwrap_or_default(),
+            params,
+            key,
         }
     }
 }

--- a/der/derive/src/bind_tokens.rs
+++ b/der/derive/src/bind_tokens.rs
@@ -1,0 +1,51 @@
+use crate::TypeAttrs;
+use proc_macro2::TokenStream;
+use quote::quote;
+use std::cmp::Ordering;
+use syn::Ident;
+
+/// A small helper for `Ident` to do comparison of `Ident` ignoring its callsite
+trait IdentEq {
+    fn ident_eq(&self, ident: &Ident) -> bool;
+}
+
+impl IdentEq for Ident {
+    fn ident_eq(&self, ident: &Ident) -> bool {
+        // Implementation detail, ordering comparison only compares the name
+        self.cmp(ident) == Ordering::Equal
+    }
+}
+
+/// Trait for extending `syn::Ident` with a helper to generate the TokenStream for binding the type
+pub(crate) trait BindTokens {
+    fn to_bind_tokens(&self, lifetime: &TokenStream, attrs: &TypeAttrs) -> Option<TokenStream>;
+}
+
+impl BindTokens for Ident {
+    fn to_bind_tokens(&self, lifetime: &TokenStream, attrs: &TypeAttrs) -> Option<TokenStream> {
+        let ident = self;
+
+        let mut bounds = Vec::new();
+
+        if attrs.params.iter().any(|i| ident.ident_eq(i)) {
+            bounds.push(quote! {
+                ::der::Choice<#lifetime> + ::der::Encode
+                    + ::der::ValueOrd + ::der::DerOrd
+            });
+        }
+        if attrs.key.iter().any(|i| ident.ident_eq(i)) {
+            bounds.push(quote! {
+                ::der::Decode<#lifetime> + ::der::Encode + ::der::FixedTag
+                    + ::der::ValueOrd + ::der::DerOrd
+            });
+        }
+
+        if !bounds.is_empty() {
+            Some(quote! {
+                #ident: #(#bounds)+*
+            })
+        } else {
+            None
+        }
+    }
+}

--- a/der/derive/src/lib.rs
+++ b/der/derive/src/lib.rs
@@ -123,6 +123,7 @@
 
 mod asn1_type;
 mod attributes;
+mod bind_tokens;
 mod choice;
 mod enumerated;
 mod sequence;

--- a/der/derive/src/sequence.rs
+++ b/der/derive/src/sequence.rs
@@ -3,7 +3,10 @@
 
 mod field;
 
-use crate::{bind_tokens::BindTokens, default_lifetime, TypeAttrs};
+use crate::{
+    bind_tokens::{BindMode, BindTokens},
+    default_lifetime, TypeAttrs,
+};
 use field::SequenceField;
 use proc_macro2::TokenStream;
 use proc_macro_error::abort;
@@ -101,7 +104,9 @@ impl DeriveSequence {
         for param in &self.type_parameters {
             type_parameters.push(param.clone());
 
-            if let Some(bound) = param.to_bind_tokens(&lifetime, &self.type_attrs) {
+            if let Some(bound) =
+                param.to_bind_tokens(&lifetime, &self.type_attrs, BindMode::Sequence)
+            {
                 type_parameters_bounds.push(bound);
             }
         }

--- a/der/derive/src/value_ord.rs
+++ b/der/derive/src/value_ord.rs
@@ -5,7 +5,10 @@
 
 // TODO(tarcieri): enum support
 
-use crate::{bind_tokens::BindTokens, default_lifetime, FieldAttrs, TypeAttrs};
+use crate::{
+    bind_tokens::{BindMode, BindTokens},
+    default_lifetime, FieldAttrs, TypeAttrs,
+};
 use proc_macro2::TokenStream;
 use proc_macro_error::abort;
 use quote::quote;
@@ -111,7 +114,9 @@ impl DeriveValueOrd {
         for param in &self.type_parameters {
             type_parameters.push(param.clone());
 
-            if let Some(bound) = param.to_bind_tokens(&lifetime, &self.type_attrs) {
+            if let Some(bound) =
+                param.to_bind_tokens(&lifetime, &self.type_attrs, BindMode::ValueOrd)
+            {
                 type_parameters_bounds.push(bound);
             }
         }

--- a/der/src/asn1.rs
+++ b/der/src/asn1.rs
@@ -49,7 +49,7 @@ pub use self::{
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub use self::{
     any::Any, bit_string::BitString, ia5_string::Ia5String, integer::bigint::Uint,
-    octet_string::OctetString, set_of::SetOfVec,
+    octet_string::OctetString, set_of::SetOfVec, teletex_string::TeletexString,
 };
 
 #[cfg(feature = "oid")]

--- a/der/src/asn1.rs
+++ b/der/src/asn1.rs
@@ -48,8 +48,8 @@ pub use self::{
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub use self::{
-    any::Any, bit_string::BitString, integer::bigint::Uint, octet_string::OctetString,
-    set_of::SetOfVec,
+    any::Any, bit_string::BitString, ia5_string::Ia5String, integer::bigint::Uint,
+    octet_string::OctetString, set_of::SetOfVec,
 };
 
 #[cfg(feature = "oid")]

--- a/der/src/asn1.rs
+++ b/der/src/asn1.rs
@@ -49,7 +49,8 @@ pub use self::{
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub use self::{
     any::Any, bit_string::BitString, ia5_string::Ia5String, integer::bigint::Uint,
-    octet_string::OctetString, set_of::SetOfVec, teletex_string::TeletexString,
+    octet_string::OctetString, printable_string::PrintableString, set_of::SetOfVec,
+    teletex_string::TeletexString,
 };
 
 #[cfg(feature = "oid")]

--- a/der/src/asn1/ia5_string.rs
+++ b/der/src/asn1/ia5_string.rs
@@ -129,6 +129,154 @@ impl<'a> fmt::Debug for Ia5StringRef<'a> {
     }
 }
 
+#[cfg(feature = "alloc")]
+pub use self::allocation::Ia5String;
+
+#[cfg(feature = "alloc")]
+mod allocation {
+    use super::Ia5StringRef;
+    use crate::{
+        asn1::{Any, AnyRef},
+        ord::OrdIsValueOrd,
+        referenced::{OwnedToRef, RefToOwned},
+        ByteSlice, DecodeValue, EncodeValue, Error, FixedTag, Header, Length, Reader, Result,
+        String, Tag, Writer,
+    };
+    use core::{fmt, ops::Deref, str};
+
+    /// ASN.1 `IA5String` type.
+    ///
+    /// Supports the [International Alphabet No. 5 (IA5)] character encoding, i.e.
+    /// the lower 128 characters of the ASCII alphabet. (Note: IA5 is now
+    /// technically known as the International Reference Alphabet or IRA as
+    /// specified in the ITU-T's T.50 recommendation).
+    ///
+    /// For UTF-8, use [`String`][`alloc::string::String`].
+    ///
+    /// [International Alphabet No. 5 (IA5)]: https://en.wikipedia.org/wiki/T.50_%28standard%29
+    #[derive(Clone, Eq, PartialEq, PartialOrd, Ord)]
+    pub struct Ia5String {
+        /// Inner value
+        inner: String,
+    }
+
+    impl Ia5String {
+        /// Create a new `IA5String`.
+        pub fn new<T>(input: &T) -> Result<Self>
+        where
+            T: AsRef<[u8]> + ?Sized,
+        {
+            let input = input.as_ref();
+            Ia5StringRef::new(input)?;
+
+            String::from_bytes(input)
+                .map(|inner| Self { inner })
+                .map_err(|_| Self::TAG.value_error())
+        }
+    }
+
+    impl Deref for Ia5String {
+        type Target = String;
+
+        fn deref(&self) -> &Self::Target {
+            &self.inner
+        }
+    }
+
+    impl AsRef<str> for Ia5String {
+        fn as_ref(&self) -> &str {
+            self.as_str()
+        }
+    }
+
+    impl AsRef<[u8]> for Ia5String {
+        fn as_ref(&self) -> &[u8] {
+            self.as_bytes()
+        }
+    }
+
+    impl<'a> DecodeValue<'a> for Ia5String {
+        fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
+            Self::new(ByteSlice::decode_value(reader, header)?.as_slice())
+        }
+    }
+
+    impl EncodeValue for Ia5String {
+        fn value_len(&self) -> Result<Length> {
+            self.inner.value_len()
+        }
+
+        fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+            self.inner.encode_value(writer)
+        }
+    }
+
+    impl FixedTag for Ia5String {
+        const TAG: Tag = Tag::Ia5String;
+    }
+
+    impl OrdIsValueOrd for Ia5String {}
+
+    impl<'a> TryFrom<&AnyRef<'a>> for Ia5String {
+        type Error = Error;
+
+        fn try_from(any: &AnyRef<'a>) -> Result<Ia5String> {
+            (*any).decode_into()
+        }
+    }
+
+    impl<'a> TryFrom<&'a Any> for Ia5String {
+        type Error = Error;
+
+        fn try_from(any: &'a Any) -> Result<Ia5String> {
+            any.decode_into()
+        }
+    }
+
+    impl<'a> From<Ia5StringRef<'a>> for Ia5String {
+        fn from(international_string: Ia5StringRef<'a>) -> Ia5String {
+            let inner = international_string.inner.into();
+            Self { inner }
+        }
+    }
+
+    impl<'a> From<&'a Ia5String> for AnyRef<'a> {
+        fn from(international_string: &'a Ia5String) -> AnyRef<'a> {
+            AnyRef::from_tag_and_value(Tag::Ia5String, (&international_string.inner).into())
+        }
+    }
+
+    impl fmt::Display for Ia5String {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str(self.as_str())
+        }
+    }
+
+    impl fmt::Debug for Ia5String {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "Ia5String({:?})", self.as_str())
+        }
+    }
+
+    impl<'a> RefToOwned<'a> for Ia5StringRef<'a> {
+        type Owned = Ia5String;
+        fn to_owned(&self) -> Self::Owned {
+            Ia5String {
+                inner: self.inner.to_owned(),
+            }
+        }
+    }
+
+    impl OwnedToRef for Ia5String {
+        type Borrowed<'a> = Ia5StringRef<'a>;
+        fn to_ref(&self) -> Self::Borrowed<'_> {
+            Ia5StringRef {
+                inner: self.inner.to_ref(),
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::Ia5StringRef;

--- a/der/src/asn1/printable_string.rs
+++ b/der/src/asn1/printable_string.rs
@@ -163,6 +163,176 @@ impl<'a> fmt::Debug for PrintableStringRef<'a> {
     }
 }
 
+#[cfg(feature = "alloc")]
+pub use self::allocation::PrintableString;
+
+#[cfg(feature = "alloc")]
+mod allocation {
+    use super::PrintableStringRef;
+
+    use crate::{
+        asn1::{Any, AnyRef},
+        ord::OrdIsValueOrd,
+        referenced::{OwnedToRef, RefToOwned},
+        ByteSlice, DecodeValue, EncodeValue, Error, FixedTag, Header, Length, Reader, Result,
+        String, Tag, Writer,
+    };
+    use core::{fmt, ops::Deref, str};
+
+    /// ASN.1 `PrintableString` type.
+    ///
+    /// Supports a subset the ASCII character set (described below).
+    ///
+    /// For UTF-8, use [`Utf8StringRef`][`crate::asn1::Utf8StringRef`] instead.
+    /// For the full ASCII character set, use
+    /// [`Ia5StringRef`][`crate::asn1::Ia5StringRef`].
+    ///
+    /// # Supported characters
+    ///
+    /// The following ASCII characters/ranges are supported:
+    ///
+    /// - `A..Z`
+    /// - `a..z`
+    /// - `0..9`
+    /// - "` `" (i.e. space)
+    /// - `\`
+    /// - `(`
+    /// - `)`
+    /// - `+`
+    /// - `,`
+    /// - `-`
+    /// - `.`
+    /// - `/`
+    /// - `:`
+    /// - `=`
+    /// - `?`
+    #[derive(Clone, Eq, PartialEq, PartialOrd, Ord)]
+    pub struct PrintableString {
+        /// Inner value
+        inner: String,
+    }
+
+    impl PrintableString {
+        /// Create a new ASN.1 `PrintableString`.
+        pub fn new<T>(input: &T) -> Result<Self>
+        where
+            T: AsRef<[u8]> + ?Sized,
+        {
+            let input = input.as_ref();
+            PrintableStringRef::new(input)?;
+
+            String::from_bytes(input)
+                .map(|inner| Self { inner })
+                .map_err(|_| Self::TAG.value_error())
+        }
+    }
+
+    impl Deref for PrintableString {
+        type Target = String;
+
+        fn deref(&self) -> &Self::Target {
+            &self.inner
+        }
+    }
+
+    impl AsRef<str> for PrintableString {
+        fn as_ref(&self) -> &str {
+            self.as_str()
+        }
+    }
+
+    impl AsRef<[u8]> for PrintableString {
+        fn as_ref(&self) -> &[u8] {
+            self.as_bytes()
+        }
+    }
+
+    impl<'a> DecodeValue<'a> for PrintableString {
+        fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
+            Self::new(ByteSlice::decode_value(reader, header)?.as_slice())
+        }
+    }
+
+    impl EncodeValue for PrintableString {
+        fn value_len(&self) -> Result<Length> {
+            self.inner.value_len()
+        }
+
+        fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+            self.inner.encode_value(writer)
+        }
+    }
+
+    impl FixedTag for PrintableString {
+        const TAG: Tag = Tag::PrintableString;
+    }
+
+    impl OrdIsValueOrd for PrintableString {}
+
+    impl<'a> From<PrintableStringRef<'a>> for PrintableString {
+        fn from(value: PrintableStringRef<'a>) -> PrintableString {
+            let inner =
+                String::from_bytes(value.inner.as_bytes()).expect("Invalid PrintableString");
+            Self { inner }
+        }
+    }
+
+    impl<'a> TryFrom<&AnyRef<'a>> for PrintableString {
+        type Error = Error;
+
+        fn try_from(any: &AnyRef<'a>) -> Result<PrintableString> {
+            (*any).decode_into()
+        }
+    }
+
+    impl<'a> TryFrom<&'a Any> for PrintableString {
+        type Error = Error;
+
+        fn try_from(any: &'a Any) -> Result<PrintableString> {
+            any.decode_into()
+        }
+    }
+
+    impl<'a> From<&'a PrintableString> for AnyRef<'a> {
+        fn from(printable_string: &'a PrintableString) -> AnyRef<'a> {
+            AnyRef::from_tag_and_value(
+                Tag::PrintableString,
+                ByteSlice::new(printable_string.inner.as_bytes()).expect("Invalid PrintableString"),
+            )
+        }
+    }
+
+    impl fmt::Display for PrintableString {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str(self.as_str())
+        }
+    }
+
+    impl fmt::Debug for PrintableString {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "PrintableString({:?})", self.as_str())
+        }
+    }
+
+    impl<'a> RefToOwned<'a> for PrintableStringRef<'a> {
+        type Owned = PrintableString;
+        fn to_owned(&self) -> Self::Owned {
+            PrintableString {
+                inner: self.inner.to_owned(),
+            }
+        }
+    }
+
+    impl OwnedToRef for PrintableString {
+        type Borrowed<'a> = PrintableStringRef<'a>;
+        fn to_ref(&self) -> Self::Borrowed<'_> {
+            PrintableStringRef {
+                inner: self.inner.to_ref(),
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::PrintableStringRef;

--- a/der/src/asn1/teletex_string.rs
+++ b/der/src/asn1/teletex_string.rs
@@ -133,6 +133,163 @@ impl<'a> fmt::Debug for TeletexStringRef<'a> {
     }
 }
 
+#[cfg(feature = "alloc")]
+pub use self::allocation::TeletexString;
+
+#[cfg(feature = "alloc")]
+mod allocation {
+    use super::TeletexStringRef;
+
+    use crate::{
+        asn1::{Any, AnyRef},
+        ord::OrdIsValueOrd,
+        referenced::{OwnedToRef, RefToOwned},
+        ByteSlice, DecodeValue, EncodeValue, Error, FixedTag, Header, Length, Reader, Result,
+        String, Tag, Writer,
+    };
+    use core::{fmt, ops::Deref, str};
+
+    /// ASN.1 `TeletexString` type.
+    ///
+    /// Supports a subset the ASCII character set (described below).
+    ///
+    /// For UTF-8, use [`Utf8StringRef`][`crate::asn1::Utf8StringRef`] instead.
+    /// For the full ASCII character set, use
+    /// [`Ia5StringRef`][`crate::asn1::Ia5StringRef`].
+    ///
+    /// # Supported characters
+    ///
+    /// The standard defines a complex character set allowed in this type. However, quoting the ASN.1
+    /// mailing list, "a sizable volume of software in the world treats TeletexString (T61String) as a
+    /// simple 8-bit string with mostly Windows Latin 1 (superset of iso-8859-1) encoding".
+    ///
+    #[derive(Clone, Eq, PartialEq, PartialOrd, Ord)]
+    pub struct TeletexString {
+        /// Inner value
+        inner: String,
+    }
+
+    impl TeletexString {
+        /// Create a new ASN.1 `TeletexString`.
+        pub fn new<T>(input: &T) -> Result<Self>
+        where
+            T: AsRef<[u8]> + ?Sized,
+        {
+            let input = input.as_ref();
+
+            TeletexStringRef::new(input)?;
+
+            String::from_bytes(input)
+                .map(|inner| Self { inner })
+                .map_err(|_| Self::TAG.value_error())
+        }
+    }
+
+    impl Deref for TeletexString {
+        type Target = String;
+
+        fn deref(&self) -> &Self::Target {
+            &self.inner
+        }
+    }
+
+    impl AsRef<str> for TeletexString {
+        fn as_ref(&self) -> &str {
+            self.as_str()
+        }
+    }
+
+    impl AsRef<[u8]> for TeletexString {
+        fn as_ref(&self) -> &[u8] {
+            self.as_bytes()
+        }
+    }
+
+    impl<'a> DecodeValue<'a> for TeletexString {
+        fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
+            Self::new(ByteSlice::decode_value(reader, header)?.as_slice())
+        }
+    }
+
+    impl EncodeValue for TeletexString {
+        fn value_len(&self) -> Result<Length> {
+            self.inner.value_len()
+        }
+
+        fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+            self.inner.encode_value(writer)
+        }
+    }
+
+    impl FixedTag for TeletexString {
+        const TAG: Tag = Tag::TeletexString;
+    }
+
+    impl OrdIsValueOrd for TeletexString {}
+
+    impl<'a> From<TeletexStringRef<'a>> for TeletexString {
+        fn from(value: TeletexStringRef<'a>) -> TeletexString {
+            let inner = String::from_bytes(value.inner.as_bytes()).expect("Invalid TeletexString");
+            Self { inner }
+        }
+    }
+
+    impl<'a> TryFrom<&AnyRef<'a>> for TeletexString {
+        type Error = Error;
+
+        fn try_from(any: &AnyRef<'a>) -> Result<TeletexString> {
+            (*any).decode_into()
+        }
+    }
+
+    impl<'a> TryFrom<&'a Any> for TeletexString {
+        type Error = Error;
+
+        fn try_from(any: &'a Any) -> Result<TeletexString> {
+            any.decode_into()
+        }
+    }
+
+    impl<'a> From<&'a TeletexString> for AnyRef<'a> {
+        fn from(teletex_string: &'a TeletexString) -> AnyRef<'a> {
+            AnyRef::from_tag_and_value(
+                Tag::TeletexString,
+                ByteSlice::new(teletex_string.inner.as_bytes()).expect("Invalid TeletexString"),
+            )
+        }
+    }
+
+    impl fmt::Display for TeletexString {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str(self.as_str())
+        }
+    }
+
+    impl fmt::Debug for TeletexString {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "TeletexString({:?})", self.as_str())
+        }
+    }
+
+    impl<'a> RefToOwned<'a> for TeletexStringRef<'a> {
+        type Owned = TeletexString;
+        fn to_owned(&self) -> Self::Owned {
+            TeletexString {
+                inner: self.inner.to_owned(),
+            }
+        }
+    }
+
+    impl OwnedToRef for TeletexString {
+        type Borrowed<'a> = TeletexStringRef<'a>;
+        fn to_ref(&self) -> Self::Borrowed<'_> {
+            TeletexStringRef {
+                inner: self.inner.to_ref(),
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::TeletexStringRef;

--- a/der/src/byte_slice.rs
+++ b/der/src/byte_slice.rs
@@ -7,6 +7,9 @@ use crate::{
 };
 use core::cmp::Ordering;
 
+#[cfg(feature = "alloc")]
+use crate::string::String;
+
 /// Byte slice newtype which respects the `Length::max()` limit.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub(crate) struct ByteSlice<'a> {
@@ -88,6 +91,19 @@ impl DerOrd for ByteSlice<'_> {
 
 impl<'a> From<StrSlice<'a>> for ByteSlice<'a> {
     fn from(s: StrSlice<'a>) -> ByteSlice<'a> {
+        let bytes = s.as_bytes();
+        debug_assert_eq!(bytes.len(), usize::try_from(s.length).expect("overflow"));
+
+        ByteSlice {
+            inner: bytes,
+            length: s.length,
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a> From<&'a String> for ByteSlice<'a> {
+    fn from(s: &'a String) -> ByteSlice<'a> {
         let bytes = s.as_bytes();
         debug_assert_eq!(bytes.len(), usize::try_from(s.length).expect("overflow"));
 

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -361,6 +361,8 @@ mod writer;
 mod bytes;
 #[cfg(feature = "alloc")]
 mod document;
+#[cfg(feature = "alloc")]
+mod string;
 
 pub use crate::{
     asn1::{AnyRef, Choice, Sequence},
@@ -409,6 +411,6 @@ pub use zeroize;
 #[cfg(all(feature = "alloc", feature = "zeroize"))]
 pub use crate::document::SecretDocument;
 
-#[cfg(feature = "alloc")]
-pub(crate) use crate::bytes::Bytes;
 pub(crate) use crate::{arrayvec::ArrayVec, byte_slice::ByteSlice, str_slice::StrSlice};
+#[cfg(feature = "alloc")]
+pub(crate) use crate::{bytes::Bytes, string::String};

--- a/der/src/str_slice.rs
+++ b/der/src/str_slice.rs
@@ -77,3 +77,16 @@ impl<'a> EncodeValue for StrSlice<'a> {
         writer.write(self.as_ref())
     }
 }
+
+#[cfg(feature = "alloc")]
+mod allocating {
+    use super::StrSlice;
+    use crate::{referenced::RefToOwned, String};
+
+    impl<'a> RefToOwned<'a> for StrSlice<'a> {
+        type Owned = String;
+        fn to_owned(&self) -> Self::Owned {
+            String::from(*self)
+        }
+    }
+}

--- a/der/src/string.rs
+++ b/der/src/string.rs
@@ -1,0 +1,105 @@
+//! Common handling for types backed by `String` with enforcement of a
+//! library-level length limitation i.e. `Length::max()`.
+
+use crate::{
+    referenced::OwnedToRef, ByteSlice, DecodeValue, EncodeValue, Header, Length, Reader, Result,
+    StrSlice, Writer,
+};
+use alloc::string::String as StringA;
+use core::str;
+
+/// String newtype which respects the [`Length::max`] limit.
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct String {
+    /// Inner value
+    pub(crate) inner: StringA,
+
+    /// Precomputed `Length` (avoids possible panicking conversions)
+    pub(crate) length: Length,
+}
+
+impl String {
+    /// Create a new [`StrSlice`], ensuring that the byte representation of
+    /// the provided `str` value is shorter than `Length::max()`.
+    pub fn new(s: &str) -> Result<Self> {
+        Ok(Self {
+            inner: StringA::from(s),
+            length: Length::try_from(s.as_bytes().len())?,
+        })
+    }
+
+    /// Parse a [`StrSlice`] from UTF-8 encoded bytes.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
+        Ok(Self {
+            inner: StringA::from_utf8(bytes.to_vec())?,
+            length: Length::try_from(bytes.len())?,
+        })
+    }
+
+    /// Borrow the inner `str`
+    pub fn as_str(&self) -> &str {
+        &self.inner
+    }
+
+    /// Borrow the inner byte slice
+    pub fn as_bytes(&self) -> &[u8] {
+        self.inner.as_bytes()
+    }
+
+    /// Get the [`Length`] of this [`StrSlice`]
+    pub fn len(&self) -> Length {
+        self.length
+    }
+
+    /// Is this [`StrSlice`] empty?
+    pub fn is_empty(&self) -> bool {
+        self.len() == Length::ZERO
+    }
+}
+
+impl AsRef<str> for String {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl AsRef<[u8]> for String {
+    fn as_ref(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}
+
+impl<'a> DecodeValue<'a> for String {
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
+        Self::from_bytes(ByteSlice::decode_value(reader, header)?.as_slice())
+    }
+}
+
+impl EncodeValue for String {
+    fn value_len(&self) -> Result<Length> {
+        Ok(self.length)
+    }
+
+    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+        writer.write(self.as_ref())
+    }
+}
+
+impl From<StrSlice<'_>> for String {
+    fn from(s: StrSlice<'_>) -> String {
+        Self {
+            inner: StringA::from(s.inner),
+            length: s.length,
+        }
+    }
+}
+
+impl OwnedToRef for String {
+    type Borrowed<'a> = StrSlice<'a>;
+    fn to_ref(&self) -> Self::Borrowed<'_> {
+        StrSlice {
+            length: self.length,
+            inner: self.inner.as_ref(),
+        }
+    }
+}

--- a/x509-cert/src/anchor.rs
+++ b/x509-cert/src/anchor.rs
@@ -81,7 +81,7 @@ pub struct CertPathControls<'a> {
     pub certificate: Option<Certificate<'a>>,
 
     #[asn1(context_specific = "1", tag_mode = "IMPLICIT", optional = "true")]
-    pub policy_set: Option<CertificatePolicies<'a>>,
+    pub policy_set: Option<CertificatePolicies>,
 
     #[asn1(context_specific = "2", tag_mode = "IMPLICIT", optional = "true")]
     pub policy_flags: Option<CertPolicyFlags>,

--- a/x509-cert/src/anchor.rs
+++ b/x509-cert/src/anchor.rs
@@ -2,7 +2,7 @@
 
 use crate::ext::pkix::{certpolicy::CertificatePolicies, NameConstraints};
 use crate::{ext::Extensions, name::Name};
-use crate::{Certificate, TbsCertificate};
+use crate::{CertificateRef, TbsCertificateRef};
 
 use alloc::string::String;
 use der::asn1::OctetString;
@@ -79,7 +79,7 @@ pub struct CertPathControls<'a> {
     pub ta_name: Name,
 
     #[asn1(context_specific = "0", tag_mode = "IMPLICIT", optional = "true")]
-    pub certificate: Option<Certificate<'a>>,
+    pub certificate: Option<CertificateRef<'a>>,
 
     #[asn1(context_specific = "1", tag_mode = "IMPLICIT", optional = "true")]
     pub policy_set: Option<CertificatePolicies>,
@@ -130,10 +130,10 @@ pub type CertPolicyFlags = FlagSet<CertPolicies>;
 #[allow(clippy::large_enum_variant)]
 #[allow(missing_docs)]
 pub enum TrustAnchorChoice<'a> {
-    Certificate(Certificate<'a>),
+    Certificate(CertificateRef<'a>),
 
     #[asn1(context_specific = "1", tag_mode = "EXPLICIT", constructed = "true")]
-    TbsCertificate(TbsCertificate<'a>),
+    TbsCertificate(TbsCertificateRef<'a>),
 
     #[asn1(context_specific = "2", tag_mode = "EXPLICIT", constructed = "true")]
     TaInfo(TrustAnchorInfo<'a>),

--- a/x509-cert/src/anchor.rs
+++ b/x509-cert/src/anchor.rs
@@ -4,7 +4,8 @@ use crate::ext::pkix::{certpolicy::CertificatePolicies, NameConstraints};
 use crate::{ext::Extensions, name::Name};
 use crate::{Certificate, TbsCertificate};
 
-use der::asn1::{OctetStringRef, Utf8StringRef};
+use alloc::string::String;
+use der::asn1::OctetString;
 use der::{Choice, Enumerated, Sequence};
 use flagset::{flags, FlagSet};
 use spki::SubjectPublicKeyInfoRef;
@@ -47,10 +48,10 @@ pub struct TrustAnchorInfo<'a> {
 
     pub pub_key: SubjectPublicKeyInfoRef<'a>,
 
-    pub key_id: OctetStringRef<'a>,
+    pub key_id: OctetString,
 
     #[asn1(optional = "true")]
-    pub ta_title: Option<Utf8StringRef<'a>>,
+    pub ta_title: Option<String>,
 
     #[asn1(optional = "true")]
     pub cert_path: Option<CertPathControls<'a>>,
@@ -59,7 +60,7 @@ pub struct TrustAnchorInfo<'a> {
     pub extensions: Option<Extensions>,
 
     #[asn1(context_specific = "2", tag_mode = "IMPLICIT", optional = "true")]
-    pub ta_title_lang_tag: Option<Utf8StringRef<'a>>,
+    pub ta_title_lang_tag: Option<String>,
 }
 
 /// ```text

--- a/x509-cert/src/anchor.rs
+++ b/x509-cert/src/anchor.rs
@@ -56,7 +56,7 @@ pub struct TrustAnchorInfo<'a> {
     pub cert_path: Option<CertPathControls<'a>>,
 
     #[asn1(context_specific = "1", tag_mode = "EXPLICIT", optional = "true")]
-    pub extensions: Option<Extensions<'a>>,
+    pub extensions: Option<Extensions>,
 
     #[asn1(context_specific = "2", tag_mode = "IMPLICIT", optional = "true")]
     pub ta_title_lang_tag: Option<Utf8StringRef<'a>>,

--- a/x509-cert/src/anchor.rs
+++ b/x509-cert/src/anchor.rs
@@ -87,7 +87,7 @@ pub struct CertPathControls<'a> {
     pub policy_flags: Option<CertPolicyFlags>,
 
     #[asn1(context_specific = "3", tag_mode = "IMPLICIT", optional = "true")]
-    pub name_constr: Option<NameConstraints<'a>>,
+    pub name_constr: Option<NameConstraints>,
 
     #[asn1(context_specific = "4", tag_mode = "IMPLICIT", optional = "true")]
     pub path_len_constraint: Option<u32>,

--- a/x509-cert/src/certificate.rs
+++ b/x509-cert/src/certificate.rs
@@ -6,7 +6,7 @@ use alloc::vec::Vec;
 use core::cmp::Ordering;
 
 use const_oid::AssociatedOid;
-use der::asn1::BitStringRef;
+use der::asn1::BitString;
 use der::{Decode, Enumerated, Error, ErrorKind, Sequence, ValueOrd};
 use spki::{AlgorithmIdentifierRef, SubjectPublicKeyInfoRef};
 
@@ -91,10 +91,10 @@ pub struct TbsCertificate<'a> {
     pub subject_public_key_info: SubjectPublicKeyInfoRef<'a>,
 
     #[asn1(context_specific = "1", tag_mode = "IMPLICIT", optional = "true")]
-    pub issuer_unique_id: Option<BitStringRef<'a>>,
+    pub issuer_unique_id: Option<BitString>,
 
     #[asn1(context_specific = "2", tag_mode = "IMPLICIT", optional = "true")]
-    pub subject_unique_id: Option<BitStringRef<'a>>,
+    pub subject_unique_id: Option<BitString>,
 
     #[asn1(context_specific = "3", tag_mode = "EXPLICIT", optional = "true")]
     pub extensions: Option<crate::ext::Extensions>,
@@ -150,7 +150,7 @@ impl<'a> TbsCertificate<'a> {
 pub struct Certificate<'a> {
     pub tbs_certificate: TbsCertificate<'a>,
     pub signature_algorithm: AlgorithmIdentifierRef<'a>,
-    pub signature: BitStringRef<'a>,
+    pub signature: BitString,
 }
 
 #[cfg(feature = "pem")]

--- a/x509-cert/src/certificate.rs
+++ b/x509-cert/src/certificate.rs
@@ -97,7 +97,7 @@ pub struct TbsCertificate<'a> {
     pub subject_unique_id: Option<BitStringRef<'a>>,
 
     #[asn1(context_specific = "3", tag_mode = "EXPLICIT", optional = "true")]
-    pub extensions: Option<crate::ext::Extensions<'a>>,
+    pub extensions: Option<crate::ext::Extensions>,
 }
 
 impl<'a> TbsCertificate<'a> {
@@ -130,7 +130,7 @@ impl<'a> TbsCertificate<'a> {
             .unwrap_or(&[])
             .iter()
             .filter(|e| e.extn_id == T::OID)
-            .map(|e| Ok((e.critical, T::from_der(e.extn_value)?)))
+            .map(|e| Ok((e.critical, T::from_der(e.extn_value.as_bytes())?)))
     }
 }
 

--- a/x509-cert/src/crl.rs
+++ b/x509-cert/src/crl.rs
@@ -8,7 +8,7 @@ use crate::Version;
 
 use alloc::vec::Vec;
 
-use der::asn1::BitStringRef;
+use der::asn1::BitString;
 use der::{Sequence, ValueOrd};
 use spki::AlgorithmIdentifierRef;
 
@@ -28,7 +28,7 @@ use spki::AlgorithmIdentifierRef;
 pub struct CertificateList<'a> {
     pub tbs_cert_list: TbsCertList<'a>,
     pub signature_algorithm: AlgorithmIdentifierRef<'a>,
-    pub signature: BitStringRef<'a>,
+    pub signature: BitString,
 }
 
 /// Implicit intermediate structure from the ASN.1 definition of `TBSCertList`.

--- a/x509-cert/src/crl.rs
+++ b/x509-cert/src/crl.rs
@@ -47,10 +47,10 @@ pub struct CertificateList<'a> {
 /// [RFC 5280 Section 5.1]: https://datatracker.ietf.org/doc/html/rfc5280#section-5.1
 #[derive(Clone, Debug, Eq, PartialEq, Sequence, ValueOrd)]
 #[allow(missing_docs)]
-pub struct RevokedCert<'a> {
+pub struct RevokedCert {
     pub serial_number: SerialNumber,
     pub revocation_date: Time,
-    pub crl_entry_extensions: Option<Extensions<'a>>,
+    pub crl_entry_extensions: Option<Extensions>,
 }
 
 /// `TbsCertList` as defined in [RFC 5280 Section 5.1].
@@ -80,8 +80,8 @@ pub struct TbsCertList<'a> {
     pub issuer: Name,
     pub this_update: Time,
     pub next_update: Option<Time>,
-    pub revoked_certificates: Option<Vec<RevokedCert<'a>>>,
+    pub revoked_certificates: Option<Vec<RevokedCert>>,
 
     #[asn1(context_specific = "0", tag_mode = "EXPLICIT", optional = "true")]
-    pub crl_extensions: Option<Extensions<'a>>,
+    pub crl_extensions: Option<Extensions>,
 }

--- a/x509-cert/src/ext.rs
+++ b/x509-cert/src/ext.rs
@@ -1,6 +1,6 @@
 //! Standardized X.509 Certificate Extensions
 
-use der::{Sequence, ValueOrd};
+use der::{asn1::OctetString, Sequence, ValueOrd};
 use spki::ObjectIdentifier;
 
 pub mod pkix;
@@ -24,14 +24,13 @@ pub mod pkix;
 /// [RFC 5280 Section 4.1.2.9]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.9
 #[derive(Clone, Debug, Eq, PartialEq, Sequence, ValueOrd)]
 #[allow(missing_docs)]
-pub struct Extension<'a> {
+pub struct Extension {
     pub extn_id: ObjectIdentifier,
 
     #[asn1(default = "Default::default")]
     pub critical: bool,
 
-    #[asn1(type = "OCTET STRING")]
-    pub extn_value: &'a [u8],
+    pub extn_value: OctetString,
 }
 
 /// Extensions as defined in [RFC 5280 Section 4.1.2.9].
@@ -41,4 +40,4 @@ pub struct Extension<'a> {
 /// ```
 ///
 /// [RFC 5280 Section 4.1.2.9]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.9
-pub type Extensions<'a> = alloc::vec::Vec<Extension<'a>>;
+pub type Extensions = alloc::vec::Vec<Extension>;

--- a/x509-cert/src/ext/pkix.rs
+++ b/x509-cert/src/ext/pkix.rs
@@ -57,13 +57,13 @@ impl_newtype!(SubjectKeyIdentifier, OctetString);
 ///
 /// [RFC 5280 Section 4.2.1.6]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.6
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct SubjectAltName<'a>(pub name::GeneralNames<'a>);
+pub struct SubjectAltName(pub name::GeneralNames);
 
-impl<'a> AssociatedOid for SubjectAltName<'a> {
+impl AssociatedOid for SubjectAltName {
     const OID: ObjectIdentifier = ID_CE_SUBJECT_ALT_NAME;
 }
 
-impl_newtype!(SubjectAltName<'a>, name::GeneralNames<'a>);
+impl_newtype!(SubjectAltName, name::GeneralNames);
 
 /// IssuerAltName as defined in [RFC 5280 Section 4.2.1.7].
 ///
@@ -73,13 +73,13 @@ impl_newtype!(SubjectAltName<'a>, name::GeneralNames<'a>);
 ///
 /// [RFC 5280 Section 4.2.1.7]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.7
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct IssuerAltName<'a>(pub name::GeneralNames<'a>);
+pub struct IssuerAltName(pub name::GeneralNames);
 
-impl<'a> AssociatedOid for IssuerAltName<'a> {
+impl AssociatedOid for IssuerAltName {
     const OID: ObjectIdentifier = ID_CE_ISSUER_ALT_NAME;
 }
 
-impl_newtype!(IssuerAltName<'a>, name::GeneralNames<'a>);
+impl_newtype!(IssuerAltName, name::GeneralNames);
 
 /// SubjectDirectoryAttributes as defined in [RFC 5280 Section 4.2.1.8].
 ///

--- a/x509-cert/src/ext/pkix.rs
+++ b/x509-cert/src/ext/pkix.rs
@@ -31,7 +31,7 @@ pub use const_oid::db::rfc5280::{
 
 use alloc::vec::Vec;
 
-use der::asn1::OctetStringRef;
+use der::asn1::OctetString;
 
 /// SubjectKeyIdentifier as defined in [RFC 5280 Section 4.2.1.2].
 ///
@@ -40,14 +40,14 @@ use der::asn1::OctetStringRef;
 /// ```
 ///
 /// [RFC 5280 Section 4.2.1.2]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.2
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct SubjectKeyIdentifier<'a>(pub OctetStringRef<'a>);
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SubjectKeyIdentifier(pub OctetString);
 
-impl<'a> AssociatedOid for SubjectKeyIdentifier<'a> {
+impl AssociatedOid for SubjectKeyIdentifier {
     const OID: ObjectIdentifier = ID_CE_SUBJECT_KEY_IDENTIFIER;
 }
 
-impl_newtype!(SubjectKeyIdentifier<'a>, OctetStringRef<'a>);
+impl_newtype!(SubjectKeyIdentifier, OctetString);
 
 /// SubjectAltName as defined in [RFC 5280 Section 4.2.1.6].
 ///

--- a/x509-cert/src/ext/pkix/access.rs
+++ b/x509-cert/src/ext/pkix/access.rs
@@ -16,13 +16,13 @@ use der::{asn1::ObjectIdentifier, Sequence, ValueOrd};
 ///
 /// [RFC 5280 Section 4.2.2.1]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.2.1
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct AuthorityInfoAccessSyntax<'a>(pub Vec<AccessDescription<'a>>);
+pub struct AuthorityInfoAccessSyntax(pub Vec<AccessDescription>);
 
-impl<'a> AssociatedOid for AuthorityInfoAccessSyntax<'a> {
+impl AssociatedOid for AuthorityInfoAccessSyntax {
     const OID: ObjectIdentifier = ID_PE_AUTHORITY_INFO_ACCESS;
 }
 
-impl_newtype!(AuthorityInfoAccessSyntax<'a>, Vec<AccessDescription<'a>>);
+impl_newtype!(AuthorityInfoAccessSyntax, Vec<AccessDescription>);
 
 /// SubjectInfoAccessSyntax as defined in [RFC 5280 Section 4.2.2.2].
 ///
@@ -32,13 +32,13 @@ impl_newtype!(AuthorityInfoAccessSyntax<'a>, Vec<AccessDescription<'a>>);
 ///
 /// [RFC 5280 Section 4.2.2.2]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.2.2
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct SubjectInfoAccessSyntax<'a>(pub Vec<AccessDescription<'a>>);
+pub struct SubjectInfoAccessSyntax(pub Vec<AccessDescription>);
 
-impl<'a> AssociatedOid for SubjectInfoAccessSyntax<'a> {
+impl AssociatedOid for SubjectInfoAccessSyntax {
     const OID: ObjectIdentifier = ID_PE_SUBJECT_INFO_ACCESS;
 }
 
-impl_newtype!(SubjectInfoAccessSyntax<'a>, Vec<AccessDescription<'a>>);
+impl_newtype!(SubjectInfoAccessSyntax, Vec<AccessDescription>);
 
 /// AccessDescription as defined in [RFC 5280 Section 4.2.2.1].
 ///
@@ -52,7 +52,7 @@ impl_newtype!(SubjectInfoAccessSyntax<'a>, Vec<AccessDescription<'a>>);
 /// [RFC 5280 Section 4.2.2.1]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.2.1
 #[derive(Clone, Debug, Eq, PartialEq, Sequence, ValueOrd)]
 #[allow(missing_docs)]
-pub struct AccessDescription<'a> {
+pub struct AccessDescription {
     pub access_method: ObjectIdentifier,
-    pub access_location: GeneralName<'a>,
+    pub access_location: GeneralName,
 }

--- a/x509-cert/src/ext/pkix/authkeyid.rs
+++ b/x509-cert/src/ext/pkix/authkeyid.rs
@@ -3,7 +3,7 @@ use crate::serial_number::SerialNumber;
 
 use const_oid::db::rfc5280::ID_CE_AUTHORITY_KEY_IDENTIFIER;
 use const_oid::{AssociatedOid, ObjectIdentifier};
-use der::asn1::OctetStringRef;
+use der::asn1::OctetString;
 use der::Sequence;
 
 /// AuthorityKeyIdentifier as defined in [RFC 5280 Section 4.2.1.1].
@@ -21,9 +21,9 @@ use der::Sequence;
 /// [RFC 5280 Section 4.2.1.1]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.1
 #[derive(Clone, Debug, Eq, PartialEq, Sequence)]
 #[allow(missing_docs)]
-pub struct AuthorityKeyIdentifier<'a> {
+pub struct AuthorityKeyIdentifier {
     #[asn1(context_specific = "0", tag_mode = "IMPLICIT", optional = "true")]
-    pub key_identifier: Option<OctetStringRef<'a>>,
+    pub key_identifier: Option<OctetString>,
 
     #[asn1(context_specific = "1", tag_mode = "IMPLICIT", optional = "true")]
     pub authority_cert_issuer: Option<GeneralNames>,
@@ -32,6 +32,6 @@ pub struct AuthorityKeyIdentifier<'a> {
     pub authority_cert_serial_number: Option<SerialNumber>,
 }
 
-impl<'a> AssociatedOid for AuthorityKeyIdentifier<'a> {
+impl AssociatedOid for AuthorityKeyIdentifier {
     const OID: ObjectIdentifier = ID_CE_AUTHORITY_KEY_IDENTIFIER;
 }

--- a/x509-cert/src/ext/pkix/authkeyid.rs
+++ b/x509-cert/src/ext/pkix/authkeyid.rs
@@ -26,7 +26,7 @@ pub struct AuthorityKeyIdentifier<'a> {
     pub key_identifier: Option<OctetStringRef<'a>>,
 
     #[asn1(context_specific = "1", tag_mode = "IMPLICIT", optional = "true")]
-    pub authority_cert_issuer: Option<GeneralNames<'a>>,
+    pub authority_cert_issuer: Option<GeneralNames>,
 
     #[asn1(context_specific = "2", tag_mode = "IMPLICIT", optional = "true")]
     pub authority_cert_serial_number: Option<SerialNumber>,

--- a/x509-cert/src/ext/pkix/certpolicy.rs
+++ b/x509-cert/src/ext/pkix/certpolicy.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 
 use const_oid::db::rfc5912::ID_CE_CERTIFICATE_POLICIES;
 use const_oid::AssociatedOid;
-use der::asn1::{GeneralizedTime, Ia5StringRef, ObjectIdentifier, UintRef, Utf8StringRef};
+use der::asn1::{GeneralizedTime, Ia5String, ObjectIdentifier, UintRef, Utf8StringRef};
 use der::{AnyRef, Choice, Sequence, ValueOrd};
 
 /// CertificatePolicies as defined in [RFC 5280 Section 4.2.1.4].
@@ -66,7 +66,7 @@ pub struct PolicyQualifierInfo<'a> {
 /// ```
 ///
 /// [RFC 5280 Section 4.2.1.4]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.4
-pub type CpsUri<'a> = Ia5StringRef<'a>;
+pub type CpsUri = Ia5String;
 
 /// UserNotice as defined in [RFC 5280 Section 4.2.1.4].
 ///
@@ -119,7 +119,7 @@ pub struct NoticeReference<'a> {
 #[allow(missing_docs)]
 pub enum DisplayText<'a> {
     #[asn1(type = "IA5String")]
-    Ia5String(Ia5StringRef<'a>),
+    Ia5String(Ia5String),
 
     #[asn1(type = "UTF8String")]
     Utf8String(Utf8StringRef<'a>),

--- a/x509-cert/src/ext/pkix/certpolicy.rs
+++ b/x509-cert/src/ext/pkix/certpolicy.rs
@@ -5,7 +5,7 @@ use alloc::{string::String, vec::Vec};
 use const_oid::db::rfc5912::ID_CE_CERTIFICATE_POLICIES;
 use const_oid::AssociatedOid;
 use der::asn1::{GeneralizedTime, Ia5String, ObjectIdentifier, UintRef};
-use der::{AnyRef, Choice, Sequence, ValueOrd};
+use der::{Any, Choice, Sequence, ValueOrd};
 
 /// CertificatePolicies as defined in [RFC 5280 Section 4.2.1.4].
 ///
@@ -15,13 +15,13 @@ use der::{AnyRef, Choice, Sequence, ValueOrd};
 ///
 /// [RFC 5280 Section 4.2.1.4]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.4
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct CertificatePolicies<'a>(pub Vec<PolicyInformation<'a>>);
+pub struct CertificatePolicies(pub Vec<PolicyInformation>);
 
-impl<'a> AssociatedOid for CertificatePolicies<'a> {
+impl AssociatedOid for CertificatePolicies {
     const OID: ObjectIdentifier = ID_CE_CERTIFICATE_POLICIES;
 }
 
-impl_newtype!(CertificatePolicies<'a>, Vec<PolicyInformation<'a>>);
+impl_newtype!(CertificatePolicies, Vec<PolicyInformation>);
 
 /// PolicyInformation as defined in [RFC 5280 Section 4.2.1.4].
 ///
@@ -37,9 +37,9 @@ impl_newtype!(CertificatePolicies<'a>, Vec<PolicyInformation<'a>>);
 /// [RFC 5280 Section 4.2.1.4]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.4
 #[derive(Clone, Debug, Eq, PartialEq, Sequence, ValueOrd)]
 #[allow(missing_docs)]
-pub struct PolicyInformation<'a> {
+pub struct PolicyInformation {
     pub policy_identifier: ObjectIdentifier,
-    pub policy_qualifiers: Option<Vec<PolicyQualifierInfo<'a>>>,
+    pub policy_qualifiers: Option<Vec<PolicyQualifierInfo>>,
 }
 
 /// PolicyQualifierInfo as defined in [RFC 5280 Section 4.2.1.4].
@@ -54,9 +54,9 @@ pub struct PolicyInformation<'a> {
 /// [RFC 5280 Section 4.2.1.4]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.4
 #[derive(Clone, Debug, Eq, PartialEq, Sequence, ValueOrd)]
 #[allow(missing_docs)]
-pub struct PolicyQualifierInfo<'a> {
+pub struct PolicyQualifierInfo {
     pub policy_qualifier_id: ObjectIdentifier,
-    pub qualifier: Option<AnyRef<'a>>,
+    pub qualifier: Option<Any>,
 }
 
 /// CpsUri as defined in [RFC 5280 Section 4.2.1.4].

--- a/x509-cert/src/ext/pkix/certpolicy.rs
+++ b/x509-cert/src/ext/pkix/certpolicy.rs
@@ -1,10 +1,10 @@
 //! PKIX Certificate Policies extension
 
-use alloc::vec::Vec;
+use alloc::{string::String, vec::Vec};
 
 use const_oid::db::rfc5912::ID_CE_CERTIFICATE_POLICIES;
 use const_oid::AssociatedOid;
-use der::asn1::{GeneralizedTime, Ia5String, ObjectIdentifier, UintRef, Utf8StringRef};
+use der::asn1::{GeneralizedTime, Ia5String, ObjectIdentifier, UintRef};
 use der::{AnyRef, Choice, Sequence, ValueOrd};
 
 /// CertificatePolicies as defined in [RFC 5280 Section 4.2.1.4].
@@ -80,9 +80,9 @@ pub type CpsUri = Ia5String;
 /// [RFC 5280 Section 4.2.1.4]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.4
 #[derive(Clone, Debug, Eq, PartialEq, Sequence)]
 #[allow(missing_docs)]
-pub struct UserNotice<'a> {
+pub struct UserNotice {
     pub notice_ref: Option<GeneralizedTime>,
-    pub explicit_text: Option<DisplayText<'a>>,
+    pub explicit_text: Option<DisplayText>,
 }
 
 /// NoticeReference as defined in [RFC 5280 Section 4.2.1.4].
@@ -97,7 +97,7 @@ pub struct UserNotice<'a> {
 #[derive(Clone, Debug, Eq, PartialEq, Sequence)]
 #[allow(missing_docs)]
 pub struct NoticeReference<'a> {
-    pub organization: DisplayText<'a>,
+    pub organization: DisplayText,
     pub notice_numbers: Option<Vec<UintRef<'a>>>,
 }
 
@@ -117,10 +117,10 @@ pub struct NoticeReference<'a> {
 /// [RFC 5280 Section 4.2.1.4]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.4
 #[derive(Choice, Clone, Debug, Eq, PartialEq)]
 #[allow(missing_docs)]
-pub enum DisplayText<'a> {
+pub enum DisplayText {
     #[asn1(type = "IA5String")]
     Ia5String(Ia5String),
 
     #[asn1(type = "UTF8String")]
-    Utf8String(Utf8StringRef<'a>),
+    Utf8String(String),
 }

--- a/x509-cert/src/ext/pkix/certpolicy.rs
+++ b/x509-cert/src/ext/pkix/certpolicy.rs
@@ -4,7 +4,7 @@ use alloc::{string::String, vec::Vec};
 
 use const_oid::db::rfc5912::ID_CE_CERTIFICATE_POLICIES;
 use const_oid::AssociatedOid;
-use der::asn1::{GeneralizedTime, Ia5String, ObjectIdentifier, UintRef};
+use der::asn1::{GeneralizedTime, Ia5String, ObjectIdentifier, Uint};
 use der::{Any, Choice, Sequence, ValueOrd};
 
 /// CertificatePolicies as defined in [RFC 5280 Section 4.2.1.4].
@@ -96,9 +96,9 @@ pub struct UserNotice {
 /// [RFC 5280 Section 4.2.1.4]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.4
 #[derive(Clone, Debug, Eq, PartialEq, Sequence)]
 #[allow(missing_docs)]
-pub struct NoticeReference<'a> {
+pub struct NoticeReference {
     pub organization: DisplayText,
-    pub notice_numbers: Option<Vec<UintRef<'a>>>,
+    pub notice_numbers: Option<Vec<Uint>>,
 }
 
 /// DisplayText as defined in [RFC 5280 Section 4.2.1.4].

--- a/x509-cert/src/ext/pkix/constraints/name.rs
+++ b/x509-cert/src/ext/pkix/constraints/name.rs
@@ -19,15 +19,15 @@ use super::super::name::GeneralName;
 /// [RFC 5280 Section 4.2.1.10]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.10
 #[derive(Clone, Debug, Eq, PartialEq, Sequence)]
 #[allow(missing_docs)]
-pub struct NameConstraints<'a> {
+pub struct NameConstraints {
     #[asn1(context_specific = "0", optional = "true", tag_mode = "IMPLICIT")]
-    pub permitted_subtrees: Option<GeneralSubtrees<'a>>,
+    pub permitted_subtrees: Option<GeneralSubtrees>,
 
     #[asn1(context_specific = "1", optional = "true", tag_mode = "IMPLICIT")]
-    pub excluded_subtrees: Option<GeneralSubtrees<'a>>,
+    pub excluded_subtrees: Option<GeneralSubtrees>,
 }
 
-impl<'a> AssociatedOid for NameConstraints<'a> {
+impl AssociatedOid for NameConstraints {
     const OID: ObjectIdentifier = ID_CE_NAME_CONSTRAINTS;
 }
 
@@ -38,7 +38,7 @@ impl<'a> AssociatedOid for NameConstraints<'a> {
 /// ```
 ///
 /// [RFC 5280 Section 4.2.1.10]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.10
-pub type GeneralSubtrees<'a> = Vec<GeneralSubtree<'a>>;
+pub type GeneralSubtrees = Vec<GeneralSubtree>;
 
 /// GeneralSubtree as defined in [RFC 5280 Section 4.2.1.10].
 ///
@@ -53,8 +53,8 @@ pub type GeneralSubtrees<'a> = Vec<GeneralSubtree<'a>>;
 /// [RFC 5280 Section 4.2.1.10]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.10
 #[derive(Clone, Debug, Eq, PartialEq, Sequence)]
 #[allow(missing_docs)]
-pub struct GeneralSubtree<'a> {
-    pub base: GeneralName<'a>,
+pub struct GeneralSubtree {
+    pub base: GeneralName,
 
     #[asn1(
         context_specific = "0",

--- a/x509-cert/src/ext/pkix/crl.rs
+++ b/x509-cert/src/ext/pkix/crl.rs
@@ -11,7 +11,7 @@ pub use dp::IssuingDistributionPoint;
 
 use alloc::vec::Vec;
 
-use der::{asn1::UintRef, Enumerated};
+use der::{asn1::Uint, Enumerated};
 
 /// CrlNumber as defined in [RFC 5280 Section 5.2.3].
 ///
@@ -20,14 +20,14 @@ use der::{asn1::UintRef, Enumerated};
 /// ```
 ///
 /// [RFC 5280 Section 5.2.3]: https://datatracker.ietf.org/doc/html/rfc5280#section-5.2.3
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct CrlNumber<'a>(pub UintRef<'a>);
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CrlNumber(pub Uint);
 
-impl<'a> AssociatedOid for CrlNumber<'a> {
+impl AssociatedOid for CrlNumber {
     const OID: ObjectIdentifier = ID_CE_CRL_NUMBER;
 }
 
-impl_newtype!(CrlNumber<'a>, UintRef<'a>);
+impl_newtype!(CrlNumber, Uint);
 
 /// BaseCRLNumber as defined in [RFC 5280 Section 5.2.4].
 ///
@@ -36,14 +36,14 @@ impl_newtype!(CrlNumber<'a>, UintRef<'a>);
 /// ```
 ///
 /// [RFC 5280 Section 5.2.4]: https://datatracker.ietf.org/doc/html/rfc5280#section-5.2.4
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct BaseCrlNumber<'a>(pub UintRef<'a>);
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BaseCrlNumber(pub Uint);
 
-impl<'a> AssociatedOid for BaseCrlNumber<'a> {
+impl AssociatedOid for BaseCrlNumber {
     const OID: ObjectIdentifier = ID_CE_DELTA_CRL_INDICATOR;
 }
 
-impl_newtype!(BaseCrlNumber<'a>, UintRef<'a>);
+impl_newtype!(BaseCrlNumber, Uint);
 
 /// CrlDistributionPoints as defined in [RFC 5280 Section 4.2.1.13].
 ///

--- a/x509-cert/src/ext/pkix/crl.rs
+++ b/x509-cert/src/ext/pkix/crl.rs
@@ -53,13 +53,13 @@ impl_newtype!(BaseCrlNumber<'a>, UintRef<'a>);
 ///
 /// [RFC 5280 Section 4.2.1.13]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.13
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct CrlDistributionPoints<'a>(pub Vec<dp::DistributionPoint<'a>>);
+pub struct CrlDistributionPoints(pub Vec<dp::DistributionPoint>);
 
-impl<'a> AssociatedOid for CrlDistributionPoints<'a> {
+impl AssociatedOid for CrlDistributionPoints {
     const OID: ObjectIdentifier = ID_CE_CRL_DISTRIBUTION_POINTS;
 }
 
-impl_newtype!(CrlDistributionPoints<'a>, Vec<dp::DistributionPoint<'a>>);
+impl_newtype!(CrlDistributionPoints, Vec<dp::DistributionPoint>);
 
 /// FreshestCrl as defined in [RFC 5280 Section 5.2.6].
 ///
@@ -69,13 +69,13 @@ impl_newtype!(CrlDistributionPoints<'a>, Vec<dp::DistributionPoint<'a>>);
 ///
 /// [RFC 5280 Section 5.2.6]: https://datatracker.ietf.org/doc/html/rfc5280#section-5.2.6
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct FreshestCrl<'a>(pub Vec<dp::DistributionPoint<'a>>);
+pub struct FreshestCrl(pub Vec<dp::DistributionPoint>);
 
-impl<'a> AssociatedOid for FreshestCrl<'a> {
+impl AssociatedOid for FreshestCrl {
     const OID: ObjectIdentifier = ID_CE_FRESHEST_CRL;
 }
 
-impl_newtype!(FreshestCrl<'a>, Vec<dp::DistributionPoint<'a>>);
+impl_newtype!(FreshestCrl, Vec<dp::DistributionPoint>);
 
 /// CRLReason as defined in [RFC 5280 Section 5.3.1].
 ///

--- a/x509-cert/src/ext/pkix/crl/dp.rs
+++ b/x509-cert/src/ext/pkix/crl/dp.rs
@@ -24,9 +24,9 @@ use crate::ext::pkix::name::{DistributionPointName, GeneralNames};
 /// [RFC 5280 Section 5.2.5]: https://datatracker.ietf.org/doc/html/rfc5280#section-5.2.5
 #[derive(Clone, Debug, Eq, PartialEq, Sequence)]
 #[allow(missing_docs)]
-pub struct IssuingDistributionPoint<'a> {
+pub struct IssuingDistributionPoint {
     #[asn1(context_specific = "0", tag_mode = "EXPLICIT", optional = "true")]
-    pub distribution_point: Option<DistributionPointName<'a>>,
+    pub distribution_point: Option<DistributionPointName>,
 
     #[asn1(
         context_specific = "1",
@@ -60,7 +60,7 @@ pub struct IssuingDistributionPoint<'a> {
     pub only_contains_attribute_certs: bool,
 }
 
-impl<'a> AssociatedOid for IssuingDistributionPoint<'a> {
+impl AssociatedOid for IssuingDistributionPoint {
     const OID: ObjectIdentifier = ID_PE_SUBJECT_INFO_ACCESS;
 }
 
@@ -76,15 +76,15 @@ impl<'a> AssociatedOid for IssuingDistributionPoint<'a> {
 /// [RFC 5280 Section 4.2.1.13]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.13
 #[derive(Clone, Debug, PartialEq, Eq, Sequence, ValueOrd)]
 #[allow(missing_docs)]
-pub struct DistributionPoint<'a> {
+pub struct DistributionPoint {
     #[asn1(context_specific = "0", tag_mode = "EXPLICIT", optional = "true")]
-    pub distribution_point: Option<DistributionPointName<'a>>,
+    pub distribution_point: Option<DistributionPointName>,
 
     #[asn1(context_specific = "1", tag_mode = "IMPLICIT", optional = "true")]
     pub reasons: Option<ReasonFlags>,
 
     #[asn1(context_specific = "2", tag_mode = "IMPLICIT", optional = "true")]
-    pub crl_issuer: Option<GeneralNames<'a>>,
+    pub crl_issuer: Option<GeneralNames>,
 }
 
 /// ReasonFlags as defined in [RFC 5280 Section 4.2.1.13].

--- a/x509-cert/src/ext/pkix/name/dirstr.rs
+++ b/x509-cert/src/ext/pkix/name/dirstr.rs
@@ -1,5 +1,5 @@
 use alloc::string::String;
-use der::asn1::{PrintableStringRef, TeletexString};
+use der::asn1::{PrintableString, TeletexString};
 use der::{Choice, ValueOrd};
 
 /// DirectoryString as defined in [RFC 5280 Section 4.2.1.4].
@@ -41,9 +41,9 @@ use der::{Choice, ValueOrd};
 /// [RFC 5280 Section 4.2.1.4]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.4
 #[derive(Clone, Debug, Eq, PartialEq, Choice, ValueOrd)]
 #[allow(missing_docs)]
-pub enum DirectoryString<'a> {
+pub enum DirectoryString {
     #[asn1(type = "PrintableString")]
-    PrintableString(PrintableStringRef<'a>),
+    PrintableString(PrintableString),
 
     #[asn1(type = "TeletexString")]
     TeletexString(TeletexString),

--- a/x509-cert/src/ext/pkix/name/dirstr.rs
+++ b/x509-cert/src/ext/pkix/name/dirstr.rs
@@ -1,4 +1,5 @@
-use der::asn1::{PrintableStringRef, TeletexStringRef, Utf8StringRef};
+use alloc::string::String;
+use der::asn1::{PrintableStringRef, TeletexStringRef};
 use der::{Choice, ValueOrd};
 
 /// DirectoryString as defined in [RFC 5280 Section 4.2.1.4].
@@ -48,5 +49,5 @@ pub enum DirectoryString<'a> {
     TeletexString(TeletexStringRef<'a>),
 
     #[asn1(type = "UTF8String")]
-    Utf8String(Utf8StringRef<'a>),
+    Utf8String(String),
 }

--- a/x509-cert/src/ext/pkix/name/dirstr.rs
+++ b/x509-cert/src/ext/pkix/name/dirstr.rs
@@ -1,5 +1,5 @@
 use alloc::string::String;
-use der::asn1::{PrintableStringRef, TeletexStringRef};
+use der::asn1::{PrintableStringRef, TeletexString};
 use der::{Choice, ValueOrd};
 
 /// DirectoryString as defined in [RFC 5280 Section 4.2.1.4].
@@ -46,7 +46,7 @@ pub enum DirectoryString<'a> {
     PrintableString(PrintableStringRef<'a>),
 
     #[asn1(type = "TeletexString")]
-    TeletexString(TeletexStringRef<'a>),
+    TeletexString(TeletexString),
 
     #[asn1(type = "UTF8String")]
     Utf8String(String),

--- a/x509-cert/src/ext/pkix/name/dp.rs
+++ b/x509-cert/src/ext/pkix/name/dp.rs
@@ -15,9 +15,9 @@ use der::{Choice, ValueOrd};
 /// [RFC 5280 Section 4.2.1.13]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.13
 #[derive(Clone, Debug, Eq, PartialEq, Choice, ValueOrd)]
 #[allow(missing_docs)]
-pub enum DistributionPointName<'a> {
+pub enum DistributionPointName {
     #[asn1(context_specific = "0", tag_mode = "IMPLICIT", constructed = "true")]
-    FullName(GeneralNames<'a>),
+    FullName(GeneralNames),
 
     #[asn1(context_specific = "1", tag_mode = "IMPLICIT", constructed = "true")]
     NameRelativeToCRLIssuer(RelativeDistinguishedName),

--- a/x509-cert/src/ext/pkix/name/ediparty.rs
+++ b/x509-cert/src/ext/pkix/name/ediparty.rs
@@ -27,10 +27,10 @@ use super::DirectoryString;
 /// [RFC 5280 Section 4.2.1.6]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.6
 #[derive(Clone, Debug, Eq, PartialEq, Sequence, ValueOrd)]
 #[allow(missing_docs)]
-pub struct EdiPartyName<'a> {
+pub struct EdiPartyName {
     #[asn1(context_specific = "0", tag_mode = "EXPLICIT", optional = "true")]
-    pub name_assigner: Option<DirectoryString<'a>>,
+    pub name_assigner: Option<DirectoryString>,
 
     #[asn1(context_specific = "1", tag_mode = "EXPLICIT")]
-    pub party_name: DirectoryString<'a>,
+    pub party_name: DirectoryString,
 }

--- a/x509-cert/src/ext/pkix/name/general.rs
+++ b/x509-cert/src/ext/pkix/name/general.rs
@@ -38,7 +38,7 @@ pub type GeneralNames<'a> = alloc::vec::Vec<GeneralName<'a>>;
 #[allow(missing_docs)]
 pub enum GeneralName<'a> {
     #[asn1(context_specific = "0", tag_mode = "IMPLICIT", constructed = "true")]
-    OtherName(OtherName<'a>),
+    OtherName(OtherName),
 
     #[asn1(context_specific = "1", tag_mode = "IMPLICIT")]
     Rfc822Name(Ia5StringRef<'a>),

--- a/x509-cert/src/ext/pkix/name/general.rs
+++ b/x509-cert/src/ext/pkix/name/general.rs
@@ -3,7 +3,7 @@
 use super::{EdiPartyName, OtherName};
 use crate::name::Name;
 
-use der::asn1::{Ia5String, ObjectIdentifier, OctetStringRef};
+use der::asn1::{Ia5String, ObjectIdentifier, OctetString};
 use der::{Choice, ValueOrd};
 
 /// GeneralNames as defined in [RFC 5280 Section 4.2.1.6].
@@ -13,7 +13,7 @@ use der::{Choice, ValueOrd};
 /// ```
 ///
 /// [RFC 5280 Section 4.2.1.6]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.6
-pub type GeneralNames<'a> = alloc::vec::Vec<GeneralName<'a>>;
+pub type GeneralNames = alloc::vec::Vec<GeneralName>;
 
 /// GeneralName as defined in [RFC 5280 Section 4.2.1.6].
 ///
@@ -36,7 +36,7 @@ pub type GeneralNames<'a> = alloc::vec::Vec<GeneralName<'a>>;
 /// [RFC 5280 Section 4.2.1.6]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.6
 #[derive(Clone, Debug, Eq, PartialEq, Choice, ValueOrd)]
 #[allow(missing_docs)]
-pub enum GeneralName<'a> {
+pub enum GeneralName {
     #[asn1(context_specific = "0", tag_mode = "IMPLICIT", constructed = "true")]
     OtherName(OtherName),
 
@@ -56,7 +56,7 @@ pub enum GeneralName<'a> {
     UniformResourceIdentifier(Ia5String),
 
     #[asn1(context_specific = "7", tag_mode = "IMPLICIT")]
-    IpAddress(OctetStringRef<'a>),
+    IpAddress(OctetString),
 
     #[asn1(context_specific = "8", tag_mode = "IMPLICIT")]
     RegisteredId(ObjectIdentifier),

--- a/x509-cert/src/ext/pkix/name/general.rs
+++ b/x509-cert/src/ext/pkix/name/general.rs
@@ -3,7 +3,7 @@
 use super::{EdiPartyName, OtherName};
 use crate::name::Name;
 
-use der::asn1::{Ia5StringRef, ObjectIdentifier, OctetStringRef};
+use der::asn1::{Ia5String, ObjectIdentifier, OctetStringRef};
 use der::{Choice, ValueOrd};
 
 /// GeneralNames as defined in [RFC 5280 Section 4.2.1.6].
@@ -41,10 +41,10 @@ pub enum GeneralName<'a> {
     OtherName(OtherName),
 
     #[asn1(context_specific = "1", tag_mode = "IMPLICIT")]
-    Rfc822Name(Ia5StringRef<'a>),
+    Rfc822Name(Ia5String),
 
     #[asn1(context_specific = "2", tag_mode = "IMPLICIT")]
-    DnsName(Ia5StringRef<'a>),
+    DnsName(Ia5String),
 
     #[asn1(context_specific = "4", tag_mode = "EXPLICIT", constructed = "true")]
     DirectoryName(Name),
@@ -53,7 +53,7 @@ pub enum GeneralName<'a> {
     EdiPartyName(EdiPartyName<'a>),
 
     #[asn1(context_specific = "6", tag_mode = "IMPLICIT")]
-    UniformResourceIdentifier(Ia5StringRef<'a>),
+    UniformResourceIdentifier(Ia5String),
 
     #[asn1(context_specific = "7", tag_mode = "IMPLICIT")]
     IpAddress(OctetStringRef<'a>),

--- a/x509-cert/src/ext/pkix/name/general.rs
+++ b/x509-cert/src/ext/pkix/name/general.rs
@@ -50,7 +50,7 @@ pub enum GeneralName<'a> {
     DirectoryName(Name),
 
     #[asn1(context_specific = "5", tag_mode = "IMPLICIT", constructed = "true")]
-    EdiPartyName(EdiPartyName<'a>),
+    EdiPartyName(EdiPartyName),
 
     #[asn1(context_specific = "6", tag_mode = "IMPLICIT")]
     UniformResourceIdentifier(Ia5String),

--- a/x509-cert/src/ext/pkix/name/other.rs
+++ b/x509-cert/src/ext/pkix/name/other.rs
@@ -1,4 +1,4 @@
-use der::{asn1::ObjectIdentifier, AnyRef, Sequence, ValueOrd};
+use der::{asn1::ObjectIdentifier, Any, Sequence, ValueOrd};
 
 /// OtherName as defined in [RFC 5280 Section 4.2.1.6].
 ///
@@ -12,11 +12,11 @@ use der::{asn1::ObjectIdentifier, AnyRef, Sequence, ValueOrd};
 /// [RFC 5280 Section 4.2.1.6]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.6
 #[derive(Clone, Debug, Eq, PartialEq, Sequence, ValueOrd)]
 #[allow(missing_docs)]
-pub struct OtherName<'a> {
+pub struct OtherName {
     pub type_id: ObjectIdentifier,
 
     #[asn1(context_specific = "0", tag_mode = "EXPLICIT")]
-    pub value: AnyRef<'a>,
+    pub value: Any,
 }
 
 #[test]
@@ -29,7 +29,7 @@ fn test() {
     let input = hex!("3021060A2B060104018237140203A0130C1155706E5F323134393530313330406D696C");
     let decoded = OtherName::from_der(&input).unwrap();
 
-    let onval = Utf8StringRef::try_from(decoded.value).unwrap();
+    let onval = Utf8StringRef::try_from(&decoded.value).unwrap();
     assert_eq!(onval.to_string(), "Upn_214950130@mil");
 
     let encoded = decoded.to_vec().unwrap();

--- a/x509-cert/src/lib.rs
+++ b/x509-cert/src/lib.rs
@@ -31,6 +31,8 @@ pub mod request;
 pub mod serial_number;
 pub mod time;
 
-pub use certificate::{Certificate, PkiPath, TbsCertificate, Version};
+pub use certificate::{
+    Certificate, CertificateRef, PkiPath, TbsCertificate, TbsCertificateRef, Version,
+};
 pub use der;
 pub use spki;

--- a/x509-cert/src/request.rs
+++ b/x509-cert/src/request.rs
@@ -97,10 +97,10 @@ impl<'a> TryFrom<&'a [u8]> for CertReq<'a> {
 ///
 /// [RFC 5272 Section 3.1]: https://datatracker.ietf.org/doc/html/rfc5272#section-3.1
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct ExtensionReq<'a>(pub Vec<Extension<'a>>);
+pub struct ExtensionReq(pub Vec<Extension>);
 
-impl<'a> AssociatedOid for ExtensionReq<'a> {
+impl AssociatedOid for ExtensionReq {
     const OID: ObjectIdentifier = ID_EXTENSION_REQ;
 }
 
-impl_newtype!(ExtensionReq<'a>, Vec<Extension<'a>>);
+impl_newtype!(ExtensionReq, Vec<Extension>);

--- a/x509-cert/src/request.rs
+++ b/x509-cert/src/request.rs
@@ -7,7 +7,7 @@ use alloc::vec::Vec;
 
 use const_oid::db::rfc5912::ID_EXTENSION_REQ;
 use const_oid::{AssociatedOid, ObjectIdentifier};
-use der::asn1::BitStringRef;
+use der::asn1::BitString;
 use der::{Decode, Enumerated, Sequence};
 use spki::{AlgorithmIdentifierRef, SubjectPublicKeyInfoRef};
 
@@ -78,7 +78,7 @@ pub struct CertReq<'a> {
     pub algorithm: AlgorithmIdentifierRef<'a>,
 
     /// Signature.
-    pub signature: BitStringRef<'a>,
+    pub signature: BitString,
 }
 
 impl<'a> TryFrom<&'a [u8]> for CertReq<'a> {

--- a/x509-cert/tests/certificate.rs
+++ b/x509-cert/tests/certificate.rs
@@ -7,7 +7,7 @@ use der::{
 use hex_literal::hex;
 use spki::AlgorithmIdentifierRef;
 use x509_cert::serial_number::SerialNumber;
-use x509_cert::Certificate;
+use x509_cert::CertificateRef;
 use x509_cert::*;
 
 // TODO - parse and compare extension values
@@ -113,7 +113,7 @@ fn reencode_cert() {
         include_bytes!("examples/026EDA6FA1EDFA8C253936C75B5EEBD954BFF452.fake.der");
     let defer_cert = DeferDecodeCertificate::from_der(der_encoded_cert).unwrap();
 
-    let parsed_tbs = TbsCertificate::from_der(defer_cert.tbs_certificate).unwrap();
+    let parsed_tbs = TbsCertificateRef::from_der(defer_cert.tbs_certificate).unwrap();
     let reencoded_tbs = parsed_tbs.to_vec().unwrap();
     assert_eq!(defer_cert.tbs_certificate, reencoded_tbs);
 
@@ -189,8 +189,8 @@ fn decode_cert() {
     // extensions otherwise
     let der_encoded_cert =
         include_bytes!("examples/026EDA6FA1EDFA8C253936C75B5EEBD954BFF452.fake.der");
-    let result = Certificate::from_der(der_encoded_cert);
-    let cert: Certificate = result.unwrap();
+    let result = CertificateRef::from_der(der_encoded_cert);
+    let cert: CertificateRef = result.unwrap();
     println!("{:?}", cert);
     let exts = cert.tbs_certificate.extensions.unwrap();
     for (ext, (oid, crit)) in exts.iter().zip(EXTENSIONS) {
@@ -198,8 +198,8 @@ fn decode_cert() {
         assert_eq!(ext.critical, *crit);
     }
 
-    let result = Certificate::from_der(der_encoded_cert);
-    let cert: Certificate = result.unwrap();
+    let result = CertificateRef::from_der(der_encoded_cert);
+    let cert: CertificateRef = result.unwrap();
 
     assert_eq!(cert.tbs_certificate.version, Version::V3);
     let target_serial: [u8; 16] = [

--- a/x509-cert/tests/certreq.rs
+++ b/x509-cert/tests/certreq.rs
@@ -68,7 +68,7 @@ fn decode_rsa_2048_der() {
         attribute.values.get(0).unwrap().decode_into().unwrap();
     for (ext, (oid, val)) in extensions.iter().zip(EXTENSIONS) {
         assert_eq!(ext.extn_id, oid.parse().unwrap());
-        assert_eq!(ext.extn_value, *val);
+        assert_eq!(ext.extn_value.as_bytes(), *val);
         assert!(!ext.critical);
     }
 

--- a/x509-cert/tests/pkix_extensions.rs
+++ b/x509-cert/tests/pkix_extensions.rs
@@ -1,6 +1,6 @@
 //! Certificate tests
 use const_oid::AssociatedOid;
-use der::asn1::{Ia5StringRef, PrintableStringRef, Utf8StringRef};
+use der::asn1::{Ia5StringRef, OctetString, PrintableStringRef, Utf8StringRef};
 use der::{Decode, Encode, ErrorKind, Length, Tag, Tagged};
 use hex_literal::hex;
 use x509_cert::ext::pkix::crl::dp::{DistributionPoint, ReasonFlags, Reasons};
@@ -17,93 +17,149 @@ fn spin_over_exts(exts: Extensions) {
     for ext in exts {
         match ext.extn_id {
             SubjectDirectoryAttributes::OID => {
-                let decoded = SubjectDirectoryAttributes::from_der(ext.extn_value).unwrap();
-                assert_eq!(ext.extn_value, decoded.to_vec().unwrap());
+                let decoded =
+                    SubjectDirectoryAttributes::from_der(ext.extn_value.as_bytes()).unwrap();
+                assert_eq!(
+                    ext.extn_value,
+                    decoded.to_vec().and_then(OctetString::new).unwrap()
+                );
             }
 
             SubjectKeyIdentifier::OID => {
-                let decoded = SubjectKeyIdentifier::from_der(ext.extn_value).unwrap();
-                assert_eq!(ext.extn_value, decoded.to_vec().unwrap());
+                let decoded = SubjectKeyIdentifier::from_der(ext.extn_value.as_bytes()).unwrap();
+                assert_eq!(
+                    ext.extn_value,
+                    decoded.to_vec().and_then(OctetString::new).unwrap()
+                );
             }
 
             KeyUsage::OID => {
-                let decoded = KeyUsage::from_der(ext.extn_value).unwrap();
-                assert_eq!(ext.extn_value, decoded.to_vec().unwrap());
+                let decoded = KeyUsage::from_der(ext.extn_value.as_bytes()).unwrap();
+                assert_eq!(
+                    ext.extn_value,
+                    decoded.to_vec().and_then(OctetString::new).unwrap()
+                );
             }
 
             PrivateKeyUsagePeriod::OID => {
-                let decoded = PrivateKeyUsagePeriod::from_der(ext.extn_value).unwrap();
-                assert_eq!(ext.extn_value, decoded.to_vec().unwrap());
+                let decoded = PrivateKeyUsagePeriod::from_der(ext.extn_value.as_bytes()).unwrap();
+                assert_eq!(
+                    ext.extn_value,
+                    decoded.to_vec().and_then(OctetString::new).unwrap()
+                );
             }
 
             SubjectAltName::OID => {
-                let decoded = SubjectAltName::from_der(ext.extn_value).unwrap();
-                assert_eq!(ext.extn_value, decoded.to_vec().unwrap());
+                let decoded = SubjectAltName::from_der(ext.extn_value.as_bytes()).unwrap();
+                assert_eq!(
+                    ext.extn_value,
+                    decoded.to_vec().and_then(OctetString::new).unwrap()
+                );
             }
 
             IssuerAltName::OID => {
-                let decoded = IssuerAltName::from_der(ext.extn_value).unwrap();
-                assert_eq!(ext.extn_value, decoded.to_vec().unwrap());
+                let decoded = IssuerAltName::from_der(ext.extn_value.as_bytes()).unwrap();
+                assert_eq!(
+                    ext.extn_value,
+                    decoded.to_vec().and_then(OctetString::new).unwrap()
+                );
             }
 
             BasicConstraints::OID => {
-                let decoded = BasicConstraints::from_der(ext.extn_value).unwrap();
-                assert_eq!(ext.extn_value, decoded.to_vec().unwrap());
+                let decoded = BasicConstraints::from_der(ext.extn_value.as_bytes()).unwrap();
+                assert_eq!(
+                    ext.extn_value,
+                    decoded.to_vec().and_then(OctetString::new).unwrap()
+                );
             }
 
             NameConstraints::OID => {
-                let decoded = NameConstraints::from_der(ext.extn_value).unwrap();
-                assert_eq!(ext.extn_value, decoded.to_vec().unwrap());
+                let decoded = NameConstraints::from_der(ext.extn_value.as_bytes()).unwrap();
+                assert_eq!(
+                    ext.extn_value,
+                    decoded.to_vec().and_then(OctetString::new).unwrap()
+                );
             }
 
             CrlDistributionPoints::OID => {
-                let decoded = CrlDistributionPoints::from_der(ext.extn_value).unwrap();
-                assert_eq!(ext.extn_value, decoded.to_vec().unwrap());
+                let decoded = CrlDistributionPoints::from_der(ext.extn_value.as_bytes()).unwrap();
+                assert_eq!(
+                    ext.extn_value,
+                    decoded.to_vec().and_then(OctetString::new).unwrap()
+                );
             }
 
             CertificatePolicies::OID => {
-                let decoded = CertificatePolicies::from_der(ext.extn_value).unwrap();
-                assert_eq!(ext.extn_value, decoded.to_vec().unwrap());
+                let decoded = CertificatePolicies::from_der(ext.extn_value.as_bytes()).unwrap();
+                assert_eq!(
+                    ext.extn_value,
+                    decoded.to_vec().and_then(OctetString::new).unwrap()
+                );
             }
 
             PolicyMappings::OID => {
-                let decoded = PolicyMappings::from_der(ext.extn_value).unwrap();
-                assert_eq!(ext.extn_value, decoded.to_vec().unwrap());
+                let decoded = PolicyMappings::from_der(ext.extn_value.as_bytes()).unwrap();
+                assert_eq!(
+                    ext.extn_value,
+                    decoded.to_vec().and_then(OctetString::new).unwrap()
+                );
             }
 
             AuthorityKeyIdentifier::OID => {
-                let decoded = AuthorityKeyIdentifier::from_der(ext.extn_value).unwrap();
-                assert_eq!(ext.extn_value, decoded.to_vec().unwrap());
+                let decoded = AuthorityKeyIdentifier::from_der(ext.extn_value.as_bytes()).unwrap();
+                assert_eq!(
+                    ext.extn_value,
+                    decoded.to_vec().and_then(OctetString::new).unwrap()
+                );
             }
 
             PolicyConstraints::OID => {
-                let decoded = PolicyConstraints::from_der(ext.extn_value).unwrap();
-                assert_eq!(ext.extn_value, decoded.to_vec().unwrap());
+                let decoded = PolicyConstraints::from_der(ext.extn_value.as_bytes()).unwrap();
+                assert_eq!(
+                    ext.extn_value,
+                    decoded.to_vec().and_then(OctetString::new).unwrap()
+                );
             }
 
             ExtendedKeyUsage::OID => {
-                let decoded = ExtendedKeyUsage::from_der(ext.extn_value).unwrap();
-                assert_eq!(ext.extn_value, decoded.to_vec().unwrap());
+                let decoded = ExtendedKeyUsage::from_der(ext.extn_value.as_bytes()).unwrap();
+                assert_eq!(
+                    ext.extn_value,
+                    decoded.to_vec().and_then(OctetString::new).unwrap()
+                );
             }
 
             FreshestCrl::OID => {
-                let decoded = FreshestCrl::from_der(ext.extn_value).unwrap();
-                assert_eq!(ext.extn_value, decoded.to_vec().unwrap());
+                let decoded = FreshestCrl::from_der(ext.extn_value.as_bytes()).unwrap();
+                assert_eq!(
+                    ext.extn_value,
+                    decoded.to_vec().and_then(OctetString::new).unwrap()
+                );
             }
 
             InhibitAnyPolicy::OID => {
-                let decoded = InhibitAnyPolicy::from_der(ext.extn_value).unwrap();
-                assert_eq!(ext.extn_value, decoded.to_vec().unwrap());
+                let decoded = InhibitAnyPolicy::from_der(ext.extn_value.as_bytes()).unwrap();
+                assert_eq!(
+                    ext.extn_value,
+                    decoded.to_vec().and_then(OctetString::new).unwrap()
+                );
             }
 
             AuthorityInfoAccessSyntax::OID => {
-                let decoded = AuthorityInfoAccessSyntax::from_der(ext.extn_value).unwrap();
-                assert_eq!(ext.extn_value, decoded.to_vec().unwrap());
+                let decoded =
+                    AuthorityInfoAccessSyntax::from_der(ext.extn_value.as_bytes()).unwrap();
+                assert_eq!(
+                    ext.extn_value,
+                    decoded.to_vec().and_then(OctetString::new).unwrap()
+                );
             }
 
             SubjectInfoAccessSyntax::OID => {
-                let decoded = SubjectInfoAccessSyntax::from_der(ext.extn_value).unwrap();
-                assert_eq!(ext.extn_value, decoded.to_vec().unwrap());
+                let decoded = SubjectInfoAccessSyntax::from_der(ext.extn_value.as_bytes()).unwrap();
+                assert_eq!(
+                    ext.extn_value,
+                    decoded.to_vec().and_then(OctetString::new).unwrap()
+                );
             }
 
             _ => {
@@ -162,27 +218,27 @@ fn decode_cert() {
             assert_eq!(ext.extn_id.to_string(), ID_CE_KEY_USAGE.to_string());
             assert_eq!(ext.critical, true);
 
-            let ku = KeyUsage::from_der(ext.extn_value).unwrap();
+            let ku = KeyUsage::from_der(ext.extn_value.as_bytes()).unwrap();
             assert_eq!(KeyUsages::KeyCertSign | KeyUsages::CRLSign, ku);
 
-            let reencoded = ku.to_vec().unwrap();
+            let reencoded = ku.to_vec().and_then(OctetString::new).unwrap();
             assert_eq!(ext.extn_value, reencoded);
         } else if 1 == counter {
             assert_eq!(ext.extn_id.to_string(), ID_CE_BASIC_CONSTRAINTS.to_string());
             assert_eq!(ext.critical, true);
-            let bc = BasicConstraints::from_der(ext.extn_value).unwrap();
+            let bc = BasicConstraints::from_der(ext.extn_value.as_bytes()).unwrap();
             assert_eq!(true, bc.ca);
             assert!(bc.path_len_constraint.is_none());
 
-            let reencoded = bc.to_vec().unwrap();
+            let reencoded = bc.to_vec().and_then(OctetString::new).unwrap();
             assert_eq!(ext.extn_value, reencoded);
         } else if 2 == counter {
             assert_eq!(ext.extn_id.to_string(), ID_CE_POLICY_MAPPINGS.to_string());
             assert_eq!(ext.critical, false);
-            let pm = PolicyMappings::from_der(ext.extn_value).unwrap();
+            let pm = PolicyMappings::from_der(ext.extn_value.as_bytes()).unwrap();
             assert_eq!(19, pm.0.len());
 
-            let reencoded = pm.to_vec().unwrap();
+            let reencoded = pm.to_vec().and_then(OctetString::new).unwrap();
             assert_eq!(ext.extn_value, reencoded);
 
             let subject_domain_policy: [&str; 19] = [
@@ -247,10 +303,10 @@ fn decode_cert() {
                 ID_CE_CERTIFICATE_POLICIES.to_string()
             );
             assert_eq!(ext.critical, false);
-            let cps = CertificatePolicies::from_der(ext.extn_value).unwrap();
+            let cps = CertificatePolicies::from_der(ext.extn_value.as_bytes()).unwrap();
             assert_eq!(19, cps.0.len());
 
-            let reencoded = cps.to_vec().unwrap();
+            let reencoded = cps.to_vec().and_then(OctetString::new).unwrap();
             assert_eq!(ext.extn_value, reencoded);
 
             let ids: [&str; 19] = [
@@ -308,14 +364,14 @@ fn decode_cert() {
                 ID_CE_SUBJECT_KEY_IDENTIFIER.to_string()
             );
             assert_eq!(ext.critical, false);
-            let skid = SubjectKeyIdentifier::from_der(ext.extn_value).unwrap();
+            let skid = SubjectKeyIdentifier::from_der(ext.extn_value.as_bytes()).unwrap();
             assert_eq!(Length::new(21), skid.0.len());
             assert_eq!(
                 &hex!("DBD3DEBF0D7B615B32803BC0206CD7AADD39B8ACFF"),
                 skid.0.as_bytes()
             );
 
-            let reencoded = skid.to_vec().unwrap();
+            let reencoded = skid.to_vec().and_then(OctetString::new).unwrap();
             assert_eq!(ext.extn_value, reencoded);
         } else if 5 == counter {
             assert_eq!(
@@ -323,10 +379,10 @@ fn decode_cert() {
                 ID_CE_CRL_DISTRIBUTION_POINTS.to_string()
             );
             assert_eq!(ext.critical, false);
-            let crl_dps = CrlDistributionPoints::from_der(ext.extn_value).unwrap();
+            let crl_dps = CrlDistributionPoints::from_der(ext.extn_value.as_bytes()).unwrap();
             assert_eq!(2, crl_dps.0.len());
 
-            let reencoded = crl_dps.to_vec().unwrap();
+            let reencoded = crl_dps.to_vec().and_then(OctetString::new).unwrap();
             assert_eq!(ext.extn_value, reencoded);
 
             let mut crldp_counter = 0;
@@ -381,10 +437,10 @@ fn decode_cert() {
                 ID_PE_SUBJECT_INFO_ACCESS.to_string()
             );
             assert_eq!(ext.critical, false);
-            let sias = SubjectInfoAccessSyntax::from_der(ext.extn_value).unwrap();
+            let sias = SubjectInfoAccessSyntax::from_der(ext.extn_value.as_bytes()).unwrap();
             assert_eq!(1, sias.0.len());
 
-            let reencoded = sias.to_vec().unwrap();
+            let reencoded = sias.to_vec().and_then(OctetString::new).unwrap();
             assert_eq!(ext.extn_value, reencoded);
 
             for sia in sias.0 {
@@ -408,11 +464,11 @@ fn decode_cert() {
                 ID_PE_AUTHORITY_INFO_ACCESS.to_string()
             );
             assert_eq!(ext.critical, false);
-            let aias = AuthorityInfoAccessSyntax::from_der(ext.extn_value).unwrap();
+            let aias = AuthorityInfoAccessSyntax::from_der(ext.extn_value.as_bytes()).unwrap();
             assert_eq!(2, aias.0.len());
             let mut aia_counter = 0;
 
-            let reencoded = aias.to_vec().unwrap();
+            let reencoded = aias.to_vec().and_then(OctetString::new).unwrap();
             assert_eq!(ext.extn_value, reencoded);
 
             for aia in aias.0 {
@@ -454,10 +510,10 @@ fn decode_cert() {
                 ID_CE_INHIBIT_ANY_POLICY.to_string()
             );
             assert_eq!(ext.critical, false);
-            let iap = InhibitAnyPolicy::from_der(ext.extn_value).unwrap();
+            let iap = InhibitAnyPolicy::from_der(ext.extn_value.as_bytes()).unwrap();
             assert_eq!(0, iap.0);
 
-            let reencoded = iap.to_vec().unwrap();
+            let reencoded = iap.to_vec().and_then(OctetString::new).unwrap();
             assert_eq!(ext.extn_value, reencoded);
         } else if 9 == counter {
             assert_eq!(
@@ -465,13 +521,13 @@ fn decode_cert() {
                 ID_CE_AUTHORITY_KEY_IDENTIFIER.to_string()
             );
             assert_eq!(ext.critical, false);
-            let akid = AuthorityKeyIdentifier::from_der(ext.extn_value).unwrap();
+            let akid = AuthorityKeyIdentifier::from_der(ext.extn_value.as_bytes()).unwrap();
             assert_eq!(
                 &hex!("7C4C863AB80BD589870BEDB7E11BBD2A08BB3D23FF"),
                 akid.key_identifier.unwrap().as_bytes()
             );
 
-            let reencoded = akid.to_vec().unwrap();
+            let reencoded = akid.to_vec().and_then(OctetString::new).unwrap();
             assert_eq!(ext.extn_value, reencoded);
         }
 
@@ -625,7 +681,7 @@ fn decode_cert() {
                 ID_CE_AUTHORITY_KEY_IDENTIFIER.to_string()
             );
             assert_eq!(ext.critical, false);
-            let akid = AuthorityKeyIdentifier::from_der(ext.extn_value).unwrap();
+            let akid = AuthorityKeyIdentifier::from_der(ext.extn_value.as_bytes()).unwrap();
             assert_eq!(
                 akid.key_identifier.unwrap().as_bytes(),
                 &hex!("E47D5FD15C9586082C05AEBE75B665A7D95DA866")[..]
@@ -636,7 +692,7 @@ fn decode_cert() {
                 ID_CE_SUBJECT_KEY_IDENTIFIER.to_string()
             );
             assert_eq!(ext.critical, false);
-            let skid = SubjectKeyIdentifier::from_der(ext.extn_value).unwrap();
+            let skid = SubjectKeyIdentifier::from_der(ext.extn_value.as_bytes()).unwrap();
             assert_eq!(
                 skid.0.as_bytes(),
                 &hex!("580184241BBC2B52944A3DA510721451F5AF3AC9")[..]
@@ -644,7 +700,7 @@ fn decode_cert() {
         } else if 2 == counter {
             assert_eq!(ext.extn_id.to_string(), ID_CE_KEY_USAGE.to_string());
             assert_eq!(ext.critical, true);
-            let ku = KeyUsage::from_der(ext.extn_value).unwrap();
+            let ku = KeyUsage::from_der(ext.extn_value.as_bytes()).unwrap();
             assert_eq!(KeyUsages::KeyCertSign | KeyUsages::CRLSign, ku);
         } else if 3 == counter {
             assert_eq!(
@@ -652,7 +708,7 @@ fn decode_cert() {
                 ID_CE_CERTIFICATE_POLICIES.to_string()
             );
             assert_eq!(ext.critical, false);
-            let r = CertificatePolicies::from_der(ext.extn_value);
+            let r = CertificatePolicies::from_der(ext.extn_value.as_bytes());
             let cp = r.unwrap();
             let i = cp.0.iter();
             for p in i {
@@ -661,7 +717,7 @@ fn decode_cert() {
         } else if 4 == counter {
             assert_eq!(ext.extn_id.to_string(), ID_CE_BASIC_CONSTRAINTS.to_string());
             assert_eq!(ext.critical, true);
-            let bc = BasicConstraints::from_der(ext.extn_value).unwrap();
+            let bc = BasicConstraints::from_der(ext.extn_value.as_bytes()).unwrap();
             assert_eq!(bc.ca, true);
             assert_eq!(bc.path_len_constraint, Option::None);
         }

--- a/x509-cert/tests/pkix_extensions.rs
+++ b/x509-cert/tests/pkix_extensions.rs
@@ -525,7 +525,7 @@ fn decode_cert() {
             let akid = AuthorityKeyIdentifier::from_der(ext.extn_value.as_bytes()).unwrap();
             assert_eq!(
                 &hex!("7C4C863AB80BD589870BEDB7E11BBD2A08BB3D23FF"),
-                akid.key_identifier.unwrap().as_bytes()
+                akid.key_identifier.as_ref().unwrap().as_bytes()
             );
 
             let reencoded = akid.to_vec().and_then(OctetString::new).unwrap();

--- a/x509-cert/tests/pkix_extensions.rs
+++ b/x509-cert/tests/pkix_extensions.rs
@@ -341,7 +341,8 @@ fn decode_cert() {
                     for pqi in pq.iter() {
                         if 0 == counter_pq {
                             assert_eq!("1.3.6.1.5.5.7.2.1", pqi.policy_qualifier_id.to_string());
-                            let cpsval = Ia5StringRef::try_from(pqi.qualifier.unwrap()).unwrap();
+                            let cpsval =
+                                Ia5StringRef::try_from(pqi.qualifier.as_ref().unwrap()).unwrap();
                             assert_eq!(
                                 "https://secure.identrust.com/certificates/policy/IGC/index.html",
                                 cpsval.to_string()

--- a/x509-cert/tests/pkix_extensions.rs
+++ b/x509-cert/tests/pkix_extensions.rs
@@ -194,7 +194,7 @@ fn decode_general_name() {
     let bytes = hex!("A021060A2B060104018237140203A0130C1155706E5F323134393530313330406D696C");
     match GeneralName::from_der(&bytes).unwrap() {
         GeneralName::OtherName(other_name) => {
-            let onval = Utf8StringRef::try_from(other_name.value).unwrap();
+            let onval = Utf8StringRef::try_from(&other_name.value).unwrap();
             assert_eq!(onval.to_string(), "Upn_214950130@mil");
         }
         _ => panic!("Failed to parse OtherName from GeneralName"),

--- a/x509-cert/tests/pkix_extensions.rs
+++ b/x509-cert/tests/pkix_extensions.rs
@@ -8,7 +8,7 @@ use x509_cert::ext::pkix::name::{DistributionPointName, GeneralName, GeneralName
 use x509_cert::ext::pkix::*;
 use x509_cert::ext::Extensions;
 use x509_cert::name::Name;
-use x509_cert::{serial_number::SerialNumber, Certificate, Version};
+use x509_cert::{serial_number::SerialNumber, CertificateRef, Version};
 
 use const_oid::db::rfc5280::*;
 use const_oid::db::rfc5912::ID_CE_CERTIFICATE_POLICIES;
@@ -208,8 +208,8 @@ fn decode_cert() {
     // extensions otherwise
     let der_encoded_cert =
         include_bytes!("examples/026EDA6FA1EDFA8C253936C75B5EEBD954BFF452.fake.der");
-    let result = Certificate::from_der(der_encoded_cert);
-    let cert: Certificate = result.unwrap();
+    let result = CertificateRef::from_der(der_encoded_cert);
+    let cert: CertificateRef = result.unwrap();
     let exts = cert.tbs_certificate.extensions.unwrap();
     let i = exts.iter();
     let mut counter = 0;
@@ -536,8 +536,8 @@ fn decode_cert() {
     }
 
     let der_encoded_cert = include_bytes!("examples/GoodCACert.crt");
-    let result = Certificate::from_der(der_encoded_cert);
-    let cert: Certificate = result.unwrap();
+    let result = CertificateRef::from_der(der_encoded_cert);
+    let cert: CertificateRef = result.unwrap();
 
     assert_eq!(cert.tbs_certificate.version, Version::V3);
     let target_serial: [u8; 1] = [2];
@@ -739,82 +739,82 @@ fn decode_cert() {
 
     // This cert adds extended key usage and netscape cert type vs above samples
     let der_encoded_cert = include_bytes!("examples/0954e2343dd5efe0a7f0967d69caf33e5f893720.der");
-    let result = Certificate::from_der(der_encoded_cert);
-    let cert: Certificate = result.unwrap();
+    let result = CertificateRef::from_der(der_encoded_cert);
+    let cert: CertificateRef = result.unwrap();
     let exts = cert.tbs_certificate.extensions.unwrap();
     spin_over_exts(exts);
 
     // This cert adds extended key usage and name constraints vs above samples
     let der_encoded_cert = include_bytes!("examples/0fcc78fbbca9f32b08b19b032b84f2c86a128f35.der");
-    let result = Certificate::from_der(der_encoded_cert);
-    let cert: Certificate = result.unwrap();
+    let result = CertificateRef::from_der(der_encoded_cert);
+    let cert: CertificateRef = result.unwrap();
     let exts = cert.tbs_certificate.extensions.unwrap();
     spin_over_exts(exts);
 
     // This cert adds logotype (which is unrecognized) vs above samples
     let der_encoded_cert = include_bytes!("examples/15b05c4865410c6b3ff76a4e8f3d87276756bd0c.der");
-    let result = Certificate::from_der(der_encoded_cert);
-    let cert: Certificate = result.unwrap();
+    let result = CertificateRef::from_der(der_encoded_cert);
+    let cert: CertificateRef = result.unwrap();
     let exts = cert.tbs_certificate.extensions.unwrap();
     spin_over_exts(exts);
 
     // This cert features an EC key unlike the above samples
     let der_encoded_cert = include_bytes!("examples/16ee54e48c76eaa1052e09010d8faefee95e5ebb.der");
-    let result = Certificate::from_der(der_encoded_cert);
-    let cert: Certificate = result.unwrap();
+    let result = CertificateRef::from_der(der_encoded_cert);
+    let cert: CertificateRef = result.unwrap();
     let exts = cert.tbs_certificate.extensions.unwrap();
     spin_over_exts(exts);
 
     // This cert adds issuer alt name vs above samples
     let der_encoded_cert = include_bytes!("examples/342cd9d3062da48c346965297f081ebc2ef68fdc.der");
-    let result = Certificate::from_der(der_encoded_cert);
-    let cert: Certificate = result.unwrap();
+    let result = CertificateRef::from_der(der_encoded_cert);
+    let cert: CertificateRef = result.unwrap();
     let exts = cert.tbs_certificate.extensions.unwrap();
     spin_over_exts(exts);
 
     // This cert adds policy constraints vs above samples
     let der_encoded_cert = include_bytes!("examples/2049a5b28f104b2c6e1a08546f9cfc0353d6fd30.der");
-    let result = Certificate::from_der(der_encoded_cert);
-    let cert: Certificate = result.unwrap();
+    let result = CertificateRef::from_der(der_encoded_cert);
+    let cert: CertificateRef = result.unwrap();
     let exts = cert.tbs_certificate.extensions.unwrap();
     spin_over_exts(exts);
 
     // This cert adds subject alt name vs above samples
     let der_encoded_cert = include_bytes!("examples/21723e7a0fb61a0bd4a29879b82a02b2fb4ad096.der");
-    let result = Certificate::from_der(der_encoded_cert);
-    let cert: Certificate = result.unwrap();
+    let result = CertificateRef::from_der(der_encoded_cert);
+    let cert: CertificateRef = result.unwrap();
     let exts = cert.tbs_certificate.extensions.unwrap();
     spin_over_exts(exts);
 
     // This cert adds subject directory attributes vs above samples
     let der_encoded_cert =
         include_bytes!("examples/085B1E2F40254F9C7A2387BE9FF4EC116C326E10.fake.der");
-    let result = Certificate::from_der(der_encoded_cert);
-    let cert: Certificate = result.unwrap();
+    let result = CertificateRef::from_der(der_encoded_cert);
+    let cert: CertificateRef = result.unwrap();
     let exts = cert.tbs_certificate.extensions.unwrap();
     spin_over_exts(exts);
 
     // This cert adds private key usage period (and an unprocessed Entrust extension) vs above samples
     let der_encoded_cert =
         include_bytes!("examples/554D5FF11DA613A155584D8D4AA07F67724D8077.fake.der");
-    let result = Certificate::from_der(der_encoded_cert);
-    let cert: Certificate = result.unwrap();
+    let result = CertificateRef::from_der(der_encoded_cert);
+    let cert: CertificateRef = result.unwrap();
     let exts = cert.tbs_certificate.extensions.unwrap();
     spin_over_exts(exts);
 
     // This cert adds OCSP no check vs above samples
     let der_encoded_cert =
         include_bytes!("examples/28879DABB0FD11618FB74E47BE049D2933866D53.fake.der");
-    let result = Certificate::from_der(der_encoded_cert);
-    let cert: Certificate = result.unwrap();
+    let result = CertificateRef::from_der(der_encoded_cert);
+    let cert: CertificateRef = result.unwrap();
     let exts = cert.tbs_certificate.extensions.unwrap();
     spin_over_exts(exts);
 
     // This cert adds PIV NACI indicator vs above samples
     let der_encoded_cert =
         include_bytes!("examples/288C8BCFEE6B89D110DAE2C9873897BF7FF53382.fake.der");
-    let result = Certificate::from_der(der_encoded_cert);
-    let cert: Certificate = result.unwrap();
+    let result = CertificateRef::from_der(der_encoded_cert);
+    let cert: CertificateRef = result.unwrap();
     let exts = cert.tbs_certificate.extensions.unwrap();
     spin_over_exts(exts);
 }

--- a/x509-ocsp/src/lib.rs
+++ b/x509-ocsp/src/lib.rs
@@ -69,7 +69,7 @@ pub struct TbsRequest<'a> {
     pub version: Version,
 
     #[asn1(context_specific = "1", optional = "true", tag_mode = "EXPLICIT")]
-    pub requestor_name: Option<GeneralName<'a>>,
+    pub requestor_name: Option<GeneralName>,
 
     pub request_list: alloc::vec::Vec<Request<'a>>,
 
@@ -405,9 +405,9 @@ pub type AcceptableResponses = Vec<ObjectIdentifier>;
 /// [RFC 6960 Section 4.4.6]: https://datatracker.ietf.org/doc/html/rfc6960#section-4.4.6
 #[derive(Clone, Debug, Eq, PartialEq, Sequence)]
 #[allow(missing_docs)]
-pub struct ServiceLocator<'a> {
+pub struct ServiceLocator {
     pub issuer: Name,
-    pub locator: AuthorityInfoAccessSyntax<'a>,
+    pub locator: AuthorityInfoAccessSyntax,
 }
 
 /// CrlID structure as defined in [RFC 6960 Section 4.4.2].

--- a/x509-ocsp/src/lib.rs
+++ b/x509-ocsp/src/lib.rs
@@ -74,7 +74,7 @@ pub struct TbsRequest<'a> {
     pub request_list: alloc::vec::Vec<Request<'a>>,
 
     #[asn1(context_specific = "2", optional = "true", tag_mode = "EXPLICIT")]
-    pub request_extensions: Option<Extensions<'a>>,
+    pub request_extensions: Option<Extensions>,
 }
 
 /// Signature structure as defined in [RFC 6960 Section 4.1.1].
@@ -133,7 +133,7 @@ pub struct Request<'a> {
     pub req_cert: CertId<'a>,
 
     #[asn1(context_specific = "0", optional = "true", tag_mode = "EXPLICIT")]
-    pub single_request_extensions: Option<Extensions<'a>>,
+    pub single_request_extensions: Option<Extensions>,
 }
 
 /// CertID structure as defined in [RFC 6960 Section 4.1.1].
@@ -265,7 +265,7 @@ pub struct ResponseData<'a> {
     pub responses: Vec<SingleResponse<'a>>,
 
     #[asn1(context_specific = "1", optional = "true", tag_mode = "EXPLICIT")]
-    pub response_extensions: Option<Extensions<'a>>,
+    pub response_extensions: Option<Extensions>,
 }
 
 /// ResponderID structure as defined in [RFC 6960 Section 4.2.1].
@@ -323,7 +323,7 @@ pub struct SingleResponse<'a> {
     pub next_update: Option<GeneralizedTime>,
 
     #[asn1(context_specific = "1", optional = "true", tag_mode = "EXPLICIT")]
-    pub single_request_extensions: Option<Extensions<'a>>,
+    pub single_request_extensions: Option<Extensions>,
 }
 
 /// CertStatus structure as defined in [RFC 6960 Section 4.2.1].

--- a/x509-ocsp/src/lib.rs
+++ b/x509-ocsp/src/lib.rs
@@ -12,7 +12,7 @@ use x509_cert::ext::pkix::{AuthorityInfoAccessSyntax, CrlReason};
 use x509_cert::ext::Extensions;
 use x509_cert::name::Name;
 use x509_cert::serial_number::SerialNumber;
-use x509_cert::Certificate;
+use x509_cert::CertificateRef;
 
 use alloc::vec::Vec;
 use core::default::Default;
@@ -94,7 +94,7 @@ pub struct Signature<'a> {
     pub signature: BitStringRef<'a>,
 
     #[asn1(context_specific = "0", optional = "true", tag_mode = "EXPLICIT")]
-    pub certs: Option<Vec<Certificate<'a>>>,
+    pub certs: Option<Vec<CertificateRef<'a>>>,
 }
 
 /// OCSP `Version` as defined in [RFC 6960 Section 4.1.1].


### PR DESCRIPTION
This introduces the owned api for x509 certificates.