### PR TITLE
der: eliminate dynamism from encoding

### DIFF
--- a/der/LICENSE-MIT
+++ b/der/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2020-2022 The RustCrypto Project Developers
+Copyright (c) 2020-2023 The RustCrypto Project Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/der/derive/src/choice.rs
+++ b/der/derive/src/choice.rs
@@ -108,7 +108,7 @@ impl DeriveChoice {
             }
 
             impl<#lt_params> ::der::EncodeValue for #ident<#lt_params> {
-                fn encode_value(&self, encoder: &mut dyn ::der::Writer) -> ::der::Result<()> {
+                fn encode_value(&self, encoder: &mut impl ::der::Writer) -> ::der::Result<()> {
                     match self {
                         #(#encode_body)*
                     }

--- a/der/derive/src/enumerated.rs
+++ b/der/derive/src/enumerated.rs
@@ -130,7 +130,7 @@ impl DeriveEnumerated {
                     ::der::EncodeValue::value_len(&(*self as #repr))
                 }
 
-                fn encode_value(&self, encoder: &mut dyn ::der::Writer) -> ::der::Result<()> {
+                fn encode_value(&self, encoder: &mut impl ::der::Writer) -> ::der::Result<()> {
                     ::der::EncodeValue::encode_value(&(*self as #repr), encoder)
                 }
             }

--- a/der/derive/src/sequence/field.rs
+++ b/der/derive/src/sequence/field.rs
@@ -167,8 +167,7 @@ impl LowerFieldEncoder {
 
     ///  the field encoder to tokens.
     fn into_tokens(self) -> TokenStream {
-        let encoder = self.encoder;
-        quote! { &#encoder }
+        self.encoder
     }
 
     /// Apply the ASN.1 type (if defined).
@@ -295,7 +294,7 @@ mod tests {
         assert_eq!(
             field.to_encode_tokens().to_string(),
             quote! {
-                &self.example_field
+                self.example_field
             }
             .to_string()
         );
@@ -346,7 +345,7 @@ mod tests {
         assert_eq!(
             field.to_encode_tokens().to_string(),
             quote! {
-                &::der::asn1::ContextSpecificRef {
+                ::der::asn1::ContextSpecificRef {
                     tag_number: ::der::TagNumber::N0,
                     tag_mode: ::der::TagMode::Implicit,
                     value: &self.implicit_field,

--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -160,7 +160,7 @@ impl EncodeValue for AnyRef<'_> {
         Ok(self.value.len())
     }
 
-    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
         writer.write(self.value())
     }
 }
@@ -264,7 +264,7 @@ impl EncodeValue for Any {
         Ok(self.value.len())
     }
 
-    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
         writer.write(self.value.as_slice())
     }
 }

--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -8,7 +8,7 @@ use crate::{
 use core::cmp::Ordering;
 
 #[cfg(feature = "alloc")]
-use crate::BytesOwned;
+use {crate::BytesOwned, alloc::boxed::Box};
 
 #[cfg(feature = "oid")]
 use crate::asn1::ObjectIdentifier;
@@ -147,7 +147,12 @@ impl<'a> Choice<'a> for AnyRef<'a> {
 impl<'a> Decode<'a> for AnyRef<'a> {
     fn decode<R: Reader<'a>>(reader: &mut R) -> Result<AnyRef<'a>> {
         let header = Header::decode(reader)?;
+        Self::decode_value(reader, header)
+    }
+}
 
+impl<'a> DecodeValue<'a> for AnyRef<'a> {
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         Ok(Self {
             tag: header.tag,
             value: BytesRef::decode_value(reader, header)?,
@@ -217,7 +222,7 @@ pub struct Any {
 #[cfg(feature = "alloc")]
 impl Any {
     /// Create a new [`Any`] from the provided [`Tag`] and DER bytes.
-    pub fn new(tag: Tag, bytes: &[u8]) -> Result<Self> {
+    pub fn new(tag: Tag, bytes: impl Into<Box<[u8]>>) -> Result<Self> {
         let value = BytesOwned::new(bytes)?;
 
         // Ensure the tag and value are a valid `AnyRef`.
@@ -253,8 +258,15 @@ impl Choice<'_> for Any {
 impl<'a> Decode<'a> for Any {
     fn decode<R: Reader<'a>>(reader: &mut R) -> Result<Self> {
         let header = Header::decode(reader)?;
+        Self::decode_value(reader, header)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a> DecodeValue<'a> for Any {
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         let value = reader.read_vec(header.length)?;
-        Self::new(header.tag, &value)
+        Self::new(header.tag, value)
     }
 }
 

--- a/der/src/asn1/bit_string.rs
+++ b/der/src/asn1/bit_string.rs
@@ -138,7 +138,7 @@ impl EncodeValue for BitStringRef<'_> {
         self.byte_len() + Length::ONE
     }
 
-    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
         writer.write_byte(self.unused_bits)?;
         writer.write(self.raw_bytes())
     }
@@ -325,7 +325,7 @@ impl EncodeValue for BitString {
         Length::ONE + Length::try_from(self.inner.len())?
     }
 
-    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
         writer.write_byte(self.unused_bits)?;
         writer.write(&self.inner)
     }
@@ -504,7 +504,7 @@ where
         BitStringRef::new((lead % 8) as u8, buff)?.value_len()
     }
 
-    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
         let (lead, buff) = encode_flagset(self);
         let buff = &buff[..buff.len() - lead / 8];
         BitStringRef::new((lead % 8) as u8, buff)?.encode_value(writer)

--- a/der/src/asn1/boolean.rs
+++ b/der/src/asn1/boolean.rs
@@ -33,7 +33,7 @@ impl EncodeValue for bool {
         Ok(Length::ONE)
     }
 
-    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
         writer.write_byte(if *self { TRUE_OCTET } else { FALSE_OCTET })
     }
 }

--- a/der/src/asn1/context_specific.rs
+++ b/der/src/asn1/context_specific.rs
@@ -145,7 +145,7 @@ where
         }
     }
 
-    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
         match self.tag_mode {
             TagMode::Explicit => self.value.encode(writer),
             TagMode::Implicit => self.value.encode_value(writer),
@@ -239,7 +239,7 @@ where
         self.encoder().value_len()
     }
 
-    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
         self.encoder().encode_value(writer)
     }
 }

--- a/der/src/asn1/generalized_time.rs
+++ b/der/src/asn1/generalized_time.rs
@@ -113,7 +113,7 @@ impl EncodeValue for GeneralizedTime {
         Self::LENGTH.try_into()
     }
 
-    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
         let year_hi = u8::try_from(self.0.year() / 100)?;
         let year_lo = u8::try_from(self.0.year() % 100)?;
 
@@ -183,7 +183,7 @@ impl EncodeValue for DateTime {
         GeneralizedTime::from(self).value_len()
     }
 
-    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
         GeneralizedTime::from(self).encode_value(writer)
     }
 }
@@ -209,7 +209,7 @@ impl EncodeValue for SystemTime {
         GeneralizedTime::try_from(self)?.value_len()
     }
 
-    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
         GeneralizedTime::try_from(self)?.encode_value(writer)
     }
 }
