### PR TITLE
base64ct: add back to workspace

### DIFF
--- a/.github/workflows/base64ct.yml
+++ b/.github/workflows/base64ct.yml
@@ -37,6 +37,7 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: rm ../Cargo.toml # Hack to preserve MSRV <1.60
       - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features std
 
   minimal-versions:
@@ -59,4 +60,5 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
       - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: rm ../Cargo.toml # Hack to preserve MSRV <1.60
       - run: cargo hack test --feature-powerset

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,8 +73,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
 name = "base64ct"
 version = "1.5.3"
+dependencies = [
+ "base64",
+ "proptest",
+]
 
 [[package]]
 name = "basic-toml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "base16ct",
     "base32ct",
+    "base64ct",
     "cmpv2",
     "cms",
     "const-oid",
@@ -24,9 +25,6 @@ members = [
     "x509-cert",
     "x509-ocsp"
 ]
-
-# TODO(tarcieri): add back to `members` when MSRV is 1.60+
-exclude = ["base64ct"]
 
 [profile.dev]
 opt-level = 2


### PR DESCRIPTION
Removes toplevel `Cargo.toml` to allow building on MSRV <1.60