### PR TITLE
tls_codec: feat: Append a comment with the hex representation of `VLBytes` during `Debug`-printing.

### DIFF
--- a/tls_codec/src/arrays.rs
+++ b/tls_codec/src/arrays.rs
@@ -17,8 +17,7 @@ impl<const LEN: usize> Serialize for [u8; LEN] {
             Ok(written)
         } else {
             Err(Error::InvalidWriteLength(format!(
-                "Expected to write {} bytes but only {} were written.",
-                LEN, written
+                "Expected to write {LEN} bytes but only {written} were written."
             )))
         }
     }

--- a/tls_codec/src/lib.rs
+++ b/tls_codec/src/lib.rs
@@ -86,7 +86,7 @@ impl std::error::Error for Error {}
 
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_fmt(format_args!("{:?}", self))
+        f.write_fmt(format_args!("{self:?}"))
     }
 }
 
@@ -95,7 +95,7 @@ impl From<std::io::Error> for Error {
     fn from(e: std::io::Error) -> Self {
         match e.kind() {
             std::io::ErrorKind::UnexpectedEof => Self::EndOfStream,
-            _ => Self::DecodingError(format!("io error: {:?}", e)),
+            _ => Self::DecodingError(format!("io error: {e:?}")),
         }
     }
 }

--- a/tls_codec/src/quic_vec.rs
+++ b/tls_codec/src/quic_vec.rs
@@ -12,7 +12,7 @@
 //! This is in contrast to the default behaviour defined by RFC 9000 that allows
 //! up to 62-bit length values.
 use alloc::vec::Vec;
-use std::fmt;
+use core::fmt;
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};

--- a/tls_codec/src/quic_vec.rs
+++ b/tls_codec/src/quic_vec.rs
@@ -419,7 +419,7 @@ pub struct VLByteSlice<'a>(pub &'a [u8]);
 impl<'a> fmt::Debug for VLByteSlice<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("VLByteSlice")
-            .field(&SliceU8HexDebug(&self.0))
+            .field(&SliceU8HexDebug(self.0))
             .finish()
     }
 }

--- a/tls_codec/src/quic_vec.rs
+++ b/tls_codec/src/quic_vec.rs
@@ -201,7 +201,7 @@ fn write_hex(f: &mut fmt::Formatter<'_>, data: &[u8]) -> fmt::Result {
     if !data.is_empty() {
         write!(f, "0x")?;
         for byte in data {
-            write!(f, "{:02x}", byte)?;
+            write!(f, "{byte:02x}")?;
         }
     } else {
         write!(f, "b\"\"")?;
@@ -410,7 +410,7 @@ pub struct VLByteSlice<'a>(pub &'a [u8]);
 impl<'a> fmt::Debug for VLByteSlice<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "VLByteSlice {{ ")?;
-        write_hex(f, &self.0)?;
+        write_hex(f, self.0)?;
         write!(f, " }}")
     }
 }
@@ -482,16 +482,16 @@ mod test {
         ];
 
         for (test, expected) in tests.into_iter() {
-            println!("\n# {:?}", test);
+            println!("\n# {test:?}");
 
             let expected_vl_byte_slice = format!("VLByteSlice {{ {expected} }}");
             let got = format!("{:?}", VLByteSlice(&test));
-            println!("{}", got);
+            println!("{got}");
             assert_eq!(expected_vl_byte_slice, got);
 
             let expected_vl_bytes = format!("VLBytes {{ {expected} }}");
             let got = format!("{:?}", VLBytes::new(test.clone()));
-            println!("{}", got);
+            println!("{got}");
             assert_eq!(expected_vl_bytes, got);
         }
     }

