### PR TITLE
spki v0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,7 +1320,7 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "arbitrary",
  "base64ct",

--- a/spki/CHANGELOG.md
+++ b/spki/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.1 (2023-04-04)
+### Added
+- `AssociatedAlgorithmIdentifier` trait ([#962], [#966])
+- `DynAssociatedAlgorithmIdentifier` trait ([#962])
+- `SignatureAlgorithmIdentifier` trait ([#967])
+- `DynSignatureAlgorithmIdentifier` trait ([#967])
+
+### Changed
+- Bump `der` dependency to v0.7.2 ([#979])
+
+[#962]: https://github.com/RustCrypto/formats/pull/962
+[#966]: https://github.com/RustCrypto/formats/pull/966
+[#967]: https://github.com/RustCrypto/formats/pull/967
+[#979]: https://github.com/RustCrypto/formats/pull/979
+
 ## 0.7.0 (2023-02-26)
 ### Changed
 - Make `AlgorithmIdentifier` generic around `Params` ([#769])

--- a/spki/Cargo.toml
+++ b/spki/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spki"
-version = "0.7.0"
+version = "0.7.1"
 description = """
 X.509 Subject Public Key Info (RFC5280) describing public keys as well as their
 associated AlgorithmIdentifiers (i.e. OIDs)
@@ -15,7 +15,7 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-der = { version = "0.7", features = ["oid"], path = "../der" }
+der = { version = "0.7.2", features = ["oid"], path = "../der" }
 
 # Optional dependencies
 arbitrary = { version = "1.2", features = ["derive"], optional = true }


### PR DESCRIPTION
### Added
- `AssociatedAlgorithmIdentifier` trait ([#962], [#966])
- `DynAssociatedAlgorithmIdentifier` trait ([#962])
- `SignatureAlgorithmIdentifier` trait ([#967])
- `DynSignatureAlgorithmIdentifier` trait ([#967])

### Changed
- Bump `der` dependency to v0.7.2 ([#979])

[#962]: https://github.com/RustCrypto/formats/pull/962
[#966]: https://github.com/RustCrypto/formats/pull/966
[#967]: https://github.com/RustCrypto/formats/pull/967
[#979]: https://github.com/RustCrypto/formats/pull/979