### PR TITLE
der v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,7 +392,7 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.0-pre"
+version = "0.7.0"
 dependencies = [
  "arbitrary",
  "const-oid 0.9.2",
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "der_derive"
-version = "0.7.0-pre"
+version = "0.7.0"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/crmf/Cargo.toml
+++ b/crmf/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.65"
 
 [dependencies]
 cms = { version = "0.0.0", path = "../cms"}
-der = { version = "=0.7.0-pre", features = ["alloc", "derive"], path = "../der" }
+der = { version = "0.7", features = ["alloc", "derive"], path = "../der" }
 spki = { version = "=0.7.0-pre", path = "../spki" }
 x509-cert = { version = "=0.2.0-pre", default-features = false, path = "../x509-cert" }
 

--- a/der/CHANGELOG.md
+++ b/der/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 (2023-02-26)
+### Added
+- `OwnedtoRef`/`RefToOwned` traits; MSRV 1.65 ([#797])
+- `OctetStringRef::decode_into` ([#817])
+- `Int` and `IntRef` types ([#823])
+- `IndefiniteLength` type ([#830])
+- `Any::value` accessor ([#833])
+- Buffered PEM reader ([#839])
+- `OctetString::into_bytes` ([#845])
+- Blanket impls on `Box<T>` for `DecodeValue`, `EncodeValue`, and `Sequence` ([#860])
+
+### Changed
+- Rename `UIntRef` => `UintRef` ([#786])
+- Replace use of `dyn Writer` with `impl Writer` ([#828])
+- Rename `AnyRef::decode_into` -> `::decode_as` ([#829])
+- Bump `pem-rfc7468` dependency to v0.7 ([#894])
+- Rename `Encode::to_vec` => `::to_der` ([#898])
+
+### Removed
+- `Sequence::fields` method ([#828])
+- Inherent `AnyRef` decoding methods ([#829])
+
+[#786]: https://github.com/RustCrypto/formats/pull/786
+[#797]: https://github.com/RustCrypto/formats/pull/797
+[#817]: https://github.com/RustCrypto/formats/pull/817
+[#823]: https://github.com/RustCrypto/formats/pull/823
+[#828]: https://github.com/RustCrypto/formats/pull/828
+[#829]: https://github.com/RustCrypto/formats/pull/829
+[#830]: https://github.com/RustCrypto/formats/pull/830
+[#833]: https://github.com/RustCrypto/formats/pull/833
+[#839]: https://github.com/RustCrypto/formats/pull/839
+[#845]: https://github.com/RustCrypto/formats/pull/845
+[#860]: https://github.com/RustCrypto/formats/pull/860
+[#894]: https://github.com/RustCrypto/formats/pull/894
+[#898]: https://github.com/RustCrypto/formats/pull/898
+
 ## 0.6.1 (2022-12-05)
 ### Added
 - Rudimentary implementation of `TeletexString` and `VideotexString` ([#691])

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der"
-version = "0.7.0-pre"
+version = "0.7.0"
 description = """
 Pure Rust embedded-friendly implementation of the Distinguished Encoding Rules
 (DER) for Abstract Syntax Notation One (ASN.1) as described in ITU X.690 with
@@ -16,9 +16,9 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-arbitrary = { version = "1.2.3", features = ["derive"], optional = true }
+arbitrary = { version = "1.2", features = ["derive"], optional = true }
 const-oid = { version = "0.9.2", optional = true } # TODO: path = "../const-oid"
-der_derive = { version = "=0.7.0-pre", optional = true, path = "derive" }
+der_derive = { version = "0.7", optional = true, path = "derive" }
 flagset = { version = "0.4.3", optional = true }
 pem-rfc7468 = { version = "0.7", optional = true, features = ["alloc"], path = "../pem-rfc7468" }
 time = { version = "0.3.4", optional = true, default-features = false }
@@ -30,12 +30,13 @@ proptest = "1"
 
 [features]
 alloc = []
-arbitrary = [ "dep:arbitrary", "const-oid?/arbitrary", "std"]
+std = ["alloc"]
+
+arbitrary = ["dep:arbitrary", "const-oid?/arbitrary", "std"]
 derive = ["dep:der_derive"]
 oid = ["dep:const-oid"]
-pem = ["dep:pem-rfc7468", "alloc", "zeroize", ]
+pem = ["dep:pem-rfc7468", "alloc", "zeroize"]
 real = []
-std = ["alloc"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/der/derive/CHANGELOG.md
+++ b/der/derive/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 (2023-02-26)
+### Changed
+- Eliminate dynamism from encoding ([#828])
+
+[#828]: https://github.com/RustCrypto/formats/pull/828
+
 ## 0.6.1 (2022-12-05)
 ### Added
 - Support for deriving `ValueOrd` on `Choice` enums ([#723])

--- a/der/derive/Cargo.toml
+++ b/der/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der_derive"
-version = "0.7.0-pre"
+version = "0.7.0"
 description = "Custom derive support for the `der` crate's `Choice` and `Sequence` traits"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"

--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 rust-version = "1.60"
 
 [dependencies]
-der = { version = "=0.7.0-pre", features = ["oid"], path = "../der" }
+der = { version = "0.7", features = ["oid"], path = "../der" }
 spki = { version = "=0.7.0-pre", path = "../spki" }
 
 # optional dependencies

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-der = { version = "=0.7.0-pre", features = ["oid"], path = "../der" }
+der = { version = "0.7", features = ["oid"], path = "../der" }
 spki = { version = "=0.7.0-pre", path = "../spki" }
 
 # optional dependencies

--- a/pkcs7/Cargo.toml
+++ b/pkcs7/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-der = { version = "=0.7.0-pre", features = ["oid"], path = "../der" }
+der = { version = "0.7", features = ["oid"], path = "../der" }
 spki = { version = "=0.7.0-pre", path = "../spki" }
 x509-cert = { version = "=0.2.0-pre", default-features = false, path = "../x509-cert" }
 

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-der = { version = "=0.7.0-pre", features = ["oid"], path = "../der" }
+der = { version = "0.7", features = ["oid"], path = "../der" }
 spki = { version = "=0.7.0-pre", path = "../spki" }
 
 # optional dependencies

--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.65"
 
 [dependencies]
 base16ct = { version = "0.2", optional = true, default-features = false, path = "../base16ct" }
-der = { version = "=0.7.0-pre", optional = true, features = ["oid"], path = "../der" }
+der = { version = "0.7", optional = true, features = ["oid"], path = "../der" }
 generic-array = { version = "0.14.6", optional = true, default-features = false }
 pkcs8 = { version = "=0.10.0-pre", optional = true, default-features = false, path = "../pkcs8" }
 serdect = { version = "0.2", optional = true, default-features = false, features = ["alloc"], path = "../serdect" }

--- a/spki/Cargo.toml
+++ b/spki/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-der = { version = "=0.7.0-pre", features = ["oid"], path = "../der" }
+der = { version = "0.7", features = ["oid"], path = "../der" }
 
 # Optional dependencies
 arbitrary = { version = "1.2.3", features = ["derive"], optional = true }

--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.65"
 
 [dependencies]
 const-oid = { version = "0.9.2", features = ["db"] } # TODO: path = "../const-oid"
-der = { version = "=0.7.0-pre", features = ["derive", "alloc", "flagset", "oid"], path = "../der" }
+der = { version = "0.7", features = ["derive", "alloc", "flagset", "oid"], path = "../der" }
 spki = { version = "=0.7.0-pre", path = "../spki", features = ["alloc"] }
 
 # optional dependencies

--- a/x509-ocsp/Cargo.toml
+++ b/x509-ocsp/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-der = { version = "=0.7.0-pre", features = ["alloc", "derive", "oid"], path = "../der" }
+der = { version = "0.7", features = ["alloc", "derive", "oid"], path = "../der" }
 spki = { version = "=0.7.0-pre", path = "../spki" }
 x509-cert = { version = "=0.2.0-pre", default-features = false, path = "../x509-cert" }
 


### PR DESCRIPTION
### Added
- `OwnedtoRef`/`RefToOwned` traits; MSRV 1.65 ([#797])
- `OctetStringRef::decode_into` ([#817])
- `Int` and `IntRef` types ([#823])
- `IndefiniteLength` type ([#830])
- `Any::value` accessor ([#833])
- Buffered PEM reader ([#839])
- `OctetString::into_bytes` ([#845])
- Blanket impls on `Box<T>` for `DecodeValue`, `EncodeValue`, and `Sequence` ([#860])

### Changed
- Rename `UIntRef` => `UintRef` ([#786])
- Replace use of `dyn Writer` with `impl Writer` ([#828])
- Rename `AnyRef::decode_into` -> `::decode_as` ([#829])
- Bump `pem-rfc7468` dependency to v0.7 ([#894])
- Rename `Encode::to_vec` => `::to_der` ([#898])

### Removed
- `Sequence::fields` method ([#828])
- Inherent `AnyRef` decoding methods ([#829])

[#786]: https://github.com/RustCrypto/formats/pull/786
[#797]: https://github.com/RustCrypto/formats/pull/797
[#817]: https://github.com/RustCrypto/formats/pull/817
[#823]: https://github.com/RustCrypto/formats/pull/823
[#828]: https://github.com/RustCrypto/formats/pull/828
[#829]: https://github.com/RustCrypto/formats/pull/829
[#830]: https://github.com/RustCrypto/formats/pull/830
[#833]: https://github.com/RustCrypto/formats/pull/833
[#839]: https://github.com/RustCrypto/formats/pull/839
[#845]: https://github.com/RustCrypto/formats/pull/845
[#860]: https://github.com/RustCrypto/formats/pull/860
[#894]: https://github.com/RustCrypto/formats/pull/894
[#898]: https://github.com/RustCrypto/formats/pull/898