### PR TITLE
der: remove inherent `AnyRef` decoding methods

### DIFF
--- a/der/src/asn1/bit_string.rs
+++ b/der/src/asn1/bit_string.rs
@@ -163,7 +163,7 @@ impl<'a> TryFrom<AnyRef<'a>> for BitStringRef<'a> {
     type Error = Error;
 
     fn try_from(any: AnyRef<'a>) -> Result<BitStringRef<'a>> {
-        any.decode_into()
+        any.decode_as()
     }
 }
 

--- a/der/src/asn1/generalized_time.rs
+++ b/der/src/asn1/generalized_time.rs
@@ -168,7 +168,7 @@ impl TryFrom<AnyRef<'_>> for GeneralizedTime {
     type Error = Error;
 
     fn try_from(any: AnyRef<'_>) -> Result<GeneralizedTime> {
-        any.decode_into()
+        any.decode_as()
     }
 }
 

--- a/der/src/asn1/integer.rs
+++ b/der/src/asn1/integer.rs
@@ -65,7 +65,7 @@ macro_rules! impl_int_encoding {
                 type Error = Error;
 
                 fn try_from(any: AnyRef<'_>) -> Result<Self> {
-                    any.decode_into()
+                    any.decode_as()
                 }
             }
         )+
@@ -113,7 +113,7 @@ macro_rules! impl_uint_encoding {
                 type Error = Error;
 
                 fn try_from(any: AnyRef<'_>) -> Result<Self> {
-                    any.decode_into()
+                    any.decode_as()
                 }
             }
         )+

--- a/der/src/asn1/integer/bigint.rs
+++ b/der/src/asn1/integer/bigint.rs
@@ -79,7 +79,7 @@ impl<'a> TryFrom<AnyRef<'a>> for IntRef<'a> {
     type Error = Error;
 
     fn try_from(any: AnyRef<'a>) -> Result<IntRef<'a>> {
-        any.decode_into()
+        any.decode_as()
     }
 }
 
@@ -167,7 +167,7 @@ impl<'a> TryFrom<AnyRef<'a>> for UintRef<'a> {
     type Error = Error;
 
     fn try_from(any: AnyRef<'a>) -> Result<UintRef<'a>> {
-        any.decode_into()
+        any.decode_as()
     }
 }
 
@@ -265,7 +265,7 @@ mod allocating {
         type Error = Error;
 
         fn try_from(any: AnyRef<'a>) -> Result<Int> {
-            any.decode_into()
+            any.decode_as()
         }
     }
 
@@ -372,7 +372,7 @@ mod allocating {
         type Error = Error;
 
         fn try_from(any: AnyRef<'a>) -> Result<Uint> {
-            any.decode_into()
+            any.decode_as()
         }
     }
 

--- a/der/src/asn1/internal_macros.rs
+++ b/der/src/asn1/internal_macros.rs
@@ -53,7 +53,7 @@ macro_rules! impl_string_type {
                 type Error = Error;
 
                 fn try_from(any: &'__der Any) -> Result<$type> {
-                    any.decode_into()
+                    any.decode_as()
                 }
             }
         }

--- a/der/src/asn1/null.rs
+++ b/der/src/asn1/null.rs
@@ -45,7 +45,7 @@ impl TryFrom<AnyRef<'_>> for Null {
     type Error = Error;
 
     fn try_from(any: AnyRef<'_>) -> Result<Null> {
-        any.decode_into()
+        any.decode_as()
     }
 }
 

--- a/der/src/asn1/octet_string.rs
+++ b/der/src/asn1/octet_string.rs
@@ -87,7 +87,7 @@ impl<'a> TryFrom<AnyRef<'a>> for OctetStringRef<'a> {
     type Error = Error;
 
     fn try_from(any: AnyRef<'a>) -> Result<OctetStringRef<'a>> {
-        any.decode_into()
+        any.decode_as()
     }
 }
 

--- a/der/src/asn1/printable_string.rs
+++ b/der/src/asn1/printable_string.rs
@@ -112,7 +112,7 @@ impl<'a> TryFrom<AnyRef<'a>> for PrintableStringRef<'a> {
     type Error = Error;
 
     fn try_from(any: AnyRef<'a>) -> Result<PrintableStringRef<'a>> {
-        any.decode_into()
+        any.decode_as()
     }
 }
 
