### PR TITLE
Creating PKCS #7 messages

### DIFF
--- a/pkcs7/Cargo.toml
+++ b/pkcs7/Cargo.toml
@@ -17,7 +17,8 @@ rust-version = "1.65"
 [dependencies]
 der = { version = "0.7", features = ["oid"], path = "../der" }
 spki = { version = "0.7", path = "../spki" }
-x509-cert = { version = "0.2", default-features = false, path = "../x509-cert" }
+# x509-cert = { version = "0.2", default-features = false, path = "../x509-cert" }
+x509-cert = { version = "0.2", path = "../x509-cert" }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/pkcs7/Cargo.toml
+++ b/pkcs7/Cargo.toml
@@ -20,9 +20,9 @@ spki = { version = "0.7" }
 x509-cert = { version = "0.2", default-features = false }
 
 [dev-dependencies]
-der = { version = "0.7", features = ["oid", "pem"], path = "../der" }
+der = { version = "0.7", features = ["oid", "pem"] }
 hex-literal = "0.4"
-x509-cert = { version = "0.2", default-features = false, features = ["pem"], path = "../x509-cert" }
+x509-cert = { version = "0.2", default-features = false, features = ["pem"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/pkcs7/Cargo.toml
+++ b/pkcs7/Cargo.toml
@@ -17,8 +17,7 @@ rust-version = "1.65"
 [dependencies]
 der = { version = "0.7", features = ["oid"], path = "../der" }
 spki = { version = "0.7", path = "../spki" }
-# x509-cert = { version = "0.2", default-features = false, path = "../x509-cert" }
-x509-cert = { version = "0.2", path = "../x509-cert" }
+x509-cert = { version = "0.2", default-features = false, path = "../x509-cert" }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/pkcs7/Cargo.toml
+++ b/pkcs7/Cargo.toml
@@ -20,7 +20,9 @@ spki = { version = "0.7", path = "../spki" }
 x509-cert = { version = "0.2", default-features = false, path = "../x509-cert" }
 
 [dev-dependencies]
+der = { version = "0.7", features = ["oid", "pem"], path = "../der" }
 hex-literal = "0.3"
+x509-cert = { version = "0.2", default-features = false, features = ["pem"], path = "../x509-cert" }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/pkcs7/src/algorithm_identifier_types.rs
+++ b/pkcs7/src/algorithm_identifier_types.rs
@@ -1,0 +1,22 @@
+//! `Algorithm Identifier Types` [RFC 5652 § 10.1](https://datatracker.ietf.org/doc/html/rfc5652#section-10.1)
+
+use der::asn1::SetOfVec;
+use spki::AlgorithmIdentifierRef;
+
+/// ```text
+/// DigestAlgorithmIdentifier ::= AlgorithmIdentifier
+/// ```
+/// See [RFC 5652 10.1.1](https://datatracker.ietf.org/doc/html/rfc5652#section-10.1.1).
+pub type DigestAlgorithmIdentifier<'a> = AlgorithmIdentifierRef<'a>;
+
+/// ```text
+/// DigestAlgorithmIdentifiers ::= SET OF DigestAlgorithmIdentifier
+/// ```
+pub type DigestAlgorithmIdentifiers<'a> = SetOfVec<DigestAlgorithmIdentifier<'a>>;
+
+/// ```text
+/// SignatureAlgorithmIdentifier ::= AlgorithmIdentifier
+/// ```
+/// See [RFC 5652 10.1.2](https://datatracker.ietf.org/doc/html/rfc5652#section-10.1.2).
+pub type SignatureAlgorithmIdentifier<'a> = AlgorithmIdentifierRef<'a>;
+

--- a/pkcs7/src/algorithm_identifier_types.rs
+++ b/pkcs7/src/algorithm_identifier_types.rs
@@ -19,4 +19,3 @@ pub type DigestAlgorithmIdentifiers<'a> = SetOfVec<DigestAlgorithmIdentifier<'a>
 /// ```
 /// See [RFC 5652 10.1.2](https://datatracker.ietf.org/doc/html/rfc5652#section-10.1.2).
 pub type SignatureAlgorithmIdentifier<'a> = AlgorithmIdentifierRef<'a>;
-

--- a/pkcs7/src/lib.rs
+++ b/pkcs7/src/lib.rs
@@ -15,10 +15,10 @@
     unused_qualifications
 )]
 
