### PR TITLE
der: support converting a Sequence into Any

### DIFF
--- a/der/src/asn1.rs
+++ b/der/src/asn1.rs
@@ -50,7 +50,7 @@ pub use self::{
 
 #[cfg(feature = "alloc")]
 pub use self::{
-    any::Any,
+    any::{Any, AnyWrapper},
     bit_string::BitString,
     ia5_string::Ia5String,
     integer::{int::Int, uint::Uint},

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -368,7 +368,7 @@ pub use crate::{
 };
 
 #[cfg(feature = "alloc")]
-pub use crate::{asn1::Any, document::Document};
+pub use crate::{asn1::Any, asn1::AnyWrapper, document::Document};
 
 #[cfg(feature = "bigint")]
 pub use crypto_bigint as bigint;


### PR DESCRIPTION
It is useful to be able to convert a Tag+Value into Any. However directly implementing the TryFrom trait is not possible because of a clash with the default blanked implementation. Use special AnyWrapper newtype to handle such conversions.