### PR TITLE
serdect v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1202,7 +1202,7 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "base16ct",
  "der",
@@ -1273,7 +1273,7 @@ dependencies = [
 
 [[package]]
 name = "serdect"
-version = "0.2.0-pre"
+version = "0.2.0"
 dependencies = [
  "base16ct",
  "bincode",

--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sec1"
-version = "0.4.0-pre"
+version = "0.4.0"
 description = """
 Pure Rust implementation of SEC1: Elliptic Curve Cryptography encoding formats
 including ASN.1 DER-serialized private keys as well as the
@@ -20,7 +20,7 @@ base16ct = { version = "0.2", optional = true, default-features = false, path = 
 der = { version = "=0.7.0-pre", optional = true, features = ["oid"], path = "../der" }
 generic-array = { version = "0.14.6", optional = true, default-features = false }
 pkcs8 = { version = "=0.10.0-pre", optional = true, default-features = false, path = "../pkcs8" }
-serdect = { version = "=0.2.0-pre", optional = true, default-features = false, features = ["alloc"], path = "../serdect" }
+serdect = { version = "0.2", optional = true, default-features = false, features = ["alloc"], path = "../serdect" }
 subtle = { version = "2", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 

--- a/serdect/CHANGELOG.md
+++ b/serdect/CHANGELOG.md
@@ -4,5 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2023-02-26)
+### Changed
+- MSRV 1.60 ([#802])
+- Lint improvements ([#824])
+- Bump `base16ct` dependency to v0.2 ([#890])
+
+### Fixed
+- TOML test ([#864])
+
+[#802]: https://github.com/RustCrypto/formats/pull/802
+[#824]: https://github.com/RustCrypto/formats/pull/824
+[#864]: https://github.com/RustCrypto/formats/pull/864
+[#890]: https://github.com/RustCrypto/formats/pull/890
+
 ## 0.1.0 (2022-03-29)
 - Initial release

--- a/serdect/Cargo.toml
+++ b/serdect/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Constant-time serde serializer/deserializer helpers for data that potentially
 contains secrets (e.g. cryptographic keys)
 """
-version = "0.2.0-pre"
+version = "0.2.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/formats/tree/master/serdect"


### PR DESCRIPTION
### Changed
- MSRV 1.60 ([#802])
- Lint improvements ([#824])
- Bump `base16ct` dependency to v0.2 ([#890])

### Fixed
- TOML test ([#864])

[#802]: https://github.com/RustCrypto/formats/pull/802
[#824]: https://github.com/RustCrypto/formats/pull/824
[#864]: https://github.com/RustCrypto/formats/pull/864
[#890]: https://github.com/RustCrypto/formats/pull/890