### PR TITLE
der v0.7.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,7 +392,7 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "arbitrary",
  "const-oid 0.9.2",

--- a/der/CHANGELOG.md
+++ b/der/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.2 (2023-04-04)
+### Added
+- Expose `NestedReader ([#925])
+- `From<ObjectIdentifier>` impl for `Any` ([#965])
+- `Any::null` helper ([#969])
+- `Any::encode_from` ([#976])
+
+[#925]: https://github.com/RustCrypto/formats/pull/925
+[#965]: https://github.com/RustCrypto/formats/pull/965
+[#969]: https://github.com/RustCrypto/formats/pull/969
+[#976]: https://github.com/RustCrypto/formats/pull/976
+
 ## 0.7.1 (2023-03-07)
 ### Changed
 - Make `zeroize`'s `alloc` feature conditional ([#920])

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der"
-version = "0.7.1"
+version = "0.7.2"
 description = """
 Pure Rust embedded-friendly implementation of the Distinguished Encoding Rules
 (DER) for Abstract Syntax Notation One (ASN.1) as described in ITU X.690 with
@@ -22,7 +22,7 @@ der_derive = { version = "0.7", optional = true, path = "derive" }
 flagset = { version = "0.4.3", optional = true }
 pem-rfc7468 = { version = "0.7", optional = true, features = ["alloc"], path = "../pem-rfc7468" }
 time = { version = "0.3.4", optional = true, default-features = false }
-zeroize = { version = "1.6", optional = true, default-features = false }
+zeroize = { version = "1.5", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.3.3"


### PR DESCRIPTION
### Added
- Expose `NestedReader ([#925])
- `From<ObjectIdentifier>` impl for `Any` ([#965])
- `Any::null` helper ([#969])
- `Any::encode_from` ([#976])

[#925]: https://github.com/RustCrypto/formats/pull/925
[#965]: https://github.com/RustCrypto/formats/pull/965
[#969]: https://github.com/RustCrypto/formats/pull/969
[#976]: https://github.com/RustCrypto/formats/pull/976