### PR TITLE
der v0.7.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,7 +392,7 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "arbitrary",
  "const-oid 0.9.2",

--- a/der/CHANGELOG.md
+++ b/der/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.3 (2023-04-06)
+### Added
+- `UtcTime::MAX_YEAR` associated constant ([#989])
+
+[#989]: https://github.com/RustCrypto/formats/pull/989
+
 ## 0.7.2 (2023-04-04)
 ### Added
 - Expose `NestedReader ([#925])

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der"
-version = "0.7.2"
+version = "0.7.3"
 description = """
 Pure Rust embedded-friendly implementation of the Distinguished Encoding Rules
 (DER) for Abstract Syntax Notation One (ASN.1) as described in ITU X.690 with


### PR DESCRIPTION
### Added
- `UtcTime::MAX_YEAR` associated constant ([#989])

[#989]: https://github.com/RustCrypto/formats/pull/989