### PR TITLE
RsaPssParams and RsaOaepParams fixes

### DIFF
--- a/pkcs1/src/params.rs
+++ b/pkcs1/src/params.rs
@@ -14,7 +14,7 @@ const OID_PSPECIFIED: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.1
 
 const SHA_1_AI: AlgorithmIdentifierRef<'_> = AlgorithmIdentifierRef {
     oid: OID_SHA_1,
-    parameters: None,
+    parameters: Some(AnyRef::NULL),
 };
 
 /// `TrailerField` as defined in [RFC 8017 Appendix 2.3].

--- a/pkcs1/tests/params.rs
+++ b/pkcs1/tests/params.rs
@@ -1,7 +1,10 @@
 //! PKCS#1 algorithm params tests
 
 use const_oid::db;
-use der::{asn1::OctetStringRef, Encode};
+use der::{
+    asn1::{AnyRef, OctetStringRef},
+    Encode,
+};
 use hex_literal::hex;
 use pkcs1::{RsaOaepParams, RsaPssParams, TrailerField};
 
@@ -56,7 +59,7 @@ fn decode_pss_param_default() {
         .hash
         .assert_algorithm_oid(db::rfc5912::ID_SHA_1)
         .is_ok());
-    assert_eq!(param.hash.parameters, None);
+    assert_eq!(param.hash.parameters, Some(AnyRef::NULL));
     assert!(param
         .mask_gen
         .assert_algorithm_oid(db::rfc5912::ID_MGF_1)
@@ -67,6 +70,10 @@ fn decode_pss_param_default() {
         .unwrap()
         .assert_algorithm_oid(db::rfc5912::ID_SHA_1)
         .is_ok());
+    assert_eq!(
+        param.mask_gen.parameters.unwrap().parameters,
+        Some(AnyRef::NULL)
+    );
     assert_eq!(param.salt_len, 20);
     assert_eq!(param.trailer_field, TrailerField::BC);
     assert_eq!(param, Default::default())
@@ -132,7 +139,7 @@ fn decode_oaep_param_default() {
         .hash
         .assert_algorithm_oid(db::rfc5912::ID_SHA_1)
         .is_ok());
-    assert_eq!(param.hash.parameters, None);
+    assert_eq!(param.hash.parameters, Some(AnyRef::NULL));
     assert!(param
         .mask_gen
         .assert_algorithm_oid(db::rfc5912::ID_MGF_1)
@@ -143,6 +150,10 @@ fn decode_oaep_param_default() {
         .unwrap()
         .assert_algorithm_oid(db::rfc5912::ID_SHA_1)
         .is_ok());
+    assert_eq!(
+        param.mask_gen.parameters.unwrap().parameters,
+        Some(AnyRef::NULL)
+    );
     assert!(param
         .p_source
         .assert_algorithm_oid(db::rfc5912::ID_P_SPECIFIED)

--- a/pkcs1/tests/params.rs
+++ b/pkcs1/tests/params.rs
@@ -2,7 +2,8 @@
 
 use const_oid::db;
 use der::{
-    asn1::{AnyRef, OctetStringRef},
+    asn1::{AnyRef, ObjectIdentifier, OctetStringRef},
+    oid::AssociatedOid,
     Encode,
 };
 use hex_literal::hex;
@@ -11,12 +12,22 @@ use pkcs1::{RsaOaepParams, RsaPssParams, TrailerField};
 /// Default PSS parameters using all default values (SHA1, MGF1)
 const RSA_PSS_PARAMETERS_DEFAULTS: &[u8] = &hex!("3000");
 /// Example PSS parameters using SHA256 instead of SHA1
-const RSA_PSS_PARAMETERS_SHA2_256: &[u8] = &hex!("3030a00d300b0609608648016503040201a11a301806092a864886f70d010108300b0609608648016503040201a203020120");
+const RSA_PSS_PARAMETERS_SHA2_256: &[u8] = &hex!("3034a00f300d06096086480165030402010500a11c301a06092a864886f70d010108300d06096086480165030402010500a203020120");
 
 /// Default OAEP parameters using all default values (SHA1, MGF1, Empty)
 const RSA_OAEP_PARAMETERS_DEFAULTS: &[u8] = &hex!("3000");
-/// Example OAEP parameters using SHA256 instead of SHA1 and 'abc' as label
-const RSA_OAEP_PARAMETERS_SHA2_256: &[u8] = &hex!("303fa00d300b0609608648016503040201a11a301806092a864886f70d010108300b0609608648016503040201a212301006092a864886f70d0101090403abcdef");
+/// Example OAEP parameters using SHA256 instead of SHA1
+const RSA_OAEP_PARAMETERS_SHA2_256: &[u8] = &hex!("302fa00f300d06096086480165030402010500a11c301a06092a864886f70d010108300d06096086480165030402010500");
+
+struct Sha1Mock {}
+impl AssociatedOid for Sha1Mock {
+    const OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.14.3.2.26");
+}
+
+struct Sha256Mock {}
+impl AssociatedOid for Sha256Mock {
+    const OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("2.16.840.1.101.3.4.2.1");
+}
 
 #[test]
 fn decode_pss_param() {
@@ -26,7 +37,7 @@ fn decode_pss_param() {
         .hash
         .assert_algorithm_oid(db::rfc5912::ID_SHA_256)
         .is_ok());
-    assert_eq!(param.hash.parameters, None);
+    assert_eq!(param.hash.parameters, Some(AnyRef::NULL));
     assert!(param
         .mask_gen
         .assert_algorithm_oid(db::rfc5912::ID_MGF_1)
@@ -89,6 +100,23 @@ fn encode_pss_param_default() {
 }
 
 #[test]
+fn new_pss_param() {
+    let mut buf = [0_u8; 256];
+
+    let param = RsaPssParams::new::<Sha1Mock>(20);
+    assert_eq!(
+        param.encode_to_slice(&mut buf).unwrap(),
+        RSA_PSS_PARAMETERS_DEFAULTS
+    );
+
+    let param = RsaPssParams::new::<Sha256Mock>(32);
+    assert_eq!(
+        param.encode_to_slice(&mut buf).unwrap(),
+        RSA_PSS_PARAMETERS_SHA2_256
+    );
+}
+
+#[test]
 fn decode_oaep_param() {
     let param = RsaOaepParams::try_from(RSA_OAEP_PARAMETERS_SHA2_256).unwrap();
 
@@ -96,7 +124,7 @@ fn decode_oaep_param() {
         .hash
         .assert_algorithm_oid(db::rfc5912::ID_SHA_256)
         .is_ok());
-    assert_eq!(param.hash.parameters, None);
+    assert_eq!(param.hash.parameters, Some(AnyRef::NULL));
     assert!(param
         .mask_gen
         .assert_algorithm_oid(db::rfc5912::ID_MGF_1)
@@ -111,14 +139,13 @@ fn decode_oaep_param() {
         .p_source
         .assert_algorithm_oid(db::rfc5912::ID_P_SPECIFIED)
         .is_ok());
-    assert_eq!(
-        param
-            .p_source
-            .parameters_any()
-            .unwrap()
-            .decode_as::<OctetStringRef<'_>>(),
-        OctetStringRef::new(&[0xab, 0xcd, 0xef])
-    );
+    assert!(param
+        .p_source
+        .parameters_any()
+        .unwrap()
+        .decode_as::<OctetStringRef<'_>>()
+        .unwrap()
+        .is_empty(),);
 }
 
 #[test]
@@ -174,5 +201,23 @@ fn encode_oaep_param_default() {
     assert_eq!(
         RsaOaepParams::default().encode_to_slice(&mut buf).unwrap(),
         RSA_OAEP_PARAMETERS_DEFAULTS
+    );
+}
+
+#[test]
+fn new_oaep_param() {
+    let mut buf = [0_u8; 256];
+
+    let param = RsaOaepParams::new::<Sha1Mock>();
+    assert_eq!(
+        param.encode_to_slice(&mut buf).unwrap(),
+        RSA_OAEP_PARAMETERS_DEFAULTS
+    );
+
+    let param = RsaOaepParams::new::<Sha256Mock>();
+    println!("{:02x?}", param.encode_to_slice(&mut buf).unwrap());
+    assert_eq!(
+        param.encode_to_slice(&mut buf).unwrap(),
+        RSA_OAEP_PARAMETERS_SHA2_256
     );
 }


### PR DESCRIPTION
- Use NULL parameters for digest params (as required by mozilla)
- Add functions to construct known-good parameters.