### PR TITLE
Downgrade `const-oid` to v0.9

### DIFF
--- a/.github/workflows/const-oid.yml
+++ b/.github/workflows/const-oid.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.60.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -48,7 +48,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.60.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/crmf.yml
+++ b/.github/workflows/crmf.yml
@@ -39,7 +39,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
       - uses: RustCrypto/actions/cargo-hack-install@master
-      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features std,arbitrary
+      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features arbitrary,default,std
 
 # FIXME: Temporary disabled until https://github.com/rust-fuzz/arbitrary/issues/136 is fixed
 #  minimal-versions:

--- a/.github/workflows/x509-cert.yml
+++ b/.github/workflows/x509-cert.yml
@@ -38,7 +38,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
       - uses: RustCrypto/actions/cargo-hack-install@master
-      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features std,arbitrary
+      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features arbitrary,default,std
 
 # FIXME: Temporary disabled until https://github.com/rust-fuzz/arbitrary/issues/136 is fixed
 #  minimal-versions:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,10 +244,9 @@ dependencies = [
 name = "cmpv2"
 version = "0.0.0"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.2",
  "crmf",
  "der",
- "flagset",
  "hex-literal",
  "spki",
  "x509-cert",
@@ -257,13 +256,21 @@ dependencies = [
 name = "cms"
 version = "0.0.0"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.2",
  "der",
  "hex-literal",
  "pkcs5",
- "rstest 0.12.0",
  "spki",
  "x509-cert",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
+dependencies = [
+ "arbitrary",
 ]
 
 [[package]]
@@ -324,7 +331,7 @@ name = "crmf"
 version = "0.0.0"
 dependencies = [
  "cms",
- "const-oid",
+ "const-oid 0.9.2",
  "der",
  "spki",
  "x509-cert",
@@ -388,7 +395,7 @@ name = "der"
 version = "0.7.0-pre"
 dependencies = [
  "arbitrary",
- "const-oid",
+ "const-oid 0.9.2",
  "der_derive",
  "flagset",
  "hex-literal",
@@ -835,7 +842,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 name = "pkcs1"
 version = "0.5.0-pre"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.2",
  "der",
  "hex-literal",
  "pkcs8",
@@ -1083,19 +1090,6 @@ name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
-
-[[package]]
-name = "rstest"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d912f35156a3f99a66ee3e11ac2e0b3f34ac85a07e05263d05a7e2c8810d616f"
-dependencies = [
- "cfg-if",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn",
-]
 
 [[package]]
 name = "rstest"
@@ -1720,11 +1714,10 @@ name = "x509-cert"
 version = "0.2.0-pre"
 dependencies = [
  "arbitrary",
- "const-oid",
+ "const-oid 0.9.2",
  "der",
- "flagset",
  "hex-literal",
- "rstest 0.16.0",
+ "rstest",
  "spki",
 ]
 
@@ -1732,7 +1725,7 @@ dependencies = [
 name = "x509-ocsp"
 version = "0.1.0-pre.0"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.2",
  "der",
  "hex-literal",
  "spki",

--- a/cmpv2/Cargo.toml
+++ b/cmpv2/Cargo.toml
@@ -15,19 +15,19 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-der = { version = "0.7.0-pre", features = ["oid", "derive", "alloc"], path = "../der" }
-x509-cert = { version = "0.2.0-pre", path = "../x509-cert" }
-spki = { version = "0.7.0-pre", path = "../spki" }
-flagset = { version = "0.4.3" }
 crmf = {version = "0.0", path = "../crmf" }
+der = { version = "0.7.0-pre", features = ["alloc", "derive", "flagset", "oid"], path = "../der" }
+spki = { version = "0.7.0-pre", path = "../spki" }
+x509-cert = { version = "0.2.0-pre", default-features = false, path = "../x509-cert" }
 
 [dev-dependencies]
-const-oid = { version = "0.10.0-pre", path = "../const-oid" }
+const-oid = { version = "0.9", features = ["db"] } # TODO: path = "../const-oid"
 hex-literal = "0.3"
 
 [features]
 alloc = ["der/alloc"]
 std = ["der/std", "spki/std"]
+
 pem = ["alloc", "der/pem"]
 
 [package.metadata.docs.rs]

--- a/cmpv2/src/status.rs
+++ b/cmpv2/src/status.rs
@@ -1,12 +1,10 @@
 //! Status-related types
 
-use alloc::vec::Vec;
-use flagset::{flags, FlagSet};
-
-use der::asn1::{Int, OctetString};
-use der::{Enumerated, Sequence};
-
 use crate::header::PkiFreeText;
+use alloc::vec::Vec;
+use der::asn1::{Int, OctetString};
+use der::flagset::{flags, FlagSet};
+use der::{Enumerated, Sequence};
 
 /// The `PKIStatus` type is defined in [RFC 4210 Section 5.2.3].
 ///

--- a/cms/Cargo.toml
+++ b/cms/Cargo.toml
@@ -14,23 +14,19 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-der = { version = "0.7.0-pre", features = ["oid", "derive", "alloc"], path = "../der" }
-x509-cert = { version = "0.2.0-pre", path = "../x509-cert" }
-const-oid = { version = "0.10.0-pre", path = "../const-oid" }
+der = { version = "0.7.0-pre", features = ["alloc", "derive", "oid"], path = "../der" }
 spki = { version = "0.7.0-pre", path = "../spki" }
+x509-cert = { version = "0.2.0-pre", default-features = false, path = "../x509-cert" }
 
 [dev-dependencies]
+const-oid = { version = "0.9", features = ["db"] } # TODO: path = "../const-oid"
 hex-literal = "0.3"
 pkcs5 = { version = "0.6.0-pre", path = "../pkcs5" }
-
-# NOTE: upgrading requires MSRV bumps
-# - rstest v0.13 requires 1.59 (for `async-global-executor`)
-# - rstest v0.14 requires a workspace-wide 1.60 MSRV (for namespaced features)
-rstest = "0.12"
 
 [features]
 alloc = ["der/alloc"]
 std = ["der/std", "spki/std"]
+
 pem = ["alloc", "der/pem"]
 
 [package.metadata.docs.rs]

--- a/cms/src/cert.rs
+++ b/cms/src/cert.rs
@@ -1,9 +1,7 @@
 //! Certificate-related types
+
 use core::cmp::Ordering;
-
-use const_oid::ObjectIdentifier;
-use der::{Any, Choice, Sequence, ValueOrd};
-
+use der::{asn1::ObjectIdentifier, Any, Choice, Sequence, ValueOrd};
 use x509_cert::name::Name;
 use x509_cert::serial_number::SerialNumber;
 use x509_cert::Certificate;

--- a/cms/src/content_info.rs
+++ b/cms/src/content_info.rs
@@ -1,9 +1,7 @@
 //! ContentInfo types
+
 use core::cmp::Ordering;
-
-use const_oid::ObjectIdentifier;
-
-use der::{Any, Enumerated, Sequence, ValueOrd};
+use der::{asn1::ObjectIdentifier, Any, Enumerated, Sequence, ValueOrd};
 
 /// The `OtherCertificateFormat` type is defined in [RFC 5652 Section 10.2.5].
 ///

--- a/cms/src/enveloped_data.rs
+++ b/cms/src/enveloped_data.rs
@@ -1,19 +1,17 @@
 //! EnvelopedData-related types
-use core::cmp::Ordering;
-
-use const_oid::ObjectIdentifier;
-use der::asn1::{BitString, GeneralizedTime, OctetString, SetOfVec};
-use der::{Any, Choice, Sequence, ValueOrd};
-
-use spki::AlgorithmIdentifierOwned;
-use x509_cert::attr::{Attribute, Attributes};
-use x509_cert::ext::pkix::SubjectKeyIdentifier;
-use x509_cert::impl_newtype;
 
 use crate::cert::IssuerAndSerialNumber;
 use crate::content_info::CmsVersion;
 use crate::revocation::RevocationInfoChoices;
 use crate::signed_data::CertificateSet;
+
+use core::cmp::Ordering;
+use der::asn1::{BitString, GeneralizedTime, ObjectIdentifier, OctetString, SetOfVec};
+use der::{Any, Choice, Sequence, ValueOrd};
+use spki::AlgorithmIdentifierOwned;
+use x509_cert::attr::{Attribute, Attributes};
+use x509_cert::ext::pkix::SubjectKeyIdentifier;
+use x509_cert::impl_newtype;
 
 /// The `EnvelopedData` type is defined in [RFC 5652 Section 6.1].
 ///

--- a/cms/src/signed_data.rs
+++ b/cms/src/signed_data.rs
@@ -1,19 +1,16 @@
 //! SignedData-related types
 
-use core::cmp::Ordering;
+use crate::cert::{CertificateChoices, IssuerAndSerialNumber};
+use crate::content_info::CmsVersion;
+use crate::revocation::RevocationInfoChoices;
 
-use const_oid::ObjectIdentifier;
-use der::asn1::OctetString;
-use der::asn1::SetOfVec;
+use core::cmp::Ordering;
+use der::asn1::{ObjectIdentifier, OctetString, SetOfVec};
 use der::{Any, Choice, DerOrd, Sequence, ValueOrd};
 use spki::AlgorithmIdentifierOwned;
 use x509_cert::attr::Attributes;
 use x509_cert::ext::pkix::SubjectKeyIdentifier;
 use x509_cert::impl_newtype;
-
-use crate::cert::{CertificateChoices, IssuerAndSerialNumber};
-use crate::content_info::CmsVersion;
-use crate::revocation::RevocationInfoChoices;
 
 /// The `SignedData` type is defined in [RFC 5652 Section 5.1].
 ///

--- a/const-oid/CHANGELOG.md
+++ b/const-oid/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.2 (2023-02-26)
+### Added
+- `arbitrary` crate feature ([#895])
+
+[#895]: https://github.com/RustCrypto/formats/pull/895
+
 ## 0.9.1 (2022-11-12)
 ### Added
 - clippy lints for checked arithmetic and panics ([#561])

--- a/const-oid/Cargo.toml
+++ b/const-oid/Cargo.toml
@@ -14,16 +14,15 @@ categories = ["cryptography", "data-structures", "encoding", "no-std", "parser-i
 keywords = ["iso", "iec", "itu", "oid"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.60"
 
 [dependencies]
-arbitrary = { version = "1.2.3", features = ["derive"], optional = true }
+arbitrary = { version = "1.2", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 hex-literal = "0.3"
 
 [features]
-arbitrary = ["std", "dep:arbitrary"]
 db = []
 std = []
 

--- a/crmf/Cargo.toml
+++ b/crmf/Cargo.toml
@@ -15,13 +15,13 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-der = { version = "=0.7.0-pre", features = ["alloc", "derive"], path = "../der" }
-x509-cert = { version = "=0.2.0-pre", path = "../x509-cert" }
-spki = { version = "=0.7.0-pre", path = "../spki" }
 cms = { version = "0.0.0", path = "../cms"}
+der = { version = "=0.7.0-pre", features = ["alloc", "derive"], path = "../der" }
+spki = { version = "=0.7.0-pre", path = "../spki" }
+x509-cert = { version = "=0.2.0-pre", default-features = false, path = "../x509-cert" }
 
 [dev-dependencies]
-const-oid = { version = "0.10.0-pre", path = "../const-oid" }
+const-oid = { version = "0.9" } # TODO: path = "../const-oid"
 
 [features]
 alloc = ["der/alloc"]

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -17,10 +17,10 @@ rust-version = "1.65"
 
 [dependencies]
 arbitrary = { version = "1.2.3", features = ["derive"], optional = true }
-const-oid = { version = "=0.10.0-pre", optional = true, path = "../const-oid" }
+const-oid = { version = "0.9.2", optional = true } # TODO: path = "../const-oid"
 der_derive = { version = "=0.7.0-pre", optional = true, path = "derive" }
 flagset = { version = "0.4.3", optional = true }
-pem-rfc7468 = { version = "0.7", optional = true, path = "../pem-rfc7468" }
+pem-rfc7468 = { version = "0.7", optional = true, features = ["alloc"], path = "../pem-rfc7468" }
 time = { version = "0.3.4", optional = true, default-features = false }
 zeroize = { version = "1.5", optional = true, default-features = false, features = ["alloc"] }
 
@@ -30,10 +30,10 @@ proptest = "1"
 
 [features]
 alloc = []
-arbitrary = ["std", "dep:arbitrary", "const-oid?/arbitrary"]
-derive = ["der_derive"]
-oid = ["const-oid"]
-pem = ["alloc", "pem-rfc7468/alloc", "zeroize"]
+arbitrary = [ "dep:arbitrary", "const-oid?/arbitrary", "std"]
+derive = ["dep:der_derive"]
+oid = ["dep:const-oid"]
+pem = ["dep:pem-rfc7468", "alloc", "zeroize", ]
 real = []
 std = ["alloc"]
 

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -376,6 +376,9 @@ pub use crypto_bigint as bigint;
 #[cfg(feature = "derive")]
 pub use der_derive::{Choice, Enumerated, Sequence, ValueOrd};
 
+#[cfg(feature = "flagset")]
+pub use flagset;
+
 #[cfg(feature = "oid")]
 pub use const_oid as oid;
 

--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -23,9 +23,9 @@ pkcs8 = { version = "=0.10.0-pre", optional = true, default-features = false, pa
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
+const-oid = { version = "0.9", features = ["db"] } # TODO: path = "../const-oid"
 hex-literal = "0.3"
 tempfile = "3"
-const-oid = { version = "0.10.0-pre", path = "../const-oid", features = ["db"] }
 
 [features]
 alloc = ["der/alloc", "pkcs8/alloc", "zeroize/alloc"]

--- a/pkcs7/Cargo.toml
+++ b/pkcs7/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.65"
 [dependencies]
 der = { version = "=0.7.0-pre", features = ["oid"], path = "../der" }
 spki = { version = "=0.7.0-pre", path = "../spki" }
-x509-cert = { version = "=0.2.0-pre", path = "../x509-cert" }
+x509-cert = { version = "=0.2.0-pre", default-features = false, path = "../x509-cert" }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -15,20 +15,23 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-arbitrary = { version = "1.2.3", features = ["derive"], optional = true }
-const-oid = { version = "=0.10.0-pre", features = ["db"], path = "../const-oid" }
-der = { version = "=0.7.0-pre", features = ["derive", "alloc", "flagset"], path = "../der" }
-flagset = { version = "0.4.3" }
+const-oid = { version = "0.9.2", features = ["db"] } # TODO: path = "../const-oid"
+der = { version = "=0.7.0-pre", features = ["derive", "alloc", "flagset", "oid"], path = "../der" }
 spki = { version = "=0.7.0-pre", path = "../spki", features = ["alloc"] }
+
+# optional dependencies
+arbitrary = { version = "1.2.3", features = ["derive"], optional = true }
 
 [dev-dependencies]
 hex-literal = "0.3"
 rstest = "0.16"
 
 [features]
-arbitrary = ["std", "dep:arbitrary", "const-oid/arbitrary", "der/arbitrary", "spki/arbitrary"]
-pem = ["der/pem"]
-std = ["der/std", "spki/std", "const-oid/std"]
+default = ["pem", "std"]
+std = ["const-oid/std", "der/std", "spki/std"]
+
+arbitrary = ["dep:arbitrary", "std", "der/arbitrary", "spki/arbitrary"]
+pem = ["der/pem", "spki/pem"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/x509-cert/src/anchor.rs
+++ b/x509-cert/src/anchor.rs
@@ -6,8 +6,8 @@ use crate::{Certificate, TbsCertificate};
 
 use alloc::string::String;
 use der::asn1::OctetString;
+use der::flagset::{flags, FlagSet};
 use der::{Choice, Enumerated, Sequence};
-use flagset::{flags, FlagSet};
 use spki::SubjectPublicKeyInfoOwned;
 
 /// Version identifier for TrustAnchorInfo

--- a/x509-cert/src/ext/pkix/crl/dp.rs
+++ b/x509-cert/src/ext/pkix/crl/dp.rs
@@ -1,8 +1,8 @@
 //! PKIX distribution point types
 
 use const_oid::{db::rfc5280::ID_PE_SUBJECT_INFO_ACCESS, AssociatedOid, ObjectIdentifier};
+use der::flagset::{flags, FlagSet};
 use der::{Sequence, ValueOrd};
-use flagset::{flags, FlagSet};
 
 use crate::ext::pkix::name::{DistributionPointName, GeneralNames};
 

--- a/x509-cert/src/ext/pkix/keyusage.rs
+++ b/x509-cert/src/ext/pkix/keyusage.rs
@@ -5,8 +5,8 @@ use const_oid::db::rfc5280::{
 };
 use const_oid::AssociatedOid;
 use der::asn1::{GeneralizedTime, ObjectIdentifier};
+use der::flagset::{flags, FlagSet};
 use der::Sequence;
-use flagset::{flags, FlagSet};
 
 flags! {
     /// Key usage flags as defined in [RFC 5280 Section 4.2.1.3].

--- a/x509-ocsp/Cargo.toml
+++ b/x509-ocsp/Cargo.toml
@@ -15,12 +15,12 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-der = { version = "=0.7.0-pre", features = ["oid", "derive", "alloc"], path = "../der" }
-x509-cert = { version = "=0.2.0-pre", path = "../x509-cert" }
-const-oid = { version = "=0.10.0-pre", path = "../const-oid" }
+der = { version = "=0.7.0-pre", features = ["alloc", "derive", "oid"], path = "../der" }
 spki = { version = "=0.7.0-pre", path = "../spki" }
+x509-cert = { version = "=0.2.0-pre", path = "../x509-cert" }
 
 [dev-dependencies]
+const-oid = { version = "0.9", features = ["db"] } # TODO: path = "../const-oid"
 hex-literal = "0.3"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
The `const-oid` crate is a shared dependency with many other crates including the `digest` crate and several hash function implementations, which makes upgrading it rather tricky.

This punts on upgrading it for this release cycle of the `der` crate and its dependencies so we can coordinate on an upgrade along with `digest`.