### PR TITLE
tls_codec: feat: Allow const exprs in discriminant attrs

### DIFF
--- a/tls_codec/derive/src/lib.rs
+++ b/tls_codec/derive/src/lib.rs
@@ -65,7 +65,7 @@
 //! For enumerations with non-unit variants, if no variant has this attribute, the serialization
 //! discriminants will start from zero. If this attribute is used on a variant and the following
 //! variant does not have it, its discriminant will be equal to the previous variant discriminant
-//! plus 1. This behavior is refered to as "implicit discriminants".
+//! plus 1. This behavior is referred to as "implicit discriminants".
 //!
 //! You can also provide paths that lead to `const` definitions or enum Variants. The important
 //! thing is that any of those path expressions must resolve to something that can be coerced to

--- a/tls_codec/derive/tests/attributes/test_that_duplicate_skip_attributes_dont_compile.stderr
+++ b/tls_codec/derive/tests/attributes/test_that_duplicate_skip_attributes_dont_compile.stderr
@@ -1,23 +1,23 @@
-error: proc-macro derive panicked
+error: Attribute `skip` specified more than once
  --> tests/attributes/test_that_duplicate_skip_attributes_dont_compile.rs:3:10
   |
 3 | #[derive(TlsDeserialize, TlsSerialize, TlsSize)]
   |          ^^^^^^^^^^^^^^
   |
-  = help: message: called `Result::unwrap()` on an `Err` value: Error("Attribute `skip` specified more than once")
+  = note: this error originates in the derive macro `TlsDeserialize` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: proc-macro derive panicked
+error: Attribute `skip` specified more than once
  --> tests/attributes/test_that_duplicate_skip_attributes_dont_compile.rs:3:26
   |
 3 | #[derive(TlsDeserialize, TlsSerialize, TlsSize)]
   |                          ^^^^^^^^^^^^
   |
-  = help: message: called `Result::unwrap()` on an `Err` value: Error("Attribute `skip` specified more than once")
+  = note: this error originates in the derive macro `TlsSerialize` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: proc-macro derive panicked
+error: Attribute `skip` specified more than once
  --> tests/attributes/test_that_duplicate_skip_attributes_dont_compile.rs:3:40
   |
 3 | #[derive(TlsDeserialize, TlsSerialize, TlsSize)]
   |                                        ^^^^^^^
   |
-  = help: message: called `Result::unwrap()` on an `Err` value: Error("Attribute `skip` specified more than once")
+  = note: this error originates in the derive macro `TlsSize` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tls_codec/derive/tests/attributes/that_skip_attribute_does_not_compile_on_enums.stderr
+++ b/tls_codec/derive/tests/attributes/that_skip_attribute_does_not_compile_on_enums.stderr
@@ -1,23 +1,23 @@
-error: proc-macro derive panicked
+error: Unrecognized variant attribute `skip`
  --> tests/attributes/that_skip_attribute_does_not_compile_on_enums.rs:3:10
   |
 3 | #[derive(TlsDeserialize, TlsSerialize, TlsSize)]
   |          ^^^^^^^^^^^^^^
   |
-  = help: message: called `Result::unwrap()` on an `Err` value: Error("Unrecognized variant attribute `skip`")
+  = note: this error originates in the derive macro `TlsDeserialize` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: proc-macro derive panicked
+error: Unrecognized variant attribute `skip`
  --> tests/attributes/that_skip_attribute_does_not_compile_on_enums.rs:3:26
   |
 3 | #[derive(TlsDeserialize, TlsSerialize, TlsSize)]
   |                          ^^^^^^^^^^^^
   |
-  = help: message: called `Result::unwrap()` on an `Err` value: Error("Unrecognized variant attribute `skip`")
+  = note: this error originates in the derive macro `TlsSerialize` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: proc-macro derive panicked
+error: Unrecognized variant attribute `skip`
  --> tests/attributes/that_skip_attribute_does_not_compile_on_enums.rs:3:40
   |
 3 | #[derive(TlsDeserialize, TlsSerialize, TlsSize)]
   |                                        ^^^^^^^
   |
