### PR TITLE
x509-cert: make Certificate an owned type

### DIFF
--- a/der/src/asn1.rs
+++ b/der/src/asn1.rs
@@ -35,8 +35,8 @@ pub use const_oid::ObjectIdentifier;
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub use self::{
-    any::Any, bit_string::BitString, integer::bigint::Int, integer::bigint::Uint,
-    octet_string::OctetString, set_of::SetOfVec,
+    any::Any, bit_string::BitString, ia5_string::Ia5String, integer::bigint::Int,
+    integer::bigint::Uint, octet_string::OctetString, set_of::SetOfVec,
 };
 pub use self::{
     any::AnyRef,

--- a/der/src/asn1.rs
+++ b/der/src/asn1.rs
@@ -37,6 +37,7 @@ pub use const_oid::ObjectIdentifier;
 pub use self::{
     any::Any, bit_string::BitString, ia5_string::Ia5String, integer::bigint::Int,
     integer::bigint::Uint, octet_string::OctetString, set_of::SetOfVec,
+    teletex_string::TeletexString,
 };
 pub use self::{
     any::AnyRef,

--- a/der/src/asn1.rs
+++ b/der/src/asn1.rs
@@ -36,8 +36,8 @@ pub use const_oid::ObjectIdentifier;
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub use self::{
     any::Any, bit_string::BitString, ia5_string::Ia5String, integer::bigint::Int,
-    integer::bigint::Uint, octet_string::OctetString, set_of::SetOfVec,
-    teletex_string::TeletexString,
+    integer::bigint::Uint, octet_string::OctetString, printable_string::PrintableString,
+    set_of::SetOfVec, teletex_string::TeletexString,
 };
 pub use self::{
     any::AnyRef,

--- a/der/src/asn1.rs
+++ b/der/src/asn1.rs
@@ -1,6 +1,9 @@
 //! Module containing all of the various ASN.1 built-in types supported by
 //! this library.
 
+#[macro_use]
+mod internal_macros;
+
 mod any;
 mod bit_string;
 mod boolean;

--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -319,4 +319,11 @@ mod allocating {
             self.into()
         }
     }
+
+    impl Any {
+        /// Is this value an ASN.1 `NULL` value?
+        pub fn is_null(&self) -> bool {
+            self.to_ref() == AnyRef::NULL
+        }
+    }
 }

--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -2,7 +2,7 @@
 #![cfg_attr(feature = "arbitrary", allow(clippy::integer_arithmetic))]
 
 use crate::{
-    asn1::*, ByteSlice, Choice, Decode, DecodeValue, DerOrd, EncodeValue, Error, ErrorKind,
+    asn1::*, BytesRef, Choice, Decode, DecodeValue, DerOrd, EncodeValue, Error, ErrorKind,
     FixedTag, Header, Length, Reader, Result, SliceReader, Tag, Tagged, ValueOrd, Writer,
 };
 use core::cmp::Ordering;
@@ -31,24 +31,24 @@ pub struct AnyRef<'a> {
     tag: Tag,
 
     /// Inner value encoded as bytes.
-    value: ByteSlice<'a>,
+    value: BytesRef<'a>,
 }
 
 impl<'a> AnyRef<'a> {
     /// [`AnyRef`] representation of the ASN.1 `NULL` type.
     pub const NULL: Self = Self {
         tag: Tag::Null,
-        value: ByteSlice::EMPTY,
+        value: BytesRef::EMPTY,
     };
 
     /// Create a new [`AnyRef`] from the provided [`Tag`] and DER bytes.
     pub fn new(tag: Tag, bytes: &'a [u8]) -> Result<Self> {
-        let value = ByteSlice::new(bytes).map_err(|_| ErrorKind::Length { tag })?;
+        let value = BytesRef::new(bytes).map_err(|_| ErrorKind::Length { tag })?;
         Ok(Self { tag, value })
     }
 
-    /// Infallible creation of an [`AnyRef`] from a [`ByteSlice`].
-    pub(crate) fn from_tag_and_value(tag: Tag, value: ByteSlice<'a>) -> Self {
+    /// Infallible creation of an [`AnyRef`] from a [`BytesRef`].
+    pub(crate) fn from_tag_and_value(tag: Tag, value: BytesRef<'a>) -> Self {
         Self { tag, value }
     }
 
@@ -150,7 +150,7 @@ impl<'a> Decode<'a> for AnyRef<'a> {
 
         Ok(Self {
             tag: header.tag,
-            value: ByteSlice::decode_value(reader, header)?,
+            value: BytesRef::decode_value(reader, header)?,
         })
     }
 }
@@ -184,8 +184,8 @@ impl ValueOrd for AnyRef<'_> {
     }
 }
 
-impl<'a> From<AnyRef<'a>> for ByteSlice<'a> {
-    fn from(any: AnyRef<'a>) -> ByteSlice<'a> {
+impl<'a> From<AnyRef<'a>> for BytesRef<'a> {
+    fn from(any: AnyRef<'a>) -> BytesRef<'a> {
         any.value
     }
 }

--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -8,7 +8,7 @@ use crate::{
 use core::cmp::Ordering;
 
 #[cfg(feature = "alloc")]
-use crate::Bytes;
+use crate::BytesOwned;
 
 #[cfg(feature = "oid")]
 use crate::asn1::ObjectIdentifier;
@@ -211,14 +211,14 @@ pub struct Any {
     tag: Tag,
 
     /// Inner value encoded as bytes.
-    value: Bytes,
+    value: BytesOwned,
 }
 
 #[cfg(feature = "alloc")]
 impl Any {
     /// Create a new [`Any`] from the provided [`Tag`] and DER bytes.
     pub fn new(tag: Tag, bytes: &[u8]) -> Result<Self> {
-        let value = Bytes::new(bytes)?;
+        let value = BytesOwned::new(bytes)?;
 
         // Ensure the tag and value are a valid `AnyRef`.
         AnyRef::new(tag, value.as_slice())?;
@@ -293,7 +293,7 @@ where
         let anyref: AnyRef<'a> = input.into();
         Self {
             tag: anyref.tag(),
-            value: Bytes::from(anyref.value),
+            value: BytesOwned::from(anyref.value),
         }
     }
 }
@@ -308,7 +308,7 @@ mod allocating {
         fn to_owned(&self) -> Self::Owned {
             Any {
                 tag: self.tag(),
-                value: Bytes::from(self.value),
+                value: BytesOwned::from(self.value),
             }
         }
     }

--- a/der/src/asn1/bit_string.rs
+++ b/der/src/asn1/bit_string.rs
@@ -354,6 +354,23 @@ impl ValueOrd for BitString {
     }
 }
 
+// Implement by hand because the derive would create invalid values.
+// Use the constructor to create a valid value.
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for BitString {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Self::new(
+            u.int_in_range(0..=Self::MAX_UNUSED_BITS)?,
+            BytesRef::arbitrary(u)?.as_slice(),
+        )
+        .map_err(|_| arbitrary::Error::IncorrectFormat)
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        arbitrary::size_hint::and(u8::size_hint(depth), BytesRef::size_hint(depth))
+    }
+}
+
 #[cfg(feature = "alloc")]
 mod allocating {
     use super::*;

--- a/der/src/asn1/ia5_string.rs
+++ b/der/src/asn1/ia5_string.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     asn1::AnyRef, ord::OrdIsValueOrd, ByteSlice, DecodeValue, EncodeValue, Error, FixedTag, Header,
-    Length, Reader, Result, StrSlice, Tag, Writer,
+    Length, Reader, Result, StrRef, Tag, Writer,
 };
 use core::{fmt, ops::Deref, str};
 
@@ -24,7 +24,7 @@ use crate::asn1::Any;
 #[derive(Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Ia5StringRef<'a> {
     /// Inner value
-    inner: StrSlice<'a>,
+    inner: StrRef<'a>,
 }
 
 impl<'a> Ia5StringRef<'a> {
@@ -40,14 +40,14 @@ impl<'a> Ia5StringRef<'a> {
             return Err(Self::TAG.value_error());
         }
 
-        StrSlice::from_bytes(input)
+        StrRef::from_bytes(input)
             .map(|inner| Self { inner })
             .map_err(|_| Self::TAG.value_error())
     }
 }
 
 impl<'a> Deref for Ia5StringRef<'a> {
-    type Target = StrSlice<'a>;
+    type Target = StrRef<'a>;
 
     fn deref(&self) -> &Self::Target {
         &self.inner

--- a/der/src/asn1/ia5_string.rs
+++ b/der/src/asn1/ia5_string.rs
@@ -9,6 +9,76 @@ use core::{fmt, ops::Deref, str};
 #[cfg(feature = "alloc")]
 use crate::asn1::Any;
 
+macro_rules! impl_ia5_string {
+    ($type: ty) => {
+        impl_ia5_string!($type,);
+    };
+    ($type: ty, $($li: lifetime)?) => {
+        impl<$($li),*> AsRef<str> for $type {
+            fn as_ref(&self) -> &str {
+                self.as_str()
+            }
+        }
+
+        impl<$($li),*> AsRef<[u8]> for $type {
+            fn as_ref(&self) -> &[u8] {
+                self.as_bytes()
+            }
+        }
+
+        impl<'__der: $($li),*, $($li),*> DecodeValue<'__der> for $type {
+            fn decode_value<R: Reader<'__der>>(reader: &mut R, header: Header) -> Result<Self> {
+                Self::new(BytesRef::decode_value(reader, header)?.as_slice())
+            }
+        }
+
+        impl<$($li),*> EncodeValue for $type {
+            fn value_len(&self) -> Result<Length> {
+                self.inner.value_len()
+            }
+
+            fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+                self.inner.encode_value(writer)
+            }
+        }
+
+        impl<$($li),*> FixedTag for $type {
+            const TAG: Tag = Tag::Ia5String;
+        }
+
+        impl<$($li),*> OrdIsValueOrd for $type {}
+
+        impl<'__der: $($li),*, $($li),*> TryFrom<AnyRef<'__der>> for $type {
+            type Error = Error;
+
+            fn try_from(any: AnyRef<'__der>) -> Result<$type> {
+                any.decode_into()
+            }
+        }
+
+        #[cfg(feature = "alloc")]
+        impl<'__der: $($li),*, $($li),*> TryFrom<&'__der Any> for $type {
+            type Error = Error;
+
+            fn try_from(any: &'__der Any) -> Result<$type> {
+                any.decode_into()
+            }
+        }
+
+        impl<$($li),*> fmt::Display for $type {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str(self.as_str())
+            }
+        }
+
+        impl<$($li),*> fmt::Debug for $type {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "Ia5String({:?})", self.as_str())
+            }
+        }
+    };
+}
+
 /// ASN.1 `IA5String` type.
 ///
 /// Supports the [International Alphabet No. 5 (IA5)] character encoding, i.e.
@@ -46,6 +116,8 @@ impl<'a> Ia5StringRef<'a> {
     }
 }
 
+impl_ia5_string!(Ia5StringRef<'a>, 'a);
+
 impl<'a> Deref for Ia5StringRef<'a> {
     type Target = StrRef<'a>;
 
@@ -54,78 +126,103 @@ impl<'a> Deref for Ia5StringRef<'a> {
     }
 }
 
-impl AsRef<str> for Ia5StringRef<'_> {
-    fn as_ref(&self) -> &str {
-        self.as_str()
-    }
-}
-
-impl AsRef<[u8]> for Ia5StringRef<'_> {
-    fn as_ref(&self) -> &[u8] {
-        self.as_bytes()
-    }
-}
-
-impl<'a> DecodeValue<'a> for Ia5StringRef<'a> {
-    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
-        Self::new(BytesRef::decode_value(reader, header)?.as_slice())
-    }
-}
-
-impl EncodeValue for Ia5StringRef<'_> {
-    fn value_len(&self) -> Result<Length> {
-        self.inner.value_len()
-    }
-
-    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
-        self.inner.encode_value(writer)
-    }
-}
-
-impl<'a> FixedTag for Ia5StringRef<'a> {
-    const TAG: Tag = Tag::Ia5String;
-}
-
-impl OrdIsValueOrd for Ia5StringRef<'_> {}
-
 impl<'a> From<&Ia5StringRef<'a>> for Ia5StringRef<'a> {
     fn from(value: &Ia5StringRef<'a>) -> Ia5StringRef<'a> {
         *value
     }
 }
 
-impl<'a> TryFrom<AnyRef<'a>> for Ia5StringRef<'a> {
-    type Error = Error;
-
-    fn try_from(any: AnyRef<'a>) -> Result<Ia5StringRef<'a>> {
-        any.decode_into()
+impl<'a> From<Ia5StringRef<'a>> for AnyRef<'a> {
+    fn from(internationalized_string: Ia5StringRef<'a>) -> AnyRef<'a> {
+        AnyRef::from_tag_and_value(Tag::Ia5String, internationalized_string.inner.into())
     }
 }
 
 #[cfg(feature = "alloc")]
-impl<'a> TryFrom<&'a Any> for Ia5StringRef<'a> {
-    type Error = Error;
+pub use self::allocation::Ia5String;
 
-    fn try_from(any: &'a Any) -> Result<Ia5StringRef<'a>> {
-        any.decode_into()
+#[cfg(feature = "alloc")]
+mod allocation {
+    use super::Ia5StringRef;
+    use crate::{
+        asn1::{Any, AnyRef},
+        ord::OrdIsValueOrd,
+        referenced::{OwnedToRef, RefToOwned},
+        BytesRef, DecodeValue, EncodeValue, Error, FixedTag, Header, Length, Reader, Result,
+        StrOwned, Tag, Writer,
+    };
+    use core::{fmt, ops::Deref, str};
+
+    /// ASN.1 `IA5String` type.
+    ///
+    /// Supports the [International Alphabet No. 5 (IA5)] character encoding, i.e.
+    /// the lower 128 characters of the ASCII alphabet. (Note: IA5 is now
+    /// technically known as the International Reference Alphabet or IRA as
+    /// specified in the ITU-T's T.50 recommendation).
+    ///
+    /// For UTF-8, use [`String`][`alloc::string::String`].
+    ///
+    /// [International Alphabet No. 5 (IA5)]: https://en.wikipedia.org/wiki/T.50_%28standard%29
+    #[derive(Clone, Eq, PartialEq, PartialOrd, Ord)]
+    pub struct Ia5String {
+        /// Inner value
+        inner: StrOwned,
     }
-}
 
-impl<'a> From<Ia5StringRef<'a>> for AnyRef<'a> {
-    fn from(printable_string: Ia5StringRef<'a>) -> AnyRef<'a> {
-        AnyRef::from_tag_and_value(Tag::Ia5String, printable_string.inner.into())
+    impl Ia5String {
+        /// Create a new `IA5String`.
+        pub fn new<T>(input: &T) -> Result<Self>
+        where
+            T: AsRef<[u8]> + ?Sized,
+        {
+            let input = input.as_ref();
+            Ia5StringRef::new(input)?;
+
+            StrOwned::from_bytes(input)
+                .map(|inner| Self { inner })
+                .map_err(|_| Self::TAG.value_error())
+        }
     }
-}
 
-impl<'a> fmt::Display for Ia5StringRef<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.as_str())
+    impl_ia5_string!(Ia5String);
+
+    impl Deref for Ia5String {
+        type Target = StrOwned;
+
+        fn deref(&self) -> &Self::Target {
+            &self.inner
+        }
     }
-}
 
-impl<'a> fmt::Debug for Ia5StringRef<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Ia5String({:?})", self.as_str())
+    impl<'a> From<Ia5StringRef<'a>> for Ia5String {
+        fn from(international_string: Ia5StringRef<'a>) -> Ia5String {
+            let inner = international_string.inner.into();
+            Self { inner }
+        }
+    }
+
+    impl<'a> From<&'a Ia5String> for AnyRef<'a> {
+        fn from(international_string: &'a Ia5String) -> AnyRef<'a> {
+            AnyRef::from_tag_and_value(Tag::Ia5String, (&international_string.inner).into())
+        }
+    }
+
+    impl<'a> RefToOwned<'a> for Ia5StringRef<'a> {
+        type Owned = Ia5String;
+        fn to_owned(&self) -> Self::Owned {
+            Ia5String {
+                inner: self.inner.to_owned(),
+            }
+        }
+    }
+
+    impl OwnedToRef for Ia5String {
+        type Borrowed<'a> = Ia5StringRef<'a>;
+        fn to_ref(&self) -> Self::Borrowed<'_> {
+            Ia5StringRef {
+                inner: self.inner.to_ref(),
+            }
+        }
     }
 }
 
@@ -138,7 +235,7 @@ mod tests {
     #[test]
     fn parse_bytes() {
         let example_bytes = hex!("16 0d 74 65 73 74 31 40 72 73 61 2e 63 6f 6d");
-        let printable_string = Ia5StringRef::from_der(&example_bytes).unwrap();
-        assert_eq!(printable_string.as_str(), "test1@rsa.com");
+        let internationalized_string = Ia5StringRef::from_der(&example_bytes).unwrap();
+        assert_eq!(internationalized_string.as_str(), "test1@rsa.com");
     }
 }

--- a/der/src/asn1/ia5_string.rs
+++ b/der/src/asn1/ia5_string.rs
@@ -1,7 +1,7 @@
 //! ASN.1 `IA5String` support.
 
 use crate::{
-    asn1::AnyRef, ord::OrdIsValueOrd, ByteSlice, DecodeValue, EncodeValue, Error, FixedTag, Header,
+    asn1::AnyRef, ord::OrdIsValueOrd, BytesRef, DecodeValue, EncodeValue, Error, FixedTag, Header,
     Length, Reader, Result, StrRef, Tag, Writer,
 };
 use core::{fmt, ops::Deref, str};
@@ -68,7 +68,7 @@ impl AsRef<[u8]> for Ia5StringRef<'_> {
 
 impl<'a> DecodeValue<'a> for Ia5StringRef<'a> {
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
-        Self::new(ByteSlice::decode_value(reader, header)?.as_slice())
+        Self::new(BytesRef::decode_value(reader, header)?.as_slice())
     }
 }
 

--- a/der/src/asn1/ia5_string.rs
+++ b/der/src/asn1/ia5_string.rs
@@ -1,74 +1,17 @@
 //! ASN.1 `IA5String` support.
 