+pub mod algorithm_identifier_types;
 pub mod certificate_choices;
 pub mod cms_version;
 pub mod data_content;
-pub mod algorithm_identifier_types;
 pub mod encapsulated_content_info;
 pub mod encrypted_data_content;
 pub mod enveloped_data_content;

--- a/pkcs7/src/lib.rs
+++ b/pkcs7/src/lib.rs
@@ -25,7 +25,7 @@ pub mod revocation_info_choices;
 pub mod signed_data_content;
 pub mod signer_info;
 
-mod content_info;
+pub mod content_info;
 mod content_type;
 
 pub use crate::{content_info::ContentInfo, content_type::ContentType};

--- a/pkcs7/src/lib.rs
+++ b/pkcs7/src/lib.rs
@@ -18,6 +18,7 @@
 pub mod certificate_choices;
 pub mod cms_version;
 pub mod data_content;
+pub mod algorithm_identifier_types;
 pub mod encapsulated_content_info;
 pub mod encrypted_data_content;
 pub mod enveloped_data_content;
@@ -25,7 +26,7 @@ pub mod revocation_info_choices;
 pub mod signed_data_content;
 pub mod signer_info;
 
-pub mod content_info;
+mod content_info;
 mod content_type;
 
 pub use crate::{content_info::ContentInfo, content_type::ContentType};

--- a/pkcs7/src/signed_data_content.rs
+++ b/pkcs7/src/signed_data_content.rs
@@ -11,17 +11,17 @@ use spki::AlgorithmIdentifierRef;
 /// ```text
 /// DigestAlgorithmIdentifier ::= AlgorithmIdentifier
 /// ```
-type DigestAlgorithmIdentifier<'a> = AlgorithmIdentifierRef<'a>;
+pub type DigestAlgorithmIdentifier<'a> = AlgorithmIdentifierRef<'a>;
 
 /// ```text
 /// DigestAlgorithmIdentifiers ::= SET OF DigestAlgorithmIdentifier
 /// ```
-type DigestAlgorithmIdentifiers<'a> = SetOfVec<DigestAlgorithmIdentifier<'a>>;
+pub type DigestAlgorithmIdentifiers<'a> = SetOfVec<DigestAlgorithmIdentifier<'a>>;
 
 /// ```text
 /// CertificateSet ::= SET OF CertificateChoices
 /// ```
-type CertificateSet<'a> = SetOfVec<CertificateChoices<'a>>;
+pub type CertificateSet<'a> = SetOfVec<CertificateChoices<'a>>;
 
 /// Signed-data content type [RFC 5652 § 5](https://datatracker.ietf.org/doc/html/rfc5652#section-5)
 ///

--- a/pkcs7/src/signed_data_content.rs
+++ b/pkcs7/src/signed_data_content.rs
@@ -1,8 +1,8 @@
 //! `signed-data` content type [RFC 5652 § 5](https://datatracker.ietf.org/doc/html/rfc5652#section-5)
 
 use crate::{
-    certificate_choices::CertificateChoices, cms_version::CmsVersion,
     algorithm_identifier_types::DigestAlgorithmIdentifiers,
+    certificate_choices::CertificateChoices, cms_version::CmsVersion,
     encapsulated_content_info::EncapsulatedContentInfo,
     revocation_info_choices::RevocationInfoChoices, signer_info::SignerInfos,
 };

--- a/pkcs7/src/signed_data_content.rs
+++ b/pkcs7/src/signed_data_content.rs
@@ -2,21 +2,11 @@
 
 use crate::{
     certificate_choices::CertificateChoices, cms_version::CmsVersion,
+    algorithm_identifier_types::DigestAlgorithmIdentifiers,
     encapsulated_content_info::EncapsulatedContentInfo,
     revocation_info_choices::RevocationInfoChoices, signer_info::SignerInfos,
 };
 use der::{asn1::SetOfVec, Sequence};
-use spki::AlgorithmIdentifierRef;
-
-/// ```text
-/// DigestAlgorithmIdentifier ::= AlgorithmIdentifier
-/// ```
-pub type DigestAlgorithmIdentifier<'a> = AlgorithmIdentifierRef<'a>;
-
-/// ```text
-/// DigestAlgorithmIdentifiers ::= SET OF DigestAlgorithmIdentifier
-/// ```
-pub type DigestAlgorithmIdentifiers<'a> = SetOfVec<DigestAlgorithmIdentifier<'a>>;
 
 /// ```text
 /// CertificateSet ::= SET OF CertificateChoices

