### PR TITLE
spki: define trait to get associated AlgorithmIdentifier

### DIFF
--- a/spki/src/lib.rs
+++ b/spki/src/lib.rs
@@ -57,8 +57,9 @@ pub use der::{self, asn1::ObjectIdentifier};
 #[cfg(feature = "alloc")]
 pub use {
     crate::{
-        algorithm::AlgorithmIdentifierOwned, spki::SubjectPublicKeyInfoOwned,
-        traits::EncodePublicKey,
+        algorithm::AlgorithmIdentifierOwned,
+        spki::SubjectPublicKeyInfoOwned,
+        traits::{DynAssociatedAlgorithmIdentifier, EncodePublicKey},
     },
     der::Document,
 };

--- a/spki/src/traits.rs
+++ b/spki/src/traits.rs
@@ -3,6 +3,9 @@
 use crate::{Error, Result, SubjectPublicKeyInfoRef};
 
 #[cfg(feature = "alloc")]
+use crate::AlgorithmIdentifierOwned;
+
+#[cfg(feature = "alloc")]
 use der::Document;
 
 #[cfg(feature = "pem")]
@@ -92,4 +95,12 @@ pub trait EncodePublicKey {
         let doc = self.to_public_key_der()?;
         Ok(doc.write_pem_file(path, SubjectPublicKeyInfoRef::PEM_LABEL, line_ending)?)
     }
+}
+
+/// Returns AlgorithmIndentifier associated with the structure. This is mostly useful for Signing
+/// and Validation keys.
+#[cfg(feature = "alloc")]
+pub trait DynAssociatedAlgorithmIdentifier {
+    /// Returns corresponding AlgorithmIndentifier
+    fn algorithm_identifier(&self) -> AlgorithmIdentifierOwned;
 }


### PR DESCRIPTION
It is useful to get AlgorithmIdentifiers for defined keys. Add a trait implementing that functionality.