### PR TITLE
der, spki: rename to_owned method

### DIFF
--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -287,7 +287,7 @@ mod allocating {
 
     impl OwnedToRef for Any {
         type Borrowed<'a> = AnyRef<'a>;
-        fn to_ref(&self) -> Self::Borrowed<'_> {
+        fn owned_to_ref(&self) -> Self::Borrowed<'_> {
             self.into()
         }
     }
@@ -295,7 +295,7 @@ mod allocating {
     impl Any {
         /// Is this value an ASN.1 `NULL` value?
         pub fn is_null(&self) -> bool {
-            self.to_ref() == AnyRef::NULL
+            self.owned_to_ref() == AnyRef::NULL
         }
     }
 }

--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -277,7 +277,7 @@ mod allocating {
 
     impl<'a> RefToOwned<'a> for AnyRef<'a> {
         type Owned = Any;
-        fn to_owned(&self) -> Self::Owned {
+        fn ref_to_owned(&self) -> Self::Owned {
             Any {
                 tag: self.tag(),
                 value: BytesOwned::from(self.value),

--- a/der/src/asn1/bit_string.rs
+++ b/der/src/asn1/bit_string.rs
@@ -390,7 +390,7 @@ mod allocating {
 
     impl OwnedToRef for BitString {
         type Borrowed<'a> = BitStringRef<'a>;
-        fn to_ref(&self) -> Self::Borrowed<'_> {
+        fn owned_to_ref(&self) -> Self::Borrowed<'_> {
             self.into()
         }
     }

--- a/der/src/asn1/bit_string.rs
+++ b/der/src/asn1/bit_string.rs
@@ -379,7 +379,7 @@ mod allocating {
 
     impl<'a> RefToOwned<'a> for BitStringRef<'a> {
         type Owned = BitString;
-        fn to_owned(&self) -> Self::Owned {
+        fn ref_to_owned(&self) -> Self::Owned {
             BitString {
                 unused_bits: self.unused_bits,
                 bit_length: self.bit_length,

--- a/der/src/asn1/ia5_string.rs
+++ b/der/src/asn1/ia5_string.rs
@@ -150,9 +150,9 @@ mod allocation {
 
     impl<'a> RefToOwned<'a> for Ia5StringRef<'a> {
         type Owned = Ia5String;
-        fn to_owned(&self) -> Self::Owned {
+        fn ref_to_owned(&self) -> Self::Owned {
             Ia5String {
-                inner: self.inner.to_owned(),
+                inner: self.inner.ref_to_owned(),
             }
         }
     }

--- a/der/src/asn1/ia5_string.rs
+++ b/der/src/asn1/ia5_string.rs
@@ -159,9 +159,9 @@ mod allocation {
 
     impl OwnedToRef for Ia5String {
         type Borrowed<'a> = Ia5StringRef<'a>;
-        fn to_ref(&self) -> Self::Borrowed<'_> {
+        fn owned_to_ref(&self) -> Self::Borrowed<'_> {
             Ia5StringRef {
-                inner: self.inner.to_ref(),
+                inner: self.inner.owned_to_ref(),
             }
         }
     }

--- a/der/src/asn1/integer/bigint.rs
+++ b/der/src/asn1/integer/bigint.rs
@@ -286,8 +286,8 @@ mod allocating {
 
     impl OwnedToRef for Int {
         type Borrowed<'a> = IntRef<'a>;
-        fn to_ref(&self) -> Self::Borrowed<'_> {
-            let inner = self.inner.to_ref();
+        fn owned_to_ref(&self) -> Self::Borrowed<'_> {
+            let inner = self.inner.owned_to_ref();
 
             IntRef { inner }
         }
@@ -393,8 +393,8 @@ mod allocating {
 
     impl OwnedToRef for Uint {
         type Borrowed<'a> = UintRef<'a>;
-        fn to_ref(&self) -> Self::Borrowed<'_> {
-            let inner = self.inner.to_ref();
+        fn owned_to_ref(&self) -> Self::Borrowed<'_> {
+            let inner = self.inner.owned_to_ref();
 
             UintRef { inner }
         }

--- a/der/src/asn1/integer/bigint.rs
+++ b/der/src/asn1/integer/bigint.rs
@@ -277,8 +277,8 @@ mod allocating {
 
     impl<'a> RefToOwned<'a> for IntRef<'a> {
         type Owned = Int;
-        fn to_owned(&self) -> Self::Owned {
-            let inner = self.inner.to_owned();
+        fn ref_to_owned(&self) -> Self::Owned {
+            let inner = self.inner.ref_to_owned();
 
             Int { inner }
         }
@@ -384,8 +384,8 @@ mod allocating {
 
     impl<'a> RefToOwned<'a> for UintRef<'a> {
         type Owned = Uint;
-        fn to_owned(&self) -> Self::Owned {
-            let inner = self.inner.to_owned();
+        fn ref_to_owned(&self) -> Self::Owned {
+            let inner = self.inner.ref_to_owned();
 
             Uint { inner }
         }

--- a/der/src/asn1/printable_string.rs
+++ b/der/src/asn1/printable_string.rs
@@ -221,9 +221,9 @@ mod allocation {
 
     impl<'a> RefToOwned<'a> for PrintableStringRef<'a> {
         type Owned = PrintableString;
-        fn to_owned(&self) -> Self::Owned {
+        fn ref_to_owned(&self) -> Self::Owned {
             PrintableString {
-                inner: self.inner.to_owned(),
+                inner: self.inner.ref_to_owned(),
             }
         }
     }

--- a/der/src/asn1/printable_string.rs
+++ b/der/src/asn1/printable_string.rs
@@ -230,9 +230,9 @@ mod allocation {
 
     impl OwnedToRef for PrintableString {
         type Borrowed<'a> = PrintableStringRef<'a>;
-        fn to_ref(&self) -> Self::Borrowed<'_> {
+        fn owned_to_ref(&self) -> Self::Borrowed<'_> {
             PrintableStringRef {
-                inner: self.inner.to_ref(),
+                inner: self.inner.owned_to_ref(),
             }
         }
     }

--- a/der/src/asn1/teletex_string.rs
+++ b/der/src/asn1/teletex_string.rs
@@ -188,9 +188,9 @@ mod allocation {
 
     impl OwnedToRef for TeletexString {
         type Borrowed<'a> = TeletexStringRef<'a>;
-        fn to_ref(&self) -> Self::Borrowed<'_> {
+        fn owned_to_ref(&self) -> Self::Borrowed<'_> {
             TeletexStringRef {
-                inner: self.inner.to_ref(),
+                inner: self.inner.owned_to_ref(),
             }
         }
     }

--- a/der/src/asn1/teletex_string.rs
+++ b/der/src/asn1/teletex_string.rs
@@ -179,9 +179,9 @@ mod allocation {
 
     impl<'a> RefToOwned<'a> for TeletexStringRef<'a> {
         type Owned = TeletexString;
-        fn to_owned(&self) -> Self::Owned {
+        fn ref_to_owned(&self) -> Self::Owned {
             TeletexString {
-                inner: self.inner.to_owned(),
+                inner: self.inner.ref_to_owned(),
             }
         }
     }

--- a/der/src/bytes_owned.rs
+++ b/der/src/bytes_owned.rs
@@ -97,7 +97,7 @@ impl From<StrRef<'_>> for BytesOwned {
 
 impl OwnedToRef for BytesOwned {
     type Borrowed<'a> = BytesRef<'a>;
-    fn to_ref(&self) -> Self::Borrowed<'_> {
+    fn owned_to_ref(&self) -> Self::Borrowed<'_> {
         BytesRef {
             length: self.length,
             inner: self.inner.as_ref(),

--- a/der/src/bytes_ref.rs
+++ b/der/src/bytes_ref.rs
@@ -145,7 +145,7 @@ mod allocating {
 
     impl<'a> RefToOwned<'a> for BytesRef<'a> {
         type Owned = BytesOwned;
-        fn to_owned(&self) -> Self::Owned {
+        fn ref_to_owned(&self) -> Self::Owned {
             BytesOwned::from(*self)
         }
     }

--- a/der/src/referenced.rs
+++ b/der/src/referenced.rs
@@ -8,7 +8,7 @@ pub trait OwnedToRef {
         Self: 'a;
 
     /// Creates a new object referencing back to the self for storage
-    fn to_ref(&self) -> Self::Borrowed<'_>;
+    fn owned_to_ref(&self) -> Self::Borrowed<'_>;
 }
 
 /// A trait for cloning a referenced structure and getting owned objects
@@ -30,8 +30,8 @@ where
 {
     type Borrowed<'a> = Option<T::Borrowed<'a>> where T: 'a;
 
-    fn to_ref(&self) -> Self::Borrowed<'_> {
-        self.as_ref().map(|o| o.to_ref())
+    fn owned_to_ref(&self) -> Self::Borrowed<'_> {
+        self.as_ref().map(|o| o.owned_to_ref())
     }
 }
 

--- a/der/src/referenced.rs
+++ b/der/src/referenced.rs
@@ -21,7 +21,7 @@ pub trait RefToOwned<'a> {
         Self: 'a;
 
     /// Creates a new object taking ownership of the data
-    fn to_owned(&self) -> Self::Owned;
+    fn ref_to_owned(&self) -> Self::Owned;
 }
 
 impl<T> OwnedToRef for Option<T>
@@ -41,7 +41,7 @@ where
     T::Owned: OwnedToRef,
 {
     type Owned = Option<T::Owned>;
-    fn to_owned(&self) -> Self::Owned {
-        self.as_ref().map(|o| o.to_owned())
+    fn ref_to_owned(&self) -> Self::Owned {
+        self.as_ref().map(|o| o.ref_to_owned())
     }
 }

--- a/der/src/str_owned.rs
+++ b/der/src/str_owned.rs
@@ -96,7 +96,7 @@ impl From<StrRef<'_>> for StrOwned {
 
 impl OwnedToRef for StrOwned {
     type Borrowed<'a> = StrRef<'a>;
-    fn to_ref(&self) -> Self::Borrowed<'_> {
+    fn owned_to_ref(&self) -> Self::Borrowed<'_> {
         StrRef {
             length: self.length,
             inner: self.inner.as_ref(),

--- a/der/src/str_ref.rs
+++ b/der/src/str_ref.rs
@@ -85,7 +85,7 @@ mod allocating {
 
     impl<'a> RefToOwned<'a> for StrRef<'a> {
         type Owned = StrOwned;
-        fn to_owned(&self) -> Self::Owned {
+        fn ref_to_owned(&self) -> Self::Owned {
             StrOwned::from(*self)
         }
     }

--- a/spki/src/algorithm.rs
+++ b/spki/src/algorithm.rs
@@ -181,10 +181,10 @@ mod allocating {
 
     impl OwnedToRef for AlgorithmIdentifierOwned {
         type Borrowed<'a> = AlgorithmIdentifierRef<'a>;
-        fn to_ref(&self) -> Self::Borrowed<'_> {
+        fn owned_to_ref(&self) -> Self::Borrowed<'_> {
             AlgorithmIdentifier {
                 oid: self.oid,
-                parameters: self.parameters.to_ref(),
+                parameters: self.parameters.owned_to_ref(),
             }
         }
     }

--- a/spki/src/algorithm.rs
+++ b/spki/src/algorithm.rs
@@ -171,10 +171,10 @@ mod allocating {
 
     impl<'a> RefToOwned<'a> for AlgorithmIdentifierRef<'a> {
         type Owned = AlgorithmIdentifierOwned;
-        fn to_owned(&self) -> Self::Owned {
+        fn ref_to_owned(&self) -> Self::Owned {
             AlgorithmIdentifier {
                 oid: self.oid,
-                parameters: self.parameters.to_owned(),
+                parameters: self.parameters.ref_to_owned(),
             }
         }
     }

--- a/spki/src/spki.rs
+++ b/spki/src/spki.rs
@@ -203,10 +203,10 @@ mod allocating {
 
     impl OwnedToRef for SubjectPublicKeyInfoOwned {
         type Borrowed<'a> = SubjectPublicKeyInfoRef<'a>;
-        fn to_ref(&self) -> Self::Borrowed<'_> {
+        fn owned_to_ref(&self) -> Self::Borrowed<'_> {
             SubjectPublicKeyInfo {
-                algorithm: self.algorithm.to_ref(),
-                subject_public_key: self.subject_public_key.to_ref(),
+                algorithm: self.algorithm.owned_to_ref(),
+                subject_public_key: self.subject_public_key.owned_to_ref(),
             }
         }
     }

--- a/spki/src/spki.rs
+++ b/spki/src/spki.rs
@@ -193,10 +193,10 @@ mod allocating {
 
     impl<'a> RefToOwned<'a> for SubjectPublicKeyInfoRef<'a> {
         type Owned = SubjectPublicKeyInfoOwned;
-        fn to_owned(&self) -> Self::Owned {
+        fn ref_to_owned(&self) -> Self::Owned {
             SubjectPublicKeyInfo {
-                algorithm: self.algorithm.to_owned(),
-                subject_public_key: self.subject_public_key.to_owned(),
+                algorithm: self.algorithm.ref_to_owned(),
+                subject_public_key: self.subject_public_key.ref_to_owned(),
             }
         }
     }


### PR DESCRIPTION
The naming of the `to_owned` method was a bit unfortunate as it triggered conflicts with the `alloc::borrow::ToOwned` method. When used, this would make for compiler messages asking things like:
```
error[E0034]: multiple applicable items in scope
   --> certval/src/validator/name_constraints_set.rs:748:34
    |
748 |                         value: a.to_owned(),
    |                                  ^^^^^^^^ multiple `to_owned` found
    |
    = note: candidate #1 is defined in an impl of the trait `RefToOwned` for the type `AnyRef<'a>`
    = note: candidate #2 is defined in an impl of the trait `ToOwned` for the type `T`
help: disambiguate the associated function for candidate #1
    |
748 |                         value: RefToOwned::to_owned(&a),
    |                                ~~~~~~~~~~~~~~~~~~~~~~~~
help: disambiguate the associated function for candidate #2
    |
748 |                         value: ToOwned::to_owned(&a),
    |                                ~~~~~~~~~~~~~~~~~~~~~
```