### PR TITLE
Lint improvements

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.65.0
+          toolchain: 1.66.0
           components: clippy
           override: true
           profile: minimal

--- a/.github/workflows/x509-cert.yml
+++ b/.github/workflows/x509-cert.yml
@@ -73,7 +73,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2022-12-25 # Pinned due to rust-lang/rust#106247
           override: true
       - run: cargo install cargo-fuzz
       - run: cargo fuzz run certreq -- -max_total_time=30 -seed_inputs="fuzz/inputs/rsa2048-csr.der"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,6 +766,7 @@ dependencies = [
  "der",
  "hex-literal",
  "spki",
+ "x509-cert",
 ]
 
 [[package]]

--- a/base16ct/src/lib.rs
+++ b/base16ct/src/lib.rs
@@ -1,3 +1,18 @@
+#![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
+)]
+#![warn(
+    clippy::mod_module_files,
+    clippy::unwrap_used,
+    missing_docs,
+    rust_2018_idioms,
+    unused_lifetimes,
+    unused_qualifications
+)]
+
 //! Pure Rust implementation of Base16 ([RFC 4648], a.k.a. hex).
 //!
 //! Implements lower and upper case Base16 variants without data-dependent branches
@@ -43,14 +58,6 @@
 //! ```
 //!
 //! [RFC 4648]: https://tools.ietf.org/html/rfc4648
-
-#![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
-#![warn(missing_docs, rust_2018_idioms)]
-#![doc(
-    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
-)]
 
 #[cfg(feature = "alloc")]
 #[macro_use]

--- a/base32ct/src/alphabet.rs
+++ b/base32ct/src/alphabet.rs
@@ -28,7 +28,7 @@ pub trait Alphabet: 'static + Copy + Debug + Eq + Send + Sized + Sync {
             // Compute exclusive range from inclusive one
             let start = *range.start() as i16 - 1;
             let end = *range.end() as i16 + 1;
-            ret += (((start - src as i16) & (src as i16 - end)) >> 8) & (src as i16 + *offset);
+            ret += (((start - src) & (src - end)) >> 8) & (src + *offset);
         }
 
         ret

--- a/base32ct/src/lib.rs
+++ b/base32ct/src/lib.rs
@@ -34,10 +34,17 @@
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![warn(clippy::unwrap_used, missing_docs, rust_2018_idioms)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
+)]
+#![warn(
+    clippy::mod_module_files,
+    clippy::unwrap_used,
+    missing_docs,
+    rust_2018_idioms,
+    unused_lifetimes,
+    unused_qualifications
 )]
 
 #[cfg(feature = "alloc")]

--- a/base64ct/src/lib.rs
+++ b/base64ct/src/lib.rs
@@ -7,6 +7,7 @@
 #![doc = include_str!("../README.md")]
 #![warn(
     clippy::integer_arithmetic,
+    clippy::mod_module_files,
     clippy::panic,
     clippy::panic_in_result_fn,
     clippy::unwrap_used,

--- a/const-oid/src/lib.rs
+++ b/const-oid/src/lib.rs
@@ -9,6 +9,7 @@
 #![forbid(unsafe_code)]
 #![warn(
     clippy::integer_arithmetic,
+    clippy::mod_module_files,
     clippy::panic,
     clippy::panic_in_result_fn,
     clippy::unwrap_used,

