### PR TITLE
base64ct v1.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,13 +74,13 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "base64ct"
-version = "1.6.0-pre"
+version = "1.6.0"
 dependencies = [
  "base64",
  "proptest",

--- a/base64ct/CHANGELOG.md
+++ b/base64ct/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.6.0 (2023-02-26)
+### Changed
+- MSRV 1.60 ([#802])
+- Lint improvements ([#824])
+
+[#802]: https://github.com/RustCrypto/formats/pull/802
+[#824]: https://github.com/RustCrypto/formats/pull/824
+
 ## 1.5.3 (2022-10-18)
 ### Added
 - `Base64ShaCrypt` alphabet ([#742])

--- a/base64ct/Cargo.toml
+++ b/base64ct/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base64ct"
-version = "1.6.0-pre"
+version = "1.6.0"
 description = """
 Pure Rust implementation of Base64 (RFC 4648) which avoids any usages of
 data-dependent branches/LUTs and thereby provides portable "best effort"
@@ -17,7 +17,7 @@ edition = "2021"
 rust-version = "1.60"
 
 [dev-dependencies]
-base64 = "0.13"
+base64 = "0.21"
 proptest = "1"
 
 [features]

--- a/base64ct/tests/proptests.rs
+++ b/base64ct/tests/proptests.rs
@@ -1,6 +1,9 @@
 //! Equivalence tests between `base64` crate and `base64ct`.
 
 #![cfg(feature = "std")]
+// TODO(tarcieri): fix `base64` crate deprecations
+// warning: use of deprecated function `base64::encode`: Use Engine::encode
+#![allow(deprecated)]
 
 use base64ct::{Base64 as Base64ct, Encoding};
 use proptest::{prelude::*, string::*};

--- a/pem-rfc7468/Cargo.toml
+++ b/pem-rfc7468/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2021"
 rust-version = "1.60"
 
 [dependencies]
-base64ct = { version = "=1.6.0-pre", path = "../base64ct" }
+base64ct = { version = "1.4", path = "../base64ct" }
 
 [features]
 alloc = ["base64ct/alloc"]

--- a/spki/Cargo.toml
+++ b/spki/Cargo.toml
@@ -19,7 +19,7 @@ der = { version = "=0.7.0-pre", features = ["oid"], path = "../der" }
 
 # Optional dependencies
 arbitrary = { version = "1.2.3", features = ["derive"], optional = true }
-base64ct = { version = "=1.6.0-pre", path = "../base64ct", optional = true, default-features = false }
+base64ct = { version = "1", path = "../base64ct", optional = true, default-features = false }
 sha2 = { version = "0.10", optional = true, default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
### Changed
- MSRV 1.60 ([#802])
- Lint improvements ([#824])

[#802]: https://github.com/RustCrypto/formats/pull/802
[#824]: https://github.com/RustCrypto/formats/pull/824