### PR TITLE
pkcs5 v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -857,7 +857,7 @@ version = "0.0.0"
 
 [[package]]
 name = "pkcs5"
-version = "0.6.0-pre"
+version = "0.7.0"
 dependencies = [
  "aes",
  "cbc",

--- a/cms/Cargo.toml
+++ b/cms/Cargo.toml
@@ -21,7 +21,7 @@ x509-cert = { version = "0.2.0-pre", default-features = false, path = "../x509-c
 [dev-dependencies]
 const-oid = { version = "0.9", features = ["db"] } # TODO: path = "../const-oid"
 hex-literal = "0.3"
-pkcs5 = { version = "0.6.0-pre", path = "../pkcs5" }
+pkcs5 = { version = "0.7", path = "../pkcs5" }
 
 [features]
 alloc = ["der/alloc"]

--- a/pkcs5/CHANGELOG.md
+++ b/pkcs5/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 (2023-02-26)
+### Changed
+- Bump `der` dependency to v0.7 ([#899])
+- Bump `spki` dependency to v0.7 ([#900])
+
+[#899]: https://github.com/RustCrypto/formats/pull/899
+[#900]: https://github.com/RustCrypto/formats/pull/900
+
+## 0.6.0 (Skipped)
+- Skipped to synchronize version number with `der` and `spki`
+
 ## 0.5.0 (2022-05-08)
 ### Changed
 - Update `hmac`, `pbkdf2`, and `sha2`

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs5"
-version = "0.6.0-pre"
+version = "0.7.0"
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #5:
 Password-Based Cryptography Specification Version 2.1 (RFC 8018)

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -21,7 +21,7 @@ spki = { version = "0.7", path = "../spki" }
 
 # optional dependencies
 rand_core = { version = "0.6", optional = true, default-features = false }
-pkcs5 = { version = "=0.6.0-pre", optional = true, path = "../pkcs5" }
+pkcs5 = { version = "0.7", optional = true, path = "../pkcs5" }
 subtle = { version = "2", optional = true, default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
### Changed
- Bump `der` dependency to v0.7 ([#899])
- Bump `spki` dependency to v0.7 ([#900])

[#899]: https://github.com/RustCrypto/formats/pull/899
[#900]: https://github.com/RustCrypto/formats/pull/900