--- a/der/src/datetime.rs
+++ b/der/src/datetime.rs
@@ -335,7 +335,7 @@ impl TryFrom<DateTime> for PrimitiveDateTime {
     type Error = Error;
 
     fn try_from(time: DateTime) -> Result<PrimitiveDateTime> {
-        let month = (time.month() as u8).try_into()?;
+        let month = time.month().try_into()?;
         let date = time::Date::from_calendar_date(i32::from(time.year()), month, time.day())?;
         let time = time::Time::from_hms(time.hour(), time.minutes(), time.seconds())?;
 

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -15,6 +15,7 @@
     clippy::checked_conversions,
     clippy::implicit_saturating_sub,
     clippy::integer_arithmetic,
+    clippy::mod_module_files,
     clippy::panic,
     clippy::panic_in_result_fn,
     clippy::unwrap_used,

--- a/pem-rfc7468/src/lib.rs
+++ b/pem-rfc7468/src/lib.rs
@@ -8,11 +8,13 @@
 #![deny(unsafe_code)]
 #![warn(
     clippy::integer_arithmetic,
+    clippy::mod_module_files,
     clippy::panic,
     clippy::panic_in_result_fn,
     clippy::unwrap_used,
     missing_docs,
     rust_2018_idioms,
+    unused_lifetimes,
     unused_qualifications
 )]
 

--- a/pkcs1/src/lib.rs
+++ b/pkcs1/src/lib.rs
@@ -5,8 +5,15 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
 )]
-#![forbid(unsafe_code, clippy::unwrap_used)]
-#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+#![forbid(unsafe_code)]
+#![warn(
+    clippy::mod_module_files,
+    clippy::unwrap_used,
+    missing_docs,
+    rust_2018_idioms,
+    unused_lifetimes,
+    unused_qualifications
+)]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/pkcs12/src/lib.rs
+++ b/pkcs12/src/lib.rs
@@ -5,5 +5,13 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
 )]
-#![forbid(unsafe_code, clippy::unwrap_used)]
-#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+#![forbid(unsafe_code)]
+#![warn(
+    clippy::mod_module_files,
+    clippy::unwrap_used,
+    missing_docs,
+    rust_2018_idioms,
+    unused_qualifications
+)]
+
+//! TODO: PKCS#12 crate

--- a/pkcs5/src/lib.rs
+++ b/pkcs5/src/lib.rs
@@ -5,8 +5,15 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
 )]
-#![forbid(unsafe_code, clippy::unwrap_used)]
-#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+#![forbid(unsafe_code)]
+#![warn(
+    clippy::mod_module_files,
+    clippy::unwrap_used,
+    missing_docs,
+    rust_2018_idioms,
+    unused_lifetimes,
+    unused_qualifications
+)]
 
 //! # Usage
 //!

--- a/pkcs5/src/pbes2/encryption.rs
+++ b/pkcs5/src/pbes2/encryption.rs
@@ -171,7 +171,7 @@ impl EncryptionKey {
         pbkdf2::<Hmac<D>>(
             password,
             params.salt,
-            params.iteration_count as u32,
+            params.iteration_count,
             &mut buffer[..length],
         );
 

--- a/pkcs7/src/lib.rs
+++ b/pkcs7/src/lib.rs
@@ -5,13 +5,15 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
 )]
-#![forbid(unsafe_code, clippy::unwrap_used)]
-#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
-
-mod content_info;
-mod content_type;
-
-pub use crate::{content_info::ContentInfo, content_type::ContentType};
+#![forbid(unsafe_code)]
+#![warn(
+    clippy::mod_module_files,
+    clippy::unwrap_used,
+    missing_docs,
+    rust_2018_idioms,
+    unused_lifetimes,
+    unused_qualifications
+)]
 
 pub mod certificate_choices;
 pub mod cms_version;
@@ -22,6 +24,11 @@ pub mod enveloped_data_content;
 pub mod revocation_info_choices;
 pub mod signed_data_content;
 pub mod signer_info;
+
+mod content_info;
+mod content_type;
+
+pub use crate::{content_info::ContentInfo, content_type::ContentType};
 
 use der::asn1::ObjectIdentifier;
 

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -5,8 +5,15 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
 )]
-#![forbid(unsafe_code, clippy::unwrap_used)]
-#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+#![forbid(unsafe_code)]
+#![warn(
+    clippy::mod_module_files,
+    clippy::unwrap_used,
+    missing_docs,
+    rust_2018_idioms,
+    unused_lifetimes,
+    unused_qualifications
+)]
 
 //! ## About this crate
 //! This library provides generalized PKCS#8 support designed to work with a

