### PR TITLE
pkcs8 v0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,7 +858,7 @@ version = "0.0.0"
 
 [[package]]
 name = "pkcs5"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "aes",
  "cbc",
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "der",
  "hex-literal",

--- a/pkcs8/CHANGELOG.md
+++ b/pkcs8/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.10.0 (2023-02-26)
+## 0.10.1 (2023-03-05)
+### Added
+- `sha1-insecure` feature ([#913])
+
+[#913]: https://github.com/RustCrypto/formats/pull/913
+
+## 0.10.0 (2023-02-26) [YANKED]
 ### Changed
 - Use blanket impls for `Decode*` traits ([#785])
 - Bump `der` dependency to v0.7 ([#899])

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs8"
-version = "0.10.0"
+version = "0.10.1"
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #8:
 Private-Key Information Syntax Specification (RFC 5208), with additional
@@ -30,13 +30,14 @@ tempfile = "3"
 
 [features]
 alloc = ["der/alloc", "der/zeroize", "spki/alloc"]
+std = ["alloc", "der/std", "spki/std"]
+
 3des = ["encryption", "pkcs5/3des"]
 des-insecure = ["encryption", "pkcs5/des-insecure"]
 encryption = ["alloc", "pkcs5/alloc", "pkcs5/pbes2", "rand_core"]
 getrandom = ["rand_core/getrandom"]
 pem = ["alloc", "der/pem", "spki/pem"]
 sha1-insecure = ["encryption", "pkcs5/sha1-insecure"]
-std = ["alloc", "der/std", "spki/std"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
### Added
- `sha1-insecure` feature ([#913])

[#913]: https://github.com/RustCrypto/formats/pull/913