### PR TITLE
const-oid+der+spki+x509-cert: re-enable min version check

### DIFF
--- a/.github/workflows/const-oid.yml
+++ b/.github/workflows/const-oid.yml
@@ -37,11 +37,10 @@ jobs:
       - uses: RustCrypto/actions/cargo-hack-install@master
       - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features std,arbitrary
 
-# FIXME: Temporary disabled until https://github.com/rust-fuzz/arbitrary/issues/134 is fixed
-#  minimal-versions:
-#    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
-#    with:
-#        working-directory: ${{ github.workflow }}
+  minimal-versions:
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/der.yml
+++ b/.github/workflows/der.yml
@@ -38,11 +38,10 @@ jobs:
       - uses: RustCrypto/actions/cargo-hack-install@master
       - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features std,arbitrary
 
-# FIXME: Temporary disabled until https://github.com/rust-fuzz/arbitrary/issues/134 is fixed
-#  minimal-versions:
-#    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
-#    with:
-#        working-directory: ${{ github.workflow }}
+  minimal-versions:
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     strategy:

--- a/.github/workflows/spki.yml
+++ b/.github/workflows/spki.yml
@@ -40,11 +40,10 @@ jobs:
       - uses: RustCrypto/actions/cargo-hack-install@master
       - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features arbitrary,std
 
-# FIXME: Temporary disabled until https://github.com/rust-fuzz/arbitrary/issues/134 is fixed
-#  minimal-versions:
-#    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
-#    with:
-#        working-directory: ${{ github.workflow }}
+  minimal-versions:
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/x509-cert.yml
+++ b/.github/workflows/x509-cert.yml
@@ -40,11 +40,10 @@ jobs:
       - uses: RustCrypto/actions/cargo-hack-install@master
       - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features arbitrary,default,std
 
-# FIXME: Temporary disabled until https://github.com/rust-fuzz/arbitrary/issues/136 is fixed
-#  minimal-versions:
-#    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
-#    with:
-#        working-directory: ${{ github.workflow }}
+  minimal-versions:
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-arbitrary = { version = "1.2", features = ["derive"], optional = true }
+arbitrary = { version = "1.3", features = ["derive"], optional = true }
 const-oid = { version = "0.9.2", optional = true } # TODO: path = "../const-oid"
 der_derive = { version = "0.7", optional = true, path = "derive" }
 flagset = { version = "0.4.3", optional = true }


### PR DESCRIPTION
This reverts commit 517adb7b82ee3774156a80c256d0b26e14246f74.

The issue in `arbitrary` has been fixed: rust-fuzz/arbitrary#136

See #837