### PR TITLE
x509-cert v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1727,7 +1727,7 @@ dependencies = [
 
 [[package]]
 name = "x509-cert"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "arbitrary",
  "const-oid 0.9.2",

--- a/x509-cert/CHANGELOG.md
+++ b/x509-cert/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.1 (2023-03-26)
+### Added
+- `FromStr` impls for `RdnSequence` (`Name`), `RelativeDistinguishedName`, and
+  `AttributeTypeAndValue` ([#949])
+
+### Changed
+- Deprecate `encode_from_string` functions ([#951])
+
+[#949]: https://github.com/RustCrypto/formats/pull/949
+[#951]: https://github.com/RustCrypto/formats/pull/951
+
 ## 0.2.0 (2023-03-18)
 ### Added
 - Feature-gated `Arbitrary` impl for `Certificate` ([#761])

--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x509-cert"
-version = "0.2.0"
+version = "0.2.1"
 description = """
 Pure Rust implementation of the X.509 Public Key Infrastructure Certificate
 format as described in RFC 5280
@@ -16,7 +16,7 @@ rust-version = "1.65"
 
 [dependencies]
 const-oid = { version = "0.9.2", features = ["db"] } # TODO: path = "../const-oid"
-der = { version = "0.7", features = ["derive", "alloc", "flagset", "oid"], path = "../der" }
+der = { version = "0.7", features = ["alloc", "derive", "flagset", "oid"], path = "../der" }
 spki = { version = "0.7", path = "../spki", features = ["alloc"] }
 
 # optional dependencies


### PR DESCRIPTION
### Added
- `FromStr` impls for `RdnSequence` (`Name`), `RelativeDistinguishedName`, and `AttributeTypeAndValue` ([#949])

### Changed
- Deprecate `encode_from_string` functions ([#951])

[#949]: https://github.com/RustCrypto/formats/pull/949
[#951]: https://github.com/RustCrypto/formats/pull/951