### PR TITLE
pkcs8 v0.10.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "der",
  "hex-literal",

--- a/pkcs8/CHANGELOG.md
+++ b/pkcs8/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.2 (2023-04-04)
+### Changed
+- Bump `spki` to v0.7.1 ([#981])
+
+[#981]: https://github.com/RustCrypto/formats/pull/981
+
 ## 0.10.1 (2023-03-05)
 ### Added
 - `sha1-insecure` feature ([#913])

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs8"
-version = "0.10.1"
+version = "0.10.2"
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #8:
 Private-Key Information Syntax Specification (RFC 5208), with additional
@@ -17,7 +17,7 @@ rust-version = "1.65"
 
 [dependencies]
 der = { version = "0.7", features = ["oid"], path = "../der" }
-spki = { version = "0.7", path = "../spki" }
+spki = { version = "0.7.1", path = "../spki" }
 
 # optional dependencies
 rand_core = { version = "0.6", optional = true, default-features = false }


### PR DESCRIPTION
### Changed
- Bump `spki` to v0.7.1 ([#981])

[#981]: https://github.com/RustCrypto/formats/pull/981