### PR TITLE
pkcs5 v0.7.1

### DIFF
--- a/pkcs5/CHANGELOG.md
+++ b/pkcs5/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.7.0 (2023-02-26)
+## 0.7.1 (2023-03-05)
+### Changed
+- Bump `pbkdf2` to v0.12 ([#913])
+- Bump `scrypt` to v0.11 ([#913])
+
+[#913]: https://github.com/RustCrypto/formats/pull/913
+
+## 0.7.0 (2023-02-26) [YANKED]
 ### Changed
 - Bump `der` dependency to v0.7 ([#899])
 - Bump `spki` dependency to v0.7 ([#900])

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs5"
-version = "0.7.0"
+version = "0.7.1"
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #5:
 Password-Based Cryptography Specification Version 2.1 (RFC 8018)


### PR DESCRIPTION
### Changed
- Bump `pbkdf2` to v0.12 ([#913])
- Bump `scrypt` to v0.11 ([#913])

[#913]: https://github.com/RustCrypto/formats/pull/913