### PR TITLE
pkcs1 v0.7.1

### DIFF
--- a/pkcs1/CHANGELOG.md
+++ b/pkcs1/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.7.0 (2023-02-26)
+## 0.7.1 (2023-03-05)
+### Fixed
+- `DecodeRsaPublicKey` blanket impl ([#916])
+
+[#916]: https://github.com/RustCrypto/formats/pull/916
+
+## 0.7.0 (2023-02-26) [YANKED]
 ### Changed
 - Make PSS/OAEP params use generic `AlgorithmIdentifier` ([#799])
 - Bump `der` dependency to v0.7 ([#899])

--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs1"
-version = "0.7.0"
+version = "0.7.1"
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #1:
 RSA Cryptography Specifications Version 2.2 (RFC 8017)


### PR DESCRIPTION
### Fixed
- `DecodeRsaPublicKey` blanket impl ([#916])

[#916]: https://github.com/RustCrypto/formats/pull/916