### PR TITLE
crmf: minor fixups

### DIFF
--- a/.github/workflows/crmf.yml
+++ b/.github/workflows/crmf.yml
@@ -1,10 +1,11 @@
-name: x509-cert
+name: crmf
 
 on:
   pull_request:
     paths:
-      - ".github/workflows/x509-cert.yml"
+      - ".github/workflows/crmf.yml"
       - "const-oid/**"
+      - "crmf/**"
       - "der/**"
       - "spki/**"
       - "x509-cert/**"
@@ -14,7 +15,7 @@ on:
 
 defaults:
   run:
-    working-directory: x509-cert
+    working-directory: crmf
 
 env:
   CARGO_INCREMENTAL: 0
@@ -66,15 +67,4 @@ jobs:
       - uses: RustCrypto/actions/cargo-hack-install@master
       - run: cargo hack test --feature-powerset
 
-  fuzz:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly-2022-12-25 # Pinned due to rust-lang/rust#106247
-          override: true
-      - run: cargo install cargo-fuzz
-      - run: cargo fuzz run certreq -- -max_total_time=30 -seed_inputs="fuzz/inputs/rsa2048-csr.der"
-      - run: cargo fuzz run certreqinfo -- -max_total_time=30
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,12 +270,9 @@ dependencies = [
 
 [[package]]
 name = "crmf"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
- "const-oid",
  "der",
- "flagset",
- "hex-literal",
  "spki",
  "x509-cert",
 ]

--- a/crmf/Cargo.toml
+++ b/crmf/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "crmf"
-version = "0.1.0"
+version = "0.0.0"
 description = """
-Pure Rust implementation of the Certificate Request Message Format (CRMF) as described in RFC 4211
+Pure Rust implementation of the Certificate Request Message Format (CRMF) as
+described in RFC 4211
 """
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
@@ -14,15 +15,9 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-der = { version = "0.7.0-pre", features = ["oid", "derive", "alloc"], path = "../der" }
-x509-cert = { version = "0.2.0-pre", path = "../x509-cert" }
-const-oid = { version = "0.10.0-pre", path = "../const-oid" }
-spki = { version = "0.7.0-pre", path = "../spki" }
-# cms = { version = "0.1.0", path = "../cms" }
-flagset = { version = "0.4.3" }
-
-[dev-dependencies]
-hex-literal = "0.3"
+der = { version = "=0.7.0-pre", features = ["alloc", "derive"], path = "../der" }
+x509-cert = { version = "=0.2.0-pre", path = "../x509-cert" }
+spki = { version = "=0.7.0-pre", path = "../spki" }
 
 [features]
 alloc = ["der/alloc"]

--- a/crmf/README.md
+++ b/crmf/README.md
@@ -42,12 +42,12 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/x509.svg
-[crate-link]: https://crates.io/crates/x509
-[docs-image]: https://docs.rs/x509/badge.svg
-[docs-link]: https://docs.rs/x509/
-[build-image]: https://github.com/RustCrypto/formats/actions/workflows/x509.yml/badge.svg
-[build-link]: https://github.com/RustCrypto/formats/actions/workflows/x509.yml
+[crate-image]: https://img.shields.io/crates/v/crmf.svg
+[crate-link]: https://crates.io/crates/crmf
+[docs-image]: https://docs.rs/crmf/badge.svg
+[docs-link]: https://docs.rs/crmf/
+[build-image]: https://github.com/RustCrypto/formats/actions/workflows/crmf.yml/badge.svg
+[build-link]: https://github.com/RustCrypto/formats/actions/workflows/crmf.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [rustc-image]: https://img.shields.io/badge/rustc-1.57+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/crmf/src/controls.rs
+++ b/crmf/src/controls.rs
@@ -125,7 +125,7 @@ pub enum SinglePubInfoMethod {
 #[derive(Clone, Debug, PartialEq, Eq, Choice)]
 #[allow(clippy::large_enum_variant)]
 #[allow(missing_docs)]
-pub enum PKIArchiveOptions {
+pub enum PkiArchiveOptions {
     #[asn1(context_specific = "0", tag_mode = "EXPLICIT", constructed = "true")]
     EncryptedPrivKey(EncryptedKey),
     #[asn1(context_specific = "0", tag_mode = "EXPLICIT", constructed = "true")]


### PR DESCRIPTION
- Remove unused dependencies
- Bump version back to 0.0.0 (crate is unpublished)
- Fix links in README.md
- Fix capitalization style for `PkiArchiveOptions`
- Add CI configuration