### PR TITLE
sec1: encode `ECPrivateKey` version

### DIFF
--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -30,12 +30,14 @@ tempfile = "3"
 
 [features]
 default = ["der", "point"]
-alloc = ["der/alloc", "pkcs8/alloc", "zeroize/alloc"]
+alloc = ["der?/alloc", "pkcs8?/alloc", "zeroize?/alloc"]
 std = ["alloc", "der?/std"]
 
+der = ["dep:der", "zeroize"]
 pem = ["alloc", "der/pem", "pkcs8/pem"]
 point = ["dep:base16ct", "dep:generic-array"]
 serde = ["dep:serdect"]
+zeroize = ["dep:zeroize", "der?/zeroize"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/sec1/src/lib.rs
+++ b/sec1/src/lib.rs
@@ -54,7 +54,7 @@ pub use generic_array::typenum::consts;
 #[cfg(feature = "der")]
 pub use crate::{parameters::EcParameters, private_key::EcPrivateKey, traits::DecodeEcPrivateKey};
 
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", feature = "der"))]
 pub use crate::traits::EncodeEcPrivateKey;
 
 #[cfg(feature = "pem")]

--- a/sec1/src/private_key.rs
+++ b/sec1/src/private_key.rs
@@ -13,7 +13,7 @@ use der::{
     TagNumber, Writer,
 };
 
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", feature = "zeroize"))]
 use der::SecretDocument;
 
 #[cfg(feature = "pem")]
@@ -119,12 +119,14 @@ impl<'a> DecodeValue<'a> for EcPrivateKey<'a> {
 
 impl EncodeValue for EcPrivateKey<'_> {
     fn value_len(&self) -> der::Result<Length> {
-        OctetStringRef::new(self.private_key)?.encoded_len()?
+        VERSION.encoded_len()?
+            + OctetStringRef::new(self.private_key)?.encoded_len()?
             + self.context_specific_parameters().encoded_len()?
             + self.context_specific_public_key()?.encoded_len()?
     }
 
     fn encode_value(&self, writer: &mut impl Writer) -> der::Result<()> {
+        VERSION.encode(writer)?;
         OctetStringRef::new(self.private_key)?.encode(writer)?;
         self.context_specific_parameters().encode(writer)?;
         self.context_specific_public_key()?.encode(writer)?;

--- a/sec1/tests/private_key.rs
+++ b/sec1/tests/private_key.rs
@@ -6,6 +6,9 @@ use der::asn1::ObjectIdentifier;
 use hex_literal::hex;
 use sec1::{EcParameters, EcPrivateKey};
 
+#[cfg(feature = "alloc")]
+use der::Encode;
+
 /// NIST P-256 SEC1 private key encoded as ASN.1 DER.
 ///
 /// Note: this key is extracted from the corresponding `p256-priv.der`
@@ -29,4 +32,12 @@ fn decode_p256_der() {
         ))
     );
     assert_eq!(key.public_key, Some(hex!("041CACFFB55F2F2CEFD89D89EB374B2681152452802DEEA09916068137D839CF7FC481A44492304D7EF66AC117BEFE83A8D08F155F2B52F9F618DD447029048E0F").as_ref()));
+}
+
+#[cfg(feature = "alloc")]
+#[test]
+fn encode_p256_der() {
+    let key = EcPrivateKey::try_from(P256_DER_EXAMPLE).unwrap();
+    let key_encoded = key.to_der().unwrap();
+    assert_eq!(P256_DER_EXAMPLE, key_encoded);
 }

--- a/sec1/tests/traits.rs
+++ b/sec1/tests/traits.rs
@@ -1,6 +1,6 @@
 //! Tests for SEC1 encoding/decoding traits.
 
-#![cfg(any(feature = "pem", feature = "std"))]
+#![cfg(any(feature = "pem", all(feature = "der", feature = "std")))]
 
 use der::SecretDocument;
 use sec1::{DecodeEcPrivateKey, EncodeEcPrivateKey, Result};


### PR DESCRIPTION
Regression where the version number was lost from the encoder as part of the changes in #828.

It wasn't caught due to a lack of an encoding test, which has been added in this PR.