@@ -206,7 +206,7 @@ mod allocation {
         type Error = Error;
 
         fn try_from(any: &AnyRef<'a>) -> Result<PrintableString> {
-            (*any).decode_into()
+            (*any).decode_as()
         }
     }
 

--- a/der/src/asn1/teletex_string.rs
+++ b/der/src/asn1/teletex_string.rs
@@ -83,7 +83,7 @@ impl<'a> TryFrom<AnyRef<'a>> for TeletexStringRef<'a> {
     type Error = Error;
 
     fn try_from(any: AnyRef<'a>) -> Result<TeletexStringRef<'a>> {
-        any.decode_into()
+        any.decode_as()
     }
 }
 impl<'a> From<TeletexStringRef<'a>> for AnyRef<'a> {
@@ -164,7 +164,7 @@ mod allocation {
         type Error = Error;
 
         fn try_from(any: &AnyRef<'a>) -> Result<TeletexString> {
-            (*any).decode_into()
+            (*any).decode_as()
         }
     }
 

--- a/der/src/asn1/utc_time.rs
+++ b/der/src/asn1/utc_time.rs
@@ -191,7 +191,7 @@ impl TryFrom<AnyRef<'_>> for UtcTime {
     type Error = Error;
 
     fn try_from(any: AnyRef<'_>) -> Result<UtcTime> {
-        any.decode_into()
+        any.decode_as()
     }
 }
 

--- a/der/src/asn1/utf8_string.rs
+++ b/der/src/asn1/utf8_string.rs
@@ -94,7 +94,7 @@ impl<'a> TryFrom<AnyRef<'a>> for Utf8StringRef<'a> {
     type Error = Error;
 
     fn try_from(any: AnyRef<'a>) -> Result<Utf8StringRef<'a>> {
-        any.decode_into()
+        any.decode_as()
     }
 }
 
@@ -103,7 +103,7 @@ impl<'a> TryFrom<&'a Any> for Utf8StringRef<'a> {
     type Error = Error;
 
     fn try_from(any: &'a Any) -> Result<Utf8StringRef<'a>> {
-        any.decode_into()
+        any.decode_as()
     }
 }
 

--- a/der/src/asn1/videotex_string.rs
+++ b/der/src/asn1/videotex_string.rs
@@ -101,7 +101,7 @@ impl<'a> TryFrom<AnyRef<'a>> for VideotexStringRef<'a> {
     type Error = Error;
 
     fn try_from(any: AnyRef<'a>) -> Result<VideotexStringRef<'a>> {
-        any.decode_into()
+        any.decode_as()
     }
 }
 
@@ -110,7 +110,7 @@ impl<'a> TryFrom<&'a Any> for VideotexStringRef<'a> {
     type Error = Error;
 
     fn try_from(any: &'a Any) -> Result<VideotexStringRef<'a>> {
-        any.decode_into()
+        any.decode_as()
     }
 }
 

--- a/pkcs1/tests/params.rs
+++ b/pkcs1/tests/params.rs
@@ -105,7 +105,11 @@ fn decode_oaep_param() {
         .assert_algorithm_oid(db::rfc5912::ID_P_SPECIFIED)
         .is_ok());
     assert_eq!(
-        param.p_source.parameters_any().unwrap().octet_string(),
+        param
+            .p_source
+            .parameters_any()
+            .unwrap()
+            .decode_as::<OctetStringRef<'_>>(),
         OctetStringRef::new(&[0xab, 0xcd, 0xef])
     );
 }
@@ -147,7 +151,7 @@ fn decode_oaep_param_default() {
         .p_source
         .parameters_any()
         .unwrap()
-        .octet_string()
+        .decode_as::<OctetStringRef<'_>>()
         .unwrap()
         .is_empty(),);
     assert_eq!(param, Default::default())

