### PR TITLE
der: add `From<ObjectIdentifier>` impl for `Any`

### DIFF
--- a/der/src/asn1/oid.rs
+++ b/der/src/asn1/oid.rs
@@ -6,6 +6,9 @@ use crate::{
 };
 use const_oid::ObjectIdentifier;
 
+#[cfg(feature = "alloc")]
+use super::Any;
+
 impl<'a> DecodeValue<'a> for ObjectIdentifier {
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         let mut buf = [0u8; ObjectIdentifier::MAX_SIZE];
@@ -47,6 +50,13 @@ impl<'a> From<&'a ObjectIdentifier> for AnyRef<'a> {
             .expect("OID length invariant violated");
 
         AnyRef::from_tag_and_value(Tag::ObjectIdentifier, value)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl From<ObjectIdentifier> for Any {
+    fn from(oid: ObjectIdentifier) -> Any {
+        AnyRef::from(&oid).into()
     }
 }
 


### PR DESCRIPTION
This is useful for writing a blanket impl for converting generic `AlgorithmIdentifier<Params>` to `AlgorithmIdentifierOwned`, specifically for the `AlgorithmIdentifier<ObjectIdentifier>` case, but other types can opt into this same protocol.