### PR TITLE
der: add `Decode` and `Encode` impls for `PhantomData`

### DIFF
--- a/der/src/decode.rs
+++ b/der/src/decode.rs
@@ -1,6 +1,7 @@
 //! Trait definition for [`Decode`].
 
 use crate::{FixedTag, Header, Reader, Result, SliceReader};
+use core::marker::PhantomData;
 
 #[cfg(feature = "pem")]
 use crate::{pem::PemLabel, PemReader};
@@ -35,6 +36,17 @@ where
         let header = Header::decode(reader)?;
         header.tag.assert_eq(T::TAG)?;
         T::decode_value(reader, header)
+    }
+}
+
+/// Dummy implementation for [`PhantomData`] which allows deriving
+/// implementations on structs with phantom fields.
+impl<'a, T> Decode<'a> for PhantomData<T>
+where
+    T: ?Sized,
+{
+    fn decode<R: Reader<'a>>(_reader: &mut R) -> Result<PhantomData<T>> {
+        Ok(PhantomData)
     }
 }
 

--- a/der/src/encode.rs
+++ b/der/src/encode.rs
@@ -1,6 +1,7 @@
 //! Trait definition for [`Encode`].
 
 use crate::{Header, Length, Result, SliceWriter, Tagged, Writer};
+use core::marker::PhantomData;
 
 #[cfg(feature = "alloc")]
 use {alloc::boxed::Box, alloc::vec::Vec, core::iter};
@@ -79,6 +80,21 @@ where
     fn encode(&self, writer: &mut impl Writer) -> Result<()> {
         self.header()?.encode(writer)?;
         self.encode_value(writer)
+    }
+}
+
+/// Dummy implementation for [`PhantomData`] which allows deriving
+/// implementations on structs with phantom fields.
+impl<T> Encode for PhantomData<T>
+where
+    T: ?Sized,
+{
+    fn encoded_len(&self) -> Result<Length> {
+        Ok(Length::ZERO)
+    }
+
+    fn encode(&self, _writer: &mut impl Writer) -> Result<()> {
+        Ok(())
     }
 }
 

--- a/der/tests/derive.rs
+++ b/der/tests/derive.rs
@@ -200,6 +200,7 @@ mod enumerated {
 /// Custom derive test cases for the `Sequence` macro.
 #[cfg(feature = "oid")]
 mod sequence {
+    use core::marker::PhantomData;
     use der::{
         asn1::{AnyRef, ObjectIdentifier, SetOf},
         Decode, Encode, Sequence, ValueOrd,
@@ -266,6 +267,9 @@ mod sequence {
             tag_mode = "IMPLICIT"
         )]
         pub only_contains_attribute_certs: bool,
+
+        /// Test handling of PhantomData.
+        pub phantom: PhantomData<()>,
     }
 
     // Extension as defined in [RFC 5280 Section 4.1.2.9].


### PR DESCRIPTION
Allows `PhantomData` fields to be used with custom derive.

cc @baloo