### PR TITLE
pem-rfc7468 v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.7.0-pre"
+version = "0.7.0"
 dependencies = [
  "base64ct",
 ]

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -20,7 +20,7 @@ arbitrary = { version = "1.2.3", features = ["derive"], optional = true }
 const-oid = { version = "=0.10.0-pre", optional = true, path = "../const-oid" }
 der_derive = { version = "=0.7.0-pre", optional = true, path = "derive" }
 flagset = { version = "0.4.3", optional = true }
-pem-rfc7468 = { version = "=0.7.0-pre", optional = true, path = "../pem-rfc7468" }
+pem-rfc7468 = { version = "0.7", optional = true, path = "../pem-rfc7468" }
 time = { version = "0.3.4", optional = true, default-features = false }
 zeroize = { version = "1.5", optional = true, default-features = false, features = ["alloc"] }
 

--- a/pem-rfc7468/CHANGELOG.md
+++ b/pem-rfc7468/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 (2023-02-26)
+### Changed
+- MSRV 1.60 ([#802])
+- Lint improvements ([#824])
+
+[#802]: https://github.com/RustCrypto/formats/pull/802
+[#824]: https://github.com/RustCrypto/formats/pull/824
+
 ## 0.6.0 (2022-04-26)
 ### Added
 - `encapsulated_len_wrapped` ([#619])

--- a/pem-rfc7468/Cargo.toml
+++ b/pem-rfc7468/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pem-rfc7468"
-version = "0.7.0-pre"
+version = "0.7.0"
 description = """
 PEM Encoding (RFC 7468) for PKIX, PKCS, and CMS Structures, implementing a
 strict subset of the original Privacy-Enhanced Mail encoding intended


### PR DESCRIPTION
### Changed
- MSRV 1.60 ([#802])
- Lint improvements ([#824])

[#802]: https://github.com/RustCrypto/formats/pull/802
[#824]: https://github.com/RustCrypto/formats/pull/824