### PR TITLE
cmpv2+cms+crmf: version requirement fixups

### DIFF
--- a/cmpv2/Cargo.toml
+++ b/cmpv2/Cargo.toml
@@ -15,10 +15,10 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-crmf = {version = "0.0", path = "../crmf" }
-der = { version = "0.7.0-pre", features = ["alloc", "derive", "flagset", "oid"], path = "../der" }
-spki = { version = "0.7.0-pre", path = "../spki" }
-x509-cert = { version = "0.2.0-pre", default-features = false, path = "../x509-cert" }
+crmf = { version = "=0.0.0", path = "../crmf" }
+der = { version = "0.7", features = ["alloc", "derive", "flagset", "oid"], path = "../der" }
+spki = { version = "0.7", path = "../spki" }
+x509-cert = { version = "=0.2.0-pre.0", default-features = false, path = "../x509-cert" }
 
 [dev-dependencies]
 const-oid = { version = "0.9", features = ["db"] } # TODO: path = "../const-oid"

--- a/cms/Cargo.toml
+++ b/cms/Cargo.toml
@@ -14,9 +14,9 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-der = { version = "0.7.0-pre", features = ["alloc", "derive", "oid"], path = "../der" }
-spki = { version = "0.7.0-pre", path = "../spki" }
-x509-cert = { version = "0.2.0-pre", default-features = false, path = "../x509-cert" }
+der = { version = "0.7", features = ["alloc", "derive", "oid"], path = "../der" }
+spki = { version = "0.7", path = "../spki" }
+x509-cert = { version = "=0.2.0-pre.0", default-features = false, path = "../x509-cert" }
 
 [dev-dependencies]
 const-oid = { version = "0.9", features = ["db"] } # TODO: path = "../const-oid"

--- a/crmf/Cargo.toml
+++ b/crmf/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-cms = { version = "0.0.0", path = "../cms"}
+cms = { version = "=0.0.0", path = "../cms"}
 der = { version = "0.7", features = ["alloc", "derive"], path = "../der" }
 spki = { version = "0.7", path = "../spki" }
 x509-cert = { version = "=0.2.0-pre.0", default-features = false, path = "../x509-cert" }


### PR DESCRIPTION
Be explicit about prerelease versions with `=` requirements