### PR TITLE
Bump SerialNumber max length limit

### DIFF
--- a/x509-cert/src/serial_number.rs
+++ b/x509-cert/src/serial_number.rs
@@ -30,7 +30,7 @@ pub struct SerialNumber {
 
 impl SerialNumber {
     /// Maximum length in bytes for a [`SerialNumber`]
-    pub const MAX_LEN: Length = Length::new(20);
+    pub const MAX_LEN: Length = Length::new(30);
 
     /// Create a new [`SerialNumber`] from a byte slice.
     pub fn new(bytes: &[u8]) -> Result<Self> {


### PR DESCRIPTION
One of the certs in MS' root of trust has a serial number of length 21.

Bump it to 30 to be safe.

Link to the certificate: http://www.download.windowsupdate.com/msdownload/update/v3/static/trustedr/en/d3eefbcbbcf49867838626e23bb59ca01e305db7.crt

See it [on lapo.it](https://lapo.it/asn1js/#MIIDcTCCAlmgAwIBAgIVAOYJ_nrqAGiM4CS07SAbH-9StETRMA0GCSqGSIb3DQEBBQUAMFAxCzAJBgNVBAYTAlBMMSgwJgYDVQQKDB9LcmFqb3dhIEl6YmEgUm96bGljemVuaW93YSBTLkEuMRcwFQYDVQQDDA5TWkFGSVIgUk9PVCBDQTAeFw0xMTEyMDYxMTEwNTdaFw0zMTEyMDYxMTEwNTdaMFAxCzAJBgNVBAYTAlBMMSgwJgYDVQQKDB9LcmFqb3dhIEl6YmEgUm96bGljemVuaW93YSBTLkEuMRcwFQYDVQQDDA5TWkFGSVIgUk9PVCBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKxHL49ZMTml6g3wpYwrvQKkvc0Kc6oJ5sxfgmp1qZfluwbv88BdocHSiXlY8NzrVYzuWBp7J_9KULMAoWoTIzOQ6C9TNm4YbA9A1jdX1wYNL5Akylf8W5L_I4BXhT9KnlI6x-a7BVAmnr_Ttl-utT_Asms2fRfEsF2vZPMxH4UFqOAhFjxTkmJWf2Cu4nvRQJHcttB-cEAoag_hERt_-tzo4URz6x6r19toYmxx4FjjBkUhWQw1X21re__Hof2-0YgiwYT84zLbeqDqCOMOXxvH480yGDkh_QoazWX3U75HQExT_iJlwnu7I1V6HXztKIwCBjsxffbH3jOshCJtywcCAwEAAaNCMEAwDwYDVR0TAQH_BAUwAwEB_zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFFOSo33_gnbwM9TrkmdHYTMbaDsqMA0GCSqGSIb3DQEBBQUAA4IBAQA5UFWd5EL_pBviIMm1zD2JLUCpp0mJG7JkwznIOzawhGmFFaxGoxAhQBEghaP-E0KR66oAwVC6xe32QUVSHfWqWndzbODzLB8yj7WAR0cDM45ZngSBPBuFE3WuGLJX9g100ETfIX-4YBR_4NR_uvTnpnd9ete7Whl0ZfY94yuu4xQqB5QFv-P7IXXVlTOjkjuGXEcyQAjQzbFaT9vIABSbeCXWBbjvOXukJy6WgAiclzGNSYprre8RyyddfmjW9HIGwsIO03EldivvqEYL1Hv1w_Pur-6FUEOaL68PEIUovfgwIB2BAw-vZDuwcH0mX548PojGyg434cDjkSXa3mHF)