--- a/pkcs7/src/signer_info.rs
+++ b/pkcs7/src/signer_info.rs
@@ -1,24 +1,16 @@
 //! `SignerInfo` data type [RFC 5652 § 5.3](https://datatracker.ietf.org/doc/html/rfc5652#section-5.3)
 
-use crate::cms_version::CmsVersion;
+use crate::{
+    cms_version::CmsVersion,
+    algorithm_identifier_types::{DigestAlgorithmIdentifier, SignatureAlgorithmIdentifier},
+};
 use der::{
     asn1::{OctetStringRef, SetOfVec},
     Choice, Sequence, ValueOrd,
 };
-use spki::AlgorithmIdentifierRef;
 use x509_cert::{
     attr::Attribute, ext::pkix::SubjectKeyIdentifier, name::Name, serial_number::SerialNumber,
 };
-
-/// ```text
-/// DigestAlgorithmIdentifier ::= AlgorithmIdentifier
-/// ```
-type DigestAlgorithmIdentifier<'a> = AlgorithmIdentifierRef<'a>;
-
-/// ```text
-/// SignatureAlgorithmIdentifier ::= AlgorithmIdentifier
-/// ```
-type SignatureAlgorithmIdentifier<'a> = AlgorithmIdentifierRef<'a>;
 
 /// ```text
 /// SignedAttributes ::= SET SIZE (1..MAX) OF Attribute

