### PR TITLE
x509-cert: std feature implies const-oid/std

### DIFF
--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -28,7 +28,7 @@ rstest = "0.16"
 [features]
 arbitrary = ["std", "dep:arbitrary", "const-oid/arbitrary", "der/arbitrary", "spki/arbitrary"]
 pem = ["der/pem"]
-std = ["der/std", "spki/std"]
+std = ["der/std", "spki/std", "const-oid/std"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Just a small thing, noticed while trying to use the `Error` trait through a re-export here.