@@ -285,7 +285,7 @@ impl EncodeValue for PrimitiveDateTime {
         GeneralizedTime::try_from(self)?.value_len()
     }
 
-    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
         GeneralizedTime::try_from(self)?.encode_value(writer)
     }
 }

--- a/der/src/asn1/integer.rs
+++ b/der/src/asn1/integer.rs
@@ -42,7 +42,7 @@ macro_rules! impl_int_encoding {
                     }
                 }
 
-                fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+                fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
                     if *self < 0 {
                         int::encode_bytes(writer, &(*self as $uint).to_be_bytes())
                     } else {
@@ -94,7 +94,7 @@ macro_rules! impl_uint_encoding {
                     uint::encoded_len(&self.to_be_bytes())
                 }
 
-                fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+                fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
                     uint::encode_bytes(writer, &self.to_be_bytes())
                 }
             }

--- a/der/src/asn1/integer/bigint.rs
+++ b/der/src/asn1/integer/bigint.rs
@@ -64,7 +64,7 @@ impl<'a> EncodeValue for IntRef<'a> {
         int::encoded_len(self.inner.as_slice())
     }
 
-    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
         writer.write(self.as_bytes())
     }
 }
@@ -147,7 +147,7 @@ impl<'a> EncodeValue for UintRef<'a> {
         uint::encoded_len(self.inner.as_slice())
     }
 
-    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
         // Add leading `0x00` byte if required
         if self.value_len()? > self.len() {
             writer.write_byte(0)?;
@@ -249,7 +249,7 @@ mod allocating {
             int::encoded_len(self.inner.as_slice())
         }
 
-        fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+        fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
             writer.write(self.as_bytes())
         }
     }
@@ -351,7 +351,7 @@ mod allocating {
             uint::encoded_len(self.inner.as_slice())
         }
 
-        fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+        fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
             // Add leading `0x00` byte if required
             if self.value_len()? > self.len() {
                 writer.write_byte(0)?;

--- a/der/src/asn1/internal_macros.rs
+++ b/der/src/asn1/internal_macros.rs
@@ -35,7 +35,7 @@ macro_rules! impl_string_type {
                     self.inner.value_len()
                 }
 
-                fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+                fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
                     self.inner.encode_value(writer)
                 }
             }

--- a/der/src/asn1/null.rs
+++ b/der/src/asn1/null.rs
@@ -24,7 +24,7 @@ impl EncodeValue for Null {
         Ok(Length::ZERO)
     }
 
-    fn encode_value(&self, _writer: &mut dyn Writer) -> Result<()> {
+    fn encode_value(&self, _writer: &mut impl Writer) -> Result<()> {
         Ok(())
     }
 }
@@ -75,7 +75,7 @@ impl EncodeValue for () {
         Ok(Length::ZERO)
     }
 
-    fn encode_value(&self, _writer: &mut dyn Writer) -> Result<()> {
+    fn encode_value(&self, _writer: &mut impl Writer) -> Result<()> {
         Ok(())
     }
 }

--- a/der/src/asn1/octet_string.rs
+++ b/der/src/asn1/octet_string.rs
@@ -66,7 +66,7 @@ impl EncodeValue for OctetStringRef<'_> {
         self.inner.value_len()
     }
 
-    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
         self.inner.encode_value(writer)
     }
 }
@@ -165,7 +165,7 @@ impl EncodeValue for OctetString {
         self.inner.len().try_into()
     }
 
-    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
         writer.write(&self.inner)
     }
 }

--- a/der/src/asn1/oid.rs
+++ b/der/src/asn1/oid.rs
@@ -24,7 +24,7 @@ impl EncodeValue for ObjectIdentifier {
         Length::try_from(self.as_bytes().len())
     }
 
-    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
         writer.write(self.as_bytes())
     }
 }

--- a/der/src/asn1/optional.rs
+++ b/der/src/asn1/optional.rs
@@ -41,7 +41,7 @@ where
         (&self).encoded_len()
     }
 
-    fn encode(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
         (&self).encode(writer)
     }
 }
@@ -57,7 +57,7 @@ where
         }
     }
 
-    fn encode(&self, encoder: &mut dyn Writer) -> Result<()> {
+    fn encode(&self, encoder: &mut impl Writer) -> Result<()> {
         match self {
             Some(encodable) => encodable.encode(encoder),
             None => Ok(()),

--- a/der/src/asn1/real.rs
+++ b/der/src/asn1/real.rs
@@ -120,7 +120,7 @@ impl EncodeValue for f64 {
         }
     }
 
-    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
         // Check if special value
         // Encode zero first, if it's zero
         // Special value from section 8.5.9 if non zero

--- a/der/src/asn1/sequence.rs
+++ b/der/src/asn1/sequence.rs
@@ -2,52 +2,17 @@
 //! `SEQUENCE`s to Rust structs.
 
 use crate::{
-    BytesRef, Decode, DecodeValue, Encode, EncodeValue, FixedTag, Header, Length, Reader, Result,
-    Tag, Writer,
+    BytesRef, DecodeValue, EncodeValue, FixedTag, Header, Length, Reader, Result, Tag, Writer,
 };
 
-/// ASN.1 `SEQUENCE` trait.
+/// Marker trait for ASN.1 `SEQUENCE`s.
 ///
-/// Types which impl this trait receive blanket impls for the [`Decode`],
-/// [`Encode`], and [`FixedTag`] traits.
-pub trait Sequence<'a>: Decode<'a> {
-    /// Call the provided function with a slice of [`Encode`] trait objects
-    /// representing the fields of this `SEQUENCE`.
-    ///
-    /// This method uses a callback because structs with fields which aren't
-    /// directly [`Encode`] may need to construct temporary values from
-    /// their fields prior to encoding.
-    fn fields<F, T>(&self, f: F) -> Result<T>
-    where
-        F: FnOnce(&[&dyn Encode]) -> Result<T>;
-}
+/// This is mainly used for custom derive.
+pub trait Sequence<'a>: DecodeValue<'a> + EncodeValue {}
 
-impl<'a, M> EncodeValue for M
+impl<'a, S> FixedTag for S
 where
-    M: Sequence<'a>,
-{
-    fn value_len(&self) -> Result<Length> {
-        self.fields(|fields| {
-            fields
-                .iter()
-                .try_fold(Length::ZERO, |acc, field| acc + field.encoded_len()?)
-        })
-    }
-
-    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
-        self.fields(|fields| {
-            for &field in fields {
-                field.encode(writer)?;
-            }
-
-            Ok(())
-        })
-    }
-}
-
-impl<'a, M> FixedTag for M
-where
-    M: Sequence<'a>,
+    S: Sequence<'a>,
 {
     const TAG: Tag = Tag::Sequence;
 }
@@ -74,11 +39,9 @@ impl EncodeValue for SequenceRef<'_> {
         Ok(self.body.len())
     }
 
