### PR TITLE
Handle cyclic dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,31 @@ members = [
 
 [profile.dev]
 opt-level = 2
+
+[patch.crates-io]
+# A global patch crates-io block is used to avoid cyclic dependencies errors
+# If we use other crates from the RustCrypto ecosystem, they may pull redundant
+# versions of dependencies.
+base16ct          = { path = "./base16ct" }
+base32ct          = { path = "./base32ct" }
+base64ct          = { path = "./base64ct" }
+cmpv2             = { path = "./cmpv2" }
+cms               = { path = "./cms" }
+const-oid         = { path = "./const-oid" }
+crmf              = { path = "./crmf" }
+der               = { path = "./der" }
+der_derive        = { path = "./der/derive" }
+pem-rfc7468       = { path = "./pem-rfc7468" }
+pkcs1             = { path = "./pkcs1" }
+pkcs5             = { path = "./pkcs5" }
+pkcs7             = { path = "./pkcs7" }
+pkcs8             = { path = "./pkcs8" }
+pkcs12            = { path = "./pkcs12" }
+sec1              = { path = "./sec1" }
+serdect           = { path = "./serdect" }
+spki              = { path = "./spki" }
+tai64             = { path = "./tai64" }
+tls_codec         = { path = "./tls_codec" }
+tls_codec_derive  = { path = "./tls_codec/derive" }
+x509-cert         = { path = "./x509-cert" }
+x509-ocsp         = { path = "./x509-ocsp" }

--- a/cmpv2/Cargo.toml
+++ b/cmpv2/Cargo.toml
@@ -15,10 +15,10 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-crmf = { version = "=0.2.0-pre.0", path = "../crmf" }
-der = { version = "0.7", features = ["alloc", "derive", "flagset", "oid"], path = "../der" }
-spki = { version = "0.7", path = "../spki" }
-x509-cert = { version = "0.2", default-features = false, path = "../x509-cert" }
+crmf = { version = "=0.2.0-pre.0" }
+der = { version = "0.7", features = ["alloc", "derive", "flagset", "oid"] }
+spki = { version = "0.7" }
+x509-cert = { version = "0.2", default-features = false }
 
 [dev-dependencies]
 const-oid = { version = "0.9", features = ["db"] } # TODO: path = "../const-oid"

--- a/cms/Cargo.toml
+++ b/cms/Cargo.toml
@@ -14,14 +14,14 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-der = { version = "0.7", features = ["alloc", "derive", "oid"], path = "../der" }
-spki = { version = "0.7", path = "../spki" }
-x509-cert = { version = "0.2", default-features = false, path = "../x509-cert" }
+der = { version = "0.7", features = ["alloc", "derive", "oid"] }
+spki = { version = "0.7" }
+x509-cert = { version = "0.2", default-features = false }
 
 [dev-dependencies]
 const-oid = { version = "0.9", features = ["db"] } # TODO: path = "../const-oid"
 hex-literal = "0.3"
-pkcs5 = { version = "0.7", path = "../pkcs5" }
+pkcs5 = { version = "0.7" }
 
 [features]
 alloc = ["der/alloc"]

--- a/crmf/Cargo.toml
+++ b/crmf/Cargo.toml
@@ -15,10 +15,10 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-cms = { version = "0.2", path = "../cms"}
-der = { version = "0.7", features = ["alloc", "derive"], path = "../der" }
-spki = { version = "0.7", path = "../spki" }
-x509-cert = { version = "0.2", default-features = false, path = "../x509-cert" }
+cms = { version = "0.2" }
+der = { version = "0.7", features = ["alloc", "derive"] }
+spki = { version = "0.7" }
+x509-cert = { version = "0.2", default-features = false }
 
 [dev-dependencies]
 const-oid = { version = "0.9" } # TODO: path = "../const-oid"

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -18,9 +18,9 @@ rust-version = "1.65"
 [dependencies]
 arbitrary = { version = "1.3", features = ["derive"], optional = true }
 const-oid = { version = "0.9.2", optional = true } # TODO: path = "../const-oid"
-der_derive = { version = "0.7", optional = true, path = "derive" }
+der_derive = { version = "0.7", optional = true }
 flagset = { version = "0.4.3", optional = true }
-pem-rfc7468 = { version = "0.7", optional = true, features = ["alloc"], path = "../pem-rfc7468" }
+pem-rfc7468 = { version = "0.7", optional = true, features = ["alloc"] }
 time = { version = "0.3.4", optional = true, default-features = false }
 zeroize = { version = "1.5", optional = true, default-features = false }
 

--- a/pem-rfc7468/Cargo.toml
+++ b/pem-rfc7468/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2021"
 rust-version = "1.60"
 
 [dependencies]
-base64ct = { version = "1.4", path = "../base64ct" }
+base64ct = { version = "1.4" }
 
 [features]
 alloc = ["base64ct/alloc"]

--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -15,11 +15,11 @@ edition = "2021"
 rust-version = "1.60"
 
 [dependencies]
-der = { version = "0.7", features = ["oid"], path = "../der" }
-spki = { version = "0.7", path = "../spki" }
+der = { version = "0.7", features = ["oid"] }
+spki = { version = "0.7" }
 
 # optional dependencies
-pkcs8 = { version = "0.10", optional = true, default-features = false, path = "../pkcs8" }
+pkcs8 = { version = "0.10", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -15,8 +15,8 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-der = { version = "0.7", features = ["oid"], path = "../der" }
-spki = { version = "0.7", path = "../spki" }
+der = { version = "0.7", features = ["oid"] }
+spki = { version = "0.7" }
 
 # optional dependencies
 cbc = { version = "0.1.2", optional = true }

--- a/pkcs7/Cargo.toml
+++ b/pkcs7/Cargo.toml
@@ -15,9 +15,9 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-der = { version = "0.7", features = ["oid"], path = "../der" }
-spki = { version = "0.7", path = "../spki" }
-x509-cert = { version = "0.2", default-features = false, path = "../x509-cert" }
+der = { version = "0.7", features = ["oid"] }
+spki = { version = "0.7" }
+x509-cert = { version = "0.2", default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -16,12 +16,12 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-der = { version = "0.7", features = ["oid"], path = "../der" }
-spki = { version = "0.7.1", path = "../spki" }
+der = { version = "0.7", features = ["oid"] }
+spki = { version = "0.7.1" }
 
 # optional dependencies
 rand_core = { version = "0.6", optional = true, default-features = false }
-pkcs5 = { version = "0.7", optional = true, path = "../pkcs5" }
+pkcs5 = { version = "0.7", optional = true }
 subtle = { version = "2", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -16,11 +16,11 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-base16ct = { version = "0.2", optional = true, default-features = false, path = "../base16ct" }
-der = { version = "0.7", optional = true, features = ["oid"], path = "../der" }
+base16ct = { version = "0.2", optional = true, default-features = false }
+der = { version = "0.7", optional = true, features = ["oid"] }
 generic-array = { version = "0.14.7", optional = true, default-features = false }
-pkcs8 = { version = "0.10", optional = true, default-features = false, path = "../pkcs8" }
-serdect = { version = "0.2", optional = true, default-features = false, features = ["alloc"], path = "../serdect" }
+pkcs8 = { version = "0.10", optional = true, default-features = false }
+serdect = { version = "0.2", optional = true, default-features = false, features = ["alloc"] }
 subtle = { version = "2", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 

--- a/serdect/Cargo.toml
+++ b/serdect/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 rust-version = "1.60"
 
 [dependencies]
-base16ct = { version = "0.2", default-features = false, path = "../base16ct" }
+base16ct = { version = "0.2", default-features = false }
 serde = { version = "1.0.96", default-features = false }
 
 # optional features

--- a/spki/Cargo.toml
+++ b/spki/Cargo.toml
@@ -15,11 +15,11 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-der = { version = "0.7.2", features = ["oid"], path = "../der" }
+der = { version = "0.7.2", features = ["oid"] }
 
 # Optional dependencies
 arbitrary = { version = "1.2", features = ["derive"], optional = true }
-base64ct = { version = "1", optional = true, default-features = false, path = "../base64ct" }
+base64ct = { version = "1", optional = true, default-features = false }
 sha2 = { version = "0.10", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/tls_codec/Cargo.toml
+++ b/tls_codec/Cargo.toml
@@ -16,7 +16,7 @@ zeroize = { version = "1", default-features = false, features = ["alloc"] }
 # optional dependencies
 arbitrary = { version = "1", features = ["derive"], optional = true }
 serde = { version = "1.0.144", features = ["derive"], optional = true }
-tls_codec_derive = { version = "=0.3.0-pre.2", path = "derive", optional = true }
+tls_codec_derive = { version = "=0.3.0-pre.2", optional = true }
 
 [dev-dependencies]
 criterion = "0.4"

--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -16,8 +16,8 @@ rust-version = "1.65"
 
 [dependencies]
 const-oid = { version = "0.9.2", features = ["db"] } # TODO: path = "../const-oid"
-der = { version = "0.7", features = ["alloc", "derive", "flagset", "oid"], path = "../der" }
-spki = { version = "0.7", path = "../spki", features = ["alloc"] }
+der = { version = "0.7", features = ["alloc", "derive", "flagset", "oid"] }
+spki = { version = "0.7", features = ["alloc"] }
 
 # optional dependencies
 arbitrary = { version = "1.2", features = ["derive"], optional = true }

--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -20,7 +20,7 @@ der = { version = "0.7", features = ["alloc", "derive", "flagset", "oid"] }
 spki = { version = "0.7", features = ["alloc"] }
 
 # optional dependencies
-arbitrary = { version = "1.2", features = ["derive"], optional = true }
+arbitrary = { version = "1.3", features = ["derive"], optional = true }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/x509-ocsp/Cargo.toml
+++ b/x509-ocsp/Cargo.toml
@@ -15,9 +15,9 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-der = { version = "0.7", features = ["alloc", "derive", "oid"], path = "../der" }
-spki = { version = "0.7", path = "../spki" }
-x509-cert = { version = "0.2", default-features = false, path = "../x509-cert" }
+der = { version = "0.7", features = ["alloc", "derive", "oid"] }
+spki = { version = "0.7" }
+x509-cert = { version = "0.2", default-features = false }
 
 [dev-dependencies]
 const-oid = { version = "0.9", features = ["db"] } # TODO: path = "../const-oid"


### PR DESCRIPTION
When cyclic dependencies are used for either doctests or integrations tests (`x509-cert` depends on `rsa` which depends back to `der` in this workspace), the compiler will complain about lack of trait implementation because two crates will be pulled. One from this checkout as well as one from crates.io.

This migrates the inclusion from local `path` in each Cargo.toml to a global `patch.crates-io`.