### PR TITLE
spki: define trait to get associated `AlgorithmIdentifier`

### DIFF
--- a/spki/src/lib.rs
+++ b/spki/src/lib.rs
@@ -57,8 +57,9 @@ pub use der::{self, asn1::ObjectIdentifier};
 #[cfg(feature = "alloc")]
 pub use {
     crate::{
-        algorithm::AlgorithmIdentifierOwned, spki::SubjectPublicKeyInfoOwned,
-        traits::EncodePublicKey,
+        algorithm::AlgorithmIdentifierOwned,
+        spki::SubjectPublicKeyInfoOwned,
+        traits::{DynAssociatedAlgorithmIdentifier, EncodePublicKey},
     },
     der::Document,
 };

--- a/spki/src/traits.rs
+++ b/spki/src/traits.rs
@@ -3,6 +3,9 @@
 use crate::{Error, Result, SubjectPublicKeyInfoRef};
 
 #[cfg(feature = "alloc")]
+use crate::AlgorithmIdentifierOwned;
+
+#[cfg(feature = "alloc")]
 use der::Document;
 
 #[cfg(feature = "pem")]
@@ -92,4 +95,12 @@ pub trait EncodePublicKey {
         let doc = self.to_public_key_der()?;
         Ok(doc.write_pem_file(path, SubjectPublicKeyInfoRef::PEM_LABEL, line_ending)?)
     }
+}
+
+/// Returns AlgorithmIndentifier associated with the structure. This is mostly useful for Signing
+/// and Validation keys.
+#[cfg(feature = "alloc")]
+pub trait DynAssociatedAlgorithmIdentifier {
+    /// Returns corresponding AlgorithmIndentifier
+    fn algorithm_identifier(&self) -> AlgorithmIdentifierOwned;
 }

--- a/spki/src/traits.rs
+++ b/spki/src/traits.rs
@@ -1,12 +1,12 @@
 //! Traits for encoding/decoding SPKI public keys.
 
-use crate::{Error, Result, SubjectPublicKeyInfoRef};
+use crate::{AlgorithmIdentifierRef, Error, Result, SubjectPublicKeyInfoRef};
 
 #[cfg(feature = "alloc")]
-use crate::AlgorithmIdentifierOwned;
-
-#[cfg(feature = "alloc")]
-use der::Document;
+use {
+    crate::AlgorithmIdentifierOwned,
+    der::{referenced::RefToOwned, Document},
+};
 
 #[cfg(feature = "pem")]
 use {
@@ -97,10 +97,26 @@ pub trait EncodePublicKey {
     }
 }
 
-/// Returns AlgorithmIndentifier associated with the structure. This is mostly useful for Signing
-/// and Validation keys.
+/// Returns `AlgorithmIdentifier` associated with the structure.
+///
+/// This is useful for e.g. keys for digital signature algorithms.
+pub trait AssociatedAlgorithmIdentifier {
+    /// `AlgorithmIdentifier` for this structure.
+    const ALGORITHM_IDENTIFIER: AlgorithmIdentifierRef<'static>;
+}
+
+/// Returns `AlgorithmIdentifier` associated with the structure.
+///
+/// This is useful for e.g. keys for digital signature algorithms.
 #[cfg(feature = "alloc")]
 pub trait DynAssociatedAlgorithmIdentifier {
-    /// Returns corresponding AlgorithmIndentifier
+    /// `AlgorithmIdentifier` for this structure.
     fn algorithm_identifier(&self) -> AlgorithmIdentifierOwned;
+}
+
+#[cfg(feature = "alloc")]
+impl<T: AssociatedAlgorithmIdentifier> DynAssociatedAlgorithmIdentifier for T {
+    fn algorithm_identifier(&self) -> AlgorithmIdentifierOwned {
+        Self::ALGORITHM_IDENTIFIER.ref_to_owned()
+    }
 }


### PR DESCRIPTION
This is an alternative to/continuation of #954, which defines both `AssociatedAlgorithmIdentifier` and `DynAssociatedAlgorithmIdentifier`, where the former provides an associated constant `AlgorithmIdentifierRef`, and the latter a trait/object-safe way to obtain an `AlgorithmIdentifierOwned` which can be computed from `&self`.

A blanket impl links the two.