-    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
         self.body.encode_value(writer)
     }
 }
 
-impl<'a> FixedTag for SequenceRef<'a> {
-    const TAG: Tag = Tag::Sequence;
-}
+impl<'a> Sequence<'a> for SequenceRef<'a> {}

--- a/der/src/asn1/sequence_of.rs
+++ b/der/src/asn1/sequence_of.rs
@@ -88,7 +88,7 @@ where
             .fold(Ok(Length::ZERO), |len, elem| len + elem.encoded_len()?)
     }
 
-    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
         for elem in self.iter() {
             elem.encode(writer)?;
         }
@@ -155,7 +155,7 @@ where
             .fold(Ok(Length::ZERO), |len, elem| len + elem.encoded_len()?)
     }
 
-    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
         for elem in self {
             elem.encode(writer)?;
         }
@@ -207,7 +207,7 @@ where
             .fold(Ok(Length::ZERO), |len, elem| len + elem.encoded_len()?)
     }
 
-    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
         for elem in self {
             elem.encode(writer)?;
         }

--- a/der/src/asn1/set_of.rs
+++ b/der/src/asn1/set_of.rs
@@ -119,7 +119,7 @@ where
             .fold(Ok(Length::ZERO), |len, elem| len + elem.encoded_len()?)
     }
 
-    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
         for elem in self.iter() {
             elem.encode(writer)?;
         }
@@ -307,7 +307,7 @@ where
             .fold(Ok(Length::ZERO), |len, elem| len + elem.encoded_len()?)
     }
 
-    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
         for elem in self.iter() {
             elem.encode(writer)?;
         }

--- a/der/src/asn1/utc_time.rs
+++ b/der/src/asn1/utc_time.rs
@@ -120,7 +120,7 @@ impl EncodeValue for UtcTime {
         Self::LENGTH.try_into()
     }
 
-    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
         let year = match self.0.year() {
             y @ 1950..=1999 => y.checked_sub(1900),
             y @ 2000..=2049 => y.checked_sub(2000),

--- a/der/src/asn1/utf8_string.rs
+++ b/der/src/asn1/utf8_string.rs
@@ -73,7 +73,7 @@ impl EncodeValue for Utf8StringRef<'_> {
         self.inner.value_len()
     }
 
-    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
         self.inner.encode_value(writer)
     }
 }
@@ -138,7 +138,7 @@ impl EncodeValue for str {
         Utf8StringRef::new(self)?.value_len()
     }
 
-    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
         Utf8StringRef::new(self)?.encode_value(writer)
     }
 }
@@ -182,7 +182,7 @@ impl EncodeValue for String {
         Utf8StringRef::new(self)?.value_len()
     }
 
-    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
         Utf8StringRef::new(self)?.encode_value(writer)
     }
 }

--- a/der/src/asn1/videotex_string.rs
+++ b/der/src/asn1/videotex_string.rs
@@ -80,7 +80,7 @@ impl<'a> EncodeValue for VideotexStringRef<'a> {
         self.inner.value_len()
     }
 
-    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
         self.inner.encode_value(writer)
     }
 }

--- a/der/src/bytes_owned.rs
+++ b/der/src/bytes_owned.rs
@@ -63,7 +63,7 @@ impl EncodeValue for BytesOwned {
         Ok(self.length)
     }
 
-    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
         writer.write(self.as_ref())
     }
 }

--- a/der/src/bytes_owned.rs
+++ b/der/src/bytes_owned.rs
@@ -5,7 +5,7 @@ use crate::{
     referenced::OwnedToRef, BytesRef, DecodeValue, DerOrd, EncodeValue, Error, Header, Length,
     Reader, Result, StrRef, Writer,
 };
-use alloc::boxed::Box;
+use alloc::{boxed::Box, vec::Vec};
 use core::cmp::Ordering;
 
 /// Byte slice newtype which respects the `Length::max()` limit.
@@ -117,8 +117,24 @@ impl From<BytesRef<'_>> for BytesOwned {
 impl TryFrom<&[u8]> for BytesOwned {
     type Error = Error;
 
-    fn try_from(slice: &[u8]) -> Result<Self> {
-        Self::new(slice)
+    fn try_from(bytes: &[u8]) -> Result<Self> {
+        Self::new(bytes)
+    }
+}
+
+impl TryFrom<Box<[u8]>> for BytesOwned {
+    type Error = Error;
+
+    fn try_from(bytes: Box<[u8]>) -> Result<Self> {
+        Self::new(bytes)
+    }
+}
+
+impl TryFrom<Vec<u8>> for BytesOwned {
+    type Error = Error;
+
+    fn try_from(bytes: Vec<u8>) -> Result<Self> {
+        Self::new(bytes)
     }
 }
 

--- a/der/src/bytes_ref.rs
+++ b/der/src/bytes_ref.rs
@@ -68,7 +68,7 @@ impl EncodeValue for BytesRef<'_> {
         Ok(self.length)
     }
 
-    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
         writer.write(self.as_ref())
     }
 }

