### PR TITLE
small builder updates

### DIFF
--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -22,7 +22,7 @@ spki = { version = "0.7.1", features = ["alloc"] }
 # optional dependencies
 arbitrary = { version = "1.3", features = ["derive"], optional = true }
 sha1 = { version = "0.10.0", optional = true }
-signature = { version = "2.1.0", features = ["digest"], optional = true }
+signature = { version = "2.1.0", optional = true }
 
 [dev-dependencies]
 hex-literal = "0.4"

--- a/x509-cert/src/builder.rs
+++ b/x509-cert/src/builder.rs
@@ -227,13 +227,13 @@ impl Profile {
 ///     validity,
 ///     subject,
 ///     pub_key,
-///     &mut signer,
+///     &signer,
 /// )
 /// .expect("Create certificate");
 /// ```
 pub struct CertificateBuilder<'s, S> {
     tbs: TbsCertificate,
-    signer: &'s mut S,
+    signer: &'s S,
 }
 
 impl<'s, S> CertificateBuilder<'s, S>
@@ -249,7 +249,7 @@ where
         mut validity: Validity,
         subject: Name,
         subject_public_key_info: SubjectPublicKeyInfoOwned,
-        signer: &'s mut S,
+        signer: &'s S,
     ) -> Result<Self>
     where
         S: Signer<Signature>,
@@ -315,7 +315,7 @@ where
     }
 
     /// Run the certificate through the signer and build the end certificate.
-    pub fn build<Signature>(&mut self) -> Result<Certificate>
+    pub fn build<Signature>(self) -> Result<Certificate>
     where
         S: Signer<Signature>,
         Signature: SignatureEncoding,
@@ -325,7 +325,7 @@ where
 
         let cert = Certificate {
             tbs_certificate: self.tbs.clone(),
-            signature_algorithm: self.tbs.signature.clone(),
+            signature_algorithm: self.tbs.signature,
             signature,
         };
 

