### PR TITLE
pkcs7 v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs7"
-version = "0.4.0-pre.1"
+version = "0.4.0"
 dependencies = [
  "der",
  "hex-literal",

--- a/pkcs7/CHANGELOG.md
+++ b/pkcs7/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2023-03-18)
+### Added
+- `SignedData` type to ([#813])
+- `ValueOrd` impls ([#825])
+
+### Changed
+- MSRV 1.65 ([#805])
+- Bump `der` to v0.7 ([#899])
+- Bump `spki` to v0.7 ([#900])
+- Make `ContentInfo`'s `contentType` mandatory ([#924])
+- Bump `x509-cert` to v0.2 ([#934])
+
+[#805]: https://github.com/RustCrypto/formats/pull/805
+[#813]: https://github.com/RustCrypto/formats/pull/813
+[#825]: https://github.com/RustCrypto/formats/pull/825
+[#899]: https://github.com/RustCrypto/formats/pull/899
+[#900]: https://github.com/RustCrypto/formats/pull/900
+[#924]: https://github.com/RustCrypto/formats/pull/924
+[#934]: https://github.com/RustCrypto/formats/pull/934
+
 ## 0.3.0 (2021-11-15)
 - Initial release: older versions are a pre-RustCrypto crate.
 

--- a/pkcs7/Cargo.toml
+++ b/pkcs7/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs7"
-version = "0.4.0-pre.1"
+version = "0.4.0"
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #7:
 PKCS #7: Cryptographic Message Syntax Version 1.5 (RFC 5652)


### PR DESCRIPTION
### Added
- `SignedData` type to ([#813])
- `ValueOrd` impls ([#825])

### Changed
- MSRV 1.65 ([#805])
- Bump `der` to v0.7 ([#899])
- Bump `spki` to v0.7 ([#900])
- Make `ContentInfo`'s `contentType` mandatory ([#924])
- Bump `x509-cert` to v0.2 ([#934])

[#805]: https://github.com/RustCrypto/formats/pull/805
[#813]: https://github.com/RustCrypto/formats/pull/813
[#825]: https://github.com/RustCrypto/formats/pull/825
[#899]: https://github.com/RustCrypto/formats/pull/899
[#900]: https://github.com/RustCrypto/formats/pull/900
[#924]: https://github.com/RustCrypto/formats/pull/924
[#934]: https://github.com/RustCrypto/formats/pull/934