### PR TITLE
x509-cert v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1710,7 +1710,7 @@ dependencies = [
 
 [[package]]
 name = "x509-cert"
-version = "0.2.0-pre.0"
+version = "0.2.0"
 dependencies = [
  "arbitrary",
  "const-oid 0.9.2",

--- a/cmpv2/Cargo.toml
+++ b/cmpv2/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.65"
 crmf = { version = "=0.2.0-pre.0", path = "../crmf" }
 der = { version = "0.7", features = ["alloc", "derive", "flagset", "oid"], path = "../der" }
 spki = { version = "0.7", path = "../spki" }
-x509-cert = { version = "=0.2.0-pre.0", default-features = false, path = "../x509-cert" }
+x509-cert = { version = "0.2", default-features = false, path = "../x509-cert" }
 
 [dev-dependencies]
 const-oid = { version = "0.9", features = ["db"] } # TODO: path = "../const-oid"

--- a/cms/Cargo.toml
+++ b/cms/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.65"
 [dependencies]
 der = { version = "0.7", features = ["alloc", "derive", "oid"], path = "../der" }
 spki = { version = "0.7", path = "../spki" }
-x509-cert = { version = "=0.2.0-pre.0", default-features = false, path = "../x509-cert" }
+x509-cert = { version = "0.2", default-features = false, path = "../x509-cert" }
 
 [dev-dependencies]
 const-oid = { version = "0.9", features = ["db"] } # TODO: path = "../const-oid"

--- a/crmf/Cargo.toml
+++ b/crmf/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.65"
 cms = { version = "=0.2.0-pre", path = "../cms"}
 der = { version = "0.7", features = ["alloc", "derive"], path = "../der" }
 spki = { version = "0.7", path = "../spki" }
-x509-cert = { version = "=0.2.0-pre.0", default-features = false, path = "../x509-cert" }
+x509-cert = { version = "0.2", default-features = false, path = "../x509-cert" }
 
 [dev-dependencies]
 const-oid = { version = "0.9" } # TODO: path = "../const-oid"

--- a/pkcs7/Cargo.toml
+++ b/pkcs7/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.65"
 [dependencies]
 der = { version = "0.7", features = ["oid"], path = "../der" }
 spki = { version = "0.7", path = "../spki" }
-x509-cert = { version = "=0.2.0-pre.0", default-features = false, path = "../x509-cert" }
+x509-cert = { version = "0.2", default-features = false, path = "../x509-cert" }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/x509-cert/CHANGELOG.md
+++ b/x509-cert/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2023-03-18)
+### Added
+- Feature-gated `Arbitrary` impl for `Certificate` ([#761])
+- Allow request to be serialized to PEM ([#819])
+- `Display` impl for `SerialNumber` ([#820])
+- `std` feature implies `const-oid/std` ([#874])
+
+### Changed
+- Serial numbers are formatted as `PrintableString` ([#794])
+- `SerialNumber` is now a specialized object ([#795])
+- MSRV 1.65 ([#805])
+- Make types owned instead of reference-based ([#806], [#841])
+- Bump `der` to v0.7 ([#899])
+- Bump `spki` to v0.7 ([#900])
+
+### Fixed
+- Handling of negative serial numbers ([#823], [#831])
+
+### Removed
+- `alloc` feature: now unconditionally required ([#841])
+
+[#761]: https://github.com/RustCrypto/formats/pull/761
+[#794]: https://github.com/RustCrypto/formats/pull/794
+[#795]: https://github.com/RustCrypto/formats/pull/795
+[#805]: https://github.com/RustCrypto/formats/pull/805
+[#806]: https://github.com/RustCrypto/formats/pull/806
+[#819]: https://github.com/RustCrypto/formats/pull/819
+[#820]: https://github.com/RustCrypto/formats/pull/820
+[#823]: https://github.com/RustCrypto/formats/pull/823
+[#831]: https://github.com/RustCrypto/formats/pull/831
+[#841]: https://github.com/RustCrypto/formats/pull/841
+[#874]: https://github.com/RustCrypto/formats/pull/874
+[#899]: https://github.com/RustCrypto/formats/pull/899
+[#900]: https://github.com/RustCrypto/formats/pull/900
+
 ## 0.1.1 (2022-12-10)
 ### Added
 - Support `TeletexString` in `DirectoryString` ([#692])

--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x509-cert"
-version = "0.2.0-pre.0"
+version = "0.2.0"
 description = """
 Pure Rust implementation of the X.509 Public Key Infrastructure Certificate
 format as described in RFC 5280

--- a/x509-ocsp/Cargo.toml
+++ b/x509-ocsp/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.65"
 [dependencies]
 der = { version = "0.7", features = ["alloc", "derive", "oid"], path = "../der" }
 spki = { version = "0.7", path = "../spki" }
-x509-cert = { version = "=0.2.0-pre.0", default-features = false, path = "../x509-cert" }
+x509-cert = { version = "0.2", default-features = false, path = "../x509-cert" }
 
 [dev-dependencies]
 const-oid = { version = "0.9", features = ["db"] } # TODO: path = "../const-oid"


### PR DESCRIPTION
### Added
- Feature-gated `Arbitrary` impl for `Certificate` ([#761])
- Allow request to be serialized to PEM ([#819])
- `Display` impl for `SerialNumber` ([#820])
- `std` feature implies `const-oid/std` ([#874])

### Changed
- Serial numbers are formatted as `PrintableString` ([#794])
- `SerialNumber` is now a specialized object ([#795])
- MSRV 1.65 ([#805])
- Make types owned instead of reference-based ([#806], [#841])
- Bump `der` to v0.7 ([#899])
- Bump `spki` to v0.7 ([#900])

### Fixed
- Handling of negative serial numbers ([#823], [#831])

### Removed
- `alloc` feature: now unconditionally required ([#841])

[#761]: https://github.com/RustCrypto/formats/pull/761
[#794]: https://github.com/RustCrypto/formats/pull/794
[#795]: https://github.com/RustCrypto/formats/pull/795
[#805]: https://github.com/RustCrypto/formats/pull/805
[#806]: https://github.com/RustCrypto/formats/pull/806
[#819]: https://github.com/RustCrypto/formats/pull/819
[#820]: https://github.com/RustCrypto/formats/pull/820
[#823]: https://github.com/RustCrypto/formats/pull/823
[#831]: https://github.com/RustCrypto/formats/pull/831
[#841]: https://github.com/RustCrypto/formats/pull/841
[#874]: https://github.com/RustCrypto/formats/pull/874
[#899]: https://github.com/RustCrypto/formats/pull/899
[#900]: https://github.com/RustCrypto/formats/pull/900