-use crate::{
-    asn1::AnyRef, ord::OrdIsValueOrd, BytesRef, DecodeValue, EncodeValue, Error, FixedTag, Header,
-    Length, Reader, Result, StrRef, Tag, Writer,
-};
-use core::{fmt, ops::Deref, str};
-
-#[cfg(feature = "alloc")]
-use crate::asn1::Any;
+use crate::{asn1::AnyRef, FixedTag, Result, StrRef, Tag};
+use core::{fmt, ops::Deref};
 
 macro_rules! impl_ia5_string {
     ($type: ty) => {
         impl_ia5_string!($type,);
     };
     ($type: ty, $($li: lifetime)?) => {
-        impl<$($li),*> AsRef<str> for $type {
-            fn as_ref(&self) -> &str {
-                self.as_str()
-            }
-        }
-
-        impl<$($li),*> AsRef<[u8]> for $type {
-            fn as_ref(&self) -> &[u8] {
-                self.as_bytes()
-            }
-        }
-
-        impl<'__der: $($li),*, $($li),*> DecodeValue<'__der> for $type {
-            fn decode_value<R: Reader<'__der>>(reader: &mut R, header: Header) -> Result<Self> {
-                Self::new(BytesRef::decode_value(reader, header)?.as_slice())
-            }
-        }
-
-        impl<$($li),*> EncodeValue for $type {
-            fn value_len(&self) -> Result<Length> {
-                self.inner.value_len()
-            }
-
-            fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
-                self.inner.encode_value(writer)
-            }
-        }
+        impl_string_type!($type, $($li),*);
 
         impl<$($li),*> FixedTag for $type {
             const TAG: Tag = Tag::Ia5String;
-        }
-
-        impl<$($li),*> OrdIsValueOrd for $type {}
-
-        impl<'__der: $($li),*, $($li),*> TryFrom<AnyRef<'__der>> for $type {
-            type Error = Error;
-
-            fn try_from(any: AnyRef<'__der>) -> Result<$type> {
-                any.decode_into()
-            }
-        }
-
-        #[cfg(feature = "alloc")]
-        impl<'__der: $($li),*, $($li),*> TryFrom<&'__der Any> for $type {
-            type Error = Error;
-
-            fn try_from(any: &'__der Any) -> Result<$type> {
-                any.decode_into()
-            }
-        }
-
-        impl<$($li),*> fmt::Display for $type {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                f.write_str(self.as_str())
-            }
         }
 
         impl<$($li),*> fmt::Debug for $type {
@@ -145,13 +88,11 @@ pub use self::allocation::Ia5String;
 mod allocation {
     use super::Ia5StringRef;
     use crate::{
-        asn1::{Any, AnyRef},
-        ord::OrdIsValueOrd,
+        asn1::AnyRef,
         referenced::{OwnedToRef, RefToOwned},
-        BytesRef, DecodeValue, EncodeValue, Error, FixedTag, Header, Length, Reader, Result,
-        StrOwned, Tag, Writer,
+        FixedTag, Result, StrOwned, Tag,
     };
-    use core::{fmt, ops::Deref, str};
+    use core::{fmt, ops::Deref};
 
     /// ASN.1 `IA5String` type.
     ///

--- a/der/src/asn1/integer.rs
+++ b/der/src/asn1/integer.rs
@@ -7,7 +7,7 @@ pub(super) mod uint;
 use core::{cmp::Ordering, mem};
 
 use crate::{
-    asn1::AnyRef, ByteSlice, DecodeValue, EncodeValue, Error, FixedTag, Header, Length, Reader,
+    asn1::AnyRef, BytesRef, DecodeValue, EncodeValue, Error, FixedTag, Header, Length, Reader,
     Result, SliceWriter, Tag, ValueOrd, Writer,
 };
 
@@ -16,7 +16,7 @@ macro_rules! impl_int_encoding {
         $(
             impl<'a> DecodeValue<'a> for $int {
                 fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
-                    let bytes = ByteSlice::decode_value(reader, header)?.as_slice();
+                    let bytes = BytesRef::decode_value(reader, header)?.as_slice();
 
                     let result = if is_highest_bit_set(bytes) {
                         <$uint>::from_be_bytes(int::decode_to_array(bytes)?) as $int
@@ -77,7 +77,7 @@ macro_rules! impl_uint_encoding {
         $(
             impl<'a> DecodeValue<'a> for $uint {
                 fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
-                    let bytes = ByteSlice::decode_value(reader, header)?.as_slice();
+                    let bytes = BytesRef::decode_value(reader, header)?.as_slice();
                     let result = Self::from_be_bytes(uint::decode_to_array(bytes)?);
 
                     // Ensure we compute the same encoded length as the original any value

--- a/der/src/asn1/integer/bigint.rs
+++ b/der/src/asn1/integer/bigint.rs
@@ -187,7 +187,7 @@ mod allocating {
         asn1::AnyRef,
         ord::OrdIsValueOrd,
         referenced::{OwnedToRef, RefToOwned},
-        Bytes, DecodeValue, EncodeValue, Error, ErrorKind, FixedTag, Header, Length, Reader,
+        BytesOwned, DecodeValue, EncodeValue, Error, ErrorKind, FixedTag, Header, Length, Reader,
         Result, Tag, Writer,
     };
 
@@ -201,13 +201,13 @@ mod allocating {
     #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
     pub struct Int {
         /// Inner value
-        inner: Bytes,
+        inner: BytesOwned,
     }
 
     impl Int {
         /// Create a new [`Int`] from a byte slice.
         pub fn new(bytes: &[u8]) -> Result<Self> {
-            let inner = Bytes::new(int::strip_leading_ones(bytes))
+            let inner = BytesOwned::new(int::strip_leading_ones(bytes))
                 .map_err(|_| ErrorKind::Length { tag: Self::TAG })?;
 
             Ok(Self { inner })
@@ -232,7 +232,7 @@ mod allocating {
 
     impl<'a> DecodeValue<'a> for Int {
         fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
-            let bytes = Bytes::decode_value(reader, header)?;
+            let bytes = BytesOwned::decode_value(reader, header)?;
             let result = Self::new(int::decode_to_slice(bytes.as_slice())?)?;
 
             // Ensure we compute the same encoded length as the original any value.
@@ -256,7 +256,7 @@ mod allocating {
 
     impl<'a> From<&IntRef<'a>> for Int {
         fn from(value: &IntRef<'a>) -> Int {
-            let inner = Bytes::new(value.as_bytes()).expect("Invalid Int");
+            let inner = BytesOwned::new(value.as_bytes()).expect("Invalid Int");
             Int { inner }
         }
     }
@@ -303,13 +303,13 @@ mod allocating {
     #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
     pub struct Uint {
         /// Inner value
-        inner: Bytes,
+        inner: BytesOwned,
     }
 
     impl Uint {
         /// Create a new [`Uint`] from a byte slice.
         pub fn new(bytes: &[u8]) -> Result<Self> {
-            let inner = Bytes::new(uint::strip_leading_zeroes(bytes))
+            let inner = BytesOwned::new(uint::strip_leading_zeroes(bytes))
                 .map_err(|_| ErrorKind::Length { tag: Self::TAG })?;
 
             Ok(Self { inner })
@@ -334,7 +334,7 @@ mod allocating {
 
     impl<'a> DecodeValue<'a> for Uint {
         fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
-            let bytes = Bytes::decode_value(reader, header)?;
+            let bytes = BytesOwned::decode_value(reader, header)?;
             let result = Self::new(uint::decode_to_slice(bytes.as_slice())?)?;
 
             // Ensure we compute the same encoded length as the original any value.
@@ -363,7 +363,7 @@ mod allocating {
 
     impl<'a> From<&UintRef<'a>> for Uint {
         fn from(value: &UintRef<'a>) -> Uint {
-            let inner = Bytes::new(value.as_bytes()).expect("Invalid Uint");
+            let inner = BytesOwned::new(value.as_bytes()).expect("Invalid Uint");
             Uint { inner }
         }
     }

--- a/der/src/asn1/integer/bigint.rs
+++ b/der/src/asn1/integer/bigint.rs
@@ -2,7 +2,7 @@
 
 use super::{int, uint};
 use crate::{
-    asn1::AnyRef, ord::OrdIsValueOrd, ByteSlice, DecodeValue, EncodeValue, Error, ErrorKind,
+    asn1::AnyRef, ord::OrdIsValueOrd, BytesRef, DecodeValue, EncodeValue, Error, ErrorKind,
     FixedTag, Header, Length, Reader, Result, Tag, Writer,
 };
 
@@ -16,13 +16,13 @@ use crate::{
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct IntRef<'a> {
     /// Inner value
-    inner: ByteSlice<'a>,
+    inner: BytesRef<'a>,
 }
 
 impl<'a> IntRef<'a> {
     /// Create a new [`IntRef`] from a byte slice.
     pub fn new(bytes: &'a [u8]) -> Result<Self> {
-        let inner = ByteSlice::new(int::strip_leading_ones(bytes))
+        let inner = BytesRef::new(int::strip_leading_ones(bytes))
             .map_err(|_| ErrorKind::Length { tag: Self::TAG })?;
 
         Ok(Self { inner })
@@ -47,7 +47,7 @@ impl<'a> IntRef<'a> {
 
 impl<'a> DecodeValue<'a> for IntRef<'a> {
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
-        let bytes = ByteSlice::decode_value(reader, header)?.as_slice();
+        let bytes = BytesRef::decode_value(reader, header)?.as_slice();
         let result = Self::new(int::decode_to_slice(bytes)?)?;
 
         // Ensure we compute the same encoded length as the original any value.
@@ -99,13 +99,13 @@ impl<'a> OrdIsValueOrd for IntRef<'a> {}
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct UintRef<'a> {
     /// Inner value
-    inner: ByteSlice<'a>,
+    inner: BytesRef<'a>,
 }
 
 impl<'a> UintRef<'a> {
     /// Create a new [`UintRef`] from a byte slice.
     pub fn new(bytes: &'a [u8]) -> Result<Self> {
-        let inner = ByteSlice::new(uint::strip_leading_zeroes(bytes))
+        let inner = BytesRef::new(uint::strip_leading_zeroes(bytes))
             .map_err(|_| ErrorKind::Length { tag: Self::TAG })?;
 
         Ok(Self { inner })
@@ -130,7 +130,7 @@ impl<'a> UintRef<'a> {
 
 impl<'a> DecodeValue<'a> for UintRef<'a> {
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
-        let bytes = ByteSlice::decode_value(reader, header)?.as_slice();
+        let bytes = BytesRef::decode_value(reader, header)?.as_slice();
         let result = Self::new(uint::decode_to_slice(bytes)?)?;
 
         // Ensure we compute the same encoded length as the original any value.

--- a/der/src/asn1/internal_macros.rs
+++ b/der/src/asn1/internal_macros.rs
@@ -1,0 +1,61 @@
+macro_rules! impl_string_type {
+    ($type: ty, $($li: lifetime)?) => {
+        mod __impl {
+            use super::*;
+
+            use crate::{
+                ord::OrdIsValueOrd, BytesRef, DecodeValue, EncodeValue, Header, Length, Reader,
+                Result, Writer,
+            };
+            use core::{fmt, str};
+
+            #[cfg(feature = "alloc")]
+            use crate::{asn1::Any, Error};
+
+            impl<$($li),*> AsRef<str> for $type {
+                fn as_ref(&self) -> &str {
+                    self.as_str()
+                }
+            }
+
+            impl<$($li),*> AsRef<[u8]> for $type {
+                fn as_ref(&self) -> &[u8] {
+                    self.as_bytes()
+                }
+            }
+
+            impl<'__der: $($li),*, $($li),*> DecodeValue<'__der> for $type {
+                fn decode_value<R: Reader<'__der>>(reader: &mut R, header: Header) -> Result<Self> {
+                    Self::new(BytesRef::decode_value(reader, header)?.as_slice())
+                }
+            }
+
+            impl<$($li),*> EncodeValue for $type {
+                fn value_len(&self) -> Result<Length> {
+                    self.inner.value_len()
+                }
+
+                fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+                    self.inner.encode_value(writer)
+                }
+            }
+
+            impl<$($li),*> OrdIsValueOrd for $type {}
+
+            impl<$($li),*> fmt::Display for $type {
+                fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    f.write_str(self.as_str())
+                }
+            }
+
+            #[cfg(feature = "alloc")]
+            impl<'__der: $($li),*, $($li),*> TryFrom<&'__der Any> for $type {
+                type Error = Error;
+
+                fn try_from(any: &'__der Any) -> Result<$type> {
+                    any.decode_into()
+                }
+            }
+        }
+    };
+}

--- a/der/src/asn1/null.rs
+++ b/der/src/asn1/null.rs
@@ -1,7 +1,7 @@
 //! ASN.1 `NULL` support.
 
 use crate::{
-    asn1::AnyRef, ord::OrdIsValueOrd, ByteSlice, DecodeValue, EncodeValue, Error, ErrorKind,
+    asn1::AnyRef, ord::OrdIsValueOrd, BytesRef, DecodeValue, EncodeValue, Error, ErrorKind,
     FixedTag, Header, Length, Reader, Result, Tag, Writer,
 };
 
@@ -37,7 +37,7 @@ impl OrdIsValueOrd for Null {}
 
 impl<'a> From<Null> for AnyRef<'a> {
     fn from(_: Null) -> AnyRef<'a> {
-        AnyRef::from_tag_and_value(Tag::Null, ByteSlice::default())
+        AnyRef::from_tag_and_value(Tag::Null, BytesRef::default())
     }
 }
 

--- a/der/src/asn1/octet_string.rs
+++ b/der/src/asn1/octet_string.rs
@@ -1,8 +1,8 @@
 //! ASN.1 `OCTET STRING` support.
 
 use crate::{
-    asn1::AnyRef, ord::OrdIsValueOrd, ByteSlice, Decode, DecodeValue, EncodeValue, Error,
-    ErrorKind, FixedTag, Header, Length, Reader, Result, Tag, Writer,
+    asn1::AnyRef, ord::OrdIsValueOrd, BytesRef, Decode, DecodeValue, EncodeValue, Error, ErrorKind,
+    FixedTag, Header, Length, Reader, Result, Tag, Writer,
 };
 
 #[cfg(feature = "alloc")]
@@ -16,13 +16,13 @@ use alloc::vec::Vec;
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct OctetStringRef<'a> {
     /// Inner value
-    inner: ByteSlice<'a>,
+    inner: BytesRef<'a>,
 }
 
 impl<'a> OctetStringRef<'a> {
     /// Create a new ASN.1 `OCTET STRING` from a byte slice.
     pub fn new(slice: &'a [u8]) -> Result<Self> {
-        ByteSlice::new(slice)
+        BytesRef::new(slice)
             .map(|inner| Self { inner })
             .map_err(|_| ErrorKind::Length { tag: Self::TAG }.into())
     }
@@ -56,7 +56,7 @@ impl AsRef<[u8]> for OctetStringRef<'_> {
 
 impl<'a> DecodeValue<'a> for OctetStringRef<'a> {
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
-        let inner = ByteSlice::decode_value(reader, header)?;
+        let inner = BytesRef::decode_value(reader, header)?;
         Ok(Self { inner })
     }
 }

--- a/der/src/asn1/octet_string.rs
+++ b/der/src/asn1/octet_string.rs
@@ -186,6 +186,19 @@ impl<'a> From<&'a OctetString> for OctetStringRef<'a> {
 #[cfg(feature = "alloc")]
 impl OrdIsValueOrd for OctetString {}
 
+// Implement by hand because the derive would create invalid values.
+// Use the constructor to create a valid value.
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for OctetString {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Self::new(Vec::arbitrary(u)?).map_err(|_| arbitrary::Error::IncorrectFormat)
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        arbitrary::size_hint::and(u8::size_hint(depth), Vec::<u8>::size_hint(depth))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::asn1::{OctetStringRef, PrintableStringRef};

--- a/der/src/asn1/printable_string.rs
+++ b/der/src/asn1/printable_string.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     asn1::AnyRef, ord::OrdIsValueOrd, ByteSlice, DecodeValue, EncodeValue, Error, FixedTag, Header,
-    Length, Reader, Result, StrSlice, Tag, Writer,
+    Length, Reader, Result, StrRef, Tag, Writer,
 };
 use core::{fmt, ops::Deref, str};
 
@@ -41,7 +41,7 @@ use crate::asn1::Any;
 #[derive(Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub struct PrintableStringRef<'a> {
     /// Inner value
-    inner: StrSlice<'a>,
+    inner: StrRef<'a>,
 }
 
 impl<'a> PrintableStringRef<'a> {
@@ -74,14 +74,14 @@ impl<'a> PrintableStringRef<'a> {
             }
         }
 
-        StrSlice::from_bytes(input)
+        StrRef::from_bytes(input)
             .map(|inner| Self { inner })
             .map_err(|_| Self::TAG.value_error())
     }
 }
 
 impl<'a> Deref for PrintableStringRef<'a> {
-    type Target = StrSlice<'a>;
+    type Target = StrRef<'a>;
 
     fn deref(&self) -> &Self::Target {
         &self.inner

--- a/der/src/asn1/printable_string.rs
+++ b/der/src/asn1/printable_string.rs
@@ -1,7 +1,7 @@
 //! ASN.1 `PrintableString` support.
 
 use crate::{
-    asn1::AnyRef, ord::OrdIsValueOrd, ByteSlice, DecodeValue, EncodeValue, Error, FixedTag, Header,
+    asn1::AnyRef, ord::OrdIsValueOrd, BytesRef, DecodeValue, EncodeValue, Error, FixedTag, Header,
     Length, Reader, Result, StrRef, Tag, Writer,
 };
 use core::{fmt, ops::Deref, str};
@@ -102,7 +102,7 @@ impl AsRef<[u8]> for PrintableStringRef<'_> {
 
 impl<'a> DecodeValue<'a> for PrintableStringRef<'a> {
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
-        Self::new(ByteSlice::decode_value(reader, header)?.as_slice())
+        Self::new(BytesRef::decode_value(reader, header)?.as_slice())
     }
 }
 

--- a/der/src/asn1/printable_string.rs
+++ b/der/src/asn1/printable_string.rs
@@ -1,13 +1,26 @@
 //! ASN.1 `PrintableString` support.
 
-use crate::{
-    asn1::AnyRef, ord::OrdIsValueOrd, BytesRef, DecodeValue, EncodeValue, Error, FixedTag, Header,
-    Length, Reader, Result, StrRef, Tag, Writer,
-};
-use core::{fmt, ops::Deref, str};
+use crate::{asn1::AnyRef, Error, FixedTag, Result, StrRef, Tag};
+use core::{fmt, ops::Deref};
 
-#[cfg(feature = "alloc")]
-use crate::asn1::Any;
+macro_rules! impl_printable_string {
+    ($type: ty) => {
+        impl_printable_string!($type,);
+    };
+    ($type: ty, $($li: lifetime)?) => {
+        impl_string_type!($type, $($li),*);
+
+        impl<$($li),*> FixedTag for $type {
+            const TAG: Tag = Tag::PrintableString;
+        }
+
+        impl<$($li),*> fmt::Debug for $type {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "PrintableString({:?})", self.as_str())
+            }
+        }
+    };
+}
 
 /// ASN.1 `PrintableString` type.
 ///
@@ -80,6 +93,8 @@ impl<'a> PrintableStringRef<'a> {
     }
 }
 
+impl_printable_string!(PrintableStringRef<'a>, 'a);
+
 impl<'a> Deref for PrintableStringRef<'a> {
     type Target = StrRef<'a>;
 
@@ -87,41 +102,6 @@ impl<'a> Deref for PrintableStringRef<'a> {
         &self.inner
     }
 }
-
-impl AsRef<str> for PrintableStringRef<'_> {
-    fn as_ref(&self) -> &str {
-        self.as_str()
-    }
-}
-
-impl AsRef<[u8]> for PrintableStringRef<'_> {
-    fn as_ref(&self) -> &[u8] {
-        self.as_bytes()
-    }
-}
-
-impl<'a> DecodeValue<'a> for PrintableStringRef<'a> {
-    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
-        Self::new(BytesRef::decode_value(reader, header)?.as_slice())
-    }
-}
-
-impl<'a> EncodeValue for PrintableStringRef<'a> {
-    fn value_len(&self) -> Result<Length> {
-        self.inner.value_len()
-    }
-
-    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
-        self.inner.encode_value(writer)
-    }
-}
-
-impl FixedTag for PrintableStringRef<'_> {
-    const TAG: Tag = Tag::PrintableString;
-}
-
-impl OrdIsValueOrd for PrintableStringRef<'_> {}
-
 impl<'a> From<&PrintableStringRef<'a>> for PrintableStringRef<'a> {
     fn from(value: &PrintableStringRef<'a>) -> PrintableStringRef<'a> {
         *value
@@ -136,30 +116,125 @@ impl<'a> TryFrom<AnyRef<'a>> for PrintableStringRef<'a> {
     }
 }
 
-#[cfg(feature = "alloc")]
-impl<'a> TryFrom<&'a Any> for PrintableStringRef<'a> {
-    type Error = Error;
-
-    fn try_from(any: &'a Any) -> Result<PrintableStringRef<'a>> {
-        any.decode_into()
-    }
-}
-
 impl<'a> From<PrintableStringRef<'a>> for AnyRef<'a> {
     fn from(printable_string: PrintableStringRef<'a>) -> AnyRef<'a> {
         AnyRef::from_tag_and_value(Tag::PrintableString, printable_string.inner.into())
     }
 }
 
-impl<'a> fmt::Display for PrintableStringRef<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.as_str())
-    }
-}
+#[cfg(feature = "alloc")]
+pub use self::allocation::PrintableString;
 
-impl<'a> fmt::Debug for PrintableStringRef<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "PrintableString({:?})", self.as_str())
+#[cfg(feature = "alloc")]
+mod allocation {
+    use super::PrintableStringRef;
+
+    use crate::{
+        asn1::AnyRef,
+        referenced::{OwnedToRef, RefToOwned},
+        BytesRef, Error, FixedTag, Result, StrOwned, Tag,
+    };
+    use core::{fmt, ops::Deref};
+
+    /// ASN.1 `PrintableString` type.
+    ///
+    /// Supports a subset the ASCII character set (described below).
+    ///
+    /// For UTF-8, use [`Utf8StringRef`][`crate::asn1::Utf8StringRef`] instead.
+    /// For the full ASCII character set, use
+    /// [`Ia5StringRef`][`crate::asn1::Ia5StringRef`].
+    ///
+    /// # Supported characters
+    ///
+    /// The following ASCII characters/ranges are supported:
+    ///
+    /// - `A..Z`
+    /// - `a..z`
+    /// - `0..9`
+    /// - "` `" (i.e. space)
+    /// - `\`
+    /// - `(`
+    /// - `)`
+    /// - `+`
+    /// - `,`
+    /// - `-`
+    /// - `.`
+    /// - `/`
+    /// - `:`
+    /// - `=`
+    /// - `?`
+    #[derive(Clone, Eq, PartialEq, PartialOrd, Ord)]
+    pub struct PrintableString {
+        /// Inner value
+        inner: StrOwned,
+    }
+
+    impl PrintableString {
+        /// Create a new ASN.1 `PrintableString`.
+        pub fn new<T>(input: &T) -> Result<Self>
+        where
+            T: AsRef<[u8]> + ?Sized,
+        {
+            let input = input.as_ref();
+            PrintableStringRef::new(input)?;
+
+            StrOwned::from_bytes(input)
+                .map(|inner| Self { inner })
+                .map_err(|_| Self::TAG.value_error())
+        }
+    }
+
+    impl_printable_string!(PrintableString);
+
+    impl Deref for PrintableString {
+        type Target = StrOwned;
+
+        fn deref(&self) -> &Self::Target {
+            &self.inner
+        }
+    }
+
+    impl<'a> From<PrintableStringRef<'a>> for PrintableString {
+        fn from(value: PrintableStringRef<'a>) -> PrintableString {
+            let inner =
+                StrOwned::from_bytes(value.inner.as_bytes()).expect("Invalid PrintableString");
+            Self { inner }
+        }
+    }
+
+    impl<'a> TryFrom<&AnyRef<'a>> for PrintableString {
+        type Error = Error;
+
+        fn try_from(any: &AnyRef<'a>) -> Result<PrintableString> {
+            (*any).decode_into()
+        }
+    }
+
+    impl<'a> From<&'a PrintableString> for AnyRef<'a> {
+        fn from(printable_string: &'a PrintableString) -> AnyRef<'a> {
+            AnyRef::from_tag_and_value(
+                Tag::PrintableString,
+                BytesRef::new(printable_string.inner.as_bytes()).expect("Invalid PrintableString"),
+            )
+        }
+    }
+
+    impl<'a> RefToOwned<'a> for PrintableStringRef<'a> {
+        type Owned = PrintableString;
+        fn to_owned(&self) -> Self::Owned {
+            PrintableString {
+                inner: self.inner.to_owned(),
+            }
+        }
+    }
+
+    impl OwnedToRef for PrintableString {
+        type Borrowed<'a> = PrintableStringRef<'a>;
+        fn to_ref(&self) -> Self::Borrowed<'_> {
+            PrintableStringRef {
+                inner: self.inner.to_ref(),
+            }
+        }
     }
 }
 

--- a/der/src/asn1/real.rs
+++ b/der/src/asn1/real.rs
@@ -8,7 +8,7 @@
 )]
 
 use crate::{
-    ByteSlice, DecodeValue, EncodeValue, FixedTag, Header, Length, Reader, Result, StrRef, Tag,
+    BytesRef, DecodeValue, EncodeValue, FixedTag, Header, Length, Reader, Result, StrRef, Tag,
     Writer,
 };
 
@@ -17,7 +17,7 @@ use super::integer::uint::strip_leading_zeroes;
 #[cfg_attr(docsrs, doc(cfg(feature = "real")))]
 impl<'a> DecodeValue<'a> for f64 {
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
-        let bytes = ByteSlice::decode_value(reader, header)?.as_slice();
+        let bytes = BytesRef::decode_value(reader, header)?.as_slice();
 
         if header.length == Length::ZERO {
             Ok(0.0)

--- a/der/src/asn1/real.rs
+++ b/der/src/asn1/real.rs
@@ -8,8 +8,8 @@
 )]
 
 use crate::{
-    str_slice::StrSlice, ByteSlice, DecodeValue, EncodeValue, FixedTag, Header, Length, Reader,
-    Result, Tag, Writer,
+    ByteSlice, DecodeValue, EncodeValue, FixedTag, Header, Length, Reader, Result, StrRef, Tag,
+    Writer,
 };
 
 use super::integer::uint::strip_leading_zeroes;
@@ -74,7 +74,7 @@ impl<'a> DecodeValue<'a> for f64 {
                 _ => Err(Tag::Real.value_error()),
             }
         } else {
-            let astr = StrSlice::from_bytes(&bytes[1..])?;
+            let astr = StrRef::from_bytes(&bytes[1..])?;
             match astr.inner.parse::<f64>() {
                 Ok(val) => Ok(val),
                 // Real related error: encoding not supported or malformed

--- a/der/src/asn1/sequence.rs
+++ b/der/src/asn1/sequence.rs
@@ -2,7 +2,7 @@
 //! `SEQUENCE`s to Rust structs.
 
 use crate::{
-    ByteSlice, Decode, DecodeValue, Encode, EncodeValue, FixedTag, Header, Length, Reader, Result,
+    BytesRef, Decode, DecodeValue, Encode, EncodeValue, FixedTag, Header, Length, Reader, Result,
     Tag, Writer,
 };
 
@@ -58,13 +58,13 @@ where
 /// This is a zero-copy reference type which borrows from the input data.
 pub struct SequenceRef<'a> {
     /// Body of the `SEQUENCE`.
-    body: ByteSlice<'a>,
+    body: BytesRef<'a>,
 }
 
 impl<'a> DecodeValue<'a> for SequenceRef<'a> {
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         Ok(Self {
-            body: ByteSlice::decode_value(reader, header)?,
+            body: BytesRef::decode_value(reader, header)?,
         })
     }
 }

