### PR TITLE
const-oid v0.9.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "arbitrary"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e90af4de65aa7b293ef2d09daff88501eb254f58edde2e1ac02c82d873eadad"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -218,8 +227,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
+ "arbitrary",
  "hex-literal",
 ]
 
@@ -342,6 +352,17 @@ name = "der_derive"
 version = "0.6.0"
 dependencies = [
  "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8beee4701e2e229e8098bbdecdca12449bc3e322f137d269182fa1291e20bd00"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn",

--- a/const-oid/Cargo.toml
+++ b/const-oid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "const-oid"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """
@@ -15,6 +15,9 @@ keywords = ["iso", "iec", "itu", "oid"]
 readme = "README.md"
 edition = "2021"
 rust-version = "1.57"
+
+[dependencies]
+arbitrary = { version = "1.2", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 hex-literal = "0.3"


### PR DESCRIPTION
Backport release which includes changes from #761, which add optional support for the `arbitrary` crate as a feature.

Since `master` is already on v0.10.0-pre this will not be merged, but is being pushed up for historical record keeping purposes.