--- a/pkcs5/src/pbes2.rs
+++ b/pkcs5/src/pbes2.rs
@@ -320,7 +320,7 @@ impl<'a> TryFrom<AlgorithmIdentifierRef<'a>> for EncryptionScheme<'a> {
     fn try_from(alg: AlgorithmIdentifierRef<'a>) -> der::Result<Self> {
         // TODO(tarcieri): support for non-AES algorithms?
         let iv = match alg.parameters {
-            Some(params) => params.octet_string()?.as_bytes(),
+            Some(params) => params.decode_as::<OctetStringRef<'a>>()?.as_bytes(),
             None => return Err(Tag::OctetString.value_error()),
         };
 

--- a/pkcs7/tests/content_tests.rs
+++ b/pkcs7/tests/content_tests.rs
@@ -104,7 +104,7 @@ fn decode_signed_mdm_example() {
             signer_infos: _,
         })) => {
             let _content = content
-                .decode_into::<SequenceRef>()
+                .decode_as::<SequenceRef>()
                 .expect("Content should be in the correct format: SequenceRef");
         }
         _ => panic!("expected ContentInfo::SignedData(Some(_))"),
@@ -132,7 +132,7 @@ fn decode_signed_scep_example() {
             signer_infos: _,
         })) => {
             let _content = content
-                .decode_into::<OctetStringRef>()
+                .decode_as::<OctetStringRef>()
                 .expect("Content should be in the correct format: OctetStringRef");
 
             assert_eq!(ver, CmsVersion::V1)

--- a/pkcs8/tests/private_key.rs
+++ b/pkcs8/tests/private_key.rs
@@ -1,5 +1,6 @@
 //! PKCS#8 private key tests
 
+use der::asn1::ObjectIdentifier;
 use hex_literal::hex;
 use pkcs8::{PrivateKeyInfo, Version};
 
@@ -48,7 +49,11 @@ fn decode_ec_p256_der() {
     assert_eq!(pk.algorithm.oid, "1.2.840.10045.2.1".parse().unwrap());
 
     assert_eq!(
-        pk.algorithm.parameters.unwrap().oid().unwrap(),
+        pk.algorithm
+            .parameters
+            .unwrap()
+            .decode_as::<ObjectIdentifier>()
+            .unwrap(),
         "1.2.840.10045.3.1.7".parse().unwrap()
     );
 

--- a/spki/src/algorithm.rs
+++ b/spki/src/algorithm.rs
@@ -157,7 +157,7 @@ impl<'a> AlgorithmIdentifierRef<'a> {
                 None => None,
                 Some(p) => match p {
                     AnyRef::NULL => None,
-                    _ => Some(p.oid()?),
+                    _ => Some(p.decode_as::<ObjectIdentifier>()?),
                 },
             },
         ))

--- a/spki/tests/spki.rs
+++ b/spki/tests/spki.rs
@@ -1,5 +1,6 @@
 //! `SubjectPublicKeyInfo` tests.
 
+use der::asn1::ObjectIdentifier;
 use hex_literal::hex;
 use spki::SubjectPublicKeyInfoRef;
 
@@ -51,7 +52,11 @@ fn decode_ec_p256_der() {
     assert_eq!(spki.algorithm.oid, "1.2.840.10045.2.1".parse().unwrap());
 
     assert_eq!(
-        spki.algorithm.parameters.unwrap().oid().unwrap(),
+        spki.algorithm
+            .parameters
+            .unwrap()
+            .decode_as::<ObjectIdentifier>()
+            .unwrap(),
         "1.2.840.10045.3.1.7".parse().unwrap()
     );
 

--- a/x509-cert/tests/certreq.rs
+++ b/x509-cert/tests/certreq.rs
@@ -65,7 +65,7 @@ fn decode_rsa_2048_der() {
 
     // Check the extensions.
     let extensions: x509_cert::ext::Extensions =
-        attribute.values.get(0).unwrap().decode_into().unwrap();
+        attribute.values.get(0).unwrap().decode_as().unwrap();
     for (ext, (oid, val)) in extensions.iter().zip(EXTENSIONS) {
         assert_eq!(ext.extn_id, oid.parse().unwrap());
         assert_eq!(ext.extn_value.as_bytes(), *val);


### PR DESCRIPTION
Also renames `decode_into` -> `decode_as`

Removes almost all inherent methods for inherent ASN.1 types like `AnyRef::oid` and `AnyRef::octet_string`. `Any::sequence` is retained.

Replaces them with `Any::decode_as<T>`.

This simplifies the API by pushing things through the more flexible generic type-based API.