### PR TITLE
pkcs8 v0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.10.0-pre"
+version = "0.10.0"
 dependencies = [
  "der",
  "hex-literal",

--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -19,7 +19,7 @@ der = { version = "0.7", features = ["oid"], path = "../der" }
 spki = { version = "0.7", path = "../spki" }
 
 # optional dependencies
-pkcs8 = { version = "=0.10.0-pre", optional = true, default-features = false, path = "../pkcs8" }
+pkcs8 = { version = "0.10", optional = true, default-features = false, path = "../pkcs8" }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/pkcs8/CHANGELOG.md
+++ b/pkcs8/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.0 (2023-02-26)
+### Changed
+- Use blanket impls for `Decode*` traits ([#785])
+- Bump `der` dependency to v0.7 ([#899])
+- Bump `spki` dependency to v0.7 ([#900])
+- Bump `pkcs5` dependency to v0.7 ([#901])
+
+[#785]: https://github.com/RustCrypto/formats/pull/785
+[#899]: https://github.com/RustCrypto/formats/pull/899
+[#900]: https://github.com/RustCrypto/formats/pull/900
+[#901]: https://github.com/RustCrypto/formats/pull/901
+
 ## 0.9.0 (2022-05-08)
 ### Added
 - Error conversion support to `pkcs8::spki::Error` ([#335])

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs8"
-version = "0.10.0-pre"
+version = "0.10.0"
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #8:
 Private-Key Information Syntax Specification (RFC 5208), with additional

--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.65"
 base16ct = { version = "0.2", optional = true, default-features = false, path = "../base16ct" }
 der = { version = "0.7", optional = true, features = ["oid"], path = "../der" }
 generic-array = { version = "0.14.6", optional = true, default-features = false }
-pkcs8 = { version = "=0.10.0-pre", optional = true, default-features = false, path = "../pkcs8" }
+pkcs8 = { version = "0.10", optional = true, default-features = false, path = "../pkcs8" }
 serdect = { version = "0.2", optional = true, default-features = false, features = ["alloc"], path = "../serdect" }
 subtle = { version = "2", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }


### PR DESCRIPTION
### Changed
- Use blanket impls for `Decode*` traits ([#785])
- Bump `der` dependency to v0.7 ([#899])
- Bump `spki` dependency to v0.7 ([#900])
- Bump `pkcs5` dependency to v0.7 ([#901])

[#785]: https://github.com/RustCrypto/formats/pull/785
[#899]: https://github.com/RustCrypto/formats/pull/899
[#900]: https://github.com/RustCrypto/formats/pull/900
[#901]: https://github.com/RustCrypto/formats/pull/901