### PR TITLE
der: expose NestedReader

### DIFF
--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -362,7 +362,7 @@ pub use crate::{
     header::Header,
     length::{IndefiniteLength, Length},
     ord::{DerOrd, ValueOrd},
-    reader::{slice::SliceReader, Reader},
+    reader::{nested::NestedReader, slice::SliceReader, Reader},
     tag::{Class, FixedTag, Tag, TagMode, TagNumber, Tagged},
     writer::{slice::SliceWriter, Writer},
 };

--- a/der/src/reader.rs
+++ b/der/src/reader.rs
@@ -1,6 +1,6 @@
 //! Reader trait.
 
-mod nested;
+pub(crate) mod nested;
 #[cfg(feature = "pem")]
 pub(crate) mod pem;
 pub(crate) mod slice;


### PR DESCRIPTION
`NestedReader` is exposed through `Reader::read_nested` but it's not documented.