--- a/der/src/asn1/teletex_string.rs
+++ b/der/src/asn1/teletex_string.rs
@@ -1,7 +1,7 @@
 //! ASN.1 `TeletexString` support.
 
 use crate::{
-    asn1::AnyRef, ord::OrdIsValueOrd, ByteSlice, DecodeValue, EncodeValue, Error, FixedTag, Header,
+    asn1::AnyRef, ord::OrdIsValueOrd, BytesRef, DecodeValue, EncodeValue, Error, FixedTag, Header,
     Length, Reader, Result, StrRef, Tag, Writer,
 };
 use core::{fmt, ops::Deref, str};
@@ -72,7 +72,7 @@ impl AsRef<[u8]> for TeletexStringRef<'_> {
 
 impl<'a> DecodeValue<'a> for TeletexStringRef<'a> {
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
-        Self::new(ByteSlice::decode_value(reader, header)?.as_slice())
+        Self::new(BytesRef::decode_value(reader, header)?.as_slice())
     }
 }
 

--- a/der/src/asn1/teletex_string.rs
+++ b/der/src/asn1/teletex_string.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     asn1::AnyRef, ord::OrdIsValueOrd, ByteSlice, DecodeValue, EncodeValue, Error, FixedTag, Header,
-    Length, Reader, Result, StrSlice, Tag, Writer,
+    Length, Reader, Result, StrRef, Tag, Writer,
 };
 use core::{fmt, ops::Deref, str};
 
@@ -28,7 +28,7 @@ use crate::asn1::Any;
 #[derive(Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub struct TeletexStringRef<'a> {
     /// Inner value
-    inner: StrSlice<'a>,
+    inner: StrRef<'a>,
 }
 
 impl<'a> TeletexStringRef<'a> {
@@ -44,14 +44,14 @@ impl<'a> TeletexStringRef<'a> {
             return Err(Self::TAG.value_error());
         }
 
-        StrSlice::from_bytes(input)
+        StrRef::from_bytes(input)
             .map(|inner| Self { inner })
             .map_err(|_| Self::TAG.value_error())
     }
 }
 
 impl<'a> Deref for TeletexStringRef<'a> {
-    type Target = StrSlice<'a>;
+    type Target = StrRef<'a>;
 
     fn deref(&self) -> &Self::Target {
         &self.inner

--- a/der/src/asn1/teletex_string.rs
+++ b/der/src/asn1/teletex_string.rs
@@ -1,13 +1,26 @@
 //! ASN.1 `TeletexString` support.
+//!
+use crate::{asn1::AnyRef, Error, FixedTag, Result, StrRef, Tag};
+use core::{fmt, ops::Deref};
 
-use crate::{
-    asn1::AnyRef, ord::OrdIsValueOrd, BytesRef, DecodeValue, EncodeValue, Error, FixedTag, Header,
-    Length, Reader, Result, StrRef, Tag, Writer,
-};
-use core::{fmt, ops::Deref, str};
+macro_rules! impl_teletex_string {
+    ($type: ty) => {
+        impl_teletex_string!($type,);
+    };
+    ($type: ty, $($li: lifetime)?) => {
+        impl_string_type!($type, $($li),*);
 
-#[cfg(feature = "alloc")]
-use crate::asn1::Any;
+        impl<$($li),*> FixedTag for $type {
+            const TAG: Tag = Tag::TeletexString;
+        }
+
+        impl<$($li),*> fmt::Debug for $type {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "TeletexString({:?})", self.as_str())
+            }
+        }
+    };
+}
 
 /// ASN.1 `TeletexString` type.
 ///
@@ -50,6 +63,8 @@ impl<'a> TeletexStringRef<'a> {
     }
 }
 
+impl_teletex_string!(TeletexStringRef<'a>, 'a);
+
 impl<'a> Deref for TeletexStringRef<'a> {
     type Target = StrRef<'a>;
 
@@ -57,40 +72,6 @@ impl<'a> Deref for TeletexStringRef<'a> {
         &self.inner
     }
 }
-
-impl AsRef<str> for TeletexStringRef<'_> {
-    fn as_ref(&self) -> &str {
-        self.as_str()
-    }
-}
-
-impl AsRef<[u8]> for TeletexStringRef<'_> {
-    fn as_ref(&self) -> &[u8] {
-        self.as_bytes()
-    }
-}
-
-impl<'a> DecodeValue<'a> for TeletexStringRef<'a> {
-    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
-        Self::new(BytesRef::decode_value(reader, header)?.as_slice())
-    }
-}
-
-impl<'a> EncodeValue for TeletexStringRef<'a> {
-    fn value_len(&self) -> Result<Length> {
-        self.inner.value_len()
-    }
-
-    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
-        self.inner.encode_value(writer)
-    }
-}
-
-impl FixedTag for TeletexStringRef<'_> {
-    const TAG: Tag = Tag::TeletexString;
-}
-
-impl OrdIsValueOrd for TeletexStringRef<'_> {}
 
 impl<'a> From<&TeletexStringRef<'a>> for TeletexStringRef<'a> {
     fn from(value: &TeletexStringRef<'a>) -> TeletexStringRef<'a> {
@@ -105,31 +86,113 @@ impl<'a> TryFrom<AnyRef<'a>> for TeletexStringRef<'a> {
         any.decode_into()
     }
 }
-
-#[cfg(feature = "alloc")]
-impl<'a> TryFrom<&'a Any> for TeletexStringRef<'a> {
-    type Error = Error;
-
-    fn try_from(any: &'a Any) -> Result<TeletexStringRef<'a>> {
-        any.decode_into()
-    }
-}
-
 impl<'a> From<TeletexStringRef<'a>> for AnyRef<'a> {
     fn from(teletex_string: TeletexStringRef<'a>) -> AnyRef<'a> {
         AnyRef::from_tag_and_value(Tag::TeletexString, teletex_string.inner.into())
     }
 }
 
-impl<'a> fmt::Display for TeletexStringRef<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.as_str())
-    }
-}
+#[cfg(feature = "alloc")]
+pub use self::allocation::TeletexString;
 
-impl<'a> fmt::Debug for TeletexStringRef<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "TeletexString({:?})", self.as_str())
+#[cfg(feature = "alloc")]
+mod allocation {
+    use super::TeletexStringRef;
+
+    use crate::{
+        asn1::AnyRef,
+        referenced::{OwnedToRef, RefToOwned},
+        BytesRef, Error, FixedTag, Result, StrOwned, Tag,
+    };
+    use core::{fmt, ops::Deref};
+
+    /// ASN.1 `TeletexString` type.
+    ///
+    /// Supports a subset the ASCII character set (described below).
+    ///
+    /// For UTF-8, use [`Utf8StringRef`][`crate::asn1::Utf8StringRef`] instead.
+    /// For the full ASCII character set, use
+    /// [`Ia5StringRef`][`crate::asn1::Ia5StringRef`].
+    ///
+    /// # Supported characters
+    ///
+    /// The standard defines a complex character set allowed in this type. However, quoting the ASN.1
+    /// mailing list, "a sizable volume of software in the world treats TeletexString (T61String) as a
+    /// simple 8-bit string with mostly Windows Latin 1 (superset of iso-8859-1) encoding".
+    ///
+    #[derive(Clone, Eq, PartialEq, PartialOrd, Ord)]
+    pub struct TeletexString {
+        /// Inner value
+        inner: StrOwned,
+    }
+
+    impl TeletexString {
+        /// Create a new ASN.1 `TeletexString`.
+        pub fn new<T>(input: &T) -> Result<Self>
+        where
+            T: AsRef<[u8]> + ?Sized,
+        {
+            let input = input.as_ref();
+
+            TeletexStringRef::new(input)?;
+
+            StrOwned::from_bytes(input)
+                .map(|inner| Self { inner })
+                .map_err(|_| Self::TAG.value_error())
+        }
+    }
+
+    impl_teletex_string!(TeletexString);
+
+    impl Deref for TeletexString {
+        type Target = StrOwned;
+
+        fn deref(&self) -> &Self::Target {
+            &self.inner
+        }
+    }
+
+    impl<'a> From<TeletexStringRef<'a>> for TeletexString {
+        fn from(value: TeletexStringRef<'a>) -> TeletexString {
+            let inner =
+                StrOwned::from_bytes(value.inner.as_bytes()).expect("Invalid TeletexString");
+            Self { inner }
+        }
+    }
+
+    impl<'a> TryFrom<&AnyRef<'a>> for TeletexString {
+        type Error = Error;
+
+        fn try_from(any: &AnyRef<'a>) -> Result<TeletexString> {
+            (*any).decode_into()
+        }
+    }
+
+    impl<'a> From<&'a TeletexString> for AnyRef<'a> {
+        fn from(teletex_string: &'a TeletexString) -> AnyRef<'a> {
+            AnyRef::from_tag_and_value(
+                Tag::TeletexString,
+                BytesRef::new(teletex_string.inner.as_bytes()).expect("Invalid TeletexString"),
+            )
+        }
+    }
+
+    impl<'a> RefToOwned<'a> for TeletexStringRef<'a> {
+        type Owned = TeletexString;
+        fn to_owned(&self) -> Self::Owned {
+            TeletexString {
+                inner: self.inner.to_owned(),
+            }
+        }
+    }
+
+    impl OwnedToRef for TeletexString {
+        type Borrowed<'a> = TeletexStringRef<'a>;
+        fn to_ref(&self) -> Self::Borrowed<'_> {
+            TeletexStringRef {
+                inner: self.inner.to_ref(),
+            }
+        }
     }
 }
 

--- a/der/src/asn1/utf8_string.rs
+++ b/der/src/asn1/utf8_string.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     asn1::AnyRef, ord::OrdIsValueOrd, ByteSlice, DecodeValue, EncodeValue, Error, FixedTag, Header,
-    Length, Reader, Result, StrSlice, Tag, Writer,
+    Length, Reader, Result, StrRef, Tag, Writer,
 };
 use core::{fmt, ops::Deref, str};
 
@@ -29,7 +29,7 @@ use {
 #[derive(Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Utf8StringRef<'a> {
     /// Inner value
-    inner: StrSlice<'a>,
+    inner: StrRef<'a>,
 }
 
 impl<'a> Utf8StringRef<'a> {
@@ -38,12 +38,12 @@ impl<'a> Utf8StringRef<'a> {
     where
         T: AsRef<[u8]> + ?Sized,
     {
-        StrSlice::from_bytes(input.as_ref()).map(|inner| Self { inner })
+        StrRef::from_bytes(input.as_ref()).map(|inner| Self { inner })
     }
 }
 
 impl<'a> Deref for Utf8StringRef<'a> {
-    type Target = StrSlice<'a>;
+    type Target = StrRef<'a>;
 
     fn deref(&self) -> &Self::Target {
         &self.inner

--- a/der/src/asn1/utf8_string.rs
+++ b/der/src/asn1/utf8_string.rs
@@ -1,7 +1,7 @@
 //! ASN.1 `UTF8String` support.
 
 use crate::{
-    asn1::AnyRef, ord::OrdIsValueOrd, ByteSlice, DecodeValue, EncodeValue, Error, FixedTag, Header,
+    asn1::AnyRef, ord::OrdIsValueOrd, BytesRef, DecodeValue, EncodeValue, Error, FixedTag, Header,
     Length, Reader, Result, StrRef, Tag, Writer,
 };
 use core::{fmt, ops::Deref, str};
@@ -64,7 +64,7 @@ impl AsRef<[u8]> for Utf8StringRef<'_> {
 
 impl<'a> DecodeValue<'a> for Utf8StringRef<'a> {
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
-        Self::new(ByteSlice::decode_value(reader, header)?.as_slice())
+        Self::new(BytesRef::decode_value(reader, header)?.as_slice())
     }
 }
 

--- a/der/src/asn1/videotex_string.rs
+++ b/der/src/asn1/videotex_string.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     asn1::AnyRef, ord::OrdIsValueOrd, ByteSlice, DecodeValue, EncodeValue, Error, FixedTag, Header,
-    Length, Reader, Result, StrSlice, Tag, Writer,
+    Length, Reader, Result, StrRef, Tag, Writer,
 };
 use core::{fmt, ops::Deref, str};
 
@@ -26,7 +26,7 @@ use crate::asn1::Any;
 #[derive(Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub struct VideotexStringRef<'a> {
     /// Inner value
-    inner: StrSlice<'a>,
+    inner: StrRef<'a>,
 }
 
 impl<'a> VideotexStringRef<'a> {
@@ -43,14 +43,14 @@ impl<'a> VideotexStringRef<'a> {
             return Err(Self::TAG.value_error());
         }
 
-        StrSlice::from_bytes(input)
+        StrRef::from_bytes(input)
             .map(|inner| Self { inner })
             .map_err(|_| Self::TAG.value_error())
     }
 }
 
 impl<'a> Deref for VideotexStringRef<'a> {
-    type Target = StrSlice<'a>;
+    type Target = StrRef<'a>;
 
     fn deref(&self) -> &Self::Target {
         &self.inner

--- a/der/src/asn1/videotex_string.rs
+++ b/der/src/asn1/videotex_string.rs
@@ -1,7 +1,7 @@
 //! ASN.1 `VideotexString` support.
 
 use crate::{
-    asn1::AnyRef, ord::OrdIsValueOrd, ByteSlice, DecodeValue, EncodeValue, Error, FixedTag, Header,
+    asn1::AnyRef, ord::OrdIsValueOrd, BytesRef, DecodeValue, EncodeValue, Error, FixedTag, Header,
     Length, Reader, Result, StrRef, Tag, Writer,
 };
 use core::{fmt, ops::Deref, str};
@@ -71,7 +71,7 @@ impl AsRef<[u8]> for VideotexStringRef<'_> {
 
 impl<'a> DecodeValue<'a> for VideotexStringRef<'a> {
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
-        Self::new(ByteSlice::decode_value(reader, header)?.as_slice())
+        Self::new(BytesRef::decode_value(reader, header)?.as_slice())
     }
 }
 

--- a/der/src/byte_slice.rs
+++ b/der/src/byte_slice.rs
@@ -2,7 +2,7 @@
 //! library-level length limitation i.e. `Length::max()`.
 
 use crate::{
-    str_slice::StrSlice, DecodeValue, DerOrd, EncodeValue, Error, Header, Length, Reader, Result,
+    StrRef, DecodeValue, DerOrd, EncodeValue, Error, Header, Length, Reader, Result,
     Writer,
 };
 use core::cmp::Ordering;
