### PR TITLE
Use `doc_auto_cfg`

### DIFF
--- a/base16ct/src/lib.rs
+++ b/base16ct/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"

--- a/base16ct/src/lower.rs
+++ b/base16ct/src/lower.rs
@@ -9,7 +9,6 @@ pub fn decode(src: impl AsRef<[u8]>, dst: &mut [u8]) -> Result<&[u8], Error> {
 
 /// Decode a lower Base16 (hex) string into a byte vector.
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub fn decode_vec(input: impl AsRef<[u8]>) -> Result<Vec<u8>, Error> {
     let mut output = vec![0u8; decoded_len(input.as_ref())?];
     decode(input, &mut output)?;
@@ -41,7 +40,6 @@ pub fn encode_str<'a>(src: &[u8], dst: &'a mut [u8]) -> Result<&'a str, Error> {
 /// # Panics
 /// If `input` length is greater than `usize::MAX/2`.
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub fn encode_string(input: &[u8]) -> String {
     let elen = encoded_len(input);
     let mut dst = vec![0u8; elen];

--- a/base16ct/src/mixed.rs
+++ b/base16ct/src/mixed.rs
@@ -9,7 +9,6 @@ pub fn decode(src: impl AsRef<[u8]>, dst: &mut [u8]) -> Result<&[u8], Error> {
 
 /// Decode a mixed Base16 (hex) string into a byte vector.
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub fn decode_vec(input: impl AsRef<[u8]>) -> Result<Vec<u8>, Error> {
     let mut output = vec![0u8; decoded_len(input.as_ref())?];
     decode(input, &mut output)?;

--- a/base16ct/src/upper.rs
+++ b/base16ct/src/upper.rs
@@ -9,7 +9,6 @@ pub fn decode(src: impl AsRef<[u8]>, dst: &mut [u8]) -> Result<&[u8], Error> {
 
 /// Decode an upper Base16 (hex) string into a byte vector.
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub fn decode_vec(input: impl AsRef<[u8]>) -> Result<Vec<u8>, Error> {
     let mut output = vec![0u8; decoded_len(input.as_ref())?];
     decode(input, &mut output)?;
@@ -41,7 +40,6 @@ pub fn encode_str<'a>(src: &[u8], dst: &'a mut [u8]) -> Result<&'a str, Error> {
 /// # Panics
 /// If `input` length is greater than `usize::MAX/2`.
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub fn encode_string(input: &[u8]) -> String {
     let elen = encoded_len(input);
     let mut dst = vec![0u8; elen];

--- a/base32ct/src/encoding.rs
+++ b/base32ct/src/encoding.rs
@@ -14,7 +14,6 @@ pub trait Encoding: Alphabet {
 
     /// Decode a Base32 string into a byte vector.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     fn decode_vec(input: &str) -> Result<Vec<u8>>;
 
     /// Encode the input byte slice as Base32.
@@ -25,7 +24,6 @@ pub trait Encoding: Alphabet {
 
     /// Encode input byte slice into a [`String`] containing Base32.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     fn encode_string(input: &[u8]) -> String;
 
     /// Get the length of Base32 produced by encoding the given bytes.
@@ -129,7 +127,6 @@ impl<T: Alphabet> Encoding for T {
     }
 
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     fn decode_vec(input: &str) -> Result<Vec<u8>> {
         let mut output = vec![0u8; decoded_len(input.len())];
         let len = Self::decode(input, &mut output)?.len();
@@ -208,7 +205,6 @@ impl<T: Alphabet> Encoding for T {
     }
 
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     fn encode_string(input: &[u8]) -> String {
         let elen = Self::encoded_len(input);
         let mut dst = vec![0u8; elen];

--- a/base32ct/src/lib.rs
+++ b/base32ct/src/lib.rs
@@ -33,7 +33,7 @@
 // SOFTWARE.
 
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"

--- a/base64ct/src/decoder.rs
+++ b/base64ct/src/decoder.rs
@@ -166,7 +166,6 @@ impl<'i, E: Encoding> Decoder<'i, E> {
     /// If successful, this function will return the total number of bytes
     /// decoded into `buf`.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn decode_to_end<'o>(&mut self, buf: &'o mut Vec<u8>) -> Result<&'o [u8], Error> {
         let start_len = buf.len();
         let remaining_len = self.remaining_len();
@@ -249,7 +248,6 @@ impl<'i, E: Encoding> Decoder<'i, E> {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl<'i, E: Encoding> io::Read for Decoder<'i, E> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         if self.is_finished() {

--- a/base64ct/src/encoder.rs
+++ b/base64ct/src/encoder.rs
@@ -166,7 +166,6 @@ impl<'o, E: Encoding> Encoder<'o, E> {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl<'o, E: Encoding> io::Write for Encoder<'o, E> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.encode(buf)?;

--- a/base64ct/src/encoding.rs
+++ b/base64ct/src/encoding.rs
@@ -40,7 +40,6 @@ pub trait Encoding: Alphabet {
 
     /// Decode a Base64 string into a byte vector.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     fn decode_vec(input: &str) -> Result<Vec<u8>, Error>;
 
     /// Encode the input byte slice as Base64.
@@ -54,7 +53,6 @@ pub trait Encoding: Alphabet {
     /// # Panics
     /// If `input` length is greater than `usize::MAX/4`.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     fn encode_string(input: &[u8]) -> String;
 
     /// Get the length of Base64 produced by encoding the given bytes.

--- a/base64ct/src/errors.rs
+++ b/base64ct/src/errors.rs
@@ -73,7 +73,6 @@ impl From<core::str::Utf8Error> for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl From<Error> for std::io::Error {
     fn from(err: Error) -> std::io::Error {
         // TODO(tarcieri): better customize `ErrorKind`?
@@ -82,5 +81,4 @@ impl From<Error> for std::io::Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {}

--- a/base64ct/src/lib.rs
+++ b/base64ct/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"

--- a/cmpv2/src/lib.rs
+++ b/cmpv2/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",

--- a/cms/src/lib.rs
+++ b/cms/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",

--- a/const-oid/src/lib.rs
+++ b/const-oid/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
@@ -32,7 +32,6 @@ mod error;
 mod parser;
 
 #[cfg(feature = "db")]
-#[cfg_attr(docsrs, doc(cfg(feature = "db")))]
 pub mod db;
 
 pub use crate::{

--- a/crmf/src/lib.rs
+++ b/crmf/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",

--- a/der/src/asn1.rs
+++ b/der/src/asn1.rs
@@ -49,7 +49,6 @@ pub use self::{
 };
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub use self::{
     any::Any,
     bit_string::BitString,
@@ -62,5 +61,4 @@ pub use self::{
 };
 
 #[cfg(feature = "oid")]
-#[cfg_attr(docsrs, doc(cfg(feature = "oid")))]
 pub use const_oid::ObjectIdentifier;

--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -160,7 +160,6 @@ mod allocating {
     ///
     /// This type provides the same functionality as [`AnyRef`] but owns the
     /// backing data.
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
     #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
     pub struct Any {

--- a/der/src/asn1/bit_string.rs
+++ b/der/src/asn1/bit_string.rs
@@ -219,7 +219,6 @@ mod allocating {
     ///
     /// This type provides the same functionality as [`BitStringRef`] but owns the
     /// backing data.
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
     pub struct BitString {
         /// Number of unused bits in the final octet.

--- a/der/src/asn1/generalized_time.rs
+++ b/der/src/asn1/generalized_time.rs
@@ -61,7 +61,6 @@ impl GeneralizedTime {
 
     /// Instantiate from [`SystemTime`].
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn from_system_time(time: SystemTime) -> Result<Self> {
         DateTime::try_from(time)
             .map(Into::into)
@@ -70,7 +69,6 @@ impl GeneralizedTime {
 
     /// Convert to [`SystemTime`].
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn to_system_time(&self) -> SystemTime {
         self.0.to_system_time()
     }
@@ -190,7 +188,6 @@ impl FixedTag for DateTime {
 impl OrdIsValueOrd for DateTime {}
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl<'a> DecodeValue<'a> for SystemTime {
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         Ok(GeneralizedTime::decode_value(reader, header)?.into())
@@ -198,7 +195,6 @@ impl<'a> DecodeValue<'a> for SystemTime {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl EncodeValue for SystemTime {
     fn value_len(&self) -> Result<Length> {
         GeneralizedTime::try_from(self)?.value_len()
@@ -210,7 +206,6 @@ impl EncodeValue for SystemTime {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl From<GeneralizedTime> for SystemTime {
     fn from(time: GeneralizedTime) -> SystemTime {
         time.to_system_time()
@@ -218,7 +213,6 @@ impl From<GeneralizedTime> for SystemTime {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl From<&GeneralizedTime> for SystemTime {
     fn from(time: &GeneralizedTime) -> SystemTime {
         time.to_system_time()
@@ -226,7 +220,6 @@ impl From<&GeneralizedTime> for SystemTime {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl TryFrom<SystemTime> for GeneralizedTime {
     type Error = Error;
 
@@ -236,7 +229,6 @@ impl TryFrom<SystemTime> for GeneralizedTime {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl TryFrom<&SystemTime> for GeneralizedTime {
     type Error = Error;
 
@@ -246,7 +238,6 @@ impl TryFrom<&SystemTime> for GeneralizedTime {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl<'a> TryFrom<AnyRef<'a>> for SystemTime {
     type Error = Error;
 
@@ -256,17 +247,14 @@ impl<'a> TryFrom<AnyRef<'a>> for SystemTime {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl FixedTag for SystemTime {
     const TAG: Tag = Tag::GeneralizedTime;
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl OrdIsValueOrd for SystemTime {}
 
 #[cfg(feature = "time")]
-#[cfg_attr(docsrs, doc(cfg(feature = "time")))]
 impl<'a> DecodeValue<'a> for PrimitiveDateTime {
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         GeneralizedTime::decode_value(reader, header)?.try_into()
@@ -274,7 +262,6 @@ impl<'a> DecodeValue<'a> for PrimitiveDateTime {
 }
 
 #[cfg(feature = "time")]
-#[cfg_attr(docsrs, doc(cfg(feature = "time")))]
 impl EncodeValue for PrimitiveDateTime {
     fn value_len(&self) -> Result<Length> {
         GeneralizedTime::try_from(self)?.value_len()
@@ -286,17 +273,14 @@ impl EncodeValue for PrimitiveDateTime {
 }
 
 #[cfg(feature = "time")]
-#[cfg_attr(docsrs, doc(cfg(feature = "time")))]
 impl FixedTag for PrimitiveDateTime {
     const TAG: Tag = Tag::GeneralizedTime;
 }
 
 #[cfg(feature = "time")]
-#[cfg_attr(docsrs, doc(cfg(feature = "time")))]
 impl OrdIsValueOrd for PrimitiveDateTime {}
 
 #[cfg(feature = "time")]
-#[cfg_attr(docsrs, doc(cfg(feature = "time")))]
 impl TryFrom<PrimitiveDateTime> for GeneralizedTime {
     type Error = Error;
 
@@ -306,7 +290,6 @@ impl TryFrom<PrimitiveDateTime> for GeneralizedTime {
 }
 
 #[cfg(feature = "time")]
-#[cfg_attr(docsrs, doc(cfg(feature = "time")))]
 impl TryFrom<&PrimitiveDateTime> for GeneralizedTime {
     type Error = Error;
 
@@ -316,7 +299,6 @@ impl TryFrom<&PrimitiveDateTime> for GeneralizedTime {
 }
 
 #[cfg(feature = "time")]
-#[cfg_attr(docsrs, doc(cfg(feature = "time")))]
 impl TryFrom<GeneralizedTime> for PrimitiveDateTime {
     type Error = Error;
 

--- a/der/src/asn1/octet_string.rs
+++ b/der/src/asn1/octet_string.rs
@@ -109,7 +109,6 @@ mod allocating {
     ///
     /// This type provides the same functionality as [`OctetStringRef`] but owns
     /// the backing data.
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
     pub struct OctetString {
         /// Bitstring represented as a slice of bytes.

--- a/der/src/asn1/real.rs
+++ b/der/src/asn1/real.rs
@@ -14,7 +14,6 @@ use crate::{
 
 use super::integer::uint::strip_leading_zeroes;
 
-#[cfg_attr(docsrs, doc(cfg(feature = "real")))]
 impl<'a> DecodeValue<'a> for f64 {
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         let bytes = BytesRef::decode_value(reader, header)?.as_slice();
@@ -84,7 +83,6 @@ impl<'a> DecodeValue<'a> for f64 {
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "real")))]
 impl EncodeValue for f64 {
     fn value_len(&self) -> Result<Length> {
         if self.is_sign_positive() && (*self) < f64::MIN_POSITIVE {
@@ -194,7 +192,6 @@ impl EncodeValue for f64 {
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "real")))]
 impl FixedTag for f64 {
     const TAG: Tag = Tag::Real;
 }

--- a/der/src/asn1/sequence_of.rs
+++ b/der/src/asn1/sequence_of.rs
@@ -178,7 +178,6 @@ where
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<'a, T> DecodeValue<'a> for Vec<T>
 where
     T: Decode<'a>,
@@ -197,7 +196,6 @@ where
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<T> EncodeValue for Vec<T>
 where
     T: Encode,
@@ -217,13 +215,11 @@ where
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<T> FixedTag for Vec<T> {
     const TAG: Tag = Tag::Sequence;
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<T> ValueOrd for Vec<T>
 where
     T: DerOrd,

--- a/der/src/asn1/set_of.rs
+++ b/der/src/asn1/set_of.rs
@@ -185,7 +185,6 @@ impl<'a, T> ExactSizeIterator for SetOfIter<'a, T> {}
 /// This type implements an append-only `SET OF` type which is heap-backed
 /// and depends on `alloc` support.
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct SetOfVec<T>
 where
@@ -195,7 +194,6 @@ where
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<T: DerOrd> Default for SetOfVec<T> {
     fn default() -> Self {
         Self {
@@ -205,7 +203,6 @@ impl<T: DerOrd> Default for SetOfVec<T> {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<T> SetOfVec<T>
 where
     T: DerOrd,
@@ -265,7 +262,6 @@ where
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<T> AsRef<[T]> for SetOfVec<T>
 where
     T: DerOrd,
@@ -276,7 +272,6 @@ where
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<'a, T> DecodeValue<'a> for SetOfVec<T>
 where
     T: Decode<'a> + DerOrd,
@@ -297,7 +292,6 @@ where
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<'a, T> EncodeValue for SetOfVec<T>
 where
     T: 'a + Decode<'a> + Encode + DerOrd,
@@ -317,7 +311,6 @@ where
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<T> FixedTag for SetOfVec<T>
 where
     T: DerOrd,
@@ -326,7 +319,6 @@ where
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<T> From<SetOfVec<T>> for Vec<T>
 where
     T: DerOrd,
@@ -337,7 +329,6 @@ where
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<T> TryFrom<Vec<T>> for SetOfVec<T>
 where
     T: DerOrd,
@@ -352,7 +343,6 @@ where
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<T, const N: usize> TryFrom<[T; N]> for SetOfVec<T>
 where
     T: DerOrd,
@@ -365,7 +355,6 @@ where
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<T> ValueOrd for SetOfVec<T>
 where
     T: DerOrd,

--- a/der/src/asn1/utc_time.rs
+++ b/der/src/asn1/utc_time.rs
@@ -63,7 +63,6 @@ impl UtcTime {
 
     /// Instantiate from [`SystemTime`].
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn from_system_time(time: SystemTime) -> Result<Self> {
         DateTime::try_from(time)
             .map_err(|_| Self::TAG.value_error())?
@@ -72,7 +71,6 @@ impl UtcTime {
 
     /// Convert to [`SystemTime`].
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn to_system_time(&self) -> SystemTime {
         self.0.to_system_time()
     }
@@ -181,7 +179,6 @@ impl TryFrom<&DateTime> for UtcTime {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl From<UtcTime> for SystemTime {
     fn from(utc_time: UtcTime) -> SystemTime {
         utc_time.to_system_time()

--- a/der/src/asn1/utf8_string.rs
+++ b/der/src/asn1/utf8_string.rs
@@ -99,7 +99,6 @@ impl FixedTag for str {
 impl OrdIsValueOrd for str {}
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<'a> From<Utf8StringRef<'a>> for String {
     fn from(s: Utf8StringRef<'a>) -> String {
         s.as_str().to_owned()
@@ -107,7 +106,6 @@ impl<'a> From<Utf8StringRef<'a>> for String {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<'a> TryFrom<AnyRef<'a>> for String {
     type Error = Error;
 
@@ -117,7 +115,6 @@ impl<'a> TryFrom<AnyRef<'a>> for String {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<'a> DecodeValue<'a> for String {
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         Ok(String::from_utf8(reader.read_vec(header.length)?)?)
@@ -125,7 +122,6 @@ impl<'a> DecodeValue<'a> for String {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl EncodeValue for String {
     fn value_len(&self) -> Result<Length> {
         Utf8StringRef::new(self)?.value_len()
@@ -137,13 +133,11 @@ impl EncodeValue for String {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl FixedTag for String {
     const TAG: Tag = Tag::Utf8String;
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl OrdIsValueOrd for String {}
 
 #[cfg(test)]

--- a/der/src/decode.rs
+++ b/der/src/decode.rs
@@ -55,14 +55,12 @@ impl<T> DecodeOwned for T where T: for<'a> Decode<'a> {}
 /// This trait is automatically impl'd for any type which impls both
 /// [`DecodeOwned`] and [`PemLabel`].
 #[cfg(feature = "pem")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 pub trait DecodePem: DecodeOwned + PemLabel {
     /// Try to decode this type from PEM.
     fn from_pem(pem: impl AsRef<[u8]>) -> Result<Self>;
 }
 
 #[cfg(feature = "pem")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl<T: DecodeOwned + PemLabel> DecodePem for T {
     fn from_pem(pem: impl AsRef<[u8]>) -> Result<Self> {
         let mut reader = PemReader::new(pem.as_ref())?;

--- a/der/src/document.rs
+++ b/der/src/document.rs
@@ -27,7 +27,6 @@ use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 ///
 /// The [`SecretDocument`] provides a wrapper for this type with additional
 /// hardening applied.
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[derive(Clone, Eq, PartialEq)]
 pub struct Document {
     /// ASN.1 DER encoded bytes.
@@ -45,7 +44,6 @@ impl Document {
 
     /// Convert to a [`SecretDocument`].
     #[cfg(feature = "zeroize")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
     pub fn into_secret(self) -> SecretDocument {
         SecretDocument(self)
     }
@@ -81,7 +79,6 @@ impl Document {
     ///
     /// Returns the PEM label and decoded [`Document`] on success.
     #[cfg(feature = "pem")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     pub fn from_pem(pem: &str) -> Result<(&str, Self)> {
         let (label, der_bytes) = pem::decode_vec(pem.as_bytes())?;
         Ok((label, der_bytes.try_into()?))
@@ -90,35 +87,30 @@ impl Document {
     /// Encode ASN.1 DER document as a PEM string with encapsulation boundaries
     /// containing the provided PEM type `label` (e.g. `CERTIFICATE`).
     #[cfg(feature = "pem")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     pub fn to_pem(&self, label: &'static str, line_ending: pem::LineEnding) -> Result<String> {
         Ok(pem::encode_string(label, line_ending, self.as_bytes())?)
     }
 
     /// Read ASN.1 DER document from a file.
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn read_der_file(path: impl AsRef<Path>) -> Result<Self> {
         fs::read(path)?.try_into()
     }
 
     /// Write ASN.1 DER document to a file.
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn write_der_file(&self, path: impl AsRef<Path>) -> Result<()> {
         Ok(fs::write(path, self.as_bytes())?)
     }
 
     /// Read PEM-encoded ASN.1 DER document from a file.
     #[cfg(all(feature = "pem", feature = "std"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "pem", feature = "std"))))]
     pub fn read_pem_file(path: impl AsRef<Path>) -> Result<(String, Self)> {
         Self::from_pem(&fs::read_to_string(path)?).map(|(label, doc)| (label.to_owned(), doc))
     }
 
     /// Write PEM-encoded ASN.1 DER document to a file.
     #[cfg(all(feature = "pem", feature = "std"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "pem", feature = "std"))))]
     pub fn write_pem_file(
         &self,
         path: impl AsRef<Path>,
@@ -205,7 +197,6 @@ impl TryFrom<Vec<u8>> for Document {
 /// are zeroized-on-drop, and also using more restrictive file permissions when
 /// writing files to disk.
 #[cfg(feature = "zeroize")]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "alloc", feature = "zeroize"))))]
 #[derive(Clone)]
 pub struct SecretDocument(Document);
 
@@ -238,14 +229,12 @@ impl SecretDocument {
 
     /// Decode ASN.1 DER document from PEM.
     #[cfg(feature = "pem")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     pub fn from_pem(pem: &str) -> Result<(&str, Self)> {
         Document::from_pem(pem).map(|(label, doc)| (label, Self(doc)))
     }
 
     /// Encode ASN.1 DER document as a PEM string.
     #[cfg(feature = "pem")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     pub fn to_pem(
         &self,
         label: &'static str,
@@ -256,28 +245,24 @@ impl SecretDocument {
 
     /// Read ASN.1 DER document from a file.
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn read_der_file(path: impl AsRef<Path>) -> Result<Self> {
         Document::read_der_file(path).map(Self)
     }
 
     /// Write ASN.1 DER document to a file.
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn write_der_file(&self, path: impl AsRef<Path>) -> Result<()> {
         write_secret_file(path, self.as_bytes())
     }
 
     /// Read PEM-encoded ASN.1 DER document from a file.
     #[cfg(all(feature = "pem", feature = "std"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "pem", feature = "std"))))]
     pub fn read_pem_file(path: impl AsRef<Path>) -> Result<(String, Self)> {
         Document::read_pem_file(path).map(|(label, doc)| (label, Self(doc)))
     }
 
     /// Write PEM-encoded ASN.1 DER document to a file.
     #[cfg(all(feature = "pem", feature = "std"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "pem", feature = "std"))))]
     pub fn write_pem_file(
         &self,
         path: impl AsRef<Path>,

--- a/der/src/encode.rs
+++ b/der/src/encode.rs
@@ -37,7 +37,6 @@ pub trait Encode {
     /// Encode this message as ASN.1 DER, appending it to the provided
     /// byte vector.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     fn encode_to_vec(&self, buf: &mut Vec<u8>) -> Result<Length> {
         let expected_len = usize::try_from(self.encoded_len()?)?;
         buf.reserve(expected_len);
@@ -60,7 +59,6 @@ pub trait Encode {
 
     /// Serialize this message as a byte vector.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     fn to_vec(&self) -> Result<Vec<u8>> {
         let mut buf = Vec::new();
         self.encode_to_vec(&mut buf)?;
@@ -89,14 +87,12 @@ where
 /// This trait is automatically impl'd for any type which impls both
 /// [`Encode`] and [`PemLabel`].
 #[cfg(feature = "pem")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 pub trait EncodePem: Encode + PemLabel {
     /// Try to encode this type as PEM.
     fn to_pem(&self, line_ending: LineEnding) -> Result<String>;
 }
 
 #[cfg(feature = "pem")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl<T: Encode + PemLabel> EncodePem for T {
     fn to_pem(&self, line_ending: LineEnding) -> Result<String> {
         let der_len = usize::try_from(self.encoded_len()?)?;

--- a/der/src/error.rs
+++ b/der/src/error.rs
@@ -174,7 +174,6 @@ pub enum ErrorKind {
 
     /// File not found error.
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     FileNotFound,
 
     /// Message is incomplete and does not contain all of the expected data.
@@ -194,7 +193,6 @@ pub enum ErrorKind {
 
     /// I/O errors.
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     Io(std::io::ErrorKind),
 
     /// Indefinite length disallowed.
@@ -224,7 +222,6 @@ pub enum ErrorKind {
     /// to determine which OID(s) are causing the error (and then potentially
     /// contribute upstream support for algorithms they care about).
     #[cfg(feature = "oid")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "oid")))]
     OidUnknown {
         /// OID value that was unrecognized by a parser for a DER-based format.
         oid: ObjectIdentifier,
@@ -241,12 +238,10 @@ pub enum ErrorKind {
 
     /// PEM encoding errors.
     #[cfg(feature = "pem")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     Pem(pem::Error),
 
     /// Permission denied reading file.
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     PermissionDenied,
 
     /// Reader does not support the requested operation.

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
@@ -371,26 +371,21 @@ pub use crate::{
 pub use crate::{asn1::Any, document::Document};
 
 #[cfg(feature = "bigint")]
-#[cfg_attr(docsrs, doc(cfg(feature = "bigint")))]
 pub use crypto_bigint as bigint;
 
 #[cfg(feature = "derive")]
-#[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
 pub use der_derive::{Choice, Enumerated, Sequence, ValueOrd};
 
 #[cfg(feature = "oid")]
-#[cfg_attr(docsrs, doc(cfg(feature = "oid")))]
 pub use const_oid as oid;
 
 #[cfg(feature = "pem")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 pub use {
     crate::{decode::DecodePem, encode::EncodePem, reader::pem::PemReader, writer::pem::PemWriter},
     pem_rfc7468 as pem,
 };
 
 #[cfg(feature = "time")]
-#[cfg_attr(docsrs, doc(cfg(feature = "time")))]
 pub use time;
 
 #[cfg(feature = "zeroize")]

--- a/der/src/reader.rs
+++ b/der/src/reader.rs
@@ -135,7 +135,6 @@ pub trait Reader<'r>: Sized {
 
     /// Read a byte vector of the given length.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     fn read_vec(&mut self, len: Length) -> Result<Vec<u8>> {
         let mut bytes = vec![0u8; usize::try_from(len)?];
         self.read_into(&mut bytes)?;

--- a/der/src/reader/pem.rs
+++ b/der/src/reader/pem.rs
@@ -125,7 +125,6 @@ mod utils {
 
 /// `Reader` type which decodes PEM on-the-fly.
 #[cfg(feature = "pem")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 #[derive(Clone)]
 pub struct PemReader<'i> {
     /// Inner PEM decoder wrapped in a BufReader.
@@ -139,7 +138,6 @@ pub struct PemReader<'i> {
 }
 
 #[cfg(feature = "pem")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl<'i> PemReader<'i> {
     /// Create a new PEM reader which decodes data on-the-fly.
     ///
@@ -163,7 +161,6 @@ impl<'i> PemReader<'i> {
 }
 
 #[cfg(feature = "pem")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl<'i> Reader<'i> for PemReader<'i> {
     fn input_len(&self) -> Length {
         self.input_len

--- a/der/src/writer.rs
+++ b/der/src/writer.rs
@@ -21,7 +21,6 @@ pub trait Writer {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl<W: io::Write> Writer for W {
     fn write(&mut self, slice: &[u8]) -> Result<()> {
         <Self as io::Write>::write(self, slice)?;

--- a/der/src/writer/pem.rs
+++ b/der/src/writer/pem.rs
@@ -5,7 +5,6 @@ use crate::Result;
 use pem_rfc7468::{Encoder, LineEnding};
 
 /// `Writer` type which outputs PEM-encoded data.
-#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 pub struct PemWriter<'w>(Encoder<'static, 'w>);
 
 impl<'w> PemWriter<'w> {

--- a/pem-rfc7468/src/decoder.rs
+++ b/pem-rfc7468/src/decoder.rs
@@ -45,7 +45,6 @@ pub fn decode<'i, 'o>(pem: &'i [u8], buf: &'o mut [u8]) -> Result<(&'i str, &'o 
 /// Decode a PEM document according to RFC 7468's "Strict" grammar, returning
 /// the result as a [`Vec`] upon success.
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub fn decode_vec(pem: &[u8]) -> Result<(&str, Vec<u8>)> {
     let mut decoder = Decoder::new(pem).map_err(|e| check_for_headers(pem, e))?;
     let type_label = decoder.type_label();
@@ -107,7 +106,6 @@ impl<'i> Decoder<'i> {
 
     /// Decode all of the remaining data in the input buffer into `buf`.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn decode_to_end<'o>(&mut self, buf: &'o mut Vec<u8>) -> Result<&'o [u8]> {
         Ok(self.base64.decode_to_end(buf)?)
     }
@@ -130,7 +128,6 @@ impl<'i> From<Decoder<'i>> for Base64Decoder<'i> {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl<'i> io::Read for Decoder<'i> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.base64.read(buf)

--- a/pem-rfc7468/src/encoder.rs
+++ b/pem-rfc7468/src/encoder.rs
@@ -119,7 +119,6 @@ pub fn encode<'o>(
 /// Encode a PEM document according to RFC 7468's "Strict" grammar, returning
 /// the result as a [`String`].
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub fn encode_string(label: &str, line_ending: LineEnding, input: &[u8]) -> Result<String> {
     let expected_len = encoded_len(label, line_ending, input)?;
     let mut buf = vec![0u8; expected_len];
@@ -287,7 +286,6 @@ impl<'l, 'o> Encoder<'l, 'o> {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl<'l, 'o> io::Write for Encoder<'l, 'o> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.encode(buf)?;

--- a/pem-rfc7468/src/error.rs
+++ b/pem-rfc7468/src/error.rs
@@ -88,7 +88,6 @@ impl From<core::str::Utf8Error> for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl From<Error> for std::io::Error {
     fn from(err: Error) -> std::io::Error {
         let kind = match err {

--- a/pem-rfc7468/src/lib.rs
+++ b/pem-rfc7468/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",

--- a/pkcs1/src/lib.rs
+++ b/pkcs1/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
@@ -48,17 +48,14 @@ pub use crate::{
 };
 
 #[cfg(feature = "pem")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 pub use der::pem::{self, LineEnding};
 
 /// `rsaEncryption` Object Identifier (OID)
 #[cfg(feature = "pkcs8")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
 pub const ALGORITHM_OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.1");
 
 /// `AlgorithmIdentifier` for RSA.
 #[cfg(feature = "pkcs8")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
 pub const ALGORITHM_ID: pkcs8::AlgorithmIdentifierRef<'static> = pkcs8::AlgorithmIdentifierRef {
     oid: ALGORITHM_OID,
     parameters: Some(der::asn1::AnyRef::NULL),

--- a/pkcs1/src/private_key.rs
+++ b/pkcs1/src/private_key.rs
@@ -181,7 +181,6 @@ impl fmt::Debug for RsaPrivateKey<'_> {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl TryFrom<RsaPrivateKey<'_>> for SecretDocument {
     type Error = Error;
 
@@ -191,7 +190,6 @@ impl TryFrom<RsaPrivateKey<'_>> for SecretDocument {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl TryFrom<&RsaPrivateKey<'_>> for SecretDocument {
     type Error = Error;
 
@@ -201,7 +199,6 @@ impl TryFrom<&RsaPrivateKey<'_>> for SecretDocument {
 }
 
 #[cfg(feature = "pem")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl PemLabel for RsaPrivateKey<'_> {
     const PEM_LABEL: &'static str = "RSA PRIVATE KEY";
 }

--- a/pkcs1/src/private_key/other_prime_info.rs
+++ b/pkcs1/src/private_key/other_prime_info.rs
@@ -18,7 +18,6 @@ use der::{
 ///
 /// [RFC 8017 Appendix 1.2]: https://datatracker.ietf.org/doc/html/rfc8017#appendix-A.1.2
 #[derive(Clone)]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub struct OtherPrimeInfo<'a> {
     /// Prime factor `r_i` of `n`, where `i` >= 3.
     pub prime: UintRef<'a>,

--- a/pkcs1/src/public_key.rs
+++ b/pkcs1/src/public_key.rs
@@ -67,7 +67,6 @@ impl<'a> TryFrom<&'a [u8]> for RsaPublicKey<'a> {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl TryFrom<RsaPublicKey<'_>> for Document {
     type Error = Error;
 
@@ -77,7 +76,6 @@ impl TryFrom<RsaPublicKey<'_>> for Document {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl TryFrom<&RsaPublicKey<'_>> for Document {
     type Error = Error;
 
@@ -87,7 +85,6 @@ impl TryFrom<&RsaPublicKey<'_>> for Document {
 }
 
 #[cfg(feature = "pem")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl PemLabel for RsaPublicKey<'_> {
     const PEM_LABEL: &'static str = "RSA PUBLIC KEY";
 }

--- a/pkcs1/src/traits.rs
+++ b/pkcs1/src/traits.rs
@@ -41,7 +41,6 @@ pub trait DecodeRsaPrivateKey: Sized {
     /// -----BEGIN RSA PRIVATE KEY-----
     /// ```
     #[cfg(feature = "pem")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     fn from_pkcs1_pem(s: &str) -> Result<Self> {
         let (label, doc) = SecretDocument::from_pem(s)?;
         RsaPrivateKey::validate_pem_label(label)?;
@@ -51,15 +50,12 @@ pub trait DecodeRsaPrivateKey: Sized {
     /// Load PKCS#1 private key from an ASN.1 DER-encoded file on the local
     /// filesystem (binary format).
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn read_pkcs1_der_file(path: impl AsRef<Path>) -> Result<Self> {
         Self::from_pkcs1_der(SecretDocument::read_der_file(path)?.as_bytes())
     }
 
     /// Load PKCS#1 private key from a PEM-encoded file on the local filesystem.
     #[cfg(all(feature = "pem", feature = "std"))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn read_pkcs1_pem_file(path: impl AsRef<Path>) -> Result<Self> {
         let (label, doc) = SecretDocument::read_pem_file(path)?;
         RsaPrivateKey::validate_pem_label(&label)?;
@@ -81,7 +77,6 @@ pub trait DecodeRsaPublicKey: Sized {
     /// -----BEGIN RSA PUBLIC KEY-----
     /// ```
     #[cfg(feature = "pem")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     fn from_pkcs1_pem(s: &str) -> Result<Self> {
         let (label, doc) = Document::from_pem(s)?;
         RsaPublicKey::validate_pem_label(label)?;
@@ -91,7 +86,6 @@ pub trait DecodeRsaPublicKey: Sized {
     /// Load [`RsaPublicKey`] from an ASN.1 DER-encoded file on the local
     /// filesystem (binary format).
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn read_pkcs1_der_file(path: impl AsRef<Path>) -> Result<Self> {
         let doc = Document::read_der_file(path)?;
         Self::from_pkcs1_der(doc.as_bytes())
@@ -99,8 +93,6 @@ pub trait DecodeRsaPublicKey: Sized {
 
     /// Load [`RsaPublicKey`] from a PEM-encoded file on the local filesystem.
     #[cfg(all(feature = "pem", feature = "std"))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn read_pkcs1_pem_file(path: impl AsRef<Path>) -> Result<Self> {
         let (label, doc) = Document::read_pem_file(path)?;
         RsaPublicKey::validate_pem_label(&label)?;
@@ -110,14 +102,12 @@ pub trait DecodeRsaPublicKey: Sized {
 
 /// Serialize a [`RsaPrivateKey`] to a PKCS#1 encoded document.
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub trait EncodeRsaPrivateKey {
     /// Serialize a [`SecretDocument`] containing a PKCS#1-encoded private key.
     fn to_pkcs1_der(&self) -> Result<SecretDocument>;
 
     /// Serialize this private key as PEM-encoded PKCS#1 with the given [`LineEnding`].
     #[cfg(feature = "pem")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     fn to_pkcs1_pem(&self, line_ending: LineEnding) -> Result<Zeroizing<String>> {
         let doc = self.to_pkcs1_der()?;
         Ok(doc.to_pem(RsaPrivateKey::PEM_LABEL, line_ending)?)
@@ -125,14 +115,12 @@ pub trait EncodeRsaPrivateKey {
 
     /// Write ASN.1 DER-encoded PKCS#1 private key to the given path.
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn write_pkcs1_der_file(&self, path: impl AsRef<Path>) -> Result<()> {
         Ok(self.to_pkcs1_der()?.write_der_file(path)?)
     }
 
     /// Write ASN.1 DER-encoded PKCS#1 private key to the given path.
     #[cfg(all(feature = "pem", feature = "std"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "pem", feature = "std"))))]
     fn write_pkcs1_pem_file(&self, path: impl AsRef<Path>, line_ending: LineEnding) -> Result<()> {
         let doc = self.to_pkcs1_der()?;
         Ok(doc.write_pem_file(path, RsaPrivateKey::PEM_LABEL, line_ending)?)
@@ -141,14 +129,12 @@ pub trait EncodeRsaPrivateKey {
 
 /// Serialize a [`RsaPublicKey`] to a PKCS#1-encoded document.
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub trait EncodeRsaPublicKey {
     /// Serialize a [`Document`] containing a PKCS#1-encoded public key.
     fn to_pkcs1_der(&self) -> Result<Document>;
 
     /// Serialize this public key as PEM-encoded PKCS#1 with the given line ending.
     #[cfg(feature = "pem")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     fn to_pkcs1_pem(&self, line_ending: LineEnding) -> Result<String> {
         let doc = self.to_pkcs1_der()?;
         Ok(doc.to_pem(RsaPublicKey::PEM_LABEL, line_ending)?)
@@ -156,14 +142,12 @@ pub trait EncodeRsaPublicKey {
 
     /// Write ASN.1 DER-encoded public key to the given path.
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn write_pkcs1_der_file(&self, path: impl AsRef<Path>) -> Result<()> {
         Ok(self.to_pkcs1_der()?.write_der_file(path)?)
     }
 
     /// Write ASN.1 DER-encoded public key to the given path.
     #[cfg(all(feature = "pem", feature = "std"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "pem", feature = "std"))))]
     fn write_pkcs1_pem_file(&self, path: impl AsRef<Path>, line_ending: LineEnding) -> Result<()> {
         let doc = self.to_pkcs1_der()?;
         Ok(doc.write_pem_file(path, RsaPublicKey::PEM_LABEL, line_ending)?)
@@ -171,7 +155,6 @@ pub trait EncodeRsaPublicKey {
 }
 
 #[cfg(feature = "pkcs8")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
 impl<T> DecodeRsaPrivateKey for T
 where
     T: for<'a> TryFrom<pkcs8::PrivateKeyInfo<'a>, Error = pkcs8::Error>,
@@ -186,7 +169,6 @@ where
 }
 
 #[cfg(feature = "pkcs8")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
 impl<T: pkcs8::DecodePublicKey> DecodeRsaPublicKey for T
 where
     T: for<'a> TryFrom<pkcs8::SubjectPublicKeyInfoRef<'a>, Error = pkcs8::Error>,
@@ -200,7 +182,6 @@ where
 }
 
 #[cfg(all(feature = "alloc", feature = "pkcs8"))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "alloc", feature = "pkcs8"))))]
 impl<T: pkcs8::EncodePrivateKey> EncodeRsaPrivateKey for T {
     fn to_pkcs1_der(&self) -> Result<SecretDocument> {
         let pkcs8_doc = self.to_pkcs8_der()?;
@@ -211,7 +192,6 @@ impl<T: pkcs8::EncodePrivateKey> EncodeRsaPrivateKey for T {
 }
 
 #[cfg(all(feature = "alloc", feature = "pkcs8"))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "alloc", feature = "pkcs8"))))]
 impl<T: pkcs8::EncodePublicKey> EncodeRsaPublicKey for T {
     fn to_pkcs1_der(&self) -> Result<Document> {
         let doc = self.to_public_key_der()?;

--- a/pkcs12/src/lib.rs
+++ b/pkcs12/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",

--- a/pkcs5/src/lib.rs
+++ b/pkcs5/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
@@ -62,8 +62,6 @@ impl<'a> EncryptionScheme<'a> {
     /// Attempt to decrypt the given ciphertext, allocating and returning a
     /// byte vector containing the plaintext.
     #[cfg(all(feature = "alloc", feature = "pbes2"))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pbes2")))]
     pub fn decrypt(&self, password: impl AsRef<[u8]>, ciphertext: &[u8]) -> Result<Vec<u8>> {
         match self {
             Self::Pbes2(params) => params.decrypt(password, ciphertext),
@@ -78,7 +76,6 @@ impl<'a> EncryptionScheme<'a> {
     /// is unsupported, or if the ciphertext is malformed (e.g. not a multiple
     /// of a block mode's padding)
     #[cfg(feature = "pbes2")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pbes2")))]
     pub fn decrypt_in_place<'b>(
         &self,
         password: impl AsRef<[u8]>,
@@ -93,8 +90,6 @@ impl<'a> EncryptionScheme<'a> {
     /// Encrypt the given plaintext, allocating and returning a vector
     /// containing the ciphertext.
     #[cfg(all(feature = "alloc", feature = "pbes2"))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pbes2")))]
     pub fn encrypt(&self, password: impl AsRef<[u8]>, plaintext: &[u8]) -> Result<Vec<u8>> {
         match self {
             Self::Pbes2(params) => params.encrypt(password, plaintext),
@@ -105,7 +100,6 @@ impl<'a> EncryptionScheme<'a> {
     /// Encrypt the given ciphertext in-place using a key derived from the
     /// provided password and this scheme's parameters.
     #[cfg(feature = "pbes2")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pbes2")))]
     pub fn encrypt_in_place<'b>(
         &self,
         password: impl AsRef<[u8]>,

--- a/pkcs5/src/pbes2.rs
+++ b/pkcs5/src/pbes2.rs
@@ -38,12 +38,10 @@ pub const AES_256_CBC_OID: ObjectIdentifier =
 
 /// DES operating in CBC mode
 #[cfg(feature = "des-insecure")]
-#[cfg_attr(docsrs, doc(cfg(feature = "des-insecure")))]
 pub const DES_CBC_OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.14.3.2.7");
 
 /// Triple DES operating in CBC mode
 #[cfg(feature = "3des")]
-#[cfg_attr(docsrs, doc(cfg(feature = "3des")))]
 pub const DES_EDE3_CBC_OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549.3.7");
 
 /// Password-Based Encryption Scheme 2 (PBES2) OID.
@@ -107,7 +105,6 @@ impl<'a> Parameters<'a> {
     /// For more information on scrypt parameters, see documentation for the
     /// [`scrypt::Params`] struct.
     #[cfg(feature = "scrypt")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "scrypt")))]
     pub fn scrypt_aes128cbc(
         params: scrypt::Params,
         salt: &'a [u8],
@@ -127,7 +124,6 @@ impl<'a> Parameters<'a> {
     /// When in doubt, use `Default::default()` as the [`scrypt::Params`].
     /// This also avoids the need to import the type from the `scrypt` crate.
     #[cfg(feature = "scrypt")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "scrypt")))]
     pub fn scrypt_aes256cbc(
         params: scrypt::Params,
         salt: &'a [u8],
@@ -141,8 +137,6 @@ impl<'a> Parameters<'a> {
     /// Attempt to decrypt the given ciphertext, allocating and returning a
     /// byte vector containing the plaintext.
     #[cfg(all(feature = "alloc", feature = "pbes2"))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pbes2")))]
     pub fn decrypt(&self, password: impl AsRef<[u8]>, ciphertext: &[u8]) -> Result<Vec<u8>> {
         let mut buffer = ciphertext.to_vec();
         let pt_len = self.decrypt_in_place(password, &mut buffer)?.len();
@@ -157,7 +151,6 @@ impl<'a> Parameters<'a> {
     /// is unsupported, or if the ciphertext is malformed (e.g. not a multiple
     /// of a block mode's padding)
     #[cfg(feature = "pbes2")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pbes2")))]
     pub fn decrypt_in_place<'b>(
         &self,
         password: impl AsRef<[u8]>,
@@ -169,8 +162,6 @@ impl<'a> Parameters<'a> {
     /// Encrypt the given plaintext, allocating and returning a vector
     /// containing the ciphertext.
     #[cfg(all(feature = "alloc", feature = "pbes2"))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pbes2")))]
     pub fn encrypt(&self, password: impl AsRef<[u8]>, plaintext: &[u8]) -> Result<Vec<u8>> {
         // TODO(tarcieri): support non-AES ciphers?
         let mut buffer = Vec::with_capacity(plaintext.len() + AES_BLOCK_SIZE);
@@ -189,7 +180,6 @@ impl<'a> Parameters<'a> {
     /// provided password and this scheme's parameters, writing the ciphertext
     /// into the same buffer.
     #[cfg(feature = "pbes2")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pbes2")))]
     pub fn encrypt_in_place<'b>(
         &self,
         password: impl AsRef<[u8]>,

--- a/pkcs5/src/pbes2/kdf.rs
+++ b/pkcs5/src/pbes2/kdf.rs
@@ -401,7 +401,6 @@ impl<'a> ScryptParams<'a> {
     /// Get the [`ScryptParams`] for the provided upstream [`scrypt::Params`]
     /// and a provided salt string.
     #[cfg(feature = "scrypt")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "scrypt")))]
     pub fn from_params_and_salt(params: scrypt::Params, salt: &'a [u8]) -> Result<Self> {
         Ok(Self {
             salt,
@@ -457,7 +456,6 @@ impl<'a> TryFrom<AnyRef<'a>> for ScryptParams<'a> {
 }
 
 #[cfg(feature = "scrypt")]
-#[cfg_attr(docsrs, doc(cfg(feature = "scrypt")))]
 impl<'a> TryFrom<ScryptParams<'a>> for scrypt::Params {
     type Error = Error;
 
@@ -467,7 +465,6 @@ impl<'a> TryFrom<ScryptParams<'a>> for scrypt::Params {
 }
 
 #[cfg(feature = "scrypt")]
-#[cfg_attr(docsrs, doc(cfg(feature = "scrypt")))]
 impl<'a> TryFrom<&ScryptParams<'a>> for scrypt::Params {
     type Error = Error;
 

--- a/pkcs7/src/lib.rs
+++ b/pkcs7/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",

--- a/pkcs8/src/encrypted_private_key_info.rs
+++ b/pkcs8/src/encrypted_private_key_info.rs
@@ -39,7 +39,6 @@ use der::pem::PemLabel;
 /// ```
 ///
 /// [RFC 5208 Section 6]: https://tools.ietf.org/html/rfc5208#section-6
-#[cfg_attr(docsrs, doc(cfg(feature = "pkcs5")))]
 #[derive(Clone, Eq, PartialEq)]
 pub struct EncryptedPrivateKeyInfo<'a> {
     /// Algorithm identifier describing a password-based symmetric encryption
@@ -54,7 +53,6 @@ impl<'a> EncryptedPrivateKeyInfo<'a> {
     /// Attempt to decrypt this encrypted private key using the provided
     /// password to derive an encryption key.
     #[cfg(feature = "encryption")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "encryption")))]
     pub fn decrypt(&self, password: impl AsRef<[u8]>) -> Result<SecretDocument> {
         Ok(self
             .encryption_algorithm
@@ -65,7 +63,6 @@ impl<'a> EncryptedPrivateKeyInfo<'a> {
     /// Encrypt the given ASN.1 DER document using a symmetric encryption key
     /// derived from the provided password.
     #[cfg(feature = "encryption")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "encryption")))]
     pub(crate) fn encrypt(
         mut rng: impl CryptoRng + RngCore,
         password: impl AsRef<[u8]>,
@@ -84,7 +81,6 @@ impl<'a> EncryptedPrivateKeyInfo<'a> {
     /// Encrypt this private key using a symmetric encryption key derived
     /// from the provided password and [`pbes2::Parameters`].
     #[cfg(feature = "encryption")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "encryption")))]
     pub(crate) fn encrypt_with(
         pbes2_params: pbes2::Parameters<'a>,
         password: impl AsRef<[u8]>,
@@ -146,7 +142,6 @@ impl<'a> fmt::Debug for EncryptedPrivateKeyInfo<'a> {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "alloc", feature = "pkcs5"))))]
 impl TryFrom<EncryptedPrivateKeyInfo<'_>> for SecretDocument {
     type Error = Error;
 
@@ -156,7 +151,6 @@ impl TryFrom<EncryptedPrivateKeyInfo<'_>> for SecretDocument {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "alloc", feature = "pkcs5"))))]
 impl TryFrom<&EncryptedPrivateKeyInfo<'_>> for SecretDocument {
     type Error = Error;
 
@@ -166,7 +160,6 @@ impl TryFrom<&EncryptedPrivateKeyInfo<'_>> for SecretDocument {
 }
 
 #[cfg(feature = "pem")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl PemLabel for EncryptedPrivateKeyInfo<'_> {
     const PEM_LABEL: &'static str = "ENCRYPTED PRIVATE KEY";
 }

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
@@ -95,7 +95,6 @@ pub use spki::{
 };
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub use {
     crate::traits::EncodePrivateKey,
     der::{Document, SecretDocument},
@@ -103,11 +102,9 @@ pub use {
 };
 
 #[cfg(feature = "pem")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 pub use der::pem::LineEnding;
 
 #[cfg(feature = "pkcs5")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pkcs5")))]
 pub use {encrypted_private_key_info::EncryptedPrivateKeyInfo, pkcs5};
 
 #[cfg(feature = "rand_core")]

--- a/pkcs8/src/private_key_info.rs
+++ b/pkcs8/src/private_key_info.rs
@@ -135,7 +135,6 @@ impl<'a> PrivateKeyInfo<'a> {
     ///   - p: 1
     /// - Cipher: AES-256-CBC (best available option for PKCS#5 encryption)
     #[cfg(feature = "encryption")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "encryption")))]
     pub fn encrypt(
         &self,
         rng: impl CryptoRng + RngCore,
@@ -148,7 +147,6 @@ impl<'a> PrivateKeyInfo<'a> {
     /// Encrypt this private key using a symmetric encryption key derived
     /// from the provided password and [`pbes2::Parameters`].
     #[cfg(feature = "encryption")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "encryption")))]
     pub fn encrypt_with_params(
         &self,
         pbes2_params: pbes2::Parameters<'_>,
@@ -253,7 +251,6 @@ impl<'a> fmt::Debug for PrivateKeyInfo<'a> {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl TryFrom<PrivateKeyInfo<'_>> for SecretDocument {
     type Error = Error;
 
@@ -263,7 +260,6 @@ impl TryFrom<PrivateKeyInfo<'_>> for SecretDocument {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl TryFrom<&PrivateKeyInfo<'_>> for SecretDocument {
     type Error = Error;
 
@@ -273,13 +269,11 @@ impl TryFrom<&PrivateKeyInfo<'_>> for SecretDocument {
 }
 
 #[cfg(feature = "pem")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl PemLabel for PrivateKeyInfo<'_> {
     const PEM_LABEL: &'static str = "PRIVATE KEY";
 }
 
 #[cfg(feature = "subtle")]
-#[cfg_attr(docsrs, doc(cfg(feature = "subtle")))]
 impl<'a> ConstantTimeEq for PrivateKeyInfo<'a> {
     fn ct_eq(&self, other: &Self) -> Choice {
         // NOTE: public fields are not compared in constant time
@@ -291,11 +285,9 @@ impl<'a> ConstantTimeEq for PrivateKeyInfo<'a> {
 }
 
 #[cfg(feature = "subtle")]
-#[cfg_attr(docsrs, doc(cfg(feature = "subtle")))]
 impl<'a> Eq for PrivateKeyInfo<'a> {}
 
 #[cfg(feature = "subtle")]
-#[cfg_attr(docsrs, doc(cfg(feature = "subtle")))]
 impl<'a> PartialEq for PrivateKeyInfo<'a> {
     fn eq(&self, other: &Self) -> bool {
         self.ct_eq(other).into()

--- a/pkcs8/src/traits.rs
+++ b/pkcs8/src/traits.rs
@@ -29,7 +29,6 @@ pub trait DecodePrivateKey: Sized {
     /// Deserialize encrypted PKCS#8 private key from ASN.1 DER-encoded data
     /// (binary format) and attempt to decrypt it using the provided password.
     #[cfg(feature = "encryption")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "encryption")))]
     fn from_pkcs8_encrypted_der(bytes: &[u8], password: impl AsRef<[u8]>) -> Result<Self> {
         let doc = EncryptedPrivateKeyInfo::try_from(bytes)?.decrypt(password)?;
         Self::from_pkcs8_der(doc.as_bytes())
@@ -43,7 +42,6 @@ pub trait DecodePrivateKey: Sized {
     /// -----BEGIN PRIVATE KEY-----
     /// ```
     #[cfg(feature = "pem")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     fn from_pkcs8_pem(s: &str) -> Result<Self> {
         let (label, doc) = SecretDocument::from_pem(s)?;
         PrivateKeyInfo::validate_pem_label(label)?;
@@ -59,7 +57,6 @@ pub trait DecodePrivateKey: Sized {
     /// -----BEGIN ENCRYPTED PRIVATE KEY-----
     /// ```
     #[cfg(all(feature = "encryption", feature = "pem"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "encryption", feature = "pem"))))]
     fn from_pkcs8_encrypted_pem(s: &str, password: impl AsRef<[u8]>) -> Result<Self> {
         let (label, doc) = SecretDocument::from_pem(s)?;
         EncryptedPrivateKeyInfo::validate_pem_label(label)?;
@@ -69,15 +66,12 @@ pub trait DecodePrivateKey: Sized {
     /// Load PKCS#8 private key from an ASN.1 DER-encoded file on the local
     /// filesystem (binary format).
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn read_pkcs8_der_file(path: impl AsRef<Path>) -> Result<Self> {
         Self::from_pkcs8_der(SecretDocument::read_der_file(path)?.as_bytes())
     }
 
     /// Load PKCS#8 private key from a PEM-encoded file on the local filesystem.
     #[cfg(all(feature = "pem", feature = "std"))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn read_pkcs8_pem_file(path: impl AsRef<Path>) -> Result<Self> {
         let (label, doc) = SecretDocument::read_pem_file(path)?;
         PrivateKeyInfo::validate_pem_label(&label)?;
@@ -96,7 +90,6 @@ where
 
 /// Serialize a private key object to a PKCS#8 encoded document.
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub trait EncodePrivateKey {
     /// Serialize a [`SecretDocument`] containing a PKCS#8-encoded private key.
     fn to_pkcs8_der(&self) -> Result<SecretDocument>;
@@ -104,7 +97,6 @@ pub trait EncodePrivateKey {
     /// Create an [`SecretDocument`] containing the ciphertext of
     /// a PKCS#8 encoded private key encrypted under the given `password`.
     #[cfg(feature = "encryption")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "encryption")))]
     fn to_pkcs8_encrypted_der(
         &self,
         rng: impl CryptoRng + RngCore,
@@ -115,7 +107,6 @@ pub trait EncodePrivateKey {
 
     /// Serialize this private key as PEM-encoded PKCS#8 with the given [`LineEnding`].
     #[cfg(feature = "pem")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     fn to_pkcs8_pem(&self, line_ending: LineEnding) -> Result<Zeroizing<String>> {
         let doc = self.to_pkcs8_der()?;
         Ok(doc.to_pem(PrivateKeyInfo::PEM_LABEL, line_ending)?)
@@ -124,7 +115,6 @@ pub trait EncodePrivateKey {
     /// Serialize this private key as an encrypted PEM-encoded PKCS#8 private
     /// key using the `provided` to derive an encryption key.
     #[cfg(all(feature = "encryption", feature = "pem"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "encryption", feature = "pem"))))]
     fn to_pkcs8_encrypted_pem(
         &self,
         rng: impl CryptoRng + RngCore,
@@ -137,14 +127,12 @@ pub trait EncodePrivateKey {
 
     /// Write ASN.1 DER-encoded PKCS#8 private key to the given path
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn write_pkcs8_der_file(&self, path: impl AsRef<Path>) -> Result<()> {
         Ok(self.to_pkcs8_der()?.write_der_file(path)?)
     }
 
     /// Write ASN.1 DER-encoded PKCS#8 private key to the given path
     #[cfg(all(feature = "pem", feature = "std"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "pem", feature = "std"))))]
     fn write_pkcs8_pem_file(&self, path: impl AsRef<Path>, line_ending: LineEnding) -> Result<()> {
         let doc = self.to_pkcs8_der()?;
         Ok(doc.write_pem_file(path, PrivateKeyInfo::PEM_LABEL, line_ending)?)

--- a/sec1/src/error.rs
+++ b/sec1/src/error.rs
@@ -14,7 +14,6 @@ pub type Result<T> = core::result::Result<T, Error>;
 pub enum Error {
     /// ASN.1 DER-related errors.
     #[cfg(feature = "der")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "der")))]
     Asn1(der::Error),
 
     /// Cryptographic errors.
@@ -52,7 +51,6 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "der")]
-#[cfg_attr(docsrs, doc(cfg(feature = "der")))]
 impl From<der::Error> for Error {
     fn from(err: der::Error) -> Error {
         Error::Asn1(err)

--- a/sec1/src/lib.rs
+++ b/sec1/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
@@ -58,11 +58,9 @@ pub use crate::{parameters::EcParameters, private_key::EcPrivateKey, traits::Dec
 pub use crate::traits::EncodeEcPrivateKey;
 
 #[cfg(feature = "pem")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 pub use der::pem::{self, LineEnding};
 
 #[cfg(feature = "pkcs8")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
 pub use pkcs8;
 
 #[cfg(feature = "pkcs8")]
@@ -76,5 +74,4 @@ use serdect::serde;
 ///
 /// <http://oid-info.com/get/1.2.840.10045.2.1>
 #[cfg(feature = "pkcs8")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
 pub const ALGORITHM_OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.10045.2.1");

--- a/sec1/src/parameters.rs
+++ b/sec1/src/parameters.rs
@@ -18,7 +18,6 @@ use der::{
 ///   -- with ANSI X9.
 /// ```
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(docsrs, doc(cfg(feature = "der")))]
 pub enum EcParameters {
     /// Elliptic curve named by a particular OID.
     ///

--- a/sec1/src/point.rs
+++ b/sec1/src/point.rs
@@ -157,7 +157,6 @@ where
 
     /// Get boxed byte slice containing the serialized [`EncodedPoint`]
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn to_bytes(&self) -> Box<[u8]> {
         self.as_bytes().to_vec().into_boxed_slice()
     }
@@ -381,7 +380,6 @@ where
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<Size> Serialize for EncodedPoint<Size>
 where
     Size: ModulusSize,
@@ -395,7 +393,6 @@ where
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de, Size> Deserialize<'de> for EncodedPoint<Size>
 where
     Size: ModulusSize,

--- a/sec1/src/private_key.rs
+++ b/sec1/src/private_key.rs
@@ -59,7 +59,6 @@ const PUBLIC_KEY_TAG: TagNumber = TagNumber::new(1);
 /// [SEC1: Elliptic Curve Cryptography (Version 2.0)]: https://www.secg.org/sec1-v2.pdf
 /// [RFC5915 Section 3]: https://datatracker.ietf.org/doc/html/rfc5915#section-3
 #[derive(Clone)]
-#[cfg_attr(docsrs, doc(cfg(feature = "der")))]
 pub struct EcPrivateKey<'a> {
     /// Private key data.
     pub private_key: &'a [u8],
@@ -153,7 +152,6 @@ impl<'a> fmt::Debug for EcPrivateKey<'a> {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl TryFrom<EcPrivateKey<'_>> for SecretDocument {
     type Error = Error;
 
@@ -163,7 +161,6 @@ impl TryFrom<EcPrivateKey<'_>> for SecretDocument {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl TryFrom<&EcPrivateKey<'_>> for SecretDocument {
     type Error = Error;
 
@@ -173,7 +170,6 @@ impl TryFrom<&EcPrivateKey<'_>> for SecretDocument {
 }
 
 #[cfg(feature = "pem")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl PemLabel for EcPrivateKey<'_> {
     const PEM_LABEL: &'static str = "EC PRIVATE KEY";
 }

--- a/sec1/src/traits.rs
+++ b/sec1/src/traits.rs
@@ -21,7 +21,6 @@ use std::path::Path;
 use zeroize::Zeroizing;
 
 /// Parse an [`EcPrivateKey`] from a SEC1-encoded document.
-#[cfg_attr(docsrs, doc(cfg(feature = "der")))]
 pub trait DecodeEcPrivateKey: Sized {
     /// Deserialize SEC1 private key from ASN.1 DER-encoded data
     /// (binary format).
@@ -35,7 +34,6 @@ pub trait DecodeEcPrivateKey: Sized {
     /// -----BEGIN EC PRIVATE KEY-----
     /// ```
     #[cfg(feature = "pem")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     fn from_sec1_pem(s: &str) -> Result<Self> {
         let (label, doc) = SecretDocument::from_pem(s)?;
         EcPrivateKey::validate_pem_label(label)?;
@@ -45,15 +43,12 @@ pub trait DecodeEcPrivateKey: Sized {
     /// Load SEC1 private key from an ASN.1 DER-encoded file on the local
     /// filesystem (binary format).
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn read_sec1_der_file(path: impl AsRef<Path>) -> Result<Self> {
         Self::from_sec1_der(SecretDocument::read_der_file(path)?.as_bytes())
     }
 
     /// Load SEC1 private key from a PEM-encoded file on the local filesystem.
     #[cfg(all(feature = "pem", feature = "std"))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn read_sec1_pem_file(path: impl AsRef<Path>) -> Result<Self> {
         let (label, doc) = SecretDocument::read_pem_file(path)?;
         EcPrivateKey::validate_pem_label(&label)?;
@@ -63,7 +58,6 @@ pub trait DecodeEcPrivateKey: Sized {
 
 /// Serialize a [`EcPrivateKey`] to a SEC1 encoded document.
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "alloc", feature = "der"))))]
 pub trait EncodeEcPrivateKey {
     /// Serialize a [`SecretDocument`] containing a SEC1-encoded private key.
     fn to_sec1_der(&self) -> Result<SecretDocument>;
@@ -72,7 +66,6 @@ pub trait EncodeEcPrivateKey {
     ///
     /// To use the OS's native line endings, pass `Default::default()`.
     #[cfg(feature = "pem")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     fn to_sec1_pem(&self, line_ending: LineEnding) -> Result<Zeroizing<String>> {
         let doc = self.to_sec1_der()?;
         Ok(doc.to_pem(EcPrivateKey::PEM_LABEL, line_ending)?)
@@ -80,15 +73,12 @@ pub trait EncodeEcPrivateKey {
 
     /// Write ASN.1 DER-encoded SEC1 private key to the given path.
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn write_sec1_der_file(&self, path: impl AsRef<Path>) -> Result<()> {
         Ok(self.to_sec1_der()?.write_der_file(path)?)
     }
 
     /// Write ASN.1 DER-encoded SEC1 private key to the given path.
     #[cfg(all(feature = "pem", feature = "std"))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn write_sec1_pem_file(&self, path: impl AsRef<Path>, line_ending: LineEnding) -> Result<()> {
         let doc = self.to_sec1_der()?;
         Ok(doc.write_pem_file(path, EcPrivateKey::PEM_LABEL, line_ending)?)
@@ -96,7 +86,6 @@ pub trait EncodeEcPrivateKey {
 }
 
 #[cfg(feature = "pkcs8")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
 impl<T> DecodeEcPrivateKey for T
 where
     T: for<'a> TryFrom<pkcs8::PrivateKeyInfo<'a>, Error = pkcs8::Error>,
@@ -120,7 +109,6 @@ where
 }
 
 #[cfg(all(feature = "alloc", feature = "pkcs8"))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "alloc", feature = "pkcs8"))))]
 impl<T: pkcs8::EncodePrivateKey> EncodeEcPrivateKey for T {
     fn to_sec1_der(&self) -> Result<SecretDocument> {
         let doc = self.to_pkcs8_der()?;

--- a/serdect/src/array.rs
+++ b/serdect/src/array.rs
@@ -178,7 +178,6 @@ impl<'de, const N: usize, const UPPERCASE: bool> Deserialize<'de> for HexOrBin<N
 }
 
 #[cfg(feature = "zeroize")]
-#[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
 impl<const N: usize, const UPPERCASE: bool> Zeroize for HexOrBin<N, UPPERCASE> {
     fn zeroize(&mut self) {
         self.0.as_mut_slice().zeroize();

--- a/serdect/src/lib.rs
+++ b/serdect/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",

--- a/serdect/src/slice.rs
+++ b/serdect/src/slice.rs
@@ -123,7 +123,6 @@ where
 /// Deserialize from hex when using human-readable formats or binary if the
 /// format is binary.
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub fn deserialize_hex_or_bin_vec<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
 where
     D: Deserializer<'de>,
@@ -154,24 +153,20 @@ where
 
 /// [`HexOrBin`] serializer which uses lower case.
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub type HexLowerOrBin = HexOrBin<false>;
 
 /// [`HexOrBin`] serializer which uses upper case.
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub type HexUpperOrBin = HexOrBin<true>;
 
 /// Serializer/deserializer newtype which encodes bytes as either binary or hex.
 ///
 /// Use hexadecimal with human-readable formats, or raw binary with binary formats.
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[derive(Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct HexOrBin<const UPPERCASE: bool>(pub Vec<u8>);
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<const UPPERCASE: bool> AsRef<[u8]> for HexOrBin<UPPERCASE> {
     fn as_ref(&self) -> &[u8] {
         self.0.as_ref()
@@ -179,7 +174,6 @@ impl<const UPPERCASE: bool> AsRef<[u8]> for HexOrBin<UPPERCASE> {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<const UPPERCASE: bool> From<&[u8]> for HexOrBin<UPPERCASE> {
     fn from(bytes: &[u8]) -> HexOrBin<UPPERCASE> {
         Self(bytes.into())
@@ -187,7 +181,6 @@ impl<const UPPERCASE: bool> From<&[u8]> for HexOrBin<UPPERCASE> {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<const UPPERCASE: bool> From<Vec<u8>> for HexOrBin<UPPERCASE> {
     fn from(vec: Vec<u8>) -> HexOrBin<UPPERCASE> {
         Self(vec)
@@ -195,7 +188,6 @@ impl<const UPPERCASE: bool> From<Vec<u8>> for HexOrBin<UPPERCASE> {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<const UPPERCASE: bool> From<HexOrBin<UPPERCASE>> for Vec<u8> {
     fn from(vec: HexOrBin<UPPERCASE>) -> Vec<u8> {
         vec.0
@@ -203,7 +195,6 @@ impl<const UPPERCASE: bool> From<HexOrBin<UPPERCASE>> for Vec<u8> {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<const UPPERCASE: bool> Serialize for HexOrBin<UPPERCASE> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -218,7 +209,6 @@ impl<const UPPERCASE: bool> Serialize for HexOrBin<UPPERCASE> {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<'de, const UPPERCASE: bool> Deserialize<'de> for HexOrBin<UPPERCASE> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -229,7 +219,6 @@ impl<'de, const UPPERCASE: bool> Deserialize<'de> for HexOrBin<UPPERCASE> {
 }
 
 #[cfg(all(feature = "alloc", feature = "zeroize"))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "alloc", feature = "zeroize"))))]
 impl<const UPPERCASE: bool> Zeroize for HexOrBin<UPPERCASE> {
     fn zeroize(&mut self) {
         self.0.as_mut_slice().zeroize();

--- a/spki/src/fingerprint.rs
+++ b/spki/src/fingerprint.rs
@@ -12,7 +12,6 @@ pub(crate) const SIZE: usize = 32;
 /// See [RFC7469 § 2.1.1] for more information.
 ///
 /// [RFC7469 § 2.1.1]: https://datatracker.ietf.org/doc/html/rfc7469#section-2.1.1
-#[cfg_attr(docsrs, doc(cfg(feature = "fingerprint")))]
 pub type FingerprintBytes = [u8; SIZE];
 
 /// Writer newtype which accepts DER being serialized on-the-fly and computes a

--- a/spki/src/lib.rs
+++ b/spki/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",

--- a/spki/src/spki.rs
+++ b/spki/src/spki.rs
@@ -63,10 +63,6 @@ where
     ///
     /// [RFC7469 § 2.1.1]: https://datatracker.ietf.org/doc/html/rfc7469#section-2.1.1
     #[cfg(all(feature = "fingerprint", feature = "alloc", feature = "base64ct"))]
-    #[cfg_attr(
-        docsrs,
-        doc(cfg(all(feature = "fingerprint", feature = "alloc", feature = "base64ct")))
-    )]
     pub fn fingerprint_base64(&self) -> Result<alloc::string::String> {
         use base64ct::{Base64, Encoding};
         Ok(Base64::encode_string(&self.fingerprint_bytes()?))
@@ -79,7 +75,6 @@ where
     ///
     /// [RFC7469 § 2.1.1]: https://datatracker.ietf.org/doc/html/rfc7469#section-2.1.1
     #[cfg(feature = "fingerprint")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "fingerprint")))]
     pub fn fingerprint_bytes(&self) -> Result<FingerprintBytes> {
         let mut builder = fingerprint::Builder::new();
         self.encode(&mut builder)?;
@@ -151,7 +146,6 @@ where
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<'a: 'k, 'k, Params, Key: 'k> TryFrom<SubjectPublicKeyInfo<Params, Key>> for Document
 where
     Params: Choice<'a> + Encode,
@@ -166,7 +160,6 @@ where
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<'a: 'k, 'k, Params, Key: 'k> TryFrom<&SubjectPublicKeyInfo<Params, Key>> for Document
 where
     Params: Choice<'a> + Encode,
@@ -181,7 +174,6 @@ where
 }
 
 #[cfg(feature = "pem")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl<Params, Key> PemLabel for SubjectPublicKeyInfo<Params, Key> {
     const PEM_LABEL: &'static str = "PUBLIC KEY";
 }

--- a/spki/src/traits.rs
+++ b/spki/src/traits.rs
@@ -31,7 +31,6 @@ pub trait DecodePublicKey: Sized {
     /// -----BEGIN PUBLIC KEY-----
     /// ```
     #[cfg(feature = "pem")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     fn from_public_key_pem(s: &str) -> Result<Self> {
         let (label, doc) = Document::from_pem(s)?;
         SubjectPublicKeyInfoRef::validate_pem_label(label)?;
@@ -41,7 +40,6 @@ pub trait DecodePublicKey: Sized {
     /// Load public key object from an ASN.1 DER-encoded file on the local
     /// filesystem (binary format).
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn read_public_key_der_file(path: impl AsRef<Path>) -> Result<Self> {
         let doc = Document::read_der_file(path)?;
         Self::from_public_key_der(doc.as_bytes())
@@ -49,7 +47,6 @@ pub trait DecodePublicKey: Sized {
 
     /// Load public key object from a PEM-encoded file on the local filesystem.
     #[cfg(all(feature = "pem", feature = "std"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "pem", feature = "std"))))]
     fn read_public_key_pem_file(path: impl AsRef<Path>) -> Result<Self> {
         let (label, doc) = Document::read_pem_file(path)?;
         SubjectPublicKeyInfoRef::validate_pem_label(&label)?;
@@ -68,14 +65,12 @@ where
 
 /// Serialize a public key object to a SPKI-encoded document.
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub trait EncodePublicKey {
     /// Serialize a [`Document`] containing a SPKI-encoded public key.
     fn to_public_key_der(&self) -> Result<Document>;
 
     /// Serialize this public key as PEM-encoded SPKI with the given [`LineEnding`].
     #[cfg(feature = "pem")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     fn to_public_key_pem(&self, line_ending: LineEnding) -> Result<String> {
         let doc = self.to_public_key_der()?;
         Ok(doc.to_pem(SubjectPublicKeyInfoRef::PEM_LABEL, line_ending)?)
@@ -83,14 +78,12 @@ pub trait EncodePublicKey {
 
     /// Write ASN.1 DER-encoded public key to the given path
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn write_public_key_der_file(&self, path: impl AsRef<Path>) -> Result<()> {
         Ok(self.to_public_key_der()?.write_der_file(path)?)
     }
 
     /// Write ASN.1 DER-encoded public key to the given path
     #[cfg(all(feature = "pem", feature = "std"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "pem", feature = "std"))))]
     fn write_public_key_pem_file(
         &self,
         path: impl AsRef<Path>,

--- a/tls_codec/src/lib.rs
+++ b/tls_codec/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![warn(
     clippy::mod_module_files,
@@ -91,7 +91,6 @@ impl Display for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl From<std::io::Error> for Error {
     fn from(e: std::io::Error) -> Self {
         match e.kind() {
@@ -118,12 +117,10 @@ pub trait Serialize: Size {
     /// Serialize `self` and write it to the `writer`.
     /// The function returns the number of bytes written to `writer`.
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, Error>;
 
     /// Serialize `self` and return it as a byte vector.
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn tls_serialize_detached(&self) -> Result<Vec<u8>, Error> {
         let mut buffer = Vec::with_capacity(self.tls_serialized_len());
         let written = self.tls_serialize(&mut buffer)?;
@@ -154,7 +151,6 @@ pub trait Deserialize: Size {
     ///
     /// In order to get the amount of bytes read, use [`Size::tls_serialized_len`].
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn tls_deserialize<R: Read>(bytes: &mut R) -> Result<Self, Error>
     where
         Self: Sized;

--- a/x509-cert/src/certificate.rs
+++ b/x509-cert/src/certificate.rs
@@ -1,11 +1,9 @@
 //! Certificate types
 
 use crate::{name::Name, serial_number::SerialNumber, time::Validity};
-
 use alloc::vec::Vec;
-use core::cmp::Ordering;
-
 use const_oid::AssociatedOid;
+use core::cmp::Ordering;
 use der::asn1::BitString;
 use der::{Decode, Enumerated, Error, ErrorKind, Sequence, ValueOrd};
 use spki::{AlgorithmIdentifierOwned, SubjectPublicKeyInfoOwned};
@@ -155,7 +153,6 @@ pub struct Certificate {
 }
 
 #[cfg(feature = "pem")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl PemLabel for Certificate {
     const PEM_LABEL: &'static str = "CERTIFICATE";
 }

--- a/x509-cert/src/lib.rs
+++ b/x509-cert/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",

--- a/x509-cert/src/request.rs
+++ b/x509-cert/src/request.rs
@@ -77,7 +77,6 @@ pub struct CertReq {
 }
 
 #[cfg(feature = "pem")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl PemLabel for CertReq {
     const PEM_LABEL: &'static str = "CERTIFICATE REQUEST";
 }

--- a/x509-cert/src/time.rs
+++ b/x509-cert/src/time.rs
@@ -52,7 +52,6 @@ impl Time {
 
     /// Convert to [`SystemTime`].
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn to_system_time(&self) -> SystemTime {
         match self {
             Time::UtcTime(t) => t.to_system_time(),
@@ -80,7 +79,6 @@ impl From<GeneralizedTime> for Time {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl From<Time> for SystemTime {
     fn from(time: Time) -> SystemTime {
         time.to_system_time()
@@ -88,7 +86,6 @@ impl From<Time> for SystemTime {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl From<&Time> for SystemTime {
     fn from(time: &Time) -> SystemTime {
         time.to_system_time()
@@ -96,7 +93,6 @@ impl From<&Time> for SystemTime {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl TryFrom<SystemTime> for Time {
     type Error = der::Error;
 
@@ -127,7 +123,6 @@ pub struct Validity {
 impl Validity {
     /// Creates a `Validity` which starts now and lasts for `duration`.
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn from_now(duration: Duration) -> der::Result<Self> {
         let now = SystemTime::now();
         let then = now + duration;


### PR DESCRIPTION
Removes all manual `doc(cfg(...))` annotations, populating them automatically instead using `feature(doc_auto_cfg)`.

As this feature is still unstable, it's still gated on the `docsrs` cfg attributes.