### PR TITLE
base32ct v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ checksum = "23ce669cd6c8588f79e15cf450314f9638f967fc5770ff1c7c1deb0925ea7cfa"
 
 [[package]]
 name = "base32ct"
-version = "0.2.0-pre"
+version = "0.2.0"
 dependencies = [
  "base32",
  "proptest",

--- a/base32ct/CHANGELOG.md
+++ b/base32ct/CHANGELOG.md
@@ -4,5 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2023-02-26)
+### Changed
+- MSRV 1.60 ([#802])
+- Lint improvements ([#824])
+
+[#802]: https://github.com/RustCrypto/formats/pull/802
+[#824]: https://github.com/RustCrypto/formats/pull/824
+
 ## 0.1.0 (2022-06-12)
 - Initial release

--- a/base32ct/Cargo.toml
+++ b/base32ct/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base32ct"
-version = "0.2.0-pre"
+version = "0.2.0"
 description = """
 Pure Rust implementation of Base32 (RFC 4648) which avoids any usages of
 data-dependent branches/LUTs and thereby provides portable "best effort"


### PR DESCRIPTION
### Changed
- MSRV 1.60 ([#802])
- Lint improvements ([#824])

[#802]: https://github.com/RustCrypto/formats/pull/802
[#824]: https://github.com/RustCrypto/formats/pull/824