### PR TITLE
serdect: bump `toml` to v0.7; fix test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,6 +689,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom8"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1188,6 +1197,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c68e921cef53841b8925c2abadd27c9b891d9613bdc43d6b823062866df38e8"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serdect"
 version = "0.2.0-pre"
 dependencies = [
@@ -1199,7 +1217,7 @@ dependencies = [
  "serde",
  "serde-json-core",
  "serde_json",
- "toml",
+ "toml 0.7.0",
  "zeroize",
 ]
 
@@ -1353,6 +1371,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f560bc7fb3eb31f5eee1340c68a2160cad39605b7b9c9ec32045ddbdee13b85"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "886f31a9b85b6182cabd4d8b07df3b451afcc216563748201490940d2a28ed36"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233d8716cdc5d20ec88a18a839edaf545edc71efa4a5ff700ef4a102c26cd8fa"
+dependencies = [
+ "indexmap",
+ "nom8",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+]
+
+[[package]]
 name = "trybuild"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1364,7 +1416,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "termcolor",
- "toml",
+ "toml 0.5.10",
 ]
 
 [[package]]

--- a/serdect/Cargo.toml
+++ b/serdect/Cargo.toml
@@ -29,7 +29,7 @@ proptest = "1"
 serde = { version = "1.0.119", default-features = false, features = ["derive"] }
 serde_json = "1"
 serde-json-core = { version = "0.5", default-features = false, features = ["std"] }
-toml = "0.5"
+toml = "0.7"
 
 [features]
 default = ["alloc"]

--- a/serdect/tests/toml.rs
+++ b/serdect/tests/toml.rs
@@ -16,16 +16,22 @@ const HEX_LOWER: &str = "\"000102030405060708090a0b0c0d0e0f\"";
 /// Upper-case hex serialization of [`EXAMPLE_BYTES`].
 const HEX_UPPER: &str = "\"000102030405060708090A0B0C0D0E0F\"";
 
+#[derive(Deserialize, Serialize)]
+struct SliceTest {
+    lower: slice::HexLowerOrBin,
+    upper: slice::HexUpperOrBin,
+}
+
+#[derive(Deserialize, Serialize)]
+struct ArrayTest {
+    lower: array::HexLowerOrBin<16>,
+    upper: array::HexUpperOrBin<16>,
+}
+
 #[test]
 fn deserialize_slice() {
-    #[derive(Deserialize, Serialize)]
-    pub struct Test {
-        lower: slice::HexLowerOrBin,
-        upper: slice::HexUpperOrBin,
-    }
-
     let deserialized =
-        toml::from_str::<Test>(&format!("lower={}\nupper={}", HEX_LOWER, HEX_UPPER)).unwrap();
+        toml::from_str::<SliceTest>(&format!("lower={}\nupper={}", HEX_LOWER, HEX_UPPER)).unwrap();
 
     assert_eq!(deserialized.lower.0, EXAMPLE_BYTES);
     assert_eq!(deserialized.upper.0, EXAMPLE_BYTES);
@@ -33,14 +39,8 @@ fn deserialize_slice() {
 
 #[test]
 fn deserialize_array() {
-    #[derive(Deserialize, Serialize)]
-    pub struct Test {
-        lower: array::HexLowerOrBin<16>,
-        upper: array::HexUpperOrBin<16>,
-    }
-
     let deserialized =
-        toml::from_str::<Test>(&format!("lower={}\nupper={}", HEX_LOWER, HEX_UPPER)).unwrap();
+        toml::from_str::<ArrayTest>(&format!("lower={}\nupper={}", HEX_LOWER, HEX_UPPER)).unwrap();
 
     assert_eq!(deserialized.lower.0, EXAMPLE_BYTES);
     assert_eq!(deserialized.upper.0, EXAMPLE_BYTES);
@@ -48,20 +48,32 @@ fn deserialize_array() {
 
 #[test]
 fn serialize_slice() {
-    let serialized = toml::to_string(&slice::HexLowerOrBin::from(EXAMPLE_BYTES.as_ref())).unwrap();
-    assert_eq!(serialized, HEX_LOWER);
+    let test = SliceTest {
+        lower: slice::HexLowerOrBin::from(EXAMPLE_BYTES.as_ref()),
+        upper: slice::HexUpperOrBin::from(EXAMPLE_BYTES.as_ref()),
+    };
 
-    let serialized = toml::to_string(&slice::HexUpperOrBin::from(EXAMPLE_BYTES.as_ref())).unwrap();
-    assert_eq!(serialized, HEX_UPPER);
+    let serialized = toml::to_string(&test).unwrap();
+
+    assert_eq!(
+        serialized,
+        format!("lower = {}\nupper = {}\n", HEX_LOWER, HEX_UPPER)
+    );
 }
 
 #[test]
 fn serialize_array() {
-    let serialized = toml::to_string(&array::HexLowerOrBin::from(EXAMPLE_BYTES)).unwrap();
-    assert_eq!(serialized, HEX_LOWER);
+    let test = ArrayTest {
+        lower: array::HexLowerOrBin::from(EXAMPLE_BYTES),
+        upper: array::HexUpperOrBin::from(EXAMPLE_BYTES),
+    };
 
-    let serialized = toml::to_string(&array::HexUpperOrBin::from(EXAMPLE_BYTES)).unwrap();
-    assert_eq!(serialized, HEX_UPPER);
+    let serialized = toml::to_string(&test).unwrap();
+
+    assert_eq!(
+        serialized,
+        format!("lower = {}\nupper = {}\n", HEX_LOWER, HEX_UPPER)
+    );
 }
 
 proptest! {


### PR DESCRIPTION
The test was wrong in the first place, a string can't just sit there in TOML without a table.

Replaces https://github.com/RustCrypto/formats/pull/863.