### PR TITLE
der: add `Any::value` accessor

### DIFF
--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -184,6 +184,11 @@ impl Any {
         Ok(Self { tag, value })
     }
 
+    /// Allow access to value
+    pub fn value<'a>(&'a self) -> &'a [u8] {
+        self.value.as_slice()
+    }
+
     /// Attempt to decode this [`Any`] type into the inner value.
     pub fn decode_as<'a, T>(&'a self) -> Result<T>
     where

--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -185,7 +185,7 @@ impl Any {
     }
 
     /// Allow access to value
-    pub fn value<'a>(&'a self) -> &'a [u8] {
+    pub fn value(&self) -> &[u8] {
         self.value.as_slice()
     }
 

--- a/x509-ocsp/src/lib.rs
+++ b/x509-ocsp/src/lib.rs
@@ -16,7 +16,7 @@ extern crate alloc;
 use der::asn1::{BitStringRef, Ia5StringRef, ObjectIdentifier, OctetStringRef, UintRef};
 use der::asn1::{GeneralizedTime, Null};
 use der::{AnyRef, Choice, Enumerated, Sequence};
-use spki::AlgorithmIdentifierRef;
+use spki::{AlgorithmIdentifierOwned, AlgorithmIdentifierRef};
 use x509_cert::ext::pkix::name::GeneralName;
 use x509_cert::ext::pkix::{AuthorityInfoAccessSyntax, CrlReason};
 use x509_cert::ext::Extensions;
@@ -242,7 +242,7 @@ pub struct ResponseBytes<'a> {
 #[allow(missing_docs)]
 pub struct BasicOcspResponse<'a> {
     pub tbs_response_data: ResponseData<'a>,
-    pub signature_algorithm: AlgorithmIdentifierRef<'a>,
+    pub signature_algorithm: AlgorithmIdentifierOwned,
     pub signature: BitStringRef<'a>,
 
     #[asn1(context_specific = "0", optional = "true", tag_mode = "EXPLICIT")]


### PR DESCRIPTION
Add value function to Any to address #832. Also changes BasicOcspResponse to use AlgorithmIdentifierOwned (the repo needs similar owned treatment as x509-cert but changing this one field is an immediate need).