--- a/der/src/document.rs
+++ b/der/src/document.rs
@@ -166,7 +166,7 @@ impl Encode for Document {
         Ok(self.len())
     }
 
-    fn encode(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
         writer.write(self.as_bytes())
     }
 }

--- a/der/src/encode.rs
+++ b/der/src/encode.rs
@@ -24,7 +24,7 @@ pub trait Encode {
     fn encoded_len(&self) -> Result<Length>;
 
     /// Encode this value as ASN.1 DER using the provided [`Writer`].
-    fn encode(&self, encoder: &mut dyn Writer) -> Result<()>;
+    fn encode(&self, encoder: &mut impl Writer) -> Result<()>;
 
     /// Encode this value to the provided byte slice, returning a sub-slice
     /// containing the encoded message.
@@ -78,7 +78,7 @@ where
     }
 
     /// Encode this value as ASN.1 DER using the provided [`Writer`].
-    fn encode(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
         self.header()?.encode(writer)?;
         self.encode_value(writer)
     }
@@ -129,5 +129,5 @@ pub trait EncodeValue {
 
     /// Encode value (sans [`Tag`]+[`Length`] header) as ASN.1 DER using the
     /// provided [`Writer`].
-    fn encode_value(&self, encoder: &mut dyn Writer) -> Result<()>;
+    fn encode_value(&self, encoder: &mut impl Writer) -> Result<()>;
 }

--- a/der/src/encode_ref.rs
+++ b/der/src/encode_ref.rs
@@ -22,7 +22,7 @@ where
         self.0.encoded_len()
     }
 
-    fn encode(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
         self.0.encode(writer)
     }
 }
@@ -47,7 +47,7 @@ where
         self.0.value_len()
     }
 
-    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
         self.0.encode_value(writer)
     }
 }

--- a/der/src/header.rs
+++ b/der/src/header.rs
@@ -44,7 +44,7 @@ impl Encode for Header {
         self.tag.encoded_len()? + self.length.encoded_len()?
     }
 
-    fn encode(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
         self.tag.encode(writer)?;
         self.length.encode(writer)
     }

--- a/der/src/length.rs
+++ b/der/src/length.rs
@@ -246,7 +246,7 @@ impl Encode for Length {
         }
     }
 
-    fn encode(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
         match self.initial_octet() {
             Some(tag_byte) => {
                 writer.write_byte(tag_byte)?;

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -140,32 +140,19 @@
 //!     }
 //! }
 //!
-//! impl<'a> Sequence<'a> for AlgorithmIdentifier<'a> {
-//!     // The `Sequence::fields` method is used for encoding and functions as
-//!     // a visitor for all of the fields in a message.
-//!     //
-//!     // To implement it, you must define a slice containing `Encode`
-//!     // trait objects, then pass it to the provided `field_encoder`
-//!     // function, which is implemented by the `der` crate and handles
-//!     // message serialization.
-//!     //
-//!     // Trait objects are used because they allow for slices containing
-//!     // heterogeneous field types, and a callback is used to allow for the
-//!     // construction of temporary field encoder types. The latter means
-//!     // that the fields of your Rust struct don't necessarily need to
-//!     // impl the `Encode` trait, but if they don't you must construct
-//!     // a temporary wrapper value which does.
-//!     //
-//!     // Types which impl the `Sequence` trait receive blanket impls of both
-//!     // the `Encode` and `Tagged` traits (where the latter is impl'd as
-//!     // `Tagged::TAG = der::Tag::Sequence`.
-//!     fn fields<F, T>(&self, field_encoder: F) -> der::Result<T>
-//!     where
-//!         F: FnOnce(&[&dyn Encode]) -> der::Result<T>,
-//!     {
-//!         field_encoder(&[&self.algorithm, &self.parameters])
+//! impl<'a> ::der::EncodeValue for AlgorithmIdentifier<'a> {
+//!     fn value_len(&self) -> ::der::Result<::der::Length> {
+//!         self.algorithm.encoded_len()? + self.parameters.encoded_len()?
+//!     }
+//!
+//!     fn encode_value(&self, writer: &mut impl ::der::Writer) -> ::der::Result<()> {
+//!         self.algorithm.encode(writer)?;
+//!         self.parameters.encode(writer)?;
+//!         Ok(())
 //!     }
 //! }
+//!
+//! impl<'a> Sequence<'a> for AlgorithmIdentifier<'a> {}
 //!
 //! // Example parameters value: OID for the NIST P-256 elliptic curve.
 //! let parameters = "1.2.840.10045.3.1.7".parse::<ObjectIdentifier>().unwrap();

--- a/der/src/str_owned.rs
+++ b/der/src/str_owned.rs
@@ -80,7 +80,7 @@ impl EncodeValue for StrOwned {
         Ok(self.length)
     }
 
-    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
         writer.write(self.as_ref())
     }
 }

--- a/der/src/str_ref.rs
+++ b/der/src/str_ref.rs
@@ -73,7 +73,7 @@ impl<'a> EncodeValue for StrRef<'a> {
         Ok(self.length)
     }
 
-    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
         writer.write(self.as_ref())
     }
 }

--- a/der/src/tag.rs
+++ b/der/src/tag.rs
@@ -325,7 +325,7 @@ impl Encode for Tag {
         Ok(Length::ONE)
     }
 
-    fn encode(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
         writer.write_byte(self.into())
     }
 }

