### PR TITLE
sec1 v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1196,7 +1196,7 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.4.0"
+version = "0.7.0"
 dependencies = [
  "base16ct",
  "der",

--- a/sec1/CHANGELOG.md
+++ b/sec1/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 (2023-02-26)
+### Changed
+- MSRV 1.65 ([#805])
+- Bump `serdect` to v0.2 ([#893])
+- Bump `der` dependency to v0.7 ([#899])
+- Bump `spki` dependency to v0.7 ([#900])
+- Bump `pkcs8` to v0.10 ([#902])
+
+[#805]: https://github.com/RustCrypto/formats/pull/805
+[#893]: https://github.com/RustCrypto/formats/pull/893
+[#899]: https://github.com/RustCrypto/formats/pull/899
+[#900]: https://github.com/RustCrypto/formats/pull/900
+[#902]: https://github.com/RustCrypto/formats/pull/902
+
+## 0.6.0 (Skipped)
+- Skipped to synchronize version number with `der` and `spki`
+
+## 0.5.0 (Skipped)
+- Skipped to synchronize version number with `der` and `spki`
+
+## 0.4.0 (Skipped)
+- Skipped to synchronize version number with `der` and `spki`
+
 ## 0.3.0 (2022-05-08)
 ### Added
 - Make `der` feature optional but on-by-default ([#497])

--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sec1"
-version = "0.4.0"
+version = "0.7.0"
 description = """
 Pure Rust implementation of SEC1: Elliptic Curve Cryptography encoding formats
 including ASN.1 DER-serialized private keys as well as the
@@ -31,10 +31,11 @@ tempfile = "3"
 [features]
 default = ["der", "point"]
 alloc = ["der/alloc", "pkcs8/alloc", "zeroize/alloc"]
+std = ["alloc", "der?/std"]
+
 pem = ["alloc", "der/pem", "pkcs8/pem"]
-point = ["base16ct", "generic-array"]
-serde = ["serdect"]
-std = ["der/std", "alloc"]
+point = ["dep:base16ct", "dep:generic-array"]
+serde = ["dep:serdect"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
### Changed
- MSRV 1.65 ([#805])
- Bump `serdect` to v0.2 ([#893])
- Bump `der` dependency to v0.7 ([#899])
- Bump `spki` dependency to v0.7 ([#900])
- Bump `pkcs8` to v0.10 ([#902])

[#805]: https://github.com/RustCrypto/formats/pull/805
[#893]: https://github.com/RustCrypto/formats/pull/893
[#899]: https://github.com/RustCrypto/formats/pull/899
[#900]: https://github.com/RustCrypto/formats/pull/900
[#902]: https://github.com/RustCrypto/formats/pull/902