### PR TITLE
der: cleanup `Any*` conversions

### DIFF
--- a/der/src/asn1/bit_string.rs
+++ b/der/src/asn1/bit_string.rs
@@ -117,7 +117,7 @@ impl<'a> BitStringRef<'a> {
     }
 }
 
-impl_type!(BitStringRef<'a>, 'a);
+impl_any_conversions!(BitStringRef<'a>, 'a);
 
 impl<'a> DecodeValue<'a> for BitStringRef<'a> {
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
@@ -307,7 +307,7 @@ mod allocating {
         }
     }
 
-    impl_type!(BitString);
+    impl_any_conversions!(BitString);
 
     impl<'a> DecodeValue<'a> for BitString {
         fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {

--- a/der/src/asn1/generalized_time.rs
+++ b/der/src/asn1/generalized_time.rs
@@ -76,7 +76,7 @@ impl GeneralizedTime {
     }
 }
 
-impl_type!(GeneralizedTime);
+impl_any_conversions!(GeneralizedTime);
 
 impl<'a> DecodeValue<'a> for GeneralizedTime {
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {

--- a/der/src/asn1/integer/bigint.rs
+++ b/der/src/asn1/integer/bigint.rs
@@ -45,10 +45,7 @@ impl<'a> IntRef<'a> {
     }
 }
 
-mod int_impl {
-    use super::*;
-    impl_type!(IntRef<'a>, 'a);
-}
+impl_any_conversions!(IntRef<'a>, 'a);
 
 impl<'a> DecodeValue<'a> for IntRef<'a> {
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
@@ -126,10 +123,7 @@ impl<'a> UintRef<'a> {
     }
 }
 
-mod uint_impl {
-    use super::*;
-    impl_type!(UintRef<'a>, 'a);
-}
+impl_any_conversions!(UintRef<'a>, 'a);
 
 impl<'a> DecodeValue<'a> for UintRef<'a> {
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
@@ -226,10 +220,7 @@ mod allocating {
         }
     }
 
-    mod int_impl {
-        use super::*;
-        impl_type!(Int);
-    }
+    impl_any_conversions!(Int);
 
     impl<'a> DecodeValue<'a> for Int {
         fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
@@ -342,10 +333,7 @@ mod allocating {
         }
     }
 
-    mod uint_impl {
-        use super::*;
-        impl_type!(Uint);
-    }
+    impl_any_conversions!(Uint);
 
     impl<'a> DecodeValue<'a> for Uint {
         fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {

--- a/der/src/asn1/internal_macros.rs
+++ b/der/src/asn1/internal_macros.rs
@@ -1,40 +1,30 @@
-macro_rules! impl_type {
+macro_rules! impl_any_conversions {
     ($type: ty) => {
-        impl_type!($type, );
+        impl_any_conversions!($type, );
     };
     ($type: ty, $($li: lifetime)?) => {
-        mod __impl {
-            use super::*;
+        impl<'__der: $($li),*, $($li),*> TryFrom<$crate::asn1::AnyRef<'__der>> for $type {
+            type Error = $crate::Error;
 
-            use crate::{asn1::AnyRef, Error, Result};
-
-            #[cfg(feature = "alloc")]
-            use crate::asn1::Any;
-
-            #[cfg(feature = "alloc")]
-            impl<'__der: $($li),*, $($li),*> TryFrom<&'__der Any> for $type {
-                type Error = Error;
-
-                fn try_from(any: &'__der Any) -> Result<$type> {
-                    any.decode_as()
-                }
+            fn try_from(any: $crate::asn1::AnyRef<'__der>) -> Result<$type> {
+                any.decode_as()
             }
+        }
 
-            impl<'__der: $($li),*, $($li),*> TryFrom<AnyRef<'__der>> for $type {
-                type Error = Error;
+        #[cfg(feature = "alloc")]
+        impl<'__der: $($li),*, $($li),*> TryFrom<&'__der $crate::asn1::Any> for $type {
+            type Error = $crate::Error;
 
-                fn try_from(any: AnyRef<'__der>) -> Result<$type> {
-                    any.decode_as()
-                }
+            fn try_from(any: &'__der $crate::asn1::Any) -> Result<$type> {
+                any.decode_as()
             }
-
         }
     };
 }
 
 macro_rules! impl_string_type {
     ($type: ty, $($li: lifetime)?) => {
-        impl_type!($type, $($li),*);
+        impl_any_conversions!($type, $($li),*);
 
         mod __impl_string {
             use super::*;

--- a/der/src/asn1/null.rs
+++ b/der/src/asn1/null.rs
@@ -9,7 +9,7 @@ use crate::{
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Null;
 
-impl_type!(Null);
+impl_any_conversions!(Null);
 
 impl<'a> DecodeValue<'a> for Null {
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {

--- a/der/src/asn1/octet_string.rs
+++ b/der/src/asn1/octet_string.rs
@@ -45,7 +45,7 @@ impl<'a> OctetStringRef<'a> {
     }
 }
 
-impl_type!(OctetStringRef<'a>, 'a);
+impl_any_conversions!(OctetStringRef<'a>, 'a);
 
 impl AsRef<[u8]> for OctetStringRef<'_> {
     fn as_ref(&self) -> &[u8] {
@@ -148,7 +148,7 @@ mod allocating {
         }
     }
 
-    impl_type!(OctetString);
+    impl_any_conversions!(OctetString);
 
     impl AsRef<[u8]> for OctetString {
         fn as_ref(&self) -> &[u8] {

--- a/der/src/asn1/utc_time.rs
+++ b/der/src/asn1/utc_time.rs
@@ -78,7 +78,7 @@ impl UtcTime {
     }
 }
 
-impl_type!(UtcTime);
+impl_any_conversions!(UtcTime);
 
 impl<'a> DecodeValue<'a> for UtcTime {
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {


### PR DESCRIPTION
Renames the vague `impl_type!` macro to `impl_any_conversions!` and eliminates the use of superfluous nested modules.