--- a/pkcs1/LICENSE-MIT
+++ b/pkcs1/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2021-2022 The RustCrypto Project Developers
+Copyright (c) 2021-2023 The RustCrypto Project Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/pkcs1/src/params.rs
+++ b/pkcs1/src/params.rs
@@ -91,7 +91,7 @@ pub struct RsaPssParams<'a> {
 }
 
 impl<'a> RsaPssParams<'a> {
-    fn opt_hash(&self) -> Option<ContextSpecificRef<'_, AlgorithmIdentifierRef<'a>>> {
+    fn context_specific_hash(&self) -> Option<ContextSpecificRef<'_, AlgorithmIdentifierRef<'a>>> {
         if self.hash == SHA_1_AI {
             None
         } else {
@@ -103,7 +103,7 @@ impl<'a> RsaPssParams<'a> {
         }
     }
 
-    fn opt_mask_gen(
+    fn context_specific_mask_gen(
         &self,
     ) -> Option<ContextSpecificRef<'_, AlgorithmIdentifier<AlgorithmIdentifierRef<'a>>>> {
         if self.mask_gen == default_mgf1_sha1() {
@@ -117,7 +117,7 @@ impl<'a> RsaPssParams<'a> {
         }
     }
 
-    fn opt_salt_len(&self) -> Option<ContextSpecificRef<'_, u8>> {
+    fn context_specific_salt_len(&self) -> Option<ContextSpecificRef<'_, u8>> {
         if self.salt_len == SALT_LEN_DEFAULT {
             None
         } else {
@@ -129,7 +129,7 @@ impl<'a> RsaPssParams<'a> {
         }
     }
 
-    fn opt_trailer_field(&self) -> Option<ContextSpecificRef<'_, TrailerField>> {
+    fn context_specific_trailer_field(&self) -> Option<ContextSpecificRef<'_, TrailerField>> {
         if self.trailer_field == TrailerField::default() {
             None
         } else {
@@ -176,17 +176,17 @@ impl<'a> DecodeValue<'a> for RsaPssParams<'a> {
 
 impl EncodeValue for RsaPssParams<'_> {
     fn value_len(&self) -> der::Result<Length> {
-        self.opt_hash().encoded_len()?
-            + self.opt_mask_gen().encoded_len()?
-            + self.opt_salt_len().encoded_len()?
-            + self.opt_trailer_field().encoded_len()?
+        self.context_specific_hash().encoded_len()?
+            + self.context_specific_mask_gen().encoded_len()?
+            + self.context_specific_salt_len().encoded_len()?
+            + self.context_specific_trailer_field().encoded_len()?
     }
 
     fn encode_value(&self, writer: &mut impl Writer) -> der::Result<()> {
-        self.opt_hash().encode(writer)?;
-        self.opt_mask_gen().encode(writer)?;
-        self.opt_salt_len().encode(writer)?;
-        self.opt_trailer_field().encode(writer)?;
+        self.context_specific_hash().encode(writer)?;
+        self.context_specific_mask_gen().encode(writer)?;
+        self.context_specific_salt_len().encode(writer)?;
+        self.context_specific_trailer_field().encode(writer)?;
         Ok(())
     }
 }
@@ -237,7 +237,7 @@ pub struct RsaOaepParams<'a> {
 }
 
 impl<'a> RsaOaepParams<'a> {
-    fn opt_hash(&self) -> Option<ContextSpecificRef<'_, AlgorithmIdentifierRef<'a>>> {
+    fn context_specific_hash(&self) -> Option<ContextSpecificRef<'_, AlgorithmIdentifierRef<'a>>> {
         if self.hash == SHA_1_AI {
             None
         } else {
@@ -249,7 +249,7 @@ impl<'a> RsaOaepParams<'a> {
         }
     }
 
-    fn opt_mask_gen(
+    fn context_specific_mask_gen(
         &self,
     ) -> Option<ContextSpecificRef<'_, AlgorithmIdentifier<AlgorithmIdentifierRef<'a>>>> {
         if self.mask_gen == default_mgf1_sha1() {
@@ -263,7 +263,9 @@ impl<'a> RsaOaepParams<'a> {
         }
     }
 
-    fn opt_p_source(&self) -> Option<ContextSpecificRef<'_, AlgorithmIdentifierRef<'a>>> {
+    fn context_specific_p_source(
+        &self,
+    ) -> Option<ContextSpecificRef<'_, AlgorithmIdentifierRef<'a>>> {
         if self.p_source == default_pempty_string() {
             None
         } else {
@@ -306,15 +308,15 @@ impl<'a> DecodeValue<'a> for RsaOaepParams<'a> {
 
 impl EncodeValue for RsaOaepParams<'_> {
     fn value_len(&self) -> der::Result<Length> {
-        self.opt_hash().encoded_len()?
-            + self.opt_mask_gen().encoded_len()?
-            + self.opt_p_source().encoded_len()?
+        self.context_specific_hash().encoded_len()?
+            + self.context_specific_mask_gen().encoded_len()?
+            + self.context_specific_p_source().encoded_len()?
     }
 
     fn encode_value(&self, writer: &mut impl Writer) -> der::Result<()> {
-        self.opt_hash().encode(writer)?;
-        self.opt_mask_gen().encode(writer)?;
-        self.opt_p_source().encode(writer)?;
+        self.context_specific_hash().encode(writer)?;
+        self.context_specific_mask_gen().encode(writer)?;
+        self.context_specific_p_source().encode(writer)?;
         Ok(())
     }
 }

--- a/pkcs1/src/params.rs
+++ b/pkcs1/src/params.rs
@@ -51,7 +51,7 @@ impl EncodeValue for TrailerField {
         Ok(der::Length::ONE)
     }
 
-    fn encode_value(&self, writer: &mut dyn Writer) -> der::Result<()> {
+    fn encode_value(&self, writer: &mut impl Writer) -> der::Result<()> {
         (*self as u8).encode_value(writer)
     }
 }

--- a/pkcs1/src/private_key/other_prime_info.rs
+++ b/pkcs1/src/private_key/other_prime_info.rs
@@ -1,6 +1,8 @@
 //! PKCS#1 OtherPrimeInfo support.
 
-use der::{asn1::UintRef, DecodeValue, Encode, Header, Reader, Sequence};
+use der::{
+    asn1::UintRef, DecodeValue, Encode, EncodeValue, Header, Length, Reader, Sequence, Writer,
+};
 
 /// PKCS#1 OtherPrimeInfo as defined in [RFC 8017 Appendix 1.2].
 ///
@@ -40,11 +42,17 @@ impl<'a> DecodeValue<'a> for OtherPrimeInfo<'a> {
     }
 }
 
-impl<'a> Sequence<'a> for OtherPrimeInfo<'a> {
-    fn fields<F, T>(&self, f: F) -> der::Result<T>
-    where
-        F: FnOnce(&[&dyn Encode]) -> der::Result<T>,
-    {
-        f(&[&self.prime, &self.exponent, &self.coefficient])
+impl EncodeValue for OtherPrimeInfo<'_> {
+    fn value_len(&self) -> der::Result<Length> {
+        self.prime.encoded_len()? + self.exponent.encoded_len()? + self.coefficient.encoded_len()?
+    }
+
+    fn encode_value(&self, writer: &mut impl Writer) -> der::Result<()> {
+        self.prime.encode(writer)?;
+        self.exponent.encode(writer)?;
+        self.coefficient.encode(writer)?;
+        Ok(())
     }
 }
+
+impl<'a> Sequence<'a> for OtherPrimeInfo<'a> {}

--- a/pkcs1/src/version.rs
+++ b/pkcs1/src/version.rs
@@ -62,7 +62,7 @@ impl Encode for Version {
         der::Length::ONE.for_tlv()
     }
 
-    fn encode(&self, writer: &mut dyn Writer) -> der::Result<()> {
+    fn encode(&self, writer: &mut impl Writer) -> der::Result<()> {
         u8::from(*self).encode(writer)
     }
 }

--- a/pkcs5/LICENSE-MIT
+++ b/pkcs5/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2021 The RustCrypto Project Developers
+Copyright (c) 2021-2023 The RustCrypto Project Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/pkcs5/src/pbes1.rs
+++ b/pkcs5/src/pbes1.rs
@@ -231,7 +231,7 @@ impl Encode for EncryptionScheme {
         self.oid().encoded_len()
     }
 
-    fn encode(&self, writer: &mut dyn Writer) -> der::Result<()> {
+    fn encode(&self, writer: &mut impl Writer) -> der::Result<()> {
         self.oid().encode(writer)
     }
 }

--- a/pkcs5/src/pbes2.rs
+++ b/pkcs5/src/pbes2.rs
@@ -378,7 +378,7 @@ impl<'a> Encode for EncryptionScheme<'a> {
         AlgorithmIdentifierRef::try_from(*self)?.encoded_len()
     }
 
-    fn encode(&self, writer: &mut dyn Writer) -> der::Result<()> {
+    fn encode(&self, writer: &mut impl Writer) -> der::Result<()> {
         AlgorithmIdentifierRef::try_from(*self)?.encode(writer)
     }
 }

--- a/pkcs5/src/pbes2/kdf.rs
+++ b/pkcs5/src/pbes2/kdf.rs
@@ -340,7 +340,7 @@ impl Encode for Pbkdf2Prf {
         AlgorithmIdentifierRef::try_from(*self)?.encoded_len()
     }
 
-    fn encode(&self, writer: &mut dyn Writer) -> der::Result<()> {
+    fn encode(&self, writer: &mut impl Writer) -> der::Result<()> {
         AlgorithmIdentifierRef::try_from(*self)?.encode(writer)
     }
 }

--- a/pkcs5/src/pbes2/kdf.rs
+++ b/pkcs5/src/pbes2/kdf.rs
@@ -224,7 +224,7 @@ impl<'a> DecodeValue<'a> for Pbkdf2Params<'a> {
 
 impl EncodeValue for Pbkdf2Params<'_> {
     fn value_len(&self) -> der::Result<Length> {
-        let len = OctetStringRef::new(&self.salt)?.encoded_len()?
+        let len = OctetStringRef::new(self.salt)?.encoded_len()?
             + self.iteration_count.encoded_len()?
             + self.key_length.encoded_len()?;
 
@@ -236,7 +236,7 @@ impl EncodeValue for Pbkdf2Params<'_> {
     }
 
     fn encode_value(&self, writer: &mut impl Writer) -> der::Result<()> {
-        OctetStringRef::new(&self.salt)?.encode(writer)?;
+        OctetStringRef::new(self.salt)?.encode(writer)?;
         self.iteration_count.encode(writer)?;
         self.key_length.encode(writer)?;
 
@@ -421,7 +421,7 @@ impl<'a> DecodeValue<'a> for ScryptParams<'a> {
 
 impl EncodeValue for ScryptParams<'_> {
     fn value_len(&self) -> der::Result<Length> {
-        OctetStringRef::new(&self.salt)?.encoded_len()?
+        OctetStringRef::new(self.salt)?.encoded_len()?
             + self.cost_parameter.encoded_len()?
             + self.block_size.encoded_len()?
             + self.parallelization.encoded_len()?
@@ -429,7 +429,7 @@ impl EncodeValue for ScryptParams<'_> {
     }
 
     fn encode_value(&self, writer: &mut impl Writer) -> der::Result<()> {
-        OctetStringRef::new(&self.salt)?.encode(writer)?;
+        OctetStringRef::new(self.salt)?.encode(writer)?;
         self.cost_parameter.encode(writer)?;
         self.block_size.encode(writer)?;
         self.parallelization.encode(writer)?;

--- a/pkcs5/src/pbes2/kdf.rs
+++ b/pkcs5/src/pbes2/kdf.rs
@@ -3,7 +3,8 @@
 use crate::{AlgorithmIdentifierRef, Error, Result};
 use der::{
     asn1::{AnyRef, ObjectIdentifier, OctetStringRef},
-    Decode, Encode, ErrorKind, Length, Reader, Sequence, Tag, Tagged, Writer,
+    Decode, DecodeValue, Encode, EncodeValue, ErrorKind, Length, Reader, Sequence, Tag, Tagged,
+    Writer,
 };
 
 /// Password-Based Key Derivation Function (PBKDF2) OID.
@@ -98,23 +99,34 @@ impl<'a> Kdf<'a> {
     }
 }
 
-impl<'a> Decode<'a> for Kdf<'a> {
-    fn decode<R: Reader<'a>>(reader: &mut R) -> der::Result<Self> {
-        AlgorithmIdentifierRef::decode(reader)?.try_into()
+impl<'a> DecodeValue<'a> for Kdf<'a> {
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: der::Header) -> der::Result<Self> {
+        AlgorithmIdentifierRef::decode_value(reader, header)?.try_into()
     }
 }
 
-impl<'a> Sequence<'a> for Kdf<'a> {
-    fn fields<F, T>(&self, f: F) -> der::Result<T>
-    where
-        F: FnOnce(&[&dyn Encode]) -> der::Result<T>,
-    {
+impl EncodeValue for Kdf<'_> {
+    fn value_len(&self) -> der::Result<Length> {
+        self.oid().encoded_len()?
+            + match self {
+                Self::Pbkdf2(params) => params.encoded_len()?,
+                Self::Scrypt(params) => params.encoded_len()?,
+            }
+    }
+
+    fn encode_value(&self, writer: &mut impl Writer) -> der::Result<()> {
+        self.oid().encode(writer)?;
+
         match self {
-            Self::Pbkdf2(params) => f(&[&self.oid(), params]),
-            Self::Scrypt(params) => f(&[&self.oid(), params]),
+            Self::Pbkdf2(params) => params.encode(writer)?,
+            Self::Scrypt(params) => params.encode(writer)?,
         }
+
+        Ok(())
     }
 }
+
+impl<'a> Sequence<'a> for Kdf<'a> {}
 
 impl<'a> From<Pbkdf2Params<'a>> for Kdf<'a> {
     fn from(params: Pbkdf2Params<'a>) -> Self {
@@ -204,33 +216,39 @@ impl<'a> Pbkdf2Params<'a> {
     }
 }
 
-impl<'a> Decode<'a> for Pbkdf2Params<'a> {
-    fn decode<R: Reader<'a>>(reader: &mut R) -> der::Result<Self> {
-        AnyRef::decode(reader)?.try_into()
+impl<'a> DecodeValue<'a> for Pbkdf2Params<'a> {
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: der::Header) -> der::Result<Self> {
+        AnyRef::decode_value(reader, header)?.try_into()
     }
 }
 
-impl<'a> Sequence<'a> for Pbkdf2Params<'a> {
-    fn fields<F, T>(&self, f: F) -> der::Result<T>
-    where
-        F: FnOnce(&[&dyn Encode]) -> der::Result<T>,
-    {
+impl EncodeValue for Pbkdf2Params<'_> {
+    fn value_len(&self) -> der::Result<Length> {
+        let len = OctetStringRef::new(&self.salt)?.encoded_len()?
+            + self.iteration_count.encoded_len()?
+            + self.key_length.encoded_len()?;
+
         if self.prf == Pbkdf2Prf::default() {
-            f(&[
-                &OctetStringRef::new(self.salt)?,
-                &self.iteration_count,
-                &self.key_length,
-            ])
+            len
         } else {
-            f(&[
-                &OctetStringRef::new(self.salt)?,
-                &self.iteration_count,
-                &self.key_length,
-                &self.prf,
-            ])
+            len + self.prf.encoded_len()?
+        }
+    }
+
+    fn encode_value(&self, writer: &mut impl Writer) -> der::Result<()> {
+        OctetStringRef::new(&self.salt)?.encode(writer)?;
+        self.iteration_count.encode(writer)?;
+        self.key_length.encode(writer)?;
+
+        if self.prf == Pbkdf2Prf::default() {
+            Ok(())
+        } else {
+            self.prf.encode(writer)
         }
     }
 }
+
+impl<'a> Sequence<'a> for Pbkdf2Params<'a> {}
 
 impl<'a> TryFrom<AnyRef<'a>> for Pbkdf2Params<'a> {
     type Error = der::Error;
@@ -395,26 +413,32 @@ impl<'a> ScryptParams<'a> {
     }
 }
 
-impl<'a> Decode<'a> for ScryptParams<'a> {
-    fn decode<R: Reader<'a>>(reader: &mut R) -> der::Result<Self> {
-        AnyRef::decode(reader)?.try_into()
+impl<'a> DecodeValue<'a> for ScryptParams<'a> {
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: der::Header) -> der::Result<Self> {
+        AnyRef::decode_value(reader, header)?.try_into()
     }
 }
 
-impl<'a> Sequence<'a> for ScryptParams<'a> {
-    fn fields<F, T>(&self, f: F) -> der::Result<T>
-    where
-        F: FnOnce(&[&dyn Encode]) -> der::Result<T>,
-    {
-        f(&[
-            &OctetStringRef::new(self.salt)?,
-            &self.cost_parameter,
-            &self.block_size,
-            &self.parallelization,
-            &self.key_length,
-        ])
+impl EncodeValue for ScryptParams<'_> {
+    fn value_len(&self) -> der::Result<Length> {
+        OctetStringRef::new(&self.salt)?.encoded_len()?
+            + self.cost_parameter.encoded_len()?
+            + self.block_size.encoded_len()?
+            + self.parallelization.encoded_len()?
+            + self.key_length.encoded_len()?
+    }
+
+    fn encode_value(&self, writer: &mut impl Writer) -> der::Result<()> {
+        OctetStringRef::new(&self.salt)?.encode(writer)?;
+        self.cost_parameter.encode(writer)?;
+        self.block_size.encode(writer)?;
+        self.parallelization.encode(writer)?;
+        self.key_length.encode(writer)?;
+        Ok(())
     }
 }
+
+impl<'a> Sequence<'a> for ScryptParams<'a> {}
 
 impl<'a> TryFrom<AnyRef<'a>> for ScryptParams<'a> {
     type Error = der::Error;

--- a/pkcs7/LICENSE-MIT
+++ b/pkcs7/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2020 The RustCrypto Project Developers
+Copyright (c) 2021-2023 The RustCrypto Project Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/pkcs7/src/content_type.rs
+++ b/pkcs7/src/content_type.rs
@@ -34,7 +34,7 @@ impl EncodeValue for ContentType {
         ObjectIdentifier::from(*self).value_len()
     }
 
-    fn encode_value(&self, writer: &mut dyn Writer) -> der::Result<()> {
+    fn encode_value(&self, writer: &mut impl Writer) -> der::Result<()> {
         ObjectIdentifier::from(*self).encode_value(writer)
     }
 }

--- a/pkcs7/src/data_content.rs
+++ b/pkcs7/src/data_content.rs
@@ -43,7 +43,7 @@ impl<'a> EncodeValue for DataContent<'a> {
         Length::try_from(self.content.len())
     }
 
-    fn encode_value(&self, writer: &mut dyn Writer) -> der::Result<()> {
+    fn encode_value(&self, writer: &mut impl Writer) -> der::Result<()> {
         OctetStringRef::new(self.content)?.encode_value(writer)
     }
 }

--- a/pkcs7/src/encrypted_data_content.rs
+++ b/pkcs7/src/encrypted_data_content.rs
@@ -50,7 +50,7 @@ impl EncodeValue for Version {
         u8::from(*self).value_len()
     }
 
-    fn encode_value(&self, writer: &mut dyn Writer) -> der::Result<()> {
+    fn encode_value(&self, writer: &mut impl Writer) -> der::Result<()> {
         u8::from(*self).encode_value(writer)
     }
 }

--- a/pkcs7/src/encrypted_data_content.rs
+++ b/pkcs7/src/encrypted_data_content.rs
@@ -1,9 +1,7 @@
 //! `encrypted-data` content type [RFC 5652 § 8](https://datatracker.ietf.org/doc/html/rfc5652#section-8)
 
 use crate::enveloped_data_content::EncryptedContentInfo;
-use der::{
-    DecodeValue, Encode, EncodeValue, FixedTag, Header, Length, Reader, Sequence, Tag, Writer,
-};
+use der::{Enumerated, Sequence};
 
 /// Syntax version of the `encrypted-data` content type.
 ///
@@ -13,45 +11,17 @@ use der::{
 ///
 /// The only version supported by this library is `0`.
 /// See [RFC 5652 § 8](https://datatracker.ietf.org/doc/html/rfc5652#section-8).
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Enumerated, Eq, PartialEq)]
+#[asn1(type = "INTEGER")]
+#[repr(u8)]
 pub enum Version {
     /// syntax version 0 for [EncryptedDataContent].
     V0 = 0,
 }
 
-impl FixedTag for Version {
-    const TAG: Tag = Tag::Integer;
-}
-
 impl From<Version> for u8 {
     fn from(version: Version) -> Self {
         version as u8
-    }
-}
-
-impl TryFrom<u8> for Version {
-    type Error = der::Error;
-    fn try_from(byte: u8) -> der::Result<Version> {
-        match byte {
-            0 => Ok(Version::V0),
-            _ => Err(Self::TAG.value_error()),
-        }
-    }
-}
-
-impl<'a> DecodeValue<'a> for Version {
-    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> der::Result<Version> {
-        Version::try_from(u8::decode_value(reader, header)?)
-    }
-}
-
-impl EncodeValue for Version {
-    fn value_len(&self) -> der::Result<Length> {
-        u8::from(*self).value_len()
-    }
-
-    fn encode_value(&self, writer: &mut impl Writer) -> der::Result<()> {
-        u8::from(*self).encode_value(writer)
     }
 }
 
@@ -72,34 +42,11 @@ impl EncodeValue for Version {
 ///   - [`version`](EncryptedDataContent::version) is the syntax version number.
 ///   - [`encrypted_content_info`](EncryptedDataContent::encrypted_content_info) is the encrypted content
 ///     information, as in [EncryptedContentInfo].
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Sequence)]
 pub struct EncryptedDataContent<'a> {
     /// the syntax version number.
     pub version: Version,
 
     /// the encrypted content information.
     pub encrypted_content_info: EncryptedContentInfo<'a>,
-}
-
-impl<'a> DecodeValue<'a> for EncryptedDataContent<'a> {
-    fn decode_value<R: Reader<'a>>(
-        reader: &mut R,
-        header: Header,
-    ) -> der::Result<EncryptedDataContent<'a>> {
-        reader.read_nested(header.length, |reader| {
-            Ok(EncryptedDataContent {
-                version: reader.decode()?,
-                encrypted_content_info: reader.decode()?,
-            })
-        })
-    }
-}
-
-impl<'a> Sequence<'a> for EncryptedDataContent<'a> {
-    fn fields<F, T>(&self, f: F) -> der::Result<T>
-    where
-        F: FnOnce(&[&dyn Encode]) -> der::Result<T>,
-    {
-        f(&[&self.version, &self.encrypted_content_info])
-    }
 }