--- a/x509-cert/src/builder.rs
+++ b/x509-cert/src/builder.rs
@@ -164,12 +164,8 @@ impl Profile {
         // Build Key Usage extension
         match self {
             Profile::Root | Profile::SubCA { .. } => {
-                extensions.push(
-                    KeyUsage(
-                        KeyUsages::DigitalSignature | KeyUsages::KeyCertSign | KeyUsages::CRLSign,
-                    )
-                    .to_extension(tbs)?,
-                );
+                extensions
+                    .push(KeyUsage(KeyUsages::KeyCertSign | KeyUsages::CRLSign).to_extension(tbs)?);
             }
             Profile::Leaf {
                 enable_key_agreement,

--- a/x509-cert/src/builder.rs
+++ b/x509-cert/src/builder.rs
@@ -36,6 +36,9 @@ pub enum Error {
     Signature(signature::Error),
 }
 
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
+
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/x509-cert/src/builder.rs
+++ b/x509-cert/src/builder.rs
@@ -90,6 +90,8 @@ pub enum Profile {
         issuer: Name,
         /// should the key agreement flag of KeyUsage be enabled
         enable_key_agreement: bool,
+        /// should the key encipherment flag of KeyUsage be enabled
+        enable_key_encipherment: bool,
     },
     #[cfg(feature = "hazmat")]
     /// Opt-out of the default extensions
@@ -169,11 +171,13 @@ impl Profile {
             }
             Profile::Leaf {
                 enable_key_agreement,
+                enable_key_encipherment,
                 ..
             } => {
-                let mut key_usage = KeyUsages::DigitalSignature
-                    | KeyUsages::NonRepudiation
-                    | KeyUsages::KeyEncipherment;
+                let mut key_usage = KeyUsages::DigitalSignature | KeyUsages::NonRepudiation;
+                if *enable_key_encipherment {
+                    key_usage |= KeyUsages::KeyEncipherment;
+                }
                 if *enable_key_agreement {
                     key_usage |= KeyUsages::KeyAgreement;
                 }

--- a/x509-cert/src/builder.rs
+++ b/x509-cert/src/builder.rs
@@ -238,9 +238,8 @@ pub struct CertificateBuilder<'s, S> {
 
 impl<'s, S> CertificateBuilder<'s, S>
 where
-    S: Keypair,
+    S: Keypair + DynSignatureAlgorithmIdentifier,
     S::VerifyingKey: EncodePublicKey,
-    S::VerifyingKey: DynSignatureAlgorithmIdentifier,
 {
     /// Creates a new certificate builder
     pub fn new<Signature>(
@@ -260,7 +259,7 @@ where
             .to_public_key_der()?
             .decode_msg::<SubjectPublicKeyInfoOwned>()?;
 
-        let signature_alg = verifying_key.signature_algorithm_identifier()?;
+        let signature_alg = signer.signature_algorithm_identifier()?;
         let issuer = profile.get_issuer(&subject);
 
         validity.not_before.rfc5280_adjust_utc_time()?;

--- a/x509-cert/test-support/src/zlint.rs
+++ b/x509-cert/test-support/src/zlint.rs
@@ -11,7 +11,7 @@ use std::{
 };
 use tempfile::tempdir;
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Status {
     NotApplicable,
     NotEffective,
@@ -29,7 +29,7 @@ impl Status {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LintStatus {
     pub status: Status,
     pub details: Option<String>,

--- a/x509-cert/tests/builder.rs
+++ b/x509-cert/tests/builder.rs
@@ -31,15 +31,15 @@ fn root_ca_certificate() {
     let pub_key =
         SubjectPublicKeyInfoOwned::try_from(RSA_2048_DER_EXAMPLE).expect("get rsa pub key");
 
-    let mut signer = rsa_signer();
-    let mut builder = CertificateBuilder::new(
+    let signer = rsa_signer();
+    let builder = CertificateBuilder::new(
         profile,
         Version::V3,
         serial_number,
         validity,
         subject,
         pub_key,
-        &mut signer,
+        &signer,
     )
     .expect("Create certificate");
 
@@ -75,15 +75,15 @@ fn sub_ca_certificate() {
     let pub_key =
         SubjectPublicKeyInfoOwned::try_from(RSA_2048_DER_EXAMPLE).expect("get rsa pub key");
 
-    let mut signer = ecdsa_signer();
-    let mut builder = CertificateBuilder::new::<ecdsa::Signature<NistP256>>(
+    let signer = ecdsa_signer();
+    let builder = CertificateBuilder::new::<ecdsa::Signature<NistP256>>(
         profile,
         Version::V3,
         serial_number,
         validity,
         subject,
         pub_key,
-        &mut signer,
+        &signer,
     )
     .expect("Create certificate");
 
@@ -126,15 +126,15 @@ fn leaf_certificate() {
     let pub_key =
         SubjectPublicKeyInfoOwned::try_from(RSA_2048_DER_EXAMPLE).expect("get rsa pub key");
 
-    let mut signer = ecdsa_signer();
-    let mut builder = CertificateBuilder::new::<ecdsa::Signature<NistP256>>(
+    let signer = ecdsa_signer();
+    let builder = CertificateBuilder::new::<ecdsa::Signature<NistP256>>(
         profile,
         Version::V3,
         serial_number,
         validity,
         subject,
         pub_key,
-        &mut signer,
+        &signer,
     )
     .expect("Create certificate");
 

--- a/x509-cert/tests/builder.rs
+++ b/x509-cert/tests/builder.rs
@@ -49,21 +49,15 @@ fn sub_ca_certificate() {
     let serial_number = SerialNumber::from(42u32);
     let validity = Validity::from_now(Duration::new(5, 0)).unwrap();
 
-    let issuer = Name::from_str("CN=World domination corporation,O=World domination Inc,C=US")
-        .unwrap()
-        .to_der()
-        .unwrap();
-    let issuer = Name::from_der(&issuer).unwrap();
+    let issuer =
+        Name::from_str("CN=World domination corporation,O=World domination Inc,C=US").unwrap();
     let profile = Profile::SubCA {
         issuer,
         path_len_constraint: Some(0),
     };
 
-    let subject = Name::from_str("CN=World domination task force,O=World domination Inc,C=US")
-        .unwrap()
-        .to_der()
-        .unwrap();
-    let subject = Name::from_der(&subject).unwrap();
+    let subject =
+        Name::from_str("CN=World domination task force,O=World domination Inc,C=US").unwrap();
     let pub_key =
         SubjectPublicKeyInfoOwned::try_from(RSA_2048_DER_EXAMPLE).expect("get rsa pub key");
 
@@ -99,22 +93,15 @@ fn leaf_certificate() {
     let serial_number = SerialNumber::from(42u32);
     let validity = Validity::from_now(Duration::new(5, 0)).unwrap();
 
-    let issuer = Name::from_str("CN=World domination corporation,O=World domination Inc,C=US")
-        .unwrap()
-        .to_der()
-        .unwrap();
-    let issuer = Name::from_der(&issuer).unwrap();
+    let issuer =
+        Name::from_str("CN=World domination corporation,O=World domination Inc,C=US").unwrap();
     let profile = Profile::Leaf {
         issuer,
         enable_key_agreement: false,
         enable_key_encipherment: false,
     };
 
-    let subject = Name::from_str("CN=service.domination.world")
-        .unwrap()
-        .to_der()
-        .unwrap();
-    let subject = Name::from_der(&subject).unwrap();
+    let subject = Name::from_str("CN=service.domination.world").unwrap();
     let pub_key =
         SubjectPublicKeyInfoOwned::try_from(RSA_2048_DER_EXAMPLE).expect("get rsa pub key");
 

--- a/x509-cert/tests/builder.rs
+++ b/x509-cert/tests/builder.rs
@@ -9,7 +9,6 @@ use spki::SubjectPublicKeyInfoOwned;
 use std::{str::FromStr, time::Duration};
 use x509_cert::{
     builder::{CertificateBuilder, Profile},
-    certificate::Version,
     name::Name,
     serial_number::SerialNumber,
     time::Validity,
@@ -32,16 +31,9 @@ fn root_ca_certificate() {
         SubjectPublicKeyInfoOwned::try_from(RSA_2048_DER_EXAMPLE).expect("get rsa pub key");
 
     let signer = rsa_signer();
-    let builder = CertificateBuilder::new(
-        profile,
-        Version::V3,
-        serial_number,
-        validity,
-        subject,
-        pub_key,
-        &signer,
-    )
-    .expect("Create certificate");
+    let builder =
+        CertificateBuilder::new(profile, serial_number, validity, subject, pub_key, &signer)
+            .expect("Create certificate");
 
     let certificate = builder.build().unwrap();
 
@@ -78,7 +70,6 @@ fn sub_ca_certificate() {
     let signer = ecdsa_signer();
     let builder = CertificateBuilder::new::<ecdsa::Signature<NistP256>>(
         profile,
-        Version::V3,
         serial_number,
         validity,
         subject,
@@ -130,7 +121,6 @@ fn leaf_certificate() {
     let signer = ecdsa_signer();
     let builder = CertificateBuilder::new::<ecdsa::Signature<NistP256>>(
         profile,
-        Version::V3,
         serial_number,
         validity,
         subject,

--- a/x509-cert/tests/builder.rs
+++ b/x509-cert/tests/builder.rs
@@ -116,6 +116,7 @@ fn leaf_certificate() {
     let profile = Profile::Leaf {
         issuer,
         enable_key_agreement: false,
+        enable_key_encipherment: false,
     };
 
     let subject = Name::from_str("CN=service.domination.world")


### PR DESCRIPTION
I started rebasing my code to use `CertificateBuilder` and I had to make several useful modifications.

Note: It is still not possible to create RSA PSS certificates, since there is no `Signer` implementation for RSA PSS, only `RandomizedSigner` (there is no standard detereministic RSA PSS signature process).  Locally I have changed the `CertificateBuilder` to accept `RandomizedSigner` instead of bare `Signer`, however this doesn't look like an universal solution too.