@@ -86,8 +86,8 @@ impl DerOrd for ByteSlice<'_> {
     }
 }
 
-impl<'a> From<StrSlice<'a>> for ByteSlice<'a> {
-    fn from(s: StrSlice<'a>) -> ByteSlice<'a> {
+impl<'a> From<StrRef<'a>> for ByteSlice<'a> {
+    fn from(s: StrRef<'a>) -> ByteSlice<'a> {
         let bytes = s.as_bytes();
         debug_assert_eq!(bytes.len(), usize::try_from(s.length).expect("overflow"));
 

--- a/der/src/bytes.rs
+++ b/der/src/bytes.rs
@@ -2,8 +2,8 @@
 //! library-level length limitation i.e. `Length::max()`.
 
 use crate::{
-    referenced::OwnedToRef, StrRef, ByteSlice, DecodeValue, DerOrd, EncodeValue,
-    Error, Header, Length, Reader, Result, Writer,
+    referenced::OwnedToRef, BytesRef, DecodeValue, DerOrd, EncodeValue, Error, Header, Length,
+    Reader, Result, StrRef, Writer,
 };
 use alloc::boxed::Box;
 use core::cmp::Ordering;
@@ -35,7 +35,7 @@ impl Bytes {
         &self.inner
     }
 
-    /// Get the [`Length`] of this [`ByteSlice`]
+    /// Get the [`Length`] of this [`BytesRef`]
     pub fn len(&self) -> Length {
         self.length
     }
@@ -96,17 +96,17 @@ impl From<StrRef<'_>> for Bytes {
 }
 
 impl OwnedToRef for Bytes {
-    type Borrowed<'a> = ByteSlice<'a>;
+    type Borrowed<'a> = BytesRef<'a>;
     fn to_ref(&self) -> Self::Borrowed<'_> {
-        ByteSlice {
+        BytesRef {
             length: self.length,
             inner: self.inner.as_ref(),
         }
     }
 }
 
-impl From<ByteSlice<'_>> for Bytes {
-    fn from(s: ByteSlice<'_>) -> Bytes {
+impl From<BytesRef<'_>> for Bytes {
+    fn from(s: BytesRef<'_>) -> Bytes {
         Bytes {
             length: s.length,
             inner: Box::from(s.inner),

--- a/der/src/bytes.rs
+++ b/der/src/bytes.rs
@@ -2,7 +2,7 @@
 //! library-level length limitation i.e. `Length::max()`.
 
 use crate::{
-    referenced::OwnedToRef, str_slice::StrSlice, ByteSlice, DecodeValue, DerOrd, EncodeValue,
+    referenced::OwnedToRef, StrRef, ByteSlice, DecodeValue, DerOrd, EncodeValue,
     Error, Header, Length, Reader, Result, Writer,
 };
 use alloc::boxed::Box;
@@ -83,8 +83,8 @@ impl DerOrd for Bytes {
     }
 }
 
-impl From<StrSlice<'_>> for Bytes {
-    fn from(s: StrSlice<'_>) -> Bytes {
+impl From<StrRef<'_>> for Bytes {
+    fn from(s: StrRef<'_>) -> Bytes {
         let bytes = s.as_bytes();
         debug_assert_eq!(bytes.len(), usize::try_from(s.length).expect("overflow"));
 

--- a/der/src/bytes_owned.rs
+++ b/der/src/bytes_owned.rs
@@ -10,7 +10,7 @@ use core::cmp::Ordering;
 
 /// Byte slice newtype which respects the `Length::max()` limit.
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
-pub(crate) struct Bytes {
+pub(crate) struct BytesOwned {
     /// Precomputed `Length` (avoids possible panicking conversions)
     length: Length,
 
@@ -18,8 +18,8 @@ pub(crate) struct Bytes {
     inner: Box<[u8]>,
 }
 
-impl Bytes {
-    /// Create a new [`Bytes`], ensuring that the provided `slice` value
+impl BytesOwned {
+    /// Create a new [`BytesOwned`], ensuring that the provided `slice` value
     /// is shorter than `Length::max()`.
     pub fn new(data: impl Into<Box<[u8]>>) -> Result<Self> {
         let inner: Box<[u8]> = data.into();
@@ -40,25 +40,25 @@ impl Bytes {
         self.length
     }
 
-    /// Is this [`Bytes`] empty?
+    /// Is this [`BytesOwned`] empty?
     pub fn is_empty(&self) -> bool {
         self.len() == Length::ZERO
     }
 }
 
-impl AsRef<[u8]> for Bytes {
+impl AsRef<[u8]> for BytesOwned {
     fn as_ref(&self) -> &[u8] {
         self.as_slice()
     }
 }
 
-impl<'a> DecodeValue<'a> for Bytes {
+impl<'a> DecodeValue<'a> for BytesOwned {
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         reader.read_vec(header.length).and_then(Self::new)
     }
 }
 
-impl EncodeValue for Bytes {
+impl EncodeValue for BytesOwned {
     fn value_len(&self) -> Result<Length> {
         Ok(self.length)
     }
@@ -68,7 +68,7 @@ impl EncodeValue for Bytes {
     }
 }
 
-impl Default for Bytes {
+impl Default for BytesOwned {
     fn default() -> Self {
         Self {
             length: Length::ZERO,
@@ -77,25 +77,25 @@ impl Default for Bytes {
     }
 }
 
-impl DerOrd for Bytes {
+impl DerOrd for BytesOwned {
     fn der_cmp(&self, other: &Self) -> Result<Ordering> {
         Ok(self.as_slice().cmp(other.as_slice()))
     }
 }
 
-impl From<StrRef<'_>> for Bytes {
-    fn from(s: StrRef<'_>) -> Bytes {
+impl From<StrRef<'_>> for BytesOwned {
+    fn from(s: StrRef<'_>) -> BytesOwned {
         let bytes = s.as_bytes();
         debug_assert_eq!(bytes.len(), usize::try_from(s.length).expect("overflow"));
 
-        Bytes {
+        BytesOwned {
             inner: Box::from(bytes),
             length: s.length,
         }
     }
 }
 
-impl OwnedToRef for Bytes {
+impl OwnedToRef for BytesOwned {
     type Borrowed<'a> = BytesRef<'a>;
     fn to_ref(&self) -> Self::Borrowed<'_> {
         BytesRef {
@@ -105,16 +105,16 @@ impl OwnedToRef for Bytes {
     }
 }
 
-impl From<BytesRef<'_>> for Bytes {
-    fn from(s: BytesRef<'_>) -> Bytes {
-        Bytes {
+impl From<BytesRef<'_>> for BytesOwned {
+    fn from(s: BytesRef<'_>) -> BytesOwned {
+        BytesOwned {
             length: s.length,
             inner: Box::from(s.inner),
         }
     }
 }
 
-impl TryFrom<&[u8]> for Bytes {
+impl TryFrom<&[u8]> for BytesOwned {
     type Error = Error;
 
     fn try_from(slice: &[u8]) -> Result<Self> {
@@ -125,7 +125,7 @@ impl TryFrom<&[u8]> for Bytes {
 // Implement by hand because the derive would create invalid values.
 // Make sure the length and the inner.len matches.
 #[cfg(feature = "arbitrary")]
-impl<'a> arbitrary::Arbitrary<'a> for Bytes {
+impl<'a> arbitrary::Arbitrary<'a> for BytesOwned {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let length = u.arbitrary()?;
         Ok(Self {

--- a/der/src/bytes_ref.rs
+++ b/der/src/bytes_ref.rs
@@ -126,12 +126,12 @@ impl<'a> arbitrary::Arbitrary<'a> for BytesRef<'a> {
 #[cfg(feature = "alloc")]
 mod allocating {
     use super::BytesRef;
-    use crate::{referenced::RefToOwned, Bytes};
+    use crate::{referenced::RefToOwned, BytesOwned};
 
     impl<'a> RefToOwned<'a> for BytesRef<'a> {
-        type Owned = Bytes;
+        type Owned = BytesOwned;
         fn to_owned(&self) -> Self::Owned {
-            Bytes::from(*self)
+            BytesOwned::from(*self)
         }
     }
 }

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -359,7 +359,7 @@ mod tag;
 mod writer;
 
 #[cfg(feature = "alloc")]
-mod bytes;
+mod bytes_owned;
 #[cfg(feature = "alloc")]
 mod document;
 
@@ -411,5 +411,5 @@ pub use zeroize;
 pub use crate::document::SecretDocument;
 
 #[cfg(feature = "alloc")]
-pub(crate) use crate::bytes::Bytes;
+pub(crate) use crate::bytes_owned::BytesOwned;
 pub(crate) use crate::{arrayvec::ArrayVec, bytes_ref::BytesRef, str_ref::StrRef};

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -362,6 +362,8 @@ mod writer;
 mod bytes_owned;
 #[cfg(feature = "alloc")]
 mod document;
+#[cfg(feature = "alloc")]
+mod str_owned;
 
 pub use crate::{
     asn1::{AnyRef, Choice, Sequence},
@@ -410,6 +412,6 @@ pub use zeroize;
 #[cfg(all(feature = "alloc", feature = "zeroize"))]
 pub use crate::document::SecretDocument;
 
-#[cfg(feature = "alloc")]
-pub(crate) use crate::bytes_owned::BytesOwned;
 pub(crate) use crate::{arrayvec::ArrayVec, bytes_ref::BytesRef, str_ref::StrRef};
+#[cfg(feature = "alloc")]
+pub(crate) use crate::{bytes_owned::BytesOwned, str_owned::StrOwned};

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -354,7 +354,7 @@ mod header;
 mod length;
 mod ord;
 mod reader;
-mod str_slice;
+mod str_ref;
 mod tag;
 mod writer;
 
@@ -412,4 +412,4 @@ pub use crate::document::SecretDocument;
 
 #[cfg(feature = "alloc")]
 pub(crate) use crate::bytes::Bytes;
-pub(crate) use crate::{arrayvec::ArrayVec, byte_slice::ByteSlice, str_slice::StrSlice};
+pub(crate) use crate::{arrayvec::ArrayVec, byte_slice::ByteSlice, str_ref::StrRef};

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -344,7 +344,7 @@ pub mod asn1;
 pub mod referenced;
 
 pub(crate) mod arrayvec;
-mod byte_slice;
+mod bytes_ref;
 mod datetime;
 mod decode;
 mod encode;
@@ -412,4 +412,4 @@ pub use crate::document::SecretDocument;
 
 #[cfg(feature = "alloc")]
 pub(crate) use crate::bytes::Bytes;
-pub(crate) use crate::{arrayvec::ArrayVec, byte_slice::ByteSlice, str_ref::StrRef};
+pub(crate) use crate::{arrayvec::ArrayVec, bytes_ref::BytesRef, str_ref::StrRef};

--- a/der/src/reader/slice.rs
+++ b/der/src/reader/slice.rs
@@ -1,12 +1,12 @@
 //! Slice reader.
 
-use crate::{ByteSlice, Decode, Error, ErrorKind, Header, Length, Reader, Result, Tag};
+use crate::{BytesRef, Decode, Error, ErrorKind, Header, Length, Reader, Result, Tag};
 
 /// [`Reader`] which consumes an input byte slice.
 #[derive(Clone, Debug)]
 pub struct SliceReader<'a> {
     /// Byte slice being decoded.
-    bytes: ByteSlice<'a>,
+    bytes: BytesRef<'a>,
 
     /// Did the decoding operation fail?
     failed: bool,
@@ -19,7 +19,7 @@ impl<'a> SliceReader<'a> {
     /// Create a new slice reader for the given byte slice.
     pub fn new(bytes: &'a [u8]) -> Result<Self> {
         Ok(Self {
-            bytes: ByteSlice::new(bytes)?,
+            bytes: BytesRef::new(bytes)?,
             failed: false,
             position: Length::ZERO,
         })

--- a/der/src/str_owned.rs
+++ b/der/src/str_owned.rs
@@ -1,0 +1,105 @@
+//! Common handling for types backed by `String` with enforcement of a
+//! library-level length limitation i.e. `Length::max()`.
+
+use crate::{
+    referenced::OwnedToRef, BytesRef, DecodeValue, EncodeValue, Header, Length, Reader, Result,
+    StrRef, Writer,
+};
+use alloc::string::String;
+use core::str;
+
+/// String newtype which respects the [`Length::max`] limit.
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct StrOwned {
+    /// Inner value
+    pub(crate) inner: String,
+
+    /// Precomputed `Length` (avoids possible panicking conversions)
+    pub(crate) length: Length,
+}
+
+impl StrOwned {
+    /// Create a new [`StrOwned`], ensuring that the byte representation of
+    /// the provided `str` value is shorter than `Length::max()`.
+    pub fn new(s: &str) -> Result<Self> {
+        Ok(Self {
+            inner: String::from(s),
+            length: Length::try_from(s.as_bytes().len())?,
+        })
+    }
+
+    /// Parse a [`String`] from UTF-8 encoded bytes.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
+        Ok(Self {
+            inner: String::from_utf8(bytes.to_vec())?,
+            length: Length::try_from(bytes.len())?,
+        })
+    }
+
+    /// Borrow the inner `str`
+    pub fn as_str(&self) -> &str {
+        &self.inner
+    }
+
+    /// Borrow the inner byte slice
+    pub fn as_bytes(&self) -> &[u8] {
+        self.inner.as_bytes()
+    }
+
+    /// Get the [`Length`] of this [`StrOwned`]
+    pub fn len(&self) -> Length {
+        self.length
+    }
+
+    /// Is this [`StrOwned`] empty?
+    pub fn is_empty(&self) -> bool {
+        self.len() == Length::ZERO
+    }
+}
+
+impl AsRef<str> for StrOwned {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl AsRef<[u8]> for StrOwned {
+    fn as_ref(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}
+
+impl<'a> DecodeValue<'a> for StrOwned {
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
+        Self::from_bytes(BytesRef::decode_value(reader, header)?.as_slice())
+    }
+}
+
+impl EncodeValue for StrOwned {
+    fn value_len(&self) -> Result<Length> {
+        Ok(self.length)
+    }
+
+    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+        writer.write(self.as_ref())
+    }
+}
+
+impl From<StrRef<'_>> for StrOwned {
+    fn from(s: StrRef<'_>) -> StrOwned {
+        Self {
+            inner: String::from(s.inner),
+            length: s.length,
+        }
+    }
+}
+
+impl OwnedToRef for StrOwned {
+    type Borrowed<'a> = StrRef<'a>;
+    fn to_ref(&self) -> Self::Borrowed<'_> {
+        StrRef {
+            length: self.length,
+            inner: self.inner.as_ref(),
+        }
+    }
+}

--- a/der/src/str_ref.rs
+++ b/der/src/str_ref.rs
@@ -6,7 +6,7 @@ use core::str;
 
 /// String slice newtype which respects the [`Length::max`] limit.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
-pub struct StrSlice<'a> {
+pub struct StrRef<'a> {
     /// Inner value
     pub(crate) inner: &'a str,
 
@@ -14,8 +14,8 @@ pub struct StrSlice<'a> {
     pub(crate) length: Length,
 }
 
-impl<'a> StrSlice<'a> {
-    /// Create a new [`StrSlice`], ensuring that the byte representation of
+impl<'a> StrRef<'a> {
+    /// Create a new [`StrRef`], ensuring that the byte representation of
     /// the provided `str` value is shorter than `Length::max()`.
     pub fn new(s: &'a str) -> Result<Self> {
         Ok(Self {
@@ -24,7 +24,7 @@ impl<'a> StrSlice<'a> {
         })
     }
 
-    /// Parse a [`StrSlice`] from UTF-8 encoded bytes.
+    /// Parse a [`StrRef`] from UTF-8 encoded bytes.
     pub fn from_bytes(bytes: &'a [u8]) -> Result<Self> {
         Self::new(str::from_utf8(bytes)?)
     }
@@ -39,36 +39,36 @@ impl<'a> StrSlice<'a> {
         self.inner.as_bytes()
     }
 
-    /// Get the [`Length`] of this [`StrSlice`]
+    /// Get the [`Length`] of this [`StrRef`]
     pub fn len(self) -> Length {
         self.length
     }
 
-    /// Is this [`StrSlice`] empty?
+    /// Is this [`StrRef`] empty?
     pub fn is_empty(self) -> bool {
         self.len() == Length::ZERO
     }
 }
 
-impl AsRef<str> for StrSlice<'_> {
+impl AsRef<str> for StrRef<'_> {
     fn as_ref(&self) -> &str {
         self.as_str()
     }
 }
 
-impl AsRef<[u8]> for StrSlice<'_> {
+impl AsRef<[u8]> for StrRef<'_> {
     fn as_ref(&self) -> &[u8] {
         self.as_bytes()
     }
 }
 
-impl<'a> DecodeValue<'a> for StrSlice<'a> {
+impl<'a> DecodeValue<'a> for StrRef<'a> {
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         Self::from_bytes(ByteSlice::decode_value(reader, header)?.as_slice())
     }
 }
 
-impl<'a> EncodeValue for StrSlice<'a> {
+impl<'a> EncodeValue for StrRef<'a> {
     fn value_len(&self) -> Result<Length> {
         Ok(self.length)
     }

--- a/der/src/str_ref.rs
+++ b/der/src/str_ref.rs
@@ -1,7 +1,7 @@
 //! Common handling for types backed by `str` slices with enforcement of a
 //! library-level length limitation i.e. `Length::max()`.
 
-use crate::{ByteSlice, DecodeValue, EncodeValue, Header, Length, Reader, Result, Writer};
+use crate::{BytesRef, DecodeValue, EncodeValue, Header, Length, Reader, Result, Writer};
 use core::str;
 
 /// String slice newtype which respects the [`Length::max`] limit.
@@ -64,7 +64,7 @@ impl AsRef<[u8]> for StrRef<'_> {
 
 impl<'a> DecodeValue<'a> for StrRef<'a> {
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
-        Self::from_bytes(ByteSlice::decode_value(reader, header)?.as_slice())
+        Self::from_bytes(BytesRef::decode_value(reader, header)?.as_slice())
     }
 }
 

--- a/der/src/str_ref.rs
+++ b/der/src/str_ref.rs
@@ -77,3 +77,16 @@ impl<'a> EncodeValue for StrRef<'a> {
         writer.write(self.as_ref())
     }
 }
+
+#[cfg(feature = "alloc")]
+mod allocating {
+    use super::StrRef;
+    use crate::{referenced::RefToOwned, StrOwned};
+
+    impl<'a> RefToOwned<'a> for StrRef<'a> {
+        type Owned = StrOwned;
+        fn to_owned(&self) -> Self::Owned {
+            StrOwned::from(*self)
+        }
+    }
+}

--- a/pkcs7/src/certificate_choices.rs
+++ b/pkcs7/src/certificate_choices.rs
@@ -36,7 +36,7 @@ pub struct OtherCertificateFormat<'a> {
 #[allow(clippy::large_enum_variant)]
 pub enum CertificateChoices<'a> {
     /// X.509 certificate
-    Certificate(Certificate<'a>),
+    Certificate(Certificate),
 
     /// PKCS #6 extended certificate (obsolete)
     #[deprecated]

--- a/pkcs7/src/signer_info.rs
+++ b/pkcs7/src/signer_info.rs
@@ -36,13 +36,13 @@ type UnsignedAttributes<'a> = SetOfVec<Attribute>;
 //    subjectKeyIdentifier [0] SubjectKeyIdentifier }
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq, Choice, ValueOrd)]
-pub enum SignerIdentifier<'a> {
+pub enum SignerIdentifier {
     /// issuer and serial number
     IssuerAndSerialNumber(IssuerAndSerialNumber),
 
     /// subject key identifier
     #[asn1(context_specific = "0")]
-    SubjectKeyIdentifier(SubjectKeyIdentifier<'a>),
+    SubjectKeyIdentifier(SubjectKeyIdentifier),
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Sequence, ValueOrd)]
@@ -75,7 +75,7 @@ pub struct SignerInfo<'a> {
     pub version: CmsVersion,
 
     /// the signer identifier
-    pub sid: SignerIdentifier<'a>,
+    pub sid: SignerIdentifier,
 
     /// the message digest algorithm
     pub digest_algorithm: DigestAlgorithmIdentifier<'a>,

--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -19,7 +19,7 @@ arbitrary = { version = "1.2.0", features = ["derive"], optional = true }
 const-oid = { version = "=0.10.0-pre", features = ["db"], path = "../const-oid" }
 der = { version = "=0.7.0-pre", features = ["derive", "alloc", "flagset"], path = "../der" }
 flagset = { version = "0.4.3" }
-spki = { version = "=0.7.0-pre", path = "../spki" }
+spki = { version = "=0.7.0-pre", path = "../spki", features = ["alloc"] }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/x509-cert/src/anchor.rs
+++ b/x509-cert/src/anchor.rs
@@ -81,7 +81,7 @@ pub struct CertPathControls<'a> {
     pub certificate: Option<Certificate<'a>>,
 
     #[asn1(context_specific = "1", tag_mode = "IMPLICIT", optional = "true")]
-    pub policy_set: Option<CertificatePolicies<'a>>,
+    pub policy_set: Option<CertificatePolicies>,
 
     #[asn1(context_specific = "2", tag_mode = "IMPLICIT", optional = "true")]
     pub policy_flags: Option<CertPolicyFlags>,

--- a/x509-cert/src/anchor.rs
+++ b/x509-cert/src/anchor.rs
@@ -8,7 +8,7 @@ use alloc::string::String;
 use der::asn1::OctetString;
 use der::{Choice, Enumerated, Sequence};
 use flagset::{flags, FlagSet};
-use spki::SubjectPublicKeyInfoRef;
+use spki::SubjectPublicKeyInfoOwned;
 
 /// Version identifier for TrustAnchorInfo
 #[derive(Clone, Debug, Copy, PartialEq, Eq, Enumerated)]
@@ -42,11 +42,11 @@ impl Default for Version {
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq, Sequence)]
 #[allow(missing_docs)]
-pub struct TrustAnchorInfo<'a> {
+pub struct TrustAnchorInfo {
     #[asn1(default = "Default::default")]
     pub version: Version,
 
-    pub pub_key: SubjectPublicKeyInfoRef<'a>,
+    pub pub_key: SubjectPublicKeyInfoOwned,
 
     pub key_id: OctetString,
 
@@ -54,7 +54,7 @@ pub struct TrustAnchorInfo<'a> {
     pub ta_title: Option<String>,
 
     #[asn1(optional = "true")]
-    pub cert_path: Option<CertPathControls<'a>>,
+    pub cert_path: Option<CertPathControls>,
 
     #[asn1(context_specific = "1", tag_mode = "EXPLICIT", optional = "true")]
     pub extensions: Option<Extensions>,
@@ -75,11 +75,11 @@ pub struct TrustAnchorInfo<'a> {
 /// ```
 #[derive(Clone, Debug, Eq, PartialEq, Sequence)]
 #[allow(missing_docs)]
-pub struct CertPathControls<'a> {
+pub struct CertPathControls {
     pub ta_name: Name,
 
     #[asn1(context_specific = "0", tag_mode = "IMPLICIT", optional = "true")]
-    pub certificate: Option<Certificate<'a>>,
+    pub certificate: Option<Certificate>,
 
     #[asn1(context_specific = "1", tag_mode = "IMPLICIT", optional = "true")]
     pub policy_set: Option<CertificatePolicies>,
@@ -129,12 +129,12 @@ pub type CertPolicyFlags = FlagSet<CertPolicies>;
 #[derive(Clone, Debug, PartialEq, Eq, Choice)]
 #[allow(clippy::large_enum_variant)]
 #[allow(missing_docs)]
-pub enum TrustAnchorChoice<'a> {
-    Certificate(Certificate<'a>),
+pub enum TrustAnchorChoice {
+    Certificate(Certificate),
 
     #[asn1(context_specific = "1", tag_mode = "EXPLICIT", constructed = "true")]
-    TbsCertificate(TbsCertificate<'a>),
+    TbsCertificate(TbsCertificate),
 
     #[asn1(context_specific = "2", tag_mode = "EXPLICIT", constructed = "true")]
-    TaInfo(TrustAnchorInfo<'a>),
+    TaInfo(TrustAnchorInfo),
 }

--- a/x509-cert/src/anchor.rs
+++ b/x509-cert/src/anchor.rs
@@ -4,7 +4,8 @@ use crate::ext::pkix::{certpolicy::CertificatePolicies, NameConstraints};
 use crate::{ext::Extensions, name::Name};
 use crate::{Certificate, TbsCertificate};
 
-use der::asn1::{OctetStringRef, Utf8StringRef};
+use alloc::string::String;
+use der::asn1::OctetString;
 use der::{Choice, Enumerated, Sequence};
 use flagset::{flags, FlagSet};
 use spki::SubjectPublicKeyInfoRef;
@@ -47,10 +48,10 @@ pub struct TrustAnchorInfo<'a> {
 
     pub pub_key: SubjectPublicKeyInfoRef<'a>,
 
-    pub key_id: OctetStringRef<'a>,
+    pub key_id: OctetString,
 
     #[asn1(optional = "true")]
-    pub ta_title: Option<Utf8StringRef<'a>>,
+    pub ta_title: Option<String>,
 
     #[asn1(optional = "true")]
     pub cert_path: Option<CertPathControls<'a>>,
@@ -59,7 +60,7 @@ pub struct TrustAnchorInfo<'a> {
     pub extensions: Option<Extensions>,
 
     #[asn1(context_specific = "2", tag_mode = "IMPLICIT", optional = "true")]
-    pub ta_title_lang_tag: Option<Utf8StringRef<'a>>,
+    pub ta_title_lang_tag: Option<String>,
 }
 
 /// ```text

--- a/x509-cert/src/anchor.rs
+++ b/x509-cert/src/anchor.rs
@@ -56,7 +56,7 @@ pub struct TrustAnchorInfo<'a> {
     pub cert_path: Option<CertPathControls<'a>>,
 
     #[asn1(context_specific = "1", tag_mode = "EXPLICIT", optional = "true")]
-    pub extensions: Option<Extensions<'a>>,
+    pub extensions: Option<Extensions>,
 
     #[asn1(context_specific = "2", tag_mode = "IMPLICIT", optional = "true")]
     pub ta_title_lang_tag: Option<Utf8StringRef<'a>>,

--- a/x509-cert/src/anchor.rs
+++ b/x509-cert/src/anchor.rs
@@ -87,7 +87,7 @@ pub struct CertPathControls<'a> {
     pub policy_flags: Option<CertPolicyFlags>,
 
     #[asn1(context_specific = "3", tag_mode = "IMPLICIT", optional = "true")]
-    pub name_constr: Option<NameConstraints<'a>>,
+    pub name_constr: Option<NameConstraints>,
 
     #[asn1(context_specific = "4", tag_mode = "IMPLICIT", optional = "true")]
     pub path_len_constraint: Option<u32>,

--- a/x509-cert/src/certificate.rs
+++ b/x509-cert/src/certificate.rs
@@ -6,7 +6,7 @@ use alloc::vec::Vec;
 use core::cmp::Ordering;
 
 use const_oid::AssociatedOid;
-use der::asn1::BitStringRef;
+use der::asn1::BitString;
 use der::{Decode, Enumerated, Error, ErrorKind, Sequence, ValueOrd};
 use spki::{AlgorithmIdentifierRef, SubjectPublicKeyInfoRef};
 
@@ -93,10 +93,10 @@ pub struct TbsCertificate<'a> {
     pub subject_public_key_info: SubjectPublicKeyInfoRef<'a>,
 
     #[asn1(context_specific = "1", tag_mode = "IMPLICIT", optional = "true")]
-    pub issuer_unique_id: Option<BitStringRef<'a>>,
+    pub issuer_unique_id: Option<BitString>,
 
     #[asn1(context_specific = "2", tag_mode = "IMPLICIT", optional = "true")]
-    pub subject_unique_id: Option<BitStringRef<'a>>,
+    pub subject_unique_id: Option<BitString>,
 
     #[asn1(context_specific = "3", tag_mode = "EXPLICIT", optional = "true")]
     pub extensions: Option<crate::ext::Extensions>,
@@ -153,7 +153,7 @@ impl<'a> TbsCertificate<'a> {
 pub struct Certificate<'a> {
     pub tbs_certificate: TbsCertificate<'a>,
     pub signature_algorithm: AlgorithmIdentifierRef<'a>,
-    pub signature: BitStringRef<'a>,
+    pub signature: BitString,
 }
 
 #[cfg(feature = "pem")]

--- a/x509-cert/src/certificate.rs
+++ b/x509-cert/src/certificate.rs
@@ -99,7 +99,7 @@ pub struct TbsCertificate<'a> {
     pub subject_unique_id: Option<BitStringRef<'a>>,
 
     #[asn1(context_specific = "3", tag_mode = "EXPLICIT", optional = "true")]
-    pub extensions: Option<crate::ext::Extensions<'a>>,
+    pub extensions: Option<crate::ext::Extensions>,
 }
 
 impl<'a> TbsCertificate<'a> {
@@ -132,7 +132,7 @@ impl<'a> TbsCertificate<'a> {
             .unwrap_or(&[])
             .iter()
             .filter(|e| e.extn_id == T::OID)
-            .map(|e| Ok((e.critical, T::from_der(e.extn_value)?)))
+            .map(|e| Ok((e.critical, T::from_der(e.extn_value.as_bytes())?)))
     }
 }
 

--- a/x509-cert/src/certificate.rs
+++ b/x509-cert/src/certificate.rs
@@ -8,7 +8,7 @@ use core::cmp::Ordering;
 use const_oid::AssociatedOid;
 use der::asn1::BitString;
 use der::{Decode, Enumerated, Error, ErrorKind, Sequence, ValueOrd};
-use spki::{AlgorithmIdentifierRef, SubjectPublicKeyInfoRef};
+use spki::{AlgorithmIdentifierOwned, SubjectPublicKeyInfoOwned};
 
 #[cfg(feature = "pem")]
 use der::pem::PemLabel;
@@ -75,7 +75,7 @@ impl Default for Version {
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, Eq, PartialEq, Sequence, ValueOrd)]
 #[allow(missing_docs)]
-pub struct TbsCertificate<'a> {
+pub struct TbsCertificate {
     /// The certificate version
     ///
     /// Note that this value defaults to Version 1 per the RFC. However,
@@ -86,11 +86,11 @@ pub struct TbsCertificate<'a> {
     pub version: Version,
 
     pub serial_number: SerialNumber,
-    pub signature: AlgorithmIdentifierRef<'a>,
+    pub signature: AlgorithmIdentifierOwned,
     pub issuer: Name,
     pub validity: Validity,
     pub subject: Name,
-    pub subject_public_key_info: SubjectPublicKeyInfoRef<'a>,
+    pub subject_public_key_info: SubjectPublicKeyInfoOwned,
 
     #[asn1(context_specific = "1", tag_mode = "IMPLICIT", optional = "true")]
     pub issuer_unique_id: Option<BitString>,
@@ -102,15 +102,13 @@ pub struct TbsCertificate<'a> {
     pub extensions: Option<crate::ext::Extensions>,
 }
 
-impl<'a> TbsCertificate<'a> {
+impl TbsCertificate {
     /// Decodes a single extension
     ///
     /// Returns an error if multiple of these extensions is present. Returns
     /// `Ok(None)` if the extension is not present. Returns a decoding error
     /// if decoding failed. Otherwise returns the extension.
-    pub fn get<'b: 'a, T: Decode<'a> + AssociatedOid>(
-        &'b self,
-    ) -> Result<Option<(bool, T)>, Error> {
+    pub fn get<'a, T: Decode<'a> + AssociatedOid>(&'a self) -> Result<Option<(bool, T)>, Error> {
         let mut iter = self.filter::<T>().peekable();
         match iter.next() {
             None => Ok(None),
@@ -124,9 +122,9 @@ impl<'a> TbsCertificate<'a> {
     /// Filters extensions by an associated OID
     ///
     /// Returns a filtered iterator over all the extensions with the OID.
-    pub fn filter<'b: 'a, T: Decode<'a> + AssociatedOid>(
-        &'b self,
-    ) -> impl 'b + Iterator<Item = Result<(bool, T), Error>> {
+    pub fn filter<'a, T: Decode<'a> + AssociatedOid>(
+        &'a self,
+    ) -> impl 'a + Iterator<Item = Result<(bool, T), Error>> {
         self.extensions
             .as_deref()
             .unwrap_or(&[])
@@ -150,15 +148,15 @@ impl<'a> TbsCertificate<'a> {
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, Eq, PartialEq, Sequence, ValueOrd)]
 #[allow(missing_docs)]
-pub struct Certificate<'a> {
-    pub tbs_certificate: TbsCertificate<'a>,
-    pub signature_algorithm: AlgorithmIdentifierRef<'a>,
+pub struct Certificate {
+    pub tbs_certificate: TbsCertificate,
+    pub signature_algorithm: AlgorithmIdentifierOwned,
     pub signature: BitString,
 }
 
 #[cfg(feature = "pem")]
 #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-impl PemLabel for Certificate<'_> {
+impl PemLabel for Certificate {
     const PEM_LABEL: &'static str = "CERTIFICATE";
 }
 
@@ -173,4 +171,4 @@ impl PemLabel for Certificate<'_> {
 /// ```
 ///
 /// [RFC 6066]: https://datatracker.ietf.org/doc/html/rfc6066#section-10.1
-pub type PkiPath<'a> = Vec<Certificate<'a>>;
+pub type PkiPath = Vec<Certificate>;

--- a/x509-cert/src/crl.rs
+++ b/x509-cert/src/crl.rs
@@ -8,7 +8,7 @@ use crate::Version;
 
 use alloc::vec::Vec;
 
-use der::asn1::BitStringRef;
+use der::asn1::BitString;
 use der::{Sequence, ValueOrd};
 use spki::AlgorithmIdentifierRef;
 
@@ -28,7 +28,7 @@ use spki::AlgorithmIdentifierRef;
 pub struct CertificateList<'a> {
     pub tbs_cert_list: TbsCertList<'a>,
     pub signature_algorithm: AlgorithmIdentifierRef<'a>,
-    pub signature: BitStringRef<'a>,
+    pub signature: BitString,
 }
 
 /// Implicit intermediate structure from the ASN.1 definition of `TBSCertList`.

--- a/x509-cert/src/crl.rs
+++ b/x509-cert/src/crl.rs
@@ -47,10 +47,10 @@ pub struct CertificateList<'a> {
 /// [RFC 5280 Section 5.1]: https://datatracker.ietf.org/doc/html/rfc5280#section-5.1
 #[derive(Clone, Debug, Eq, PartialEq, Sequence, ValueOrd)]
 #[allow(missing_docs)]
-pub struct RevokedCert<'a> {
+pub struct RevokedCert {
     pub serial_number: SerialNumber,
     pub revocation_date: Time,
-    pub crl_entry_extensions: Option<Extensions<'a>>,
+    pub crl_entry_extensions: Option<Extensions>,
 }
 
 /// `TbsCertList` as defined in [RFC 5280 Section 5.1].
@@ -80,8 +80,8 @@ pub struct TbsCertList<'a> {
     pub issuer: Name,
     pub this_update: Time,
     pub next_update: Option<Time>,
-    pub revoked_certificates: Option<Vec<RevokedCert<'a>>>,
+    pub revoked_certificates: Option<Vec<RevokedCert>>,
 
     #[asn1(context_specific = "0", tag_mode = "EXPLICIT", optional = "true")]
-    pub crl_extensions: Option<Extensions<'a>>,
+    pub crl_extensions: Option<Extensions>,
 }

--- a/x509-cert/src/ext.rs
+++ b/x509-cert/src/ext.rs
@@ -1,6 +1,6 @@
 //! Standardized X.509 Certificate Extensions
 
-use der::{Sequence, ValueOrd};
+use der::{asn1::OctetString, Sequence, ValueOrd};
 use spki::ObjectIdentifier;
 
 pub mod pkix;
@@ -25,14 +25,13 @@ pub mod pkix;
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, Eq, PartialEq, Sequence, ValueOrd)]
 #[allow(missing_docs)]
-pub struct Extension<'a> {
+pub struct Extension {
     pub extn_id: ObjectIdentifier,
 
     #[asn1(default = "Default::default")]
     pub critical: bool,
 
-    #[asn1(type = "OCTET STRING")]
-    pub extn_value: &'a [u8],
+    pub extn_value: OctetString,
 }
 
 /// Extensions as defined in [RFC 5280 Section 4.1.2.9].
@@ -42,4 +41,4 @@ pub struct Extension<'a> {
 /// ```
 ///
 /// [RFC 5280 Section 4.1.2.9]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.9
-pub type Extensions<'a> = alloc::vec::Vec<Extension<'a>>;
+pub type Extensions = alloc::vec::Vec<Extension>;

--- a/x509-cert/src/ext/pkix.rs
+++ b/x509-cert/src/ext/pkix.rs
@@ -57,13 +57,13 @@ impl_newtype!(SubjectKeyIdentifier, OctetString);
 ///
 /// [RFC 5280 Section 4.2.1.6]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.6
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct SubjectAltName<'a>(pub name::GeneralNames<'a>);
+pub struct SubjectAltName(pub name::GeneralNames);
 
-impl<'a> AssociatedOid for SubjectAltName<'a> {
+impl AssociatedOid for SubjectAltName {
     const OID: ObjectIdentifier = ID_CE_SUBJECT_ALT_NAME;
 }
 
-impl_newtype!(SubjectAltName<'a>, name::GeneralNames<'a>);
+impl_newtype!(SubjectAltName, name::GeneralNames);
 
 /// IssuerAltName as defined in [RFC 5280 Section 4.2.1.7].
 ///
@@ -73,13 +73,13 @@ impl_newtype!(SubjectAltName<'a>, name::GeneralNames<'a>);
 ///
 /// [RFC 5280 Section 4.2.1.7]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.7
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct IssuerAltName<'a>(pub name::GeneralNames<'a>);
+pub struct IssuerAltName(pub name::GeneralNames);
 
-impl<'a> AssociatedOid for IssuerAltName<'a> {
+impl AssociatedOid for IssuerAltName {
     const OID: ObjectIdentifier = ID_CE_ISSUER_ALT_NAME;
 }
 
-impl_newtype!(IssuerAltName<'a>, name::GeneralNames<'a>);
+impl_newtype!(IssuerAltName, name::GeneralNames);
 
 /// SubjectDirectoryAttributes as defined in [RFC 5280 Section 4.2.1.8].
 ///

--- a/x509-cert/src/ext/pkix.rs
+++ b/x509-cert/src/ext/pkix.rs
@@ -31,7 +31,7 @@ pub use const_oid::db::rfc5280::{
 
 use alloc::vec::Vec;
 
-use der::asn1::OctetStringRef;
+use der::asn1::OctetString;
 
 /// SubjectKeyIdentifier as defined in [RFC 5280 Section 4.2.1.2].
 ///
@@ -40,14 +40,14 @@ use der::asn1::OctetStringRef;
 /// ```
 ///
 /// [RFC 5280 Section 4.2.1.2]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.2
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct SubjectKeyIdentifier<'a>(pub OctetStringRef<'a>);
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SubjectKeyIdentifier(pub OctetString);
 
-impl<'a> AssociatedOid for SubjectKeyIdentifier<'a> {
+impl AssociatedOid for SubjectKeyIdentifier {
     const OID: ObjectIdentifier = ID_CE_SUBJECT_KEY_IDENTIFIER;
 }
 
-impl_newtype!(SubjectKeyIdentifier<'a>, OctetStringRef<'a>);
+impl_newtype!(SubjectKeyIdentifier, OctetString);
 
 /// SubjectAltName as defined in [RFC 5280 Section 4.2.1.6].
 ///

--- a/x509-cert/src/ext/pkix/access.rs
+++ b/x509-cert/src/ext/pkix/access.rs
@@ -16,13 +16,13 @@ use der::{asn1::ObjectIdentifier, Sequence, ValueOrd};
 ///
 /// [RFC 5280 Section 4.2.2.1]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.2.1
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct AuthorityInfoAccessSyntax<'a>(pub Vec<AccessDescription<'a>>);
+pub struct AuthorityInfoAccessSyntax(pub Vec<AccessDescription>);
 
-impl<'a> AssociatedOid for AuthorityInfoAccessSyntax<'a> {
+impl AssociatedOid for AuthorityInfoAccessSyntax {
     const OID: ObjectIdentifier = ID_PE_AUTHORITY_INFO_ACCESS;
 }
 
-impl_newtype!(AuthorityInfoAccessSyntax<'a>, Vec<AccessDescription<'a>>);
+impl_newtype!(AuthorityInfoAccessSyntax, Vec<AccessDescription>);
 
 /// SubjectInfoAccessSyntax as defined in [RFC 5280 Section 4.2.2.2].
 ///
@@ -32,13 +32,13 @@ impl_newtype!(AuthorityInfoAccessSyntax<'a>, Vec<AccessDescription<'a>>);
 ///
 /// [RFC 5280 Section 4.2.2.2]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.2.2
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct SubjectInfoAccessSyntax<'a>(pub Vec<AccessDescription<'a>>);
+pub struct SubjectInfoAccessSyntax(pub Vec<AccessDescription>);
 
-impl<'a> AssociatedOid for SubjectInfoAccessSyntax<'a> {
+impl AssociatedOid for SubjectInfoAccessSyntax {
     const OID: ObjectIdentifier = ID_PE_SUBJECT_INFO_ACCESS;
 }
 
-impl_newtype!(SubjectInfoAccessSyntax<'a>, Vec<AccessDescription<'a>>);
+impl_newtype!(SubjectInfoAccessSyntax, Vec<AccessDescription>);
 
 /// AccessDescription as defined in [RFC 5280 Section 4.2.2.1].
 ///
@@ -52,7 +52,7 @@ impl_newtype!(SubjectInfoAccessSyntax<'a>, Vec<AccessDescription<'a>>);
 /// [RFC 5280 Section 4.2.2.1]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.2.1
 #[derive(Clone, Debug, Eq, PartialEq, Sequence, ValueOrd)]
 #[allow(missing_docs)]
-pub struct AccessDescription<'a> {
+pub struct AccessDescription {
     pub access_method: ObjectIdentifier,
-    pub access_location: GeneralName<'a>,
+    pub access_location: GeneralName,
 }

--- a/x509-cert/src/ext/pkix/authkeyid.rs
+++ b/x509-cert/src/ext/pkix/authkeyid.rs
@@ -3,7 +3,7 @@ use crate::serial_number::SerialNumber;
 
 use const_oid::db::rfc5280::ID_CE_AUTHORITY_KEY_IDENTIFIER;
 use const_oid::{AssociatedOid, ObjectIdentifier};
-use der::asn1::OctetStringRef;
+use der::asn1::OctetString;
 use der::Sequence;
 
 /// AuthorityKeyIdentifier as defined in [RFC 5280 Section 4.2.1.1].
@@ -21,9 +21,9 @@ use der::Sequence;
 /// [RFC 5280 Section 4.2.1.1]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.1
 #[derive(Clone, Debug, Eq, PartialEq, Sequence)]
 #[allow(missing_docs)]
-pub struct AuthorityKeyIdentifier<'a> {
+pub struct AuthorityKeyIdentifier {
     #[asn1(context_specific = "0", tag_mode = "IMPLICIT", optional = "true")]
-    pub key_identifier: Option<OctetStringRef<'a>>,
+    pub key_identifier: Option<OctetString>,
 
     #[asn1(context_specific = "1", tag_mode = "IMPLICIT", optional = "true")]
     pub authority_cert_issuer: Option<GeneralNames>,
@@ -32,6 +32,6 @@ pub struct AuthorityKeyIdentifier<'a> {
     pub authority_cert_serial_number: Option<SerialNumber>,
 }
 
-impl<'a> AssociatedOid for AuthorityKeyIdentifier<'a> {
+impl AssociatedOid for AuthorityKeyIdentifier {
     const OID: ObjectIdentifier = ID_CE_AUTHORITY_KEY_IDENTIFIER;
 }

--- a/x509-cert/src/ext/pkix/authkeyid.rs
+++ b/x509-cert/src/ext/pkix/authkeyid.rs
@@ -26,7 +26,7 @@ pub struct AuthorityKeyIdentifier<'a> {
     pub key_identifier: Option<OctetStringRef<'a>>,
 
     #[asn1(context_specific = "1", tag_mode = "IMPLICIT", optional = "true")]
-    pub authority_cert_issuer: Option<GeneralNames<'a>>,
+    pub authority_cert_issuer: Option<GeneralNames>,
 
     #[asn1(context_specific = "2", tag_mode = "IMPLICIT", optional = "true")]
     pub authority_cert_serial_number: Option<SerialNumber>,

--- a/x509-cert/src/ext/pkix/certpolicy.rs
+++ b/x509-cert/src/ext/pkix/certpolicy.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 
 use const_oid::db::rfc5912::ID_CE_CERTIFICATE_POLICIES;
 use const_oid::AssociatedOid;
-use der::asn1::{GeneralizedTime, Ia5StringRef, ObjectIdentifier, UintRef, Utf8StringRef};
+use der::asn1::{GeneralizedTime, Ia5String, ObjectIdentifier, UintRef, Utf8StringRef};
 use der::{AnyRef, Choice, Sequence, ValueOrd};
 
 /// CertificatePolicies as defined in [RFC 5280 Section 4.2.1.4].
@@ -66,7 +66,7 @@ pub struct PolicyQualifierInfo<'a> {
 /// ```
 ///
 /// [RFC 5280 Section 4.2.1.4]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.4
-pub type CpsUri<'a> = Ia5StringRef<'a>;
+pub type CpsUri = Ia5String;
 
 /// UserNotice as defined in [RFC 5280 Section 4.2.1.4].
 ///
@@ -119,7 +119,7 @@ pub struct NoticeReference<'a> {
 #[allow(missing_docs)]
 pub enum DisplayText<'a> {
     #[asn1(type = "IA5String")]
-    Ia5String(Ia5StringRef<'a>),
+    Ia5String(Ia5String),
 
     #[asn1(type = "UTF8String")]
     Utf8String(Utf8StringRef<'a>),

--- a/x509-cert/src/ext/pkix/certpolicy.rs
+++ b/x509-cert/src/ext/pkix/certpolicy.rs
@@ -5,7 +5,7 @@ use alloc::{string::String, vec::Vec};
 use const_oid::db::rfc5912::ID_CE_CERTIFICATE_POLICIES;
 use const_oid::AssociatedOid;
 use der::asn1::{GeneralizedTime, Ia5String, ObjectIdentifier, UintRef};
-use der::{AnyRef, Choice, Sequence, ValueOrd};
+use der::{Any, Choice, Sequence, ValueOrd};
 
 /// CertificatePolicies as defined in [RFC 5280 Section 4.2.1.4].
 ///
@@ -15,13 +15,13 @@ use der::{AnyRef, Choice, Sequence, ValueOrd};
 ///
 /// [RFC 5280 Section 4.2.1.4]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.4
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct CertificatePolicies<'a>(pub Vec<PolicyInformation<'a>>);
+pub struct CertificatePolicies(pub Vec<PolicyInformation>);
 
-impl<'a> AssociatedOid for CertificatePolicies<'a> {
+impl AssociatedOid for CertificatePolicies {
     const OID: ObjectIdentifier = ID_CE_CERTIFICATE_POLICIES;
 }
 
-impl_newtype!(CertificatePolicies<'a>, Vec<PolicyInformation<'a>>);
+impl_newtype!(CertificatePolicies, Vec<PolicyInformation>);
 
 /// PolicyInformation as defined in [RFC 5280 Section 4.2.1.4].
 ///
@@ -37,9 +37,9 @@ impl_newtype!(CertificatePolicies<'a>, Vec<PolicyInformation<'a>>);
 /// [RFC 5280 Section 4.2.1.4]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.4
 #[derive(Clone, Debug, Eq, PartialEq, Sequence, ValueOrd)]
 #[allow(missing_docs)]
-pub struct PolicyInformation<'a> {
+pub struct PolicyInformation {
     pub policy_identifier: ObjectIdentifier,
-    pub policy_qualifiers: Option<Vec<PolicyQualifierInfo<'a>>>,
+    pub policy_qualifiers: Option<Vec<PolicyQualifierInfo>>,
 }
 
 /// PolicyQualifierInfo as defined in [RFC 5280 Section 4.2.1.4].
@@ -54,9 +54,9 @@ pub struct PolicyInformation<'a> {
 /// [RFC 5280 Section 4.2.1.4]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.4
 #[derive(Clone, Debug, Eq, PartialEq, Sequence, ValueOrd)]
 #[allow(missing_docs)]
-pub struct PolicyQualifierInfo<'a> {
+pub struct PolicyQualifierInfo {
     pub policy_qualifier_id: ObjectIdentifier,
-    pub qualifier: Option<AnyRef<'a>>,
+    pub qualifier: Option<Any>,
 }
 
 /// CpsUri as defined in [RFC 5280 Section 4.2.1.4].

--- a/x509-cert/src/ext/pkix/certpolicy.rs
+++ b/x509-cert/src/ext/pkix/certpolicy.rs
@@ -1,10 +1,10 @@
 //! PKIX Certificate Policies extension
 
-use alloc::vec::Vec;
+use alloc::{string::String, vec::Vec};
 
 use const_oid::db::rfc5912::ID_CE_CERTIFICATE_POLICIES;
 use const_oid::AssociatedOid;
-use der::asn1::{GeneralizedTime, Ia5String, ObjectIdentifier, UintRef, Utf8StringRef};
+use der::asn1::{GeneralizedTime, Ia5String, ObjectIdentifier, UintRef};
 use der::{AnyRef, Choice, Sequence, ValueOrd};
 
 /// CertificatePolicies as defined in [RFC 5280 Section 4.2.1.4].
@@ -80,9 +80,9 @@ pub type CpsUri = Ia5String;
 /// [RFC 5280 Section 4.2.1.4]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.4
 #[derive(Clone, Debug, Eq, PartialEq, Sequence)]
 #[allow(missing_docs)]
-pub struct UserNotice<'a> {
+pub struct UserNotice {
     pub notice_ref: Option<GeneralizedTime>,
-    pub explicit_text: Option<DisplayText<'a>>,
+    pub explicit_text: Option<DisplayText>,
 }
 
 /// NoticeReference as defined in [RFC 5280 Section 4.2.1.4].
@@ -97,7 +97,7 @@ pub struct UserNotice<'a> {
 #[derive(Clone, Debug, Eq, PartialEq, Sequence)]
 #[allow(missing_docs)]
 pub struct NoticeReference<'a> {
-    pub organization: DisplayText<'a>,
+    pub organization: DisplayText,
     pub notice_numbers: Option<Vec<UintRef<'a>>>,
 }
 
@@ -117,10 +117,10 @@ pub struct NoticeReference<'a> {
 /// [RFC 5280 Section 4.2.1.4]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.4
 #[derive(Choice, Clone, Debug, Eq, PartialEq)]
 #[allow(missing_docs)]
-pub enum DisplayText<'a> {
+pub enum DisplayText {
     #[asn1(type = "IA5String")]
     Ia5String(Ia5String),
 
     #[asn1(type = "UTF8String")]
-    Utf8String(Utf8StringRef<'a>),
+    Utf8String(String),
 }

--- a/x509-cert/src/ext/pkix/certpolicy.rs
+++ b/x509-cert/src/ext/pkix/certpolicy.rs
@@ -4,7 +4,7 @@ use alloc::{string::String, vec::Vec};
 
 use const_oid::db::rfc5912::ID_CE_CERTIFICATE_POLICIES;
 use const_oid::AssociatedOid;
-use der::asn1::{GeneralizedTime, Ia5String, ObjectIdentifier, UintRef};
+use der::asn1::{GeneralizedTime, Ia5String, ObjectIdentifier, Uint};
 use der::{Any, Choice, Sequence, ValueOrd};
 
 /// CertificatePolicies as defined in [RFC 5280 Section 4.2.1.4].
@@ -96,9 +96,9 @@ pub struct UserNotice {
 /// [RFC 5280 Section 4.2.1.4]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.4
 #[derive(Clone, Debug, Eq, PartialEq, Sequence)]
 #[allow(missing_docs)]
-pub struct NoticeReference<'a> {
+pub struct NoticeReference {
     pub organization: DisplayText,
-    pub notice_numbers: Option<Vec<UintRef<'a>>>,
+    pub notice_numbers: Option<Vec<Uint>>,
 }
 
 /// DisplayText as defined in [RFC 5280 Section 4.2.1.4].

--- a/x509-cert/src/ext/pkix/constraints/name.rs
+++ b/x509-cert/src/ext/pkix/constraints/name.rs
@@ -19,15 +19,15 @@ use super::super::name::GeneralName;
 /// [RFC 5280 Section 4.2.1.10]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.10
 #[derive(Clone, Debug, Eq, PartialEq, Sequence)]
 #[allow(missing_docs)]
-pub struct NameConstraints<'a> {
+pub struct NameConstraints {
     #[asn1(context_specific = "0", optional = "true", tag_mode = "IMPLICIT")]
-    pub permitted_subtrees: Option<GeneralSubtrees<'a>>,
+    pub permitted_subtrees: Option<GeneralSubtrees>,
 
     #[asn1(context_specific = "1", optional = "true", tag_mode = "IMPLICIT")]
-    pub excluded_subtrees: Option<GeneralSubtrees<'a>>,
+    pub excluded_subtrees: Option<GeneralSubtrees>,
 }
 
-impl<'a> AssociatedOid for NameConstraints<'a> {
+impl AssociatedOid for NameConstraints {
     const OID: ObjectIdentifier = ID_CE_NAME_CONSTRAINTS;
 }
 
@@ -38,7 +38,7 @@ impl<'a> AssociatedOid for NameConstraints<'a> {
 /// ```
 ///
 /// [RFC 5280 Section 4.2.1.10]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.10
-pub type GeneralSubtrees<'a> = Vec<GeneralSubtree<'a>>;
+pub type GeneralSubtrees = Vec<GeneralSubtree>;
 
 /// GeneralSubtree as defined in [RFC 5280 Section 4.2.1.10].
 ///
@@ -53,8 +53,8 @@ pub type GeneralSubtrees<'a> = Vec<GeneralSubtree<'a>>;
 /// [RFC 5280 Section 4.2.1.10]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.10
 #[derive(Clone, Debug, Eq, PartialEq, Sequence)]
 #[allow(missing_docs)]
-pub struct GeneralSubtree<'a> {
-    pub base: GeneralName<'a>,
+pub struct GeneralSubtree {
+    pub base: GeneralName,
 
     #[asn1(
         context_specific = "0",

--- a/x509-cert/src/ext/pkix/crl.rs
+++ b/x509-cert/src/ext/pkix/crl.rs
@@ -11,7 +11,7 @@ pub use dp::IssuingDistributionPoint;
 
 use alloc::vec::Vec;
 
-use der::{asn1::UintRef, Enumerated};
+use der::{asn1::Uint, Enumerated};
 
 /// CrlNumber as defined in [RFC 5280 Section 5.2.3].
 ///
@@ -20,14 +20,14 @@ use der::{asn1::UintRef, Enumerated};
 /// ```
 ///
 /// [RFC 5280 Section 5.2.3]: https://datatracker.ietf.org/doc/html/rfc5280#section-5.2.3
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct CrlNumber<'a>(pub UintRef<'a>);
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CrlNumber(pub Uint);
 
-impl<'a> AssociatedOid for CrlNumber<'a> {
+impl AssociatedOid for CrlNumber {
     const OID: ObjectIdentifier = ID_CE_CRL_NUMBER;
 }
 
-impl_newtype!(CrlNumber<'a>, UintRef<'a>);
+impl_newtype!(CrlNumber, Uint);
 
 /// BaseCRLNumber as defined in [RFC 5280 Section 5.2.4].
 ///
@@ -36,14 +36,14 @@ impl_newtype!(CrlNumber<'a>, UintRef<'a>);
 /// ```
 ///
 /// [RFC 5280 Section 5.2.4]: https://datatracker.ietf.org/doc/html/rfc5280#section-5.2.4
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct BaseCrlNumber<'a>(pub UintRef<'a>);
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BaseCrlNumber(pub Uint);
 
-impl<'a> AssociatedOid for BaseCrlNumber<'a> {
+impl AssociatedOid for BaseCrlNumber {
     const OID: ObjectIdentifier = ID_CE_DELTA_CRL_INDICATOR;
 }
 
-impl_newtype!(BaseCrlNumber<'a>, UintRef<'a>);
+impl_newtype!(BaseCrlNumber, Uint);
 
 /// CrlDistributionPoints as defined in [RFC 5280 Section 4.2.1.13].
 ///

--- a/x509-cert/src/ext/pkix/crl.rs
+++ b/x509-cert/src/ext/pkix/crl.rs
@@ -53,13 +53,13 @@ impl_newtype!(BaseCrlNumber<'a>, UintRef<'a>);
 ///
 /// [RFC 5280 Section 4.2.1.13]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.13
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct CrlDistributionPoints<'a>(pub Vec<dp::DistributionPoint<'a>>);
+pub struct CrlDistributionPoints(pub Vec<dp::DistributionPoint>);
 
-impl<'a> AssociatedOid for CrlDistributionPoints<'a> {
+impl AssociatedOid for CrlDistributionPoints {
     const OID: ObjectIdentifier = ID_CE_CRL_DISTRIBUTION_POINTS;
 }
 
-impl_newtype!(CrlDistributionPoints<'a>, Vec<dp::DistributionPoint<'a>>);
+impl_newtype!(CrlDistributionPoints, Vec<dp::DistributionPoint>);
 
 /// FreshestCrl as defined in [RFC 5280 Section 5.2.6].
 ///
@@ -69,13 +69,13 @@ impl_newtype!(CrlDistributionPoints<'a>, Vec<dp::DistributionPoint<'a>>);
 ///
 /// [RFC 5280 Section 5.2.6]: https://datatracker.ietf.org/doc/html/rfc5280#section-5.2.6
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct FreshestCrl<'a>(pub Vec<dp::DistributionPoint<'a>>);
+pub struct FreshestCrl(pub Vec<dp::DistributionPoint>);
 
-impl<'a> AssociatedOid for FreshestCrl<'a> {
+impl AssociatedOid for FreshestCrl {
     const OID: ObjectIdentifier = ID_CE_FRESHEST_CRL;
 }
 
-impl_newtype!(FreshestCrl<'a>, Vec<dp::DistributionPoint<'a>>);
+impl_newtype!(FreshestCrl, Vec<dp::DistributionPoint>);
 
 /// CRLReason as defined in [RFC 5280 Section 5.3.1].
 ///

--- a/x509-cert/src/ext/pkix/crl/dp.rs
+++ b/x509-cert/src/ext/pkix/crl/dp.rs
@@ -24,9 +24,9 @@ use crate::ext::pkix::name::{DistributionPointName, GeneralNames};
 /// [RFC 5280 Section 5.2.5]: https://datatracker.ietf.org/doc/html/rfc5280#section-5.2.5
 #[derive(Clone, Debug, Eq, PartialEq, Sequence)]
 #[allow(missing_docs)]
-pub struct IssuingDistributionPoint<'a> {
+pub struct IssuingDistributionPoint {
     #[asn1(context_specific = "0", tag_mode = "EXPLICIT", optional = "true")]
-    pub distribution_point: Option<DistributionPointName<'a>>,
+    pub distribution_point: Option<DistributionPointName>,
 
     #[asn1(
         context_specific = "1",
@@ -60,7 +60,7 @@ pub struct IssuingDistributionPoint<'a> {
     pub only_contains_attribute_certs: bool,
 }
 
-impl<'a> AssociatedOid for IssuingDistributionPoint<'a> {
+impl AssociatedOid for IssuingDistributionPoint {
     const OID: ObjectIdentifier = ID_PE_SUBJECT_INFO_ACCESS;
 }
 
@@ -76,15 +76,15 @@ impl<'a> AssociatedOid for IssuingDistributionPoint<'a> {
 /// [RFC 5280 Section 4.2.1.13]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.13
 #[derive(Clone, Debug, PartialEq, Eq, Sequence, ValueOrd)]
 #[allow(missing_docs)]
-pub struct DistributionPoint<'a> {
+pub struct DistributionPoint {
     #[asn1(context_specific = "0", tag_mode = "EXPLICIT", optional = "true")]
-    pub distribution_point: Option<DistributionPointName<'a>>,
+    pub distribution_point: Option<DistributionPointName>,
 
     #[asn1(context_specific = "1", tag_mode = "IMPLICIT", optional = "true")]
     pub reasons: Option<ReasonFlags>,
 
     #[asn1(context_specific = "2", tag_mode = "IMPLICIT", optional = "true")]
-    pub crl_issuer: Option<GeneralNames<'a>>,
+    pub crl_issuer: Option<GeneralNames>,
 }
 
 /// ReasonFlags as defined in [RFC 5280 Section 4.2.1.13].

--- a/x509-cert/src/ext/pkix/name/dirstr.rs
+++ b/x509-cert/src/ext/pkix/name/dirstr.rs
@@ -1,5 +1,5 @@
 use alloc::string::String;
-use der::asn1::{PrintableStringRef, TeletexString};
+use der::asn1::{PrintableString, TeletexString};
 use der::{Choice, ValueOrd};
 
 /// DirectoryString as defined in [RFC 5280 Section 4.2.1.4].
@@ -41,9 +41,9 @@ use der::{Choice, ValueOrd};
 /// [RFC 5280 Section 4.2.1.4]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.4
 #[derive(Clone, Debug, Eq, PartialEq, Choice, ValueOrd)]
 #[allow(missing_docs)]
-pub enum DirectoryString<'a> {
+pub enum DirectoryString {
     #[asn1(type = "PrintableString")]
-    PrintableString(PrintableStringRef<'a>),
+    PrintableString(PrintableString),
 
     #[asn1(type = "TeletexString")]
     TeletexString(TeletexString),

--- a/x509-cert/src/ext/pkix/name/dirstr.rs
+++ b/x509-cert/src/ext/pkix/name/dirstr.rs
@@ -1,4 +1,5 @@
-use der::asn1::{PrintableStringRef, TeletexStringRef, Utf8StringRef};
+use alloc::string::String;
+use der::asn1::{PrintableStringRef, TeletexStringRef};
 use der::{Choice, ValueOrd};
 
 /// DirectoryString as defined in [RFC 5280 Section 4.2.1.4].
@@ -48,5 +49,5 @@ pub enum DirectoryString<'a> {
     TeletexString(TeletexStringRef<'a>),
 
     #[asn1(type = "UTF8String")]
-    Utf8String(Utf8StringRef<'a>),
+    Utf8String(String),
 }

--- a/x509-cert/src/ext/pkix/name/dirstr.rs
+++ b/x509-cert/src/ext/pkix/name/dirstr.rs
@@ -1,5 +1,5 @@
 use alloc::string::String;
-use der::asn1::{PrintableStringRef, TeletexStringRef};
+use der::asn1::{PrintableStringRef, TeletexString};
 use der::{Choice, ValueOrd};
 
 /// DirectoryString as defined in [RFC 5280 Section 4.2.1.4].
@@ -46,7 +46,7 @@ pub enum DirectoryString<'a> {
     PrintableString(PrintableStringRef<'a>),
 
     #[asn1(type = "TeletexString")]
-    TeletexString(TeletexStringRef<'a>),
+    TeletexString(TeletexString),
 
     #[asn1(type = "UTF8String")]
     Utf8String(String),

--- a/x509-cert/src/ext/pkix/name/dp.rs
+++ b/x509-cert/src/ext/pkix/name/dp.rs
@@ -15,9 +15,9 @@ use der::{Choice, ValueOrd};
 /// [RFC 5280 Section 4.2.1.13]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.13
 #[derive(Clone, Debug, Eq, PartialEq, Choice, ValueOrd)]
 #[allow(missing_docs)]
-pub enum DistributionPointName<'a> {
+pub enum DistributionPointName {
     #[asn1(context_specific = "0", tag_mode = "IMPLICIT", constructed = "true")]
-    FullName(GeneralNames<'a>),
+    FullName(GeneralNames),
 
     #[asn1(context_specific = "1", tag_mode = "IMPLICIT", constructed = "true")]
     NameRelativeToCRLIssuer(RelativeDistinguishedName),

--- a/x509-cert/src/ext/pkix/name/ediparty.rs
+++ b/x509-cert/src/ext/pkix/name/ediparty.rs
@@ -27,10 +27,10 @@ use super::DirectoryString;
 /// [RFC 5280 Section 4.2.1.6]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.6
 #[derive(Clone, Debug, Eq, PartialEq, Sequence, ValueOrd)]
 #[allow(missing_docs)]
-pub struct EdiPartyName<'a> {
+pub struct EdiPartyName {
     #[asn1(context_specific = "0", tag_mode = "EXPLICIT", optional = "true")]
-    pub name_assigner: Option<DirectoryString<'a>>,
+    pub name_assigner: Option<DirectoryString>,
 
     #[asn1(context_specific = "1", tag_mode = "EXPLICIT")]
-    pub party_name: DirectoryString<'a>,
+    pub party_name: DirectoryString,
 }

--- a/x509-cert/src/ext/pkix/name/general.rs
+++ b/x509-cert/src/ext/pkix/name/general.rs
@@ -38,7 +38,7 @@ pub type GeneralNames<'a> = alloc::vec::Vec<GeneralName<'a>>;
 #[allow(missing_docs)]
 pub enum GeneralName<'a> {
     #[asn1(context_specific = "0", tag_mode = "IMPLICIT", constructed = "true")]
-    OtherName(OtherName<'a>),
+    OtherName(OtherName),
 
     #[asn1(context_specific = "1", tag_mode = "IMPLICIT")]
     Rfc822Name(Ia5StringRef<'a>),

--- a/x509-cert/src/ext/pkix/name/general.rs
+++ b/x509-cert/src/ext/pkix/name/general.rs
@@ -3,7 +3,7 @@
 use super::{EdiPartyName, OtherName};
 use crate::name::Name;
 
-use der::asn1::{Ia5String, ObjectIdentifier, OctetStringRef};
+use der::asn1::{Ia5String, ObjectIdentifier, OctetString};
 use der::{Choice, ValueOrd};
 
 /// GeneralNames as defined in [RFC 5280 Section 4.2.1.6].
@@ -13,7 +13,7 @@ use der::{Choice, ValueOrd};
 /// ```
 ///
 /// [RFC 5280 Section 4.2.1.6]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.6
-pub type GeneralNames<'a> = alloc::vec::Vec<GeneralName<'a>>;
+pub type GeneralNames = alloc::vec::Vec<GeneralName>;
 
 /// GeneralName as defined in [RFC 5280 Section 4.2.1.6].
 ///
@@ -36,7 +36,7 @@ pub type GeneralNames<'a> = alloc::vec::Vec<GeneralName<'a>>;
 /// [RFC 5280 Section 4.2.1.6]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.6
 #[derive(Clone, Debug, Eq, PartialEq, Choice, ValueOrd)]
 #[allow(missing_docs)]
-pub enum GeneralName<'a> {
+pub enum GeneralName {
     #[asn1(context_specific = "0", tag_mode = "IMPLICIT", constructed = "true")]
     OtherName(OtherName),
 
@@ -56,7 +56,7 @@ pub enum GeneralName<'a> {
     UniformResourceIdentifier(Ia5String),
 
     #[asn1(context_specific = "7", tag_mode = "IMPLICIT")]
-    IpAddress(OctetStringRef<'a>),
+    IpAddress(OctetString),
 
     #[asn1(context_specific = "8", tag_mode = "IMPLICIT")]
     RegisteredId(ObjectIdentifier),

--- a/x509-cert/src/ext/pkix/name/general.rs
+++ b/x509-cert/src/ext/pkix/name/general.rs
@@ -3,7 +3,7 @@
 use super::{EdiPartyName, OtherName};
 use crate::name::Name;
 
-use der::asn1::{Ia5StringRef, ObjectIdentifier, OctetStringRef};
+use der::asn1::{Ia5String, ObjectIdentifier, OctetStringRef};
 use der::{Choice, ValueOrd};
 
 /// GeneralNames as defined in [RFC 5280 Section 4.2.1.6].
@@ -41,10 +41,10 @@ pub enum GeneralName<'a> {
     OtherName(OtherName),
 
     #[asn1(context_specific = "1", tag_mode = "IMPLICIT")]
-    Rfc822Name(Ia5StringRef<'a>),
+    Rfc822Name(Ia5String),
 
     #[asn1(context_specific = "2", tag_mode = "IMPLICIT")]
-    DnsName(Ia5StringRef<'a>),
+    DnsName(Ia5String),
 
     #[asn1(context_specific = "4", tag_mode = "EXPLICIT", constructed = "true")]
     DirectoryName(Name),
@@ -53,7 +53,7 @@ pub enum GeneralName<'a> {
     EdiPartyName(EdiPartyName<'a>),
 
     #[asn1(context_specific = "6", tag_mode = "IMPLICIT")]
-    UniformResourceIdentifier(Ia5StringRef<'a>),
+    UniformResourceIdentifier(Ia5String),
 
     #[asn1(context_specific = "7", tag_mode = "IMPLICIT")]
     IpAddress(OctetStringRef<'a>),

--- a/x509-cert/src/ext/pkix/name/general.rs
+++ b/x509-cert/src/ext/pkix/name/general.rs
@@ -50,7 +50,7 @@ pub enum GeneralName<'a> {
     DirectoryName(Name),
 
     #[asn1(context_specific = "5", tag_mode = "IMPLICIT", constructed = "true")]
-    EdiPartyName(EdiPartyName<'a>),
+    EdiPartyName(EdiPartyName),
 
     #[asn1(context_specific = "6", tag_mode = "IMPLICIT")]
     UniformResourceIdentifier(Ia5String),

--- a/x509-cert/src/ext/pkix/name/other.rs
+++ b/x509-cert/src/ext/pkix/name/other.rs
@@ -1,4 +1,4 @@
-use der::{asn1::ObjectIdentifier, AnyRef, Sequence, ValueOrd};
+use der::{asn1::ObjectIdentifier, Any, Sequence, ValueOrd};
 
 /// OtherName as defined in [RFC 5280 Section 4.2.1.6].
 ///
@@ -12,11 +12,11 @@ use der::{asn1::ObjectIdentifier, AnyRef, Sequence, ValueOrd};
 /// [RFC 5280 Section 4.2.1.6]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.6
 #[derive(Clone, Debug, Eq, PartialEq, Sequence, ValueOrd)]
 #[allow(missing_docs)]
-pub struct OtherName<'a> {
+pub struct OtherName {
     pub type_id: ObjectIdentifier,
 
     #[asn1(context_specific = "0", tag_mode = "EXPLICIT")]
-    pub value: AnyRef<'a>,
+    pub value: Any,
 }
 
 #[test]
@@ -29,7 +29,7 @@ fn test() {
     let input = hex!("3021060A2B060104018237140203A0130C1155706E5F323134393530313330406D696C");
     let decoded = OtherName::from_der(&input).unwrap();
 
-    let onval = Utf8StringRef::try_from(decoded.value).unwrap();
+    let onval = Utf8StringRef::try_from(&decoded.value).unwrap();
     assert_eq!(onval.to_string(), "Upn_214950130@mil");
 
     let encoded = decoded.to_vec().unwrap();

--- a/x509-cert/src/request.rs
+++ b/x509-cert/src/request.rs
@@ -106,10 +106,10 @@ impl<'a> TryFrom<&'a [u8]> for CertReq<'a> {
 ///
 /// [RFC 5272 Section 3.1]: https://datatracker.ietf.org/doc/html/rfc5272#section-3.1
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct ExtensionReq<'a>(pub Vec<Extension<'a>>);
+pub struct ExtensionReq(pub Vec<Extension>);
 
-impl<'a> AssociatedOid for ExtensionReq<'a> {
+impl AssociatedOid for ExtensionReq {
     const OID: ObjectIdentifier = ID_EXTENSION_REQ;
 }
 
-impl_newtype!(ExtensionReq<'a>, Vec<Extension<'a>>);
+impl_newtype!(ExtensionReq, Vec<Extension>);

--- a/x509-cert/src/request.rs
+++ b/x509-cert/src/request.rs
@@ -7,7 +7,7 @@ use alloc::vec::Vec;
 
 use const_oid::db::rfc5912::ID_EXTENSION_REQ;
 use const_oid::{AssociatedOid, ObjectIdentifier};
-use der::asn1::BitStringRef;
+use der::asn1::BitString;
 use der::{Decode, Enumerated, Sequence};
 use spki::{AlgorithmIdentifierRef, SubjectPublicKeyInfoRef};
 
@@ -81,7 +81,7 @@ pub struct CertReq<'a> {
     pub algorithm: AlgorithmIdentifierRef<'a>,
 
     /// Signature.
-    pub signature: BitStringRef<'a>,
+    pub signature: BitString,
 }
 
 #[cfg(feature = "pem")]

--- a/x509-cert/tests/certificate.rs
+++ b/x509-cert/tests/certificate.rs
@@ -215,11 +215,21 @@ fn decode_cert() {
         "1.2.840.113549.1.1.11"
     );
     assert_eq!(
-        cert.tbs_certificate.signature.parameters.unwrap().tag(),
+        cert.tbs_certificate
+            .signature
+            .parameters
+            .as_ref()
+            .unwrap()
+            .tag(),
         Tag::Null
     );
     assert_eq!(
-        cert.tbs_certificate.signature.parameters.unwrap().is_null(),
+        cert.tbs_certificate
+            .signature
+            .parameters
+            .as_ref()
+            .unwrap()
+            .is_null(),
         true
     );
 
@@ -334,6 +344,7 @@ fn decode_cert() {
             .subject_public_key_info
             .algorithm
             .parameters
+            .as_ref()
             .unwrap()
             .tag(),
         Tag::Null
@@ -343,6 +354,7 @@ fn decode_cert() {
             .subject_public_key_info
             .algorithm
             .parameters
+            .as_ref()
             .unwrap()
             .is_null(),
         true
@@ -361,7 +373,7 @@ fn decode_cert() {
         "1.2.840.113549.1.1.11"
     );
     assert_eq!(
-        cert.signature_algorithm.parameters.unwrap().tag(),
+        cert.signature_algorithm.parameters.as_ref().unwrap().tag(),
         Tag::Null
     );
     assert_eq!(cert.signature_algorithm.parameters.unwrap().is_null(), true);

--- a/x509-cert/tests/certreq.rs
+++ b/x509-cert/tests/certreq.rs
@@ -68,7 +68,7 @@ fn decode_rsa_2048_der() {
         attribute.values.get(0).unwrap().decode_into().unwrap();
     for (ext, (oid, val)) in extensions.iter().zip(EXTENSIONS) {
         assert_eq!(ext.extn_id, oid.parse().unwrap());
-        assert_eq!(ext.extn_value, *val);
+        assert_eq!(ext.extn_value.as_bytes(), *val);
         assert!(!ext.critical);
     }
 

--- a/x509-cert/tests/pkix_extensions.rs
+++ b/x509-cert/tests/pkix_extensions.rs
@@ -1,6 +1,6 @@
 //! Certificate tests
 use const_oid::AssociatedOid;
-use der::asn1::{Ia5StringRef, PrintableStringRef, Utf8StringRef};
+use der::asn1::{Ia5StringRef, OctetString, PrintableStringRef, Utf8StringRef};
 use der::{Decode, Encode, ErrorKind, Length, Tag, Tagged};
 use hex_literal::hex;
 use x509_cert::ext::pkix::crl::dp::{DistributionPoint, ReasonFlags, Reasons};
@@ -17,93 +17,149 @@ fn spin_over_exts(exts: Extensions) {
     for ext in exts {
         match ext.extn_id {
             SubjectDirectoryAttributes::OID => {
-                let decoded = SubjectDirectoryAttributes::from_der(ext.extn_value).unwrap();
-                assert_eq!(ext.extn_value, decoded.to_vec().unwrap());
+                let decoded =
+                    SubjectDirectoryAttributes::from_der(ext.extn_value.as_bytes()).unwrap();
+                assert_eq!(
+                    ext.extn_value,
+                    decoded.to_vec().and_then(OctetString::new).unwrap()
+                );
             }
 
             SubjectKeyIdentifier::OID => {
-                let decoded = SubjectKeyIdentifier::from_der(ext.extn_value).unwrap();
-                assert_eq!(ext.extn_value, decoded.to_vec().unwrap());
+                let decoded = SubjectKeyIdentifier::from_der(ext.extn_value.as_bytes()).unwrap();
+                assert_eq!(
+                    ext.extn_value,
+                    decoded.to_vec().and_then(OctetString::new).unwrap()
+                );
             }
 
             KeyUsage::OID => {
-                let decoded = KeyUsage::from_der(ext.extn_value).unwrap();
-                assert_eq!(ext.extn_value, decoded.to_vec().unwrap());
+                let decoded = KeyUsage::from_der(ext.extn_value.as_bytes()).unwrap();
+                assert_eq!(
+                    ext.extn_value,
+                    decoded.to_vec().and_then(OctetString::new).unwrap()
+                );
             }
 
             PrivateKeyUsagePeriod::OID => {
-                let decoded = PrivateKeyUsagePeriod::from_der(ext.extn_value).unwrap();
-                assert_eq!(ext.extn_value, decoded.to_vec().unwrap());
+                let decoded = PrivateKeyUsagePeriod::from_der(ext.extn_value.as_bytes()).unwrap();
+                assert_eq!(
+                    ext.extn_value,
+                    decoded.to_vec().and_then(OctetString::new).unwrap()
+                );
             }
 
             SubjectAltName::OID => {
-                let decoded = SubjectAltName::from_der(ext.extn_value).unwrap();
-                assert_eq!(ext.extn_value, decoded.to_vec().unwrap());
+                let decoded = SubjectAltName::from_der(ext.extn_value.as_bytes()).unwrap();
+                assert_eq!(
+                    ext.extn_value,
+                    decoded.to_vec().and_then(OctetString::new).unwrap()
+                );
             }
 
             IssuerAltName::OID => {
-                let decoded = IssuerAltName::from_der(ext.extn_value).unwrap();
-                assert_eq!(ext.extn_value, decoded.to_vec().unwrap());
+                let decoded = IssuerAltName::from_der(ext.extn_value.as_bytes()).unwrap();
+                assert_eq!(
+                    ext.extn_value,
+                    decoded.to_vec().and_then(OctetString::new).unwrap()
+                );
             }
 
             BasicConstraints::OID => {
-                let decoded = BasicConstraints::from_der(ext.extn_value).unwrap();
-                assert_eq!(ext.extn_value, decoded.to_vec().unwrap());
+                let decoded = BasicConstraints::from_der(ext.extn_value.as_bytes()).unwrap();
+                assert_eq!(
+                    ext.extn_value,
+                    decoded.to_vec().and_then(OctetString::new).unwrap()
+                );
             }
 
             NameConstraints::OID => {
-                let decoded = NameConstraints::from_der(ext.extn_value).unwrap();
-                assert_eq!(ext.extn_value, decoded.to_vec().unwrap());
+                let decoded = NameConstraints::from_der(ext.extn_value.as_bytes()).unwrap();
+                assert_eq!(
+                    ext.extn_value,
+                    decoded.to_vec().and_then(OctetString::new).unwrap()
+                );
             }
 
             CrlDistributionPoints::OID => {
-                let decoded = CrlDistributionPoints::from_der(ext.extn_value).unwrap();
-                assert_eq!(ext.extn_value, decoded.to_vec().unwrap());
+                let decoded = CrlDistributionPoints::from_der(ext.extn_value.as_bytes()).unwrap();
+                assert_eq!(
+                    ext.extn_value,
+                    decoded.to_vec().and_then(OctetString::new).unwrap()
+                );
             }
 
             CertificatePolicies::OID => {
-                let decoded = CertificatePolicies::from_der(ext.extn_value).unwrap();
-                assert_eq!(ext.extn_value, decoded.to_vec().unwrap());
+                let decoded = CertificatePolicies::from_der(ext.extn_value.as_bytes()).unwrap();
+                assert_eq!(
+                    ext.extn_value,
+                    decoded.to_vec().and_then(OctetString::new).unwrap()
+                );
             }
 
             PolicyMappings::OID => {
-                let decoded = PolicyMappings::from_der(ext.extn_value).unwrap();
-                assert_eq!(ext.extn_value, decoded.to_vec().unwrap());
+                let decoded = PolicyMappings::from_der(ext.extn_value.as_bytes()).unwrap();
+                assert_eq!(
+                    ext.extn_value,
+                    decoded.to_vec().and_then(OctetString::new).unwrap()
+                );
             }
 
             AuthorityKeyIdentifier::OID => {
-                let decoded = AuthorityKeyIdentifier::from_der(ext.extn_value).unwrap();
-                assert_eq!(ext.extn_value, decoded.to_vec().unwrap());
+                let decoded = AuthorityKeyIdentifier::from_der(ext.extn_value.as_bytes()).unwrap();
+                assert_eq!(
+                    ext.extn_value,
+                    decoded.to_vec().and_then(OctetString::new).unwrap()
+                );
             }
 
             PolicyConstraints::OID => {
-                let decoded = PolicyConstraints::from_der(ext.extn_value).unwrap();
-                assert_eq!(ext.extn_value, decoded.to_vec().unwrap());
+                let decoded = PolicyConstraints::from_der(ext.extn_value.as_bytes()).unwrap();
+                assert_eq!(
+                    ext.extn_value,
+                    decoded.to_vec().and_then(OctetString::new).unwrap()
+                );
             }
 
             ExtendedKeyUsage::OID => {
-                let decoded = ExtendedKeyUsage::from_der(ext.extn_value).unwrap();
-                assert_eq!(ext.extn_value, decoded.to_vec().unwrap());
+                let decoded = ExtendedKeyUsage::from_der(ext.extn_value.as_bytes()).unwrap();
+                assert_eq!(
+                    ext.extn_value,
+                    decoded.to_vec().and_then(OctetString::new).unwrap()
+                );
             }
 
             FreshestCrl::OID => {
-                let decoded = FreshestCrl::from_der(ext.extn_value).unwrap();
-                assert_eq!(ext.extn_value, decoded.to_vec().unwrap());
+                let decoded = FreshestCrl::from_der(ext.extn_value.as_bytes()).unwrap();
+                assert_eq!(
+                    ext.extn_value,
+                    decoded.to_vec().and_then(OctetString::new).unwrap()
+                );
             }
 
             InhibitAnyPolicy::OID => {
-                let decoded = InhibitAnyPolicy::from_der(ext.extn_value).unwrap();
-                assert_eq!(ext.extn_value, decoded.to_vec().unwrap());
+                let decoded = InhibitAnyPolicy::from_der(ext.extn_value.as_bytes()).unwrap();
+                assert_eq!(
+                    ext.extn_value,
+                    decoded.to_vec().and_then(OctetString::new).unwrap()
+                );
             }
 
             AuthorityInfoAccessSyntax::OID => {
-                let decoded = AuthorityInfoAccessSyntax::from_der(ext.extn_value).unwrap();
-                assert_eq!(ext.extn_value, decoded.to_vec().unwrap());
+                let decoded =
+                    AuthorityInfoAccessSyntax::from_der(ext.extn_value.as_bytes()).unwrap();
+                assert_eq!(
+                    ext.extn_value,
+                    decoded.to_vec().and_then(OctetString::new).unwrap()
+                );
             }
 
             SubjectInfoAccessSyntax::OID => {
-                let decoded = SubjectInfoAccessSyntax::from_der(ext.extn_value).unwrap();
-                assert_eq!(ext.extn_value, decoded.to_vec().unwrap());
+                let decoded = SubjectInfoAccessSyntax::from_der(ext.extn_value.as_bytes()).unwrap();
+                assert_eq!(
+                    ext.extn_value,
+                    decoded.to_vec().and_then(OctetString::new).unwrap()
+                );
             }
 
             _ => {
@@ -162,27 +218,27 @@ fn decode_cert() {
             assert_eq!(ext.extn_id.to_string(), ID_CE_KEY_USAGE.to_string());
             assert_eq!(ext.critical, true);
 
-            let ku = KeyUsage::from_der(ext.extn_value).unwrap();
+            let ku = KeyUsage::from_der(ext.extn_value.as_bytes()).unwrap();
             assert_eq!(KeyUsages::KeyCertSign | KeyUsages::CRLSign, ku);
 
-            let reencoded = ku.to_vec().unwrap();
+            let reencoded = ku.to_vec().and_then(OctetString::new).unwrap();
             assert_eq!(ext.extn_value, reencoded);
         } else if 1 == counter {
             assert_eq!(ext.extn_id.to_string(), ID_CE_BASIC_CONSTRAINTS.to_string());
             assert_eq!(ext.critical, true);
-            let bc = BasicConstraints::from_der(ext.extn_value).unwrap();
+            let bc = BasicConstraints::from_der(ext.extn_value.as_bytes()).unwrap();
             assert_eq!(true, bc.ca);
             assert!(bc.path_len_constraint.is_none());
 
-            let reencoded = bc.to_vec().unwrap();
+            let reencoded = bc.to_vec().and_then(OctetString::new).unwrap();
             assert_eq!(ext.extn_value, reencoded);
         } else if 2 == counter {
             assert_eq!(ext.extn_id.to_string(), ID_CE_POLICY_MAPPINGS.to_string());
             assert_eq!(ext.critical, false);
-            let pm = PolicyMappings::from_der(ext.extn_value).unwrap();
+            let pm = PolicyMappings::from_der(ext.extn_value.as_bytes()).unwrap();
             assert_eq!(19, pm.0.len());
 
-            let reencoded = pm.to_vec().unwrap();
+            let reencoded = pm.to_vec().and_then(OctetString::new).unwrap();
             assert_eq!(ext.extn_value, reencoded);
 
             let subject_domain_policy: [&str; 19] = [
@@ -247,10 +303,10 @@ fn decode_cert() {
                 ID_CE_CERTIFICATE_POLICIES.to_string()
             );
             assert_eq!(ext.critical, false);
-            let cps = CertificatePolicies::from_der(ext.extn_value).unwrap();
+            let cps = CertificatePolicies::from_der(ext.extn_value.as_bytes()).unwrap();
             assert_eq!(19, cps.0.len());
 
-            let reencoded = cps.to_vec().unwrap();
+            let reencoded = cps.to_vec().and_then(OctetString::new).unwrap();
             assert_eq!(ext.extn_value, reencoded);
 
             let ids: [&str; 19] = [
@@ -308,14 +364,14 @@ fn decode_cert() {
                 ID_CE_SUBJECT_KEY_IDENTIFIER.to_string()
             );
             assert_eq!(ext.critical, false);
-            let skid = SubjectKeyIdentifier::from_der(ext.extn_value).unwrap();
+            let skid = SubjectKeyIdentifier::from_der(ext.extn_value.as_bytes()).unwrap();
             assert_eq!(Length::new(21), skid.0.len());
             assert_eq!(
                 &hex!("DBD3DEBF0D7B615B32803BC0206CD7AADD39B8ACFF"),
                 skid.0.as_bytes()
             );
 
-            let reencoded = skid.to_vec().unwrap();
+            let reencoded = skid.to_vec().and_then(OctetString::new).unwrap();
             assert_eq!(ext.extn_value, reencoded);
         } else if 5 == counter {
             assert_eq!(
@@ -323,10 +379,10 @@ fn decode_cert() {
                 ID_CE_CRL_DISTRIBUTION_POINTS.to_string()
             );
             assert_eq!(ext.critical, false);
-            let crl_dps = CrlDistributionPoints::from_der(ext.extn_value).unwrap();
+            let crl_dps = CrlDistributionPoints::from_der(ext.extn_value.as_bytes()).unwrap();
             assert_eq!(2, crl_dps.0.len());
 
-            let reencoded = crl_dps.to_vec().unwrap();
+            let reencoded = crl_dps.to_vec().and_then(OctetString::new).unwrap();
             assert_eq!(ext.extn_value, reencoded);
 
             let mut crldp_counter = 0;
@@ -381,10 +437,10 @@ fn decode_cert() {
                 ID_PE_SUBJECT_INFO_ACCESS.to_string()
             );
             assert_eq!(ext.critical, false);
-            let sias = SubjectInfoAccessSyntax::from_der(ext.extn_value).unwrap();
+            let sias = SubjectInfoAccessSyntax::from_der(ext.extn_value.as_bytes()).unwrap();
             assert_eq!(1, sias.0.len());
 
-            let reencoded = sias.to_vec().unwrap();
+            let reencoded = sias.to_vec().and_then(OctetString::new).unwrap();
             assert_eq!(ext.extn_value, reencoded);
 
             for sia in sias.0 {
@@ -408,11 +464,11 @@ fn decode_cert() {
                 ID_PE_AUTHORITY_INFO_ACCESS.to_string()
             );
             assert_eq!(ext.critical, false);
-            let aias = AuthorityInfoAccessSyntax::from_der(ext.extn_value).unwrap();
+            let aias = AuthorityInfoAccessSyntax::from_der(ext.extn_value.as_bytes()).unwrap();
             assert_eq!(2, aias.0.len());
             let mut aia_counter = 0;
 
-            let reencoded = aias.to_vec().unwrap();
+            let reencoded = aias.to_vec().and_then(OctetString::new).unwrap();
             assert_eq!(ext.extn_value, reencoded);
 
             for aia in aias.0 {
@@ -454,10 +510,10 @@ fn decode_cert() {
                 ID_CE_INHIBIT_ANY_POLICY.to_string()
             );
             assert_eq!(ext.critical, false);
-            let iap = InhibitAnyPolicy::from_der(ext.extn_value).unwrap();
+            let iap = InhibitAnyPolicy::from_der(ext.extn_value.as_bytes()).unwrap();
             assert_eq!(0, iap.0);
 
-            let reencoded = iap.to_vec().unwrap();
+            let reencoded = iap.to_vec().and_then(OctetString::new).unwrap();
             assert_eq!(ext.extn_value, reencoded);
         } else if 9 == counter {
             assert_eq!(
@@ -465,13 +521,13 @@ fn decode_cert() {
                 ID_CE_AUTHORITY_KEY_IDENTIFIER.to_string()
             );
             assert_eq!(ext.critical, false);
-            let akid = AuthorityKeyIdentifier::from_der(ext.extn_value).unwrap();
+            let akid = AuthorityKeyIdentifier::from_der(ext.extn_value.as_bytes()).unwrap();
             assert_eq!(
                 &hex!("7C4C863AB80BD589870BEDB7E11BBD2A08BB3D23FF"),
                 akid.key_identifier.unwrap().as_bytes()
             );
 
-            let reencoded = akid.to_vec().unwrap();
+            let reencoded = akid.to_vec().and_then(OctetString::new).unwrap();
             assert_eq!(ext.extn_value, reencoded);
         }
 
@@ -625,7 +681,7 @@ fn decode_cert() {
                 ID_CE_AUTHORITY_KEY_IDENTIFIER.to_string()
             );
             assert_eq!(ext.critical, false);
-            let akid = AuthorityKeyIdentifier::from_der(ext.extn_value).unwrap();
+            let akid = AuthorityKeyIdentifier::from_der(ext.extn_value.as_bytes()).unwrap();
             assert_eq!(
                 akid.key_identifier.unwrap().as_bytes(),
                 &hex!("E47D5FD15C9586082C05AEBE75B665A7D95DA866")[..]
@@ -636,7 +692,7 @@ fn decode_cert() {
                 ID_CE_SUBJECT_KEY_IDENTIFIER.to_string()
             );
             assert_eq!(ext.critical, false);
-            let skid = SubjectKeyIdentifier::from_der(ext.extn_value).unwrap();
+            let skid = SubjectKeyIdentifier::from_der(ext.extn_value.as_bytes()).unwrap();
             assert_eq!(
                 skid.0.as_bytes(),
                 &hex!("580184241BBC2B52944A3DA510721451F5AF3AC9")[..]
@@ -644,7 +700,7 @@ fn decode_cert() {
         } else if 2 == counter {
             assert_eq!(ext.extn_id.to_string(), ID_CE_KEY_USAGE.to_string());
             assert_eq!(ext.critical, true);
-            let ku = KeyUsage::from_der(ext.extn_value).unwrap();
+            let ku = KeyUsage::from_der(ext.extn_value.as_bytes()).unwrap();
             assert_eq!(KeyUsages::KeyCertSign | KeyUsages::CRLSign, ku);
         } else if 3 == counter {
             assert_eq!(
@@ -652,7 +708,7 @@ fn decode_cert() {
                 ID_CE_CERTIFICATE_POLICIES.to_string()
             );
             assert_eq!(ext.critical, false);
-            let r = CertificatePolicies::from_der(ext.extn_value);
+            let r = CertificatePolicies::from_der(ext.extn_value.as_bytes());
             let cp = r.unwrap();
             let i = cp.0.iter();
             for p in i {
@@ -661,7 +717,7 @@ fn decode_cert() {
         } else if 4 == counter {
             assert_eq!(ext.extn_id.to_string(), ID_CE_BASIC_CONSTRAINTS.to_string());
             assert_eq!(ext.critical, true);
-            let bc = BasicConstraints::from_der(ext.extn_value).unwrap();
+            let bc = BasicConstraints::from_der(ext.extn_value.as_bytes()).unwrap();
             assert_eq!(bc.ca, true);
             assert_eq!(bc.path_len_constraint, Option::None);
         }

--- a/x509-cert/tests/pkix_extensions.rs
+++ b/x509-cert/tests/pkix_extensions.rs
@@ -525,7 +525,7 @@ fn decode_cert() {
             let akid = AuthorityKeyIdentifier::from_der(ext.extn_value.as_bytes()).unwrap();
             assert_eq!(
                 &hex!("7C4C863AB80BD589870BEDB7E11BBD2A08BB3D23FF"),
-                akid.key_identifier.unwrap().as_bytes()
+                akid.key_identifier.as_ref().unwrap().as_bytes()
             );
 
             let reencoded = akid.to_vec().and_then(OctetString::new).unwrap();

--- a/x509-cert/tests/pkix_extensions.rs
+++ b/x509-cert/tests/pkix_extensions.rs
@@ -550,11 +550,21 @@ fn decode_cert() {
         "1.2.840.113549.1.1.11"
     );
     assert_eq!(
-        cert.tbs_certificate.signature.parameters.unwrap().tag(),
+        cert.tbs_certificate
+            .signature
+            .parameters
+            .as_ref()
+            .unwrap()
+            .tag(),
         Tag::Null
     );
     assert_eq!(
-        cert.tbs_certificate.signature.parameters.unwrap().is_null(),
+        cert.tbs_certificate
+            .signature
+            .parameters
+            .as_ref()
+            .unwrap()
+            .is_null(),
         true
     );
 
@@ -656,6 +666,7 @@ fn decode_cert() {
             .subject_public_key_info
             .algorithm
             .parameters
+            .as_ref()
             .unwrap()
             .tag(),
         Tag::Null
@@ -665,6 +676,7 @@ fn decode_cert() {
             .subject_public_key_info
             .algorithm
             .parameters
+            .as_ref()
             .unwrap()
             .is_null(),
         true
@@ -730,7 +742,7 @@ fn decode_cert() {
         "1.2.840.113549.1.1.11"
     );
     assert_eq!(
-        cert.signature_algorithm.parameters.unwrap().tag(),
+        cert.signature_algorithm.parameters.as_ref().unwrap().tag(),
         Tag::Null
     );
     assert_eq!(cert.signature_algorithm.parameters.unwrap().is_null(), true);

--- a/x509-cert/tests/pkix_extensions.rs
+++ b/x509-cert/tests/pkix_extensions.rs
@@ -341,7 +341,8 @@ fn decode_cert() {
                     for pqi in pq.iter() {
                         if 0 == counter_pq {
                             assert_eq!("1.3.6.1.5.5.7.2.1", pqi.policy_qualifier_id.to_string());
-                            let cpsval = Ia5StringRef::try_from(pqi.qualifier.unwrap()).unwrap();
+                            let cpsval =
+                                Ia5StringRef::try_from(pqi.qualifier.as_ref().unwrap()).unwrap();
                             assert_eq!(
                                 "https://secure.identrust.com/certificates/policy/IGC/index.html",
                                 cpsval.to_string()

--- a/x509-cert/tests/pkix_extensions.rs
+++ b/x509-cert/tests/pkix_extensions.rs
@@ -194,7 +194,7 @@ fn decode_general_name() {
     let bytes = hex!("A021060A2B060104018237140203A0130C1155706E5F323134393530313330406D696C");
     match GeneralName::from_der(&bytes).unwrap() {
         GeneralName::OtherName(other_name) => {
-            let onval = Utf8StringRef::try_from(other_name.value).unwrap();
+            let onval = Utf8StringRef::try_from(&other_name.value).unwrap();
             assert_eq!(onval.to_string(), "Upn_214950130@mil");
         }
         _ => panic!("Failed to parse OtherName from GeneralName"),

--- a/x509-ocsp/src/lib.rs
+++ b/x509-ocsp/src/lib.rs
@@ -79,7 +79,7 @@ pub struct TbsRequest<'a> {
     pub version: Version,
 
     #[asn1(context_specific = "1", optional = "true", tag_mode = "EXPLICIT")]
-    pub requestor_name: Option<GeneralName<'a>>,
+    pub requestor_name: Option<GeneralName>,
 
     pub request_list: Vec<Request<'a>>,
 
@@ -415,9 +415,9 @@ pub type AcceptableResponses = Vec<ObjectIdentifier>;
 /// [RFC 6960 Section 4.4.6]: https://datatracker.ietf.org/doc/html/rfc6960#section-4.4.6
 #[derive(Clone, Debug, Eq, PartialEq, Sequence)]
 #[allow(missing_docs)]
-pub struct ServiceLocator<'a> {
+pub struct ServiceLocator {
     pub issuer: Name,
-    pub locator: AuthorityInfoAccessSyntax<'a>,
+    pub locator: AuthorityInfoAccessSyntax,
 }
 
 /// CrlID structure as defined in [RFC 6960 Section 4.4.2].

--- a/x509-ocsp/src/lib.rs
+++ b/x509-ocsp/src/lib.rs
@@ -104,7 +104,7 @@ pub struct Signature<'a> {
     pub signature: BitStringRef<'a>,
 
     #[asn1(context_specific = "0", optional = "true", tag_mode = "EXPLICIT")]
-    pub certs: Option<Vec<Certificate<'a>>>,
+    pub certs: Option<Vec<Certificate>>,
 }
 
 /// OCSP `Version` as defined in [RFC 6960 Section 4.1.1].

--- a/x509-ocsp/src/lib.rs
+++ b/x509-ocsp/src/lib.rs
@@ -84,7 +84,7 @@ pub struct TbsRequest<'a> {
     pub request_list: Vec<Request<'a>>,
 
     #[asn1(context_specific = "2", optional = "true", tag_mode = "EXPLICIT")]
-    pub request_extensions: Option<Extensions<'a>>,
+    pub request_extensions: Option<Extensions>,
 }
 
 /// Signature structure as defined in [RFC 6960 Section 4.1.1].
@@ -143,7 +143,7 @@ pub struct Request<'a> {
     pub req_cert: CertId<'a>,
 
     #[asn1(context_specific = "0", optional = "true", tag_mode = "EXPLICIT")]
-    pub single_request_extensions: Option<Extensions<'a>>,
+    pub single_request_extensions: Option<Extensions>,
 }
 
 /// CertID structure as defined in [RFC 6960 Section 4.1.1].
@@ -275,7 +275,7 @@ pub struct ResponseData<'a> {
     pub responses: Vec<SingleResponse<'a>>,
 
     #[asn1(context_specific = "1", optional = "true", tag_mode = "EXPLICIT")]
-    pub response_extensions: Option<Extensions<'a>>,
+    pub response_extensions: Option<Extensions>,
 }
 
 /// ResponderID structure as defined in [RFC 6960 Section 4.2.1].
@@ -333,7 +333,7 @@ pub struct SingleResponse<'a> {
     pub next_update: Option<GeneralizedTime>,
 
     #[asn1(context_specific = "1", optional = "true", tag_mode = "EXPLICIT")]
-    pub single_request_extensions: Option<Extensions<'a>>,
+    pub single_request_extensions: Option<Extensions>,
 }
 
 /// CertStatus structure as defined in [RFC 6960 Section 4.2.1].


### PR DESCRIPTION
As discussed in #803 let's make `Certificate` an owned type. We'll revisit that in a follow up PR to accept a `trait Profile` as parameter allowing it to be either a reference or an owned type.