### PR TITLE
added `impl AsRef<[u8]> for SecretDocument`

### DIFF
--- a/der/src/document.rs
+++ b/der/src/document.rs
@@ -287,6 +287,14 @@ impl SecretDocument {
         write_secret_file(path, self.to_pem(label, line_ending)?.as_bytes())
     }
 }
+
+#[cfg(feature = "zeroize")]
+impl AsRef<[u8]> for SecretDocument {
+    fn as_ref(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}
+
 #[cfg(feature = "zeroize")]
 impl Debug for SecretDocument {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
Hey, I'm using `std::fs::write` and its signature looks like that: (it has AsRef generic)
![image](https://user-images.githubusercontent.com/109800286/209727127-90d2d6b6-5271-4ff4-b643-c10ef6d65bee.png)

and I think I found one hole in your API:
```
error[E0277]: the trait bound `SecretDocument: AsRef<[u8]>` is not satisfied
   --> keypair/build.rs:25:55
    |
25  |     fs::write(keys_dir.join("private_key_pkcs1.der"), private_key_der)?;
    |     ---------                                         ^^^^^^^^^^^^^^^ the trait `AsRef<[u8]>` is not implemented for `SecretDocument`
    |     |
    |     required by a bound introduced by this call
```

 Now the developer needs to manually call `.as_bytes()` for `SecretDocument`, but `Document` already has `impl AsRef<[u8]> for Document`
![image1](https://user-images.githubusercontent.com/109800286/209727362-19c23bf1-0b25-40aa-82ca-62f4bb407171.png)