-  = help: message: called `Result::unwrap()` on an `Err` value: Error("Unrecognized variant attribute `skip`")
+  = note: this error originates in the derive macro `TlsSize` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tls_codec/derive/tests/decode.rs
+++ b/tls_codec/derive/tests/decode.rs
@@ -306,6 +306,44 @@ fn enum_with_data_and_discriminant() {
     }
 }
 
+mod discriminant {
+    pub mod test {
+        pub mod constant {
+            pub const TEST_CONST: u8 = 3;
+        }
+        pub mod enum_val {
+            pub enum Test {
+                Potato = 0x0004,
+            }
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, TlsDeserialize, TlsSerialize, TlsSize)]
+#[repr(u16)]
+enum EnumWithDataAndConstDiscriminant {
+    #[tls_codec(discriminant = "discriminant::test::constant::TEST_CONST")]
+    A(u8),
+    #[tls_codec(discriminant = "discriminant::test::enum_val::Test::Potato")]
+    B,
+    #[tls_codec(discriminant = 12)]
+    C,
+}
+
+#[test]
+fn enum_with_data_and_const_discriminant() {
+    for x in [
+        EnumWithDataAndConstDiscriminant::A(4),
+        EnumWithDataAndConstDiscriminant::B,
+        EnumWithDataAndConstDiscriminant::C,
+    ] {
+        let serialized = x.tls_serialize_detached().unwrap();
+        let deserialized =
+            EnumWithDataAndConstDiscriminant::tls_deserialize(&mut &*serialized).unwrap();
+        assert_eq!(deserialized, x);
+    }
+}
+
 #[derive(Debug, PartialEq, TlsDeserialize, TlsSerialize, TlsSize)]
 #[repr(u8)]
 enum EnumWithCustomSerializedField {

--- a/tls_codec/derive/tests/decode.rs
+++ b/tls_codec/derive/tests/decode.rs
@@ -309,9 +309,10 @@ fn enum_with_data_and_discriminant() {
 mod discriminant {
     pub mod test {
         pub mod constant {
-            pub const TEST_CONST: u8 = 3;
+            pub const TEST_CONST: u16 = 3;
         }
         pub mod enum_val {
+            #[repr(u16)]
             pub enum Test {
                 Potato = 0x0004,
             }

--- a/tls_codec/derive/tests/encode.rs
+++ b/tls_codec/derive/tests/encode.rs
@@ -211,6 +211,46 @@ fn discriminant_is_incremented_implicitly() {
     assert_eq!(vec![0, 4], serialized);
 }
 
+mod discriminant {
+    pub mod test {
+        pub mod constant {
+            pub const TEST_CONST: u8 = 3;
+        }
+        pub mod enum_val {
+            pub enum Test {
+                Potato = 0x0004,
+            }
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, TlsSerialize, TlsSize)]
+#[repr(u16)]
+enum EnumWithDataAndConstDiscriminant {
+    #[tls_codec(discriminant = "discriminant::test::constant::TEST_CONST")]
+    A(u8),
+    #[tls_codec(discriminant = "discriminant::test::enum_val::Test::Potato")]
+    B,
+    #[tls_codec(discriminant = 12)]
+    C,
+}
+
+#[test]
+fn enum_with_data_and_const_discriminant() {
+    let serialized = EnumWithDataAndConstDiscriminant::A(4)
+        .tls_serialize_detached()
+        .unwrap();
+    assert_eq!(vec![0, 3, 4], serialized);
+    let serialized = EnumWithDataAndConstDiscriminant::B
+        .tls_serialize_detached()
+        .unwrap();
+    assert_eq!(vec![0, 4], serialized);
+    let serialized = EnumWithDataAndConstDiscriminant::C
+        .tls_serialize_detached()
+        .unwrap();
+    assert_eq!(vec![0, 12], serialized);
+}
+
 #[derive(TlsSerialize, TlsSize)]
 #[repr(u8)]
 enum EnumWithCustomSerializedField {


### PR DESCRIPTION
You can now provide paths to `#[tls_codec(discriminant = ...)]`, like so `#[tls_codec(discriminant ="path::to::const::or::enum::Variant")]`

I'm going to do a pass on documenting the new behavior and will undraft this PR.

Changes: 

* Allowed `PathExpr`s in `#[tls_codec(discriminant = ...)]` attributes that resolve to constants or enum variants that can be coerced to the enum's repr.
* Fixed the proc macros panicking instead of returning a compile time error