### PR TITLE
x509-cert: use `ErrorKind::Value` for overlength serial

### DIFF
--- a/x509-cert/src/serial_number.rs
+++ b/x509-cert/src/serial_number.rs
@@ -80,7 +80,7 @@ impl<'a> DecodeValue<'a> for SerialNumber {
         // since some X.509 implementations interpret the limit of 20 bytes to refer
         // to the pre-encoded value.
         if inner.len() > SerialNumber::MAX_DECODE_LEN {
-            return Err(ErrorKind::Overlength.into());
+            return Err(Tag::Integer.value_error());
         }
 
         Ok(Self { inner })


### PR DESCRIPTION
This at least surfaces that the error has to do with an integer field, which would've been helpful with tracing it down to SerialNumber.

`Overlength` has a bit of a specific meaning in the context of the `ErrorKind`, namely it's used for framing errors, which isn't what's occurring here.

Perhaps the `der` documentation should help clarify this.