### PR TITLE
ci: nodejs12 is deprecated

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,10 +1,14 @@
 name: Security Audit
 on:
   pull_request:
-    paths: Cargo.lock
+    paths:
+      - "Cargo.lock"
+      - ".github/workflows/security-audit.yml"
   push:
     branches: master
-    paths: Cargo.lock
+    paths:
+      - "Cargo.lock"
+      - ".github/workflows/security-audit.yml"
   schedule:
     - cron: "0 0 * * *"
 
@@ -21,7 +25,7 @@ jobs:
         with:
           path: ~/.cargo/bin
           key: ${{ runner.os }}-cargo-audit-v0.15.2
-      - uses: actions-rs/audit-check@v1
+      - uses: rustsec/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
move audit-check to the one maintained by `rustsec` to stand away from nodejs 12.

See https://github.com/actions-rs/audit-check/issues/227