### PR TITLE
tls_codec: expose vlbytes_len_len

### DIFF
--- a/tls_codec/src/lib.rs
+++ b/tls_codec/src/lib.rs
@@ -51,7 +51,7 @@ pub use tls_vec::{
 };
 
 #[cfg(feature = "std")]
-pub use quic_vec::{VLByteSlice, VLBytes};
+pub use quic_vec::{vlbytes_len_len, VLByteSlice, VLBytes};
 
 #[cfg(feature = "derive")]
 pub use tls_codec_derive::{TlsDeserialize, TlsSerialize, TlsSize};
@@ -106,6 +106,7 @@ impl From<std::io::Error> for Error {
 /// This allows to collect the length of a serialized structure before allocating
 /// memory.
 pub trait Size {
+    /// The length of the serialized object.
     fn tls_serialized_len(&self) -> usize;
 }
 

--- a/tls_codec/src/quic_vec.rs
+++ b/tls_codec/src/quic_vec.rs
@@ -63,6 +63,7 @@ fn read_variable_length<R: std::io::Read>(bytes: &mut R) -> Result<(usize, usize
     Ok((length, len_len))
 }
 
+/// Get the number of bytes required to encode the `length`.
 #[inline]
 fn length_encoding_bytes(length: u64) -> Result<usize, Error> {
     if !cfg!(fuzzing) {
@@ -72,7 +73,15 @@ fn length_encoding_bytes(length: u64) -> Result<usize, Error> {
         return Err(Error::InvalidVectorLength);
     }
 
-    Ok(if length < 0x40 {
+    Ok(vlbytes_len_len(length))
+}
+
+/// Get the number of bytes required to encode the `length`.
+///
+/// Note that this function will always return 8 for anything that is >= `0x3fff_ffff`.
+#[inline]
+pub fn vlbytes_len_len(length: u64) -> usize {
+    if length < 0x40 {
         1
     } else if length < 0x3fff {
         2
@@ -80,7 +89,7 @@ fn length_encoding_bytes(length: u64) -> Result<usize, Error> {
         4
     } else {
         8
-    })
+    }
 }
 
 // === (De)Serialize for `Vec<T>` and &[T].


### PR DESCRIPTION
This allows consumers to get the number of bytes required to encode a variable length enoded vector.