### PR TITLE
WIP: Parsing with `lax` mode

### DIFF
--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -30,6 +30,7 @@ proptest = "1"
 [features]
 alloc = []
 derive = ["der_derive"]
+lax = []
 oid = ["const-oid"]
 pem = ["alloc", "pem-rfc7468/alloc", "zeroize"]
 real = []

--- a/der/src/error.rs
+++ b/der/src/error.rs
@@ -165,6 +165,9 @@ pub enum ErrorKind {
     /// Date-and-time related errors.
     DateTime,
 
+    /// Emd-of-content related errors.
+    EndOfContent,
+
     /// This error indicates a previous DER parsing operation resulted in
     /// an error and tainted the state of a `Decoder` or `Encoder`.
     ///
@@ -308,6 +311,7 @@ impl fmt::Display for ErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ErrorKind::DateTime => write!(f, "date/time error"),
+            ErrorKind::EndOfContent => write!(f, "end-of-content invalid"),
             ErrorKind::Failed => write!(f, "operation failed"),
             #[cfg(feature = "std")]
             ErrorKind::FileNotFound => write!(f, "file not found"),

--- a/der/src/tag.rs
+++ b/der/src/tag.rs
@@ -281,6 +281,8 @@ impl TryFrom<u8> for Tag {
             0x18 => Ok(Tag::GeneralizedTime),
             0x1A => Ok(Tag::VisibleString),
             0x1d => Ok(Tag::BmpString),
+            #[cfg(feature = "lax")]
+            0x24 => Ok(Tag::OctetString), // constructed
             0x30 => Ok(Tag::Sequence), // constructed
             0x31 => Ok(Tag::Set),      // constructed
             0x40..=0x7E => Ok(Tag::Application {


### PR DESCRIPTION
This allows parsing DER with some "features" from BER that are in use (in the apple universe)

* Reading indefinite length tags by using `length = 0`
* Reading constructed/encapsulated OctetStrings (only if 1! OctetString is part of a indefinite length OctetString) as that is east without alloc

This is my first try to address [this issue](https://github.com/RustCrypto/formats/issues/779)