--- a/tls_codec/src/quic_vec.rs
+++ b/tls_codec/src/quic_vec.rs
@@ -125,7 +125,7 @@ impl<T: Deserialize> Deserialize for Vec<T> {
 fn write_length<W: std::io::Write>(writer: &mut W, content_length: usize) -> Result<usize, Error> {
     let len_len = length_encoding_bytes(content_length.try_into()?)?;
     if !cfg!(fuzzing) {
-        debug_assert!(len_len <= 8, "Invalid vector len_len {}", len_len);
+        debug_assert!(len_len <= 8, "Invalid vector len_len {len_len}");
     }
     if len_len > 8 {
         return Err(Error::LibraryError);
@@ -138,7 +138,7 @@ fn write_length<W: std::io::Write>(writer: &mut W, content_length: usize) -> Res
         8 => length_bytes[0] = 0x80,
         _ => {
             if !cfg!(fuzzing) {
-                debug_assert!(false, "Invalid vector len_len {}", len_len);
+                debug_assert!(false, "Invalid vector len_len {len_len}");
             }
             return Err(Error::InvalidVectorLength);
         }
@@ -294,9 +294,7 @@ fn tls_serialize_bytes<W: std::io::Write>(writer: &mut W, bytes: &[u8]) -> Resul
     if !cfg!(fuzzing) {
         debug_assert!(
             content_length as u64 <= MAX_LEN,
-            "Vector can't be encoded. It's too large. {} >= {}",
-            content_length,
-            MAX_LEN
+            "Vector can't be encoded. It's too large. {content_length} >= {MAX_LEN}",
         );
     }
     if content_length as u64 > MAX_LEN {
@@ -312,14 +310,12 @@ fn tls_serialize_bytes<W: std::io::Write>(writer: &mut W, bytes: &[u8]) -> Resul
     if !cfg!(fuzzing) {
         debug_assert_eq!(
             written, content_length,
-            "{} bytes should have been serialized but {} were written",
-            content_length, written
+            "{content_length} bytes should have been serialized but {written} were written",
         );
     }
     if written != content_length {
         return Err(Error::EncodingError(format!(
-            "{} bytes should have been serialized but {} were written",
-            content_length, written
+            "{content_length} bytes should have been serialized but {written} were written",
         )));
     }
     Ok(written + len_len)
@@ -359,15 +355,12 @@ impl Deserialize for VLBytes {
         if !cfg!(fuzzing) {
             debug_assert!(
                 length <= MAX_LEN as usize,
-                "Trying to allocate {} bytes. Only {} allowed.",
-                length,
-                MAX_LEN
+                "Trying to allocate {length} bytes. Only {MAX_LEN} allowed.",
             );
         }
         if length > MAX_LEN as usize {
             return Err(Error::DecodingError(format!(
-                "Trying to allocate {} bytes. Only {} allowed.",
-                length, MAX_LEN
+                "Trying to allocate {length} bytes. Only {MAX_LEN} allowed.",
             )));
         }
         let mut result = Self {
@@ -380,13 +373,11 @@ impl Deserialize for VLBytes {
         if !cfg!(fuzzing) {
             debug_assert_eq!(
                 read, length,
-                "Expected to read {} bytes but {} were read.",
-                length, read
+                "Expected to read {length} bytes but {read} were read.",
             );
         }
         Err(Error::DecodingError(format!(
-            "{} bytes were read but {} were expected",
-            read, length
+            "{read} bytes were read but {length} were expected",
         )))
     }
 }


### PR DESCRIPTION
This PR makes it so that the `Debug`-print of `VLBytes` and `VLByteSlice` will have an additional comment `/* 0x... */` with the hex representation of the bytes.

Example: `Debug`-print of `VLBytes { vec: [0] }`:

```
VLBytes { vec: [0] /* 0x00 */ }

// "Pretty"
VLBytes {
    vec: [
        0,
    ] /* 0x00 */,
}
```

I decided against `[0x00, 0x01, ...]` because `0x0001` seems more useful to copy&paste (for use in hex editors, Python's binascii.unhexlify, JSON, ...). Also, having both representations at hand might be useful as well.