--- a/sec1/src/lib.rs
+++ b/sec1/src/lib.rs
@@ -5,8 +5,14 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
 )]
-#![forbid(unsafe_code, clippy::unwrap_used)]
-#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+#![forbid(unsafe_code)]
+#![warn(
+    clippy::mod_module_files,
+    clippy::unwrap_used,
+    missing_docs,
+    rust_2018_idioms,
+    unused_qualifications
+)]
 
 //! ## `serde` support
 //!

--- a/sec1/src/point.rs
+++ b/sec1/src/point.rs
@@ -405,7 +405,7 @@ where
         D: de::Deserializer<'de>,
     {
         let bytes = serdect::slice::deserialize_hex_or_bin_vec(deserializer)?;
-        Self::from_bytes(&bytes).map_err(de::Error::custom)
+        Self::from_bytes(bytes).map_err(de::Error::custom)
     }
 }
 

--- a/serdect/src/lib.rs
+++ b/serdect/src/lib.rs
@@ -7,6 +7,8 @@
 )]
 #![forbid(unsafe_code)]
 #![warn(
+    clippy::mod_module_files,
+    clippy::unwrap_used,
     missing_docs,
     rust_2018_idioms,
     unused_lifetimes,

--- a/spki/src/lib.rs
+++ b/spki/src/lib.rs
@@ -5,9 +5,15 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
 )]
-#![forbid(unsafe_code, clippy::unwrap_used)]
-#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
-
+#![forbid(unsafe_code)]
+#![warn(
+    clippy::mod_module_files,
+    clippy::unwrap_used,
+    missing_docs,
+    rust_2018_idioms,
+    unused_lifetimes,
+    unused_qualifications
+)]
 //! # Usage
 //! The following example demonstrates how to use an OID as the `parameters`
 //! of an [`AlgorithmIdentifier`].

--- a/tai64/src/lib.rs
+++ b/tai64/src/lib.rs
@@ -5,7 +5,14 @@
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
 )]
 #![forbid(unsafe_code)]
-#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+#![warn(
+    clippy::mod_module_files,
+    clippy::unwrap_used,
+    missing_docs,
+    rust_2018_idioms,
+    unused_lifetimes,
+    unused_qualifications
+)]
 
 #[cfg(feature = "std")]
 extern crate std;
@@ -181,6 +188,7 @@ impl Tai64N {
             let s = (self.0).0 - carry - (other.0).0;
             Ok(Duration::new(s, n))
         } else {
+            #[allow(clippy::unwrap_used)]
             Err(other.duration_since(self).unwrap())
         }
     }

--- a/tls_codec/benches/quic_vec.rs
+++ b/tls_codec/benches/quic_vec.rs
@@ -73,7 +73,7 @@ fn slice(c: &mut Criterion) {
         b.iter_batched(
             || vec![77u8; 65535],
             |long_vector| {
-                let _serialized_long_vec = (&long_vector).tls_serialize_detached().unwrap();
+                let _serialized_long_vec = long_vector.tls_serialize_detached().unwrap();
             },
             BatchSize::SmallInput,
         )

--- a/tls_codec/src/lib.rs
+++ b/tls_codec/src/lib.rs
@@ -1,6 +1,12 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc = include_str!("../README.md")]
+#![warn(
+    clippy::mod_module_files,
+    clippy::unwrap_used,
+    rust_2018_idioms,
+    unused_lifetimes
+)]
 
 //! ## Usage
 //!

