### PR TITLE
CI: add missing configuration files

### DIFF
--- a/.github/workflows/cmpv2.yml
+++ b/.github/workflows/cmpv2.yml
@@ -1,12 +1,13 @@
-name: pkcs7
+name: cmpv2
 
 on:
   pull_request:
     paths:
-      - ".github/workflows/pkcs7.yml"
+      - ".github/workflows/cmpv2.yml"
       - "const-oid/**"
+      - "cmpv2/**"
       - "der/**"
-      - "pkcs7/**"
+      - "spki/**"
       - "x509-cert/**"
       - "Cargo.*"
   push:
@@ -14,7 +15,7 @@ on:
 
 defaults:
   run:
-    working-directory: pkcs7
+    working-directory: cmpv2
 
 env:
   CARGO_INCREMENTAL: 0
@@ -38,12 +39,13 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
       - uses: RustCrypto/actions/cargo-hack-install@master
-      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset
+      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features arbitrary,default,std
 
-  minimal-versions:
-    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
-    with:
-        working-directory: ${{ github.workflow }}
+# FIXME: Temporary disabled until https://github.com/rust-fuzz/arbitrary/issues/136 is fixed
+#  minimal-versions:
+#    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+#    with:
+#        working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest
@@ -59,3 +61,5 @@ jobs:
           toolchain: ${{ matrix.rust }}
       - uses: RustCrypto/actions/cargo-hack-install@master
       - run: cargo hack test --feature-powerset
+
+

--- a/.github/workflows/cms.yml
+++ b/.github/workflows/cms.yml
@@ -1,12 +1,13 @@
-name: pkcs7
+name: cms
 
 on:
   pull_request:
     paths:
-      - ".github/workflows/pkcs7.yml"
+      - ".github/workflows/cms.yml"
       - "const-oid/**"
+      - "cms/**"
       - "der/**"
-      - "pkcs7/**"
+      - "spki/**"
       - "x509-cert/**"
       - "Cargo.*"
   push:
@@ -14,7 +15,7 @@ on:
 
 defaults:
   run:
-    working-directory: pkcs7
+    working-directory: cms
 
 env:
   CARGO_INCREMENTAL: 0
@@ -38,12 +39,13 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
       - uses: RustCrypto/actions/cargo-hack-install@master
-      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset
+      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features arbitrary,default,std
 
-  minimal-versions:
-    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
-    with:
-        working-directory: ${{ github.workflow }}
+# FIXME: Temporary disabled until https://github.com/rust-fuzz/arbitrary/issues/136 is fixed
+#  minimal-versions:
+#    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+#    with:
+#        working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest
@@ -59,3 +61,5 @@ jobs:
           toolchain: ${{ matrix.rust }}
       - uses: RustCrypto/actions/cargo-hack-install@master
       - run: cargo hack test --feature-powerset
+
+

--- a/.github/workflows/crmf.yml
+++ b/.github/workflows/crmf.yml
@@ -56,7 +56,6 @@ jobs:
           - stable
     steps:
       - uses: actions/checkout@v3
-      
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}

--- a/.github/workflows/pkcs12.yml
+++ b/.github/workflows/pkcs12.yml
@@ -1,20 +1,22 @@
-name: pkcs7
+name: pkcs12
 
 on:
   pull_request:
     paths:
-      - ".github/workflows/pkcs7.yml"
+      - ".github/workflows/pkcs12.yml"
+      - "base64ct/**"
       - "const-oid/**"
       - "der/**"
-      - "pkcs7/**"
-      - "x509-cert/**"
+      - "pem-rfc7468/**"
+      - "pkcs12/**"
+      - "spki/**"
       - "Cargo.*"
   push:
     branches: master
 
 defaults:
   run:
-    working-directory: pkcs7
+    working-directory: pkcs12
 
 env:
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/x509-ocsp.yml
+++ b/.github/workflows/x509-ocsp.yml
@@ -1,12 +1,12 @@
-name: pkcs7
+name: x509-ocsp
 
 on:
   pull_request:
     paths:
-      - ".github/workflows/pkcs7.yml"
+      - ".github/workflows/x509-ocsp.yml"
       - "const-oid/**"
       - "der/**"
-      - "pkcs7/**"
+      - "x509-ocsp/**"
       - "x509-cert/**"
       - "Cargo.*"
   push:
@@ -14,7 +14,7 @@ on:
 
 defaults:
   run:
-    working-directory: pkcs7
+    working-directory: x509-ocsp
 
 env:
   CARGO_INCREMENTAL: 0

--- a/x509-ocsp/Cargo.toml
+++ b/x509-ocsp/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.65"
 [dependencies]
 der = { version = "=0.7.0-pre", features = ["alloc", "derive", "oid"], path = "../der" }
 spki = { version = "=0.7.0-pre", path = "../spki" }
-x509-cert = { version = "=0.2.0-pre", path = "../x509-cert" }
+x509-cert = { version = "=0.2.0-pre", default-features = false, path = "../x509-cert" }
 
 [dev-dependencies]
 const-oid = { version = "0.9", features = ["db"] } # TODO: path = "../const-oid"


### PR DESCRIPTION
The following crates did not have a CI config (most of which are newly merged and/or nascent):

- `cmpv2`
- `cms`
- `pkcs12`
- `x509-ocsp`