--- a/pkcs7/src/signer_info.rs
+++ b/pkcs7/src/signer_info.rs
@@ -1,8 +1,8 @@
 //! `SignerInfo` data type [RFC 5652 § 5.3](https://datatracker.ietf.org/doc/html/rfc5652#section-5.3)
 
 use crate::{
-    cms_version::CmsVersion,
     algorithm_identifier_types::{DigestAlgorithmIdentifier, SignatureAlgorithmIdentifier},
+    cms_version::CmsVersion,
 };
 use der::{
     asn1::{OctetStringRef, SetOfVec},

--- a/pkcs7/tests/content_tests.rs
+++ b/pkcs7/tests/content_tests.rs
@@ -146,7 +146,6 @@ fn decode_signed_scep_example() {
 
     let mut buf = vec![0u8; bytes.len()];
     let encoded_content = encode_content_info(&content, &mut buf);
-    println!("{:?}", encoded_content);
 }
 
 // TODO(tarcieri): BER support

--- a/pkcs7/tests/content_tests.rs
+++ b/pkcs7/tests/content_tests.rs
@@ -2,9 +2,13 @@
 
 use der::{
     asn1::{ObjectIdentifier, OctetStringRef, SequenceRef},
-    Decode, SliceWriter,
+    Decode, DecodePem, SliceWriter,
 };
 use hex_literal::hex;
+use pkcs7::algorithm_identifier_types::{DigestAlgorithmIdentifier, DigestAlgorithmIdentifiers};
+use pkcs7::certificate_choices::CertificateChoices;
+use pkcs7::signed_data_content::CertificateSet;
+use pkcs7::signer_info::SignerInfos;
 use pkcs7::{
     cms_version::CmsVersion, encapsulated_content_info::EncapsulatedContentInfo,
     encrypted_data_content::EncryptedDataContent, enveloped_data_content::EncryptedContentInfo,
@@ -191,54 +195,54 @@ fn decode_signed_der() {
     );
 }
 
-use pkcs7::{
-    signed_data_content::{CertificateSet, DigestAlgorithmIdentifier, DigestAlgorithmIdentifiers},
-    signer_info::{SignerInfo, SignerInfos},
-};
-
-const OID_ED25519: &str = "1.3.101.112"; // {iso(1) identified-organization(3) thawte(101) id-Ed25519(112)}
-const OID_PKCS7_SIGNED_DATA: &str = "1.2.840.113549.1.7.2"; // {iso(1) member-body(2) us(840) rsadsi(113549) pkcs(1) pkcs-7(7) signedData(2)}
 
 #[test]
-fn test_make_pkcs7_signed_data() {
+fn create_pkcs7_signed_data() {
+    // {iso(1) identified-organization(3) thawte(101) id-Ed25519(112)}
+    const OID_ED25519: &str = "1.3.101.112";
+    // {iso(1) member-body(2) us(840) rsadsi(113549) pkcs(1) pkcs-7(7) signedData(2)}
+    const OID_PKCS7_SIGNED_DATA: &str = "1.2.840.113549.1.7.2";
+
+    let digest_algorithms = {
+        let digest_algorithm = DigestAlgorithmIdentifier {
+            oid: der::asn1::ObjectIdentifier::new(OID_ED25519).unwrap(),
+            parameters: None,
+        };
+        let mut digest_algorithms = DigestAlgorithmIdentifiers::new();
+        digest_algorithms.add(digest_algorithm).unwrap();
+        digest_algorithms
+    };
+
+    let encap_content_info = {
+        EncapsulatedContentInfo {
+            e_content_type: der::asn1::ObjectIdentifier::new(OID_PKCS7_SIGNED_DATA).unwrap(),
+            e_content: None,
+        }
+    };
+
+    let certificates = {
+        let cert_pem = include_bytes!("../tests/examples/cert.pem");
+        let cert: x509_cert::Certificate = x509_cert::Certificate::from_pem(cert_pem).unwrap();
+        let cert_choice = CertificateChoices::Certificate(cert);
+        let mut certs = CertificateSet::new();
+        certs.add(cert_choice).unwrap();
+        Some(certs)
+    };
+
+    fn get_signer_infos<'a>() -> SignerInfos<'a> {
+        let signer_infos = SignerInfos::new();
+        signer_infos
+    }
 
     let content_info = ContentInfo::SignedData(SignedDataContent {
         version: pkcs7::cms_version::CmsVersion::V1,
-        digest_algorithms: get_digest_algorithms(),
-        encap_content_info: get_encap_content_info(),
-        certificates: get_certificates(),
+        digest_algorithms,
+        encap_content_info,
+        certificates,
         crls: None,
         signer_infos: get_signer_infos(),
     });
 
-    let mut buf = vec![0u8; 10000];
-    let _encoded_content = encode_content_info(&content_info, &mut buf);
+    let mut buf = vec![0u8; 10000]; // buffer length must be guessed in advance :|
+    encode_content_info(&content_info, &mut buf);
 }
-
-fn get_digest_algorithms<'a>() -> DigestAlgorithmIdentifiers<'a> {
-    let digest_algorithm = DigestAlgorithmIdentifier {
-        oid: der::asn1::ObjectIdentifier::new(OID_ED25519).unwrap(),
-        parameters: None
-    };
-    let mut digest_algorithms = DigestAlgorithmIdentifiers::new();
-    digest_algorithms.add(digest_algorithm).unwrap();
-    digest_algorithms
-}
-
-fn get_encap_content_info<'a>() -> EncapsulatedContentInfo<'a> {
-    EncapsulatedContentInfo {
-        e_content_type: der::asn1::ObjectIdentifier::new(OID_PKCS7_SIGNED_DATA).unwrap(),
-        e_content: None,
-    }
-}
-
-fn get_certificates<'a>() -> Option<CertificateSet<'a>> {
-    None
-}
-
-fn get_signer_infos<'a>() -> SignerInfos<'a> {
-    let signer_infos = SignerInfos::new();
-    signer_infos
-}
-
-

--- a/pkcs7/tests/content_tests.rs
+++ b/pkcs7/tests/content_tests.rs
@@ -195,7 +195,6 @@ fn decode_signed_der() {
     );
 }
 
-
 #[test]
 fn create_pkcs7_signed_data() {
     // {iso(1) identified-organization(3) thawte(101) id-Ed25519(112)}

--- a/pkcs7/tests/content_tests.rs
+++ b/pkcs7/tests/content_tests.rs
@@ -145,7 +145,7 @@ fn decode_signed_scep_example() {
     }
 
     let mut buf = vec![0u8; bytes.len()];
-    let encoded_content = encode_content_info(&content, &mut buf);
+    encode_content_info(&content, &mut buf);
 }
 
 // TODO(tarcieri): BER support


### PR DESCRIPTION
This is a proposal (say: a trial ballon) for how PKSC #7 messages could be created. The work is not done with this request. Signing and encryption is missing, but by making some types public, we can at least get a PKSC #7 scaffolding with certificates.
Is this a good way? Should I proceed with it? Or do you already have other plans?