### PR TITLE
x509-cert: deprecate `encode_from_string` functions

### DIFF
--- a/x509-cert/src/attr.rs
+++ b/x509-cert/src/attr.rs
@@ -205,11 +205,20 @@ impl AttributeTypeAndValue {
     /// This function follows the rules in [RFC 4514].
     ///
     /// [RFC 4514]: https://datatracker.ietf.org/doc/html/rfc4514
+    #[deprecated(
+        since = "0.2.1",
+        note = "use AttributeTypeAndValue::from_str(...)?.to_der()"
+    )]
     pub fn encode_from_string(s: &str) -> Result<Vec<u8>, Error> {
         Self::from_str(s)?.to_der()
     }
 }
 
+/// Parse an [`AttributeTypeAndValue`] string.
+///
+/// This function follows the rules in [RFC 4514].
+///
+/// [RFC 4514]: https://datatracker.ietf.org/doc/html/rfc4514
 impl FromStr for AttributeTypeAndValue {
     type Err = Error;
 

--- a/x509-cert/src/name.rs
+++ b/x509-cert/src/name.rs
@@ -26,16 +26,18 @@ pub type Name = RdnSequence;
 pub struct RdnSequence(pub Vec<RelativeDistinguishedName>);
 
 impl RdnSequence {
-    /// Converts an RDNSequence string into an encoded RDNSequence
-    ///
-    /// This function follows the rules in [RFC 4514].
-    ///
-    /// [RFC 4514]: https://datatracker.ietf.org/doc/html/rfc4514
+    /// Converts an `RDNSequence` string into an encoded `RDNSequence`.
+    #[deprecated(since = "0.2.1", note = "use RdnSequence::from_str(...)?.to_der()")]
     pub fn encode_from_string(s: &str) -> Result<Vec<u8>, der::Error> {
         Self::from_str(s)?.to_der()
     }
 }
 
+/// Parse an [`RdnSequence`] string.
+///
+/// Follows the rules in [RFC 4514].
+///
+/// [RFC 4514]: https://datatracker.ietf.org/doc/html/rfc4514
 impl FromStr for RdnSequence {
     type Err = der::Error;
 
@@ -133,15 +135,20 @@ pub struct RelativeDistinguishedName(pub SetOfVec<AttributeTypeAndValue>);
 
 impl RelativeDistinguishedName {
     /// Converts an RelativeDistinguishedName string into an encoded RelativeDistinguishedName
-    ///
-    /// This function follows the rules in [RFC 4514].
-    ///
-    /// [RFC 4514]: https://datatracker.ietf.org/doc/html/rfc4514
+    #[deprecated(
+        since = "0.2.1",
+        note = "use RelativeDistinguishedName::from_str(...)?.to_der()"
+    )]
     pub fn encode_from_string(s: &str) -> Result<Vec<u8>, der::Error> {
         Self::from_str(s)?.to_der()
     }
 }
 
+/// Parse a [`RelativeDistinguishedName`] string.
+///
+/// This function follows the rules in [RFC 4514].
+///
+/// [RFC 4514]: https://datatracker.ietf.org/doc/html/rfc4514
 impl FromStr for RelativeDistinguishedName {
     type Err = der::Error;
 

--- a/x509-cert/tests/name.rs
+++ b/x509-cert/tests/name.rs
@@ -328,7 +328,11 @@ fn rdns_serde() {
         for input in inputs.iter() {
             eprintln!("input: {}", input);
 
-            let der = RdnSequence::encode_from_string(input).unwrap();
+            let der = input
+                .parse::<RdnSequence>()
+                .and_then(|rdn| rdn.to_der())
+                .unwrap();
+
             let rdns = RdnSequence::from_der(&der).unwrap();
 
             for (l, r) in brdns.0.iter().zip(rdns.0.iter()) {


### PR DESCRIPTION
Defined on the following types:

- `RdnSequence`
- `RelativeDistingiushedName`
- `AttributeTypeAndValue`

The name is confusing and it can now be expressed as the combination of `FromStr` and `Encode::to_der`.