--- a/tls_codec/src/quic_vec.rs
+++ b/tls_codec/src/quic_vec.rs
@@ -111,7 +111,7 @@ impl<T: Deserialize> Deserialize for Vec<T> {
 
         let mut result = Vec::new();
         let mut read = len_len;
-        while (read - len_len) < length as usize {
+        while (read - len_len) < length {
             let element = T::tls_deserialize(bytes)?;
             read += element.tls_serialized_len();
             result.push(element);

--- a/tls_codec/src/tls_vec.rs
+++ b/tls_codec/src/tls_vec.rs
@@ -484,7 +484,7 @@ macro_rules! impl_tls_vec_generic {
 
                             fn expecting(
                                 &self,
-                                formatter: &mut core::fmt::Formatter,
+                                formatter: &mut core::fmt::Formatter<'_>,
                             ) -> core::fmt::Result {
                                 formatter.write_str("`vec`")
                             }
@@ -513,7 +513,7 @@ macro_rules! impl_tls_vec_generic {
                     T: $($bounds + )* serde::de::Deserialize<'de>,
                 {
                     type Value = $name<T>;
-                    fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+                    fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                         formatter.write_fmt(format_args!("struct {}<T>", stringify!($name)))
                     }
                     fn visit_seq<V>(self, mut seq: V) -> Result<$name<T>, V::Error>
@@ -676,7 +676,7 @@ macro_rules! impl_tls_vec {
 
                             fn expecting(
                                 &self,
-                                formatter: &mut core::fmt::Formatter,
+                                formatter: &mut core::fmt::Formatter<'_>,
                             ) -> core::fmt::Result {
                                 formatter.write_str("`vec`")
                             }
@@ -702,7 +702,10 @@ macro_rules! impl_tls_vec {
 
                 impl<'de> serde::de::Visitor<'de> for TlsVecVisitor {
                     type Value = $name;
-                    fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+                    fn expecting(
+                        &self,
+                        formatter: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
                         formatter.write_fmt(format_args!("struct {}", stringify!($name)))
                     }
                     fn visit_seq<V>(self, mut seq: V) -> Result<$name, V::Error>

--- a/tls_codec/tests/decode.rs
+++ b/tls_codec/tests/decode.rs
@@ -30,7 +30,7 @@ fn deserialize_tls_vec() {
     let a = u8::tls_deserialize(&mut b).expect("Unable to tls_deserialize");
     assert_eq!(1, a);
     assert_eq!(1, a.tls_serialized_len());
-    println!("b: {:?}", b);
+    println!("b: {b:?}");
     let v = TlsVecU8::<u8>::tls_deserialize(&mut b).expect("Unable to tls_deserialize");
     assert_eq!(5, v.tls_serialized_len());
     assert_eq!(&[77, 88, 1, 99], v.as_slice());
@@ -57,7 +57,7 @@ fn deserialize_tls_byte_vec() {
     let a = u8::tls_deserialize(&mut b).expect("Unable to tls_deserialize");
     assert_eq!(1, a);
     assert_eq!(1, a.tls_serialized_len());
-    println!("b: {:?}", b);
+    println!("b: {b:?}");
     let v = TlsByteVecU8::tls_deserialize(&mut b).expect("Unable to tls_deserialize");
     assert_eq!(5, v.tls_serialized_len());
     assert_eq!(&[77, 88, 1, 99], v.as_slice());
@@ -117,7 +117,7 @@ fn deserialize_var_len_vec() {
 
     let v = vec![9u8, 2, 98, 34, 55, 90, 54];
     let serialized = v.tls_serialize_detached().expect("Error encoding vector");
-    assert_eq!(serialized, vec![0b00 << 6 | 7, 9, 2, 98, 34, 55, 90, 54]);
+    assert_eq!(serialized, vec![7, 9, 2, 98, 34, 55, 90, 54]);
     test_it(v);
 
     let v  = b"Geilo is a centre in the municipality of Hol in Viken county, Norway. Geilo is primarily a ski resort town, with around 2,500 inhabitants. It is situated in the valley of Hallingdal, 250 km from Oslo and 260 km from Bergen. The Bergen Line facilitated Geilo's development as the first skiing resort in the country, and it is still one of the largest. It is also known for having some of the most luxurious and expensive holiday cabins in Norway. The center of the town lies at 800 meters above sea level, and its highest point is 1178 meters above sea level.".to_vec();

--- a/tls_codec/tests/encode.rs
+++ b/tls_codec/tests/encode.rs
@@ -28,7 +28,7 @@ fn serialize_tls_vec() {
 fn serialize_var_len_vec() {
     let v = vec![9u8, 2, 98, 34, 55, 90, 54];
     let serialized = v.tls_serialize_detached().expect("Error encoding vector");
-    assert_eq!(serialized, vec![0b00 << 6 | 7, 9, 2, 98, 34, 55, 90, 54]);
+    assert_eq!(serialized, vec![7, 9, 2, 98, 34, 55, 90, 54]);
 
     let serialized = Vec::<u8>::new()
         .tls_serialize_detached()
@@ -40,7 +40,7 @@ fn serialize_var_len_vec() {
 fn serialize_var_len_bytes() {
     let v = VLBytes::new(vec![9u8, 2, 98, 34, 55, 90, 54]);
     let serialized = v.tls_serialize_detached().expect("Error encoding vector");
-    assert_eq!(serialized, vec![0b00 << 6 | 7, 9, 2, 98, 34, 55, 90, 54]);
+    assert_eq!(serialized, vec![7, 9, 2, 98, 34, 55, 90, 54]);
 
     let serialized = VLBytes::new(vec![])
         .tls_serialize_detached()
@@ -51,7 +51,7 @@ fn serialize_var_len_bytes() {
     let serialized = VLByteSlice(&v)
         .tls_serialize_detached()
         .expect("Error encoding vector");
-    assert_eq!(serialized, vec![0b00 << 6 | 7, 9, 2, 98, 34, 55, 90, 54]);
+    assert_eq!(serialized, vec![7, 9, 2, 98, 34, 55, 90, 54]);
 
     let serialized = VLByteSlice(&[])
         .tls_serialize_detached()

--- a/x509-cert/src/lib.rs
+++ b/x509-cert/src/lib.rs
@@ -7,6 +7,8 @@
 )]
 #![forbid(unsafe_code)]
 #![warn(
+    clippy::mod_module_files,
+    clippy::unwrap_used,
     missing_docs,
     rust_2018_idioms,
     unused_lifetimes,

--- a/x509-ocsp/src/lib.rs
+++ b/x509-ocsp/src/lib.rs
@@ -1,5 +1,15 @@
-//! The ocsp module features encoders and decoders for the structures defined in [RFC 6960](https://datatracker.ietf.org/doc/html/rfc6960).
 #![no_std]
+#![warn(
+    clippy::mod_module_files,
+    clippy::unwrap_used,
+    missing_docs,
+    rust_2018_idioms,
+    unused_lifetimes,
+    unused_qualifications
+)]
+
+//! The ocsp module features encoders and decoders for the structures defined in
+//! [RFC 6960](https://datatracker.ietf.org/doc/html/rfc6960).
 
 extern crate alloc;
 
@@ -71,7 +81,7 @@ pub struct TbsRequest<'a> {
     #[asn1(context_specific = "1", optional = "true", tag_mode = "EXPLICIT")]
     pub requestor_name: Option<GeneralName<'a>>,
 
-    pub request_list: alloc::vec::Vec<Request<'a>>,
+    pub request_list: Vec<Request<'a>>,
 
     #[asn1(context_specific = "2", optional = "true", tag_mode = "EXPLICIT")]
     pub request_extensions: Option<Extensions<'a>>,
@@ -236,7 +246,7 @@ pub struct BasicOcspResponse<'a> {
     pub signature: BitStringRef<'a>,
 
     #[asn1(context_specific = "0", optional = "true", tag_mode = "EXPLICIT")]
-    pub certs: Option<alloc::vec::Vec<AnyRef<'a>>>,
+    pub certs: Option<Vec<AnyRef<'a>>>,
 }
 
 /// ResponseData structure as defined in [RFC 6960 Section 4.2.1].


### PR DESCRIPTION
Adopts the following lints as a baseline (with a few exceptions):

    #![warn(
        clippy::mod_module_files,
        clippy::unwrap_used,
        missing_docs,
        rust_2018_idioms,
        unused_lifetimes,
        unused_qualifications
    )]