### PR TITLE
spki v0.7.0

### DIFF
--- a/.github/workflows/spki.yml
+++ b/.github/workflows/spki.yml
@@ -38,7 +38,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
       - uses: RustCrypto/actions/cargo-hack-install@master
-      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features std,arbitrary
+      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features arbitrary,std
 
 # FIXME: Temporary disabled until https://github.com/rust-fuzz/arbitrary/issues/134 is fixed
 #  minimal-versions:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1314,7 +1314,7 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.7.0-pre"
+version = "0.7.0"
 dependencies = [
  "arbitrary",
  "base64ct",

--- a/crmf/Cargo.toml
+++ b/crmf/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.65"
 [dependencies]
 cms = { version = "0.0.0", path = "../cms"}
 der = { version = "0.7", features = ["alloc", "derive"], path = "../der" }
-spki = { version = "=0.7.0-pre", path = "../spki" }
+spki = { version = "0.7", path = "../spki" }
 x509-cert = { version = "=0.2.0-pre", default-features = false, path = "../x509-cert" }
 
 [dev-dependencies]

--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.60"
 
 [dependencies]
 der = { version = "0.7", features = ["oid"], path = "../der" }
-spki = { version = "=0.7.0-pre", path = "../spki" }
+spki = { version = "0.7", path = "../spki" }
 
 # optional dependencies
 pkcs8 = { version = "=0.10.0-pre", optional = true, default-features = false, path = "../pkcs8" }

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.65"
 
 [dependencies]
 der = { version = "0.7", features = ["oid"], path = "../der" }
-spki = { version = "=0.7.0-pre", path = "../spki" }
+spki = { version = "0.7", path = "../spki" }
 
 # optional dependencies
 cbc = { version = "0.1.2", optional = true }

--- a/pkcs7/Cargo.toml
+++ b/pkcs7/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.65"
 
 [dependencies]
 der = { version = "0.7", features = ["oid"], path = "../der" }
-spki = { version = "=0.7.0-pre", path = "../spki" }
+spki = { version = "0.7", path = "../spki" }
 x509-cert = { version = "=0.2.0-pre", default-features = false, path = "../x509-cert" }
 
 [dev-dependencies]

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.65"
 
 [dependencies]
 der = { version = "0.7", features = ["oid"], path = "../der" }
-spki = { version = "=0.7.0-pre", path = "../spki" }
+spki = { version = "0.7", path = "../spki" }
 
 # optional dependencies
 rand_core = { version = "0.6", optional = true, default-features = false }

--- a/spki/CHANGELOG.md
+++ b/spki/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 (2023-02-26)
+### Changed
+- Make `AlgorithmIdentifier` generic around `Params` ([#769])
+- Use blanket impls for `Decode*` traits ([#785])
+- Make `SubjectPublicKeyInfo` own the public key ([#790])
+- Rename `to_owned` method ([#835])
+- Bump `der` dependency to v0.7 ([#899])
+
+[#769]: https://github.com/RustCrypto/formats/pull/769
+[#785]: https://github.com/RustCrypto/formats/pull/785
+[#790]: https://github.com/RustCrypto/formats/pull/790
+[#835]: https://github.com/RustCrypto/formats/pull/835
+[#899]: https://github.com/RustCrypto/formats/pull/899
+
 ## 0.6.0 (2022-05-08)
 ### Added
 - `AlgorithmIdentifier::oids()` helper function ([#443])

--- a/spki/Cargo.toml
+++ b/spki/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spki"
-version = "0.7.0-pre"
+version = "0.7.0"
 description = """
 X.509 Subject Public Key Info (RFC5280) describing public keys as well as their
 associated AlgorithmIdentifiers (i.e. OIDs)
@@ -18,8 +18,8 @@ rust-version = "1.65"
 der = { version = "0.7", features = ["oid"], path = "../der" }
 
 # Optional dependencies
-arbitrary = { version = "1.2.3", features = ["derive"], optional = true }
-base64ct = { version = "1", path = "../base64ct", optional = true, default-features = false }
+arbitrary = { version = "1.2", features = ["derive"], optional = true }
+base64ct = { version = "1", optional = true, default-features = false, path = "../base64ct" }
 sha2 = { version = "0.10", optional = true, default-features = false }
 
 [dev-dependencies]
@@ -28,10 +28,12 @@ tempfile = "3"
 
 [features]
 alloc = ["base64ct?/alloc", "der/alloc"]
+std = ["der/std", "alloc"]
+
 arbitrary = ["std", "dep:arbitrary", "der/arbitrary"]
+base64 = ["dep:base64ct"]
 fingerprint = ["sha2"]
 pem = ["alloc", "der/pem"]
-std = ["der/std", "alloc"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/spki/src/spki.rs
+++ b/spki/src/spki.rs
@@ -62,7 +62,7 @@ where
     /// See [RFC7469 § 2.1.1] for more information.
     ///
     /// [RFC7469 § 2.1.1]: https://datatracker.ietf.org/doc/html/rfc7469#section-2.1.1
-    #[cfg(all(feature = "fingerprint", feature = "alloc", feature = "base64ct"))]
+    #[cfg(all(feature = "fingerprint", feature = "alloc", feature = "base64"))]
     pub fn fingerprint_base64(&self) -> Result<alloc::string::String> {
         use base64ct::{Base64, Encoding};
         Ok(Base64::encode_string(&self.fingerprint_bytes()?))

--- a/spki/tests/spki.rs
+++ b/spki/tests/spki.rs
@@ -35,7 +35,7 @@ const RSA_2048_PEM_EXAMPLE: &str = include_str!("examples/rsa2048-pub.pem");
 /// The SPKI fingerprint for `ED25519_SPKI_FINGERPRINT` as a Base64 string
 ///
 /// Generated using `cat ed25519-pub.der | openssl dgst -binary -sha256 | base64`
-#[cfg(all(feature = "fingerprint", feature = "alloc", feature = "base64ct"))]
+#[cfg(all(feature = "alloc", feature = "base64", feature = "fingerprint"))]
 const ED25519_SPKI_FINGERPRINT_BASE64: &str = "Vd1MdLDkhTTi9OFzzs61DfjyenrCqomRzHrpFOAwvO0=";
 
 /// The SPKI fingerprint for `ED25519_SPKI_FINGERPRINT` as straight hash bytes
@@ -84,7 +84,7 @@ fn decode_ed25519_and_fingerprint_spki() {
 }
 
 #[test]
-#[cfg(all(feature = "fingerprint", feature = "alloc", feature = "base64ct"))]
+#[cfg(all(feature = "alloc", feature = "base64", feature = "fingerprint"))]
 fn decode_ed25519_and_fingerprint_base64() {
     // Repeat the decode test from the pkcs8 crate
     let spki = SubjectPublicKeyInfoRef::try_from(ED25519_DER_EXAMPLE).unwrap();

--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -17,10 +17,10 @@ rust-version = "1.65"
 [dependencies]
 const-oid = { version = "0.9.2", features = ["db"] } # TODO: path = "../const-oid"
 der = { version = "0.7", features = ["derive", "alloc", "flagset", "oid"], path = "../der" }
-spki = { version = "=0.7.0-pre", path = "../spki", features = ["alloc"] }
+spki = { version = "0.7", path = "../spki", features = ["alloc"] }
 
 # optional dependencies
-arbitrary = { version = "1.2.3", features = ["derive"], optional = true }
+arbitrary = { version = "1.2", features = ["derive"], optional = true }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/x509-ocsp/Cargo.toml
+++ b/x509-ocsp/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.65"
 
 [dependencies]
 der = { version = "0.7", features = ["alloc", "derive", "oid"], path = "../der" }
-spki = { version = "=0.7.0-pre", path = "../spki" }
+spki = { version = "0.7", path = "../spki" }
 x509-cert = { version = "=0.2.0-pre", default-features = false, path = "../x509-cert" }
 
 [dev-dependencies]


### PR DESCRIPTION
### Changed
- Make `AlgorithmIdentifier` generic around `Params` ([#769])
- Use blanket impls for `Decode*` traits ([#785])
- Make `SubjectPublicKeyInfo` own the public key ([#790])
- Rename `to_owned` method ([#835])
- Bump `der` dependency to v0.7 ([#899])

[#769]: https://github.com/RustCrypto/formats/pull/769
[#785]: https://github.com/RustCrypto/formats/pull/785
[#790]: https://github.com/RustCrypto/formats/pull/790
[#835]: https://github.com/RustCrypto/formats/pull/835
[#899]: https://github.com/RustCrypto/formats/pull/899