--- a/pkcs7/tests/content_tests.rs
+++ b/pkcs7/tests/content_tests.rs
@@ -72,7 +72,7 @@ fn decode_encrypted_key_example() {
             assert_eq!(salt.as_bytes(), expected_salt);
             assert_eq!(iter, 2048);
 
-            assert_eq!(bytes.len(), 552)
+            assert_eq!(552u32, bytes.len().into())
         }
         _ => panic!("expected ContentInfo::Data(Some(_))"),
     }

--- a/pkcs8/LICENSE-MIT
+++ b/pkcs8/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2020 The RustCrypto Project Developers
+Copyright (c) 2020-2023 The RustCrypto Project Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/pkcs8/src/version.rs
+++ b/pkcs8/src/version.rs
@@ -36,7 +36,7 @@ impl Encode for Version {
         der::Length::from(1u8).for_tlv()
     }
 
-    fn encode(&self, writer: &mut dyn Writer) -> der::Result<()> {
+    fn encode(&self, writer: &mut impl Writer) -> der::Result<()> {
         u8::from(*self).encode(writer)
     }
 }

--- a/sec1/src/parameters.rs
+++ b/sec1/src/parameters.rs
@@ -41,7 +41,7 @@ impl EncodeValue for EcParameters {
         }
     }
 
