### PR TITLE
Fix tls_codec-ci badge

### DIFF
--- a/tls_codec/README.md
+++ b/tls_codec/README.md
@@ -69,7 +69,7 @@ dual licensed as above, without any additional terms or conditions.
 [RustCrypto]: https://github.com/rustcrypto
 [rfc 8446]: https://tools.ietf.org/html/rfc8446
 [mls]: https://messaginglayersecurity.rocks/mls-protocol/draft-ietf-mls-protocol.html
-[tls_codec-ci]: https://img.shields.io/github/workflow/status/RustCrypto/formats/tls_codec?style=for-the-badge
+[tls_codec-ci]: https://img.shields.io/github/actions/workflow/status/RustCrypto/formats/tls_codec.yml?branch=master&style=for-the-badge
 [tls_codec-ci-link]: https://github.com/RustCrypto/formats/actions/workflows/tls_codec.yml
 [tls_codec]: https://img.shields.io/crates/v/tls_codec?style=for-the-badge
 [tls_codec-link]: https://crates.io/crates/tls_codec


### PR DESCRIPTION
The path needed to be updated per
https://github.com/badges/shields/issues/8671