-    fn encode_value(&self, writer: &mut dyn Writer) -> der::Result<()> {
+    fn encode_value(&self, writer: &mut impl Writer) -> der::Result<()> {
         match self {
             Self::NamedCurve(oid) => oid.encode_value(writer),
         }

--- a/spki/LICENSE-MIT
+++ b/spki/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2021-2022 The RustCrypto Project Developers
+Copyright (c) 2021-2023 The RustCrypto Project Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/x509-cert/src/macros.rs
+++ b/x509-cert/src/macros.rs
@@ -61,7 +61,7 @@ macro_rules! impl_newtype {
 
         #[allow(unused_lifetimes)]
         impl<'a> ::der::EncodeValue for $newtype {
-            fn encode_value(&self, encoder: &mut dyn ::der::Writer) -> ::der::Result<()> {
+            fn encode_value(&self, encoder: &mut impl ::der::Writer) -> ::der::Result<()> {
                 self.0.encode_value(encoder)
             }
 

--- a/x509-cert/src/serial_number.rs
+++ b/x509-cert/src/serial_number.rs
@@ -55,7 +55,7 @@ impl EncodeValue for SerialNumber {
         self.inner.value_len()
     }
 
-    fn encode_value(&self, writer: &mut dyn Writer) -> Result<()> {
+    fn encode_value(&self, writer: &mut impl Writer) -> Result<()> {
         self.inner.encode_value(writer)
     }
 }


### PR DESCRIPTION
Replaces use of `dyn Writer` with `impl Writer`.

Removes the `Sequence::fields` method, which was used for a blanket impl of `EncodeValue`.

Instead, very small changes to the custom derive can be used to derive a monomorphic implementation of `EncodeValue` that doesn't rely on trait objects, where calls to the `Writer` can be potentially inlined.