### PR TITLE
pkcs1 v0.7.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -969,7 +969,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs1"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "const-oid 0.9.2",
  "der",

--- a/pkcs1/CHANGELOG.md
+++ b/pkcs1/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.3 (2023-04-18)
+### Added
+- Provide functions to construct `RsaPss` and `RsaOaepParams` ([#1010])
+
+### Changed
+- Use `NULL` parameters for SHA `AlgorithmIdentifier`s ([#1010])
+
+[#1010]: https://github.com/RustCrypto/formats/pull/1010
+
 ## 0.7.2 (2023-04-04)
 ### Added
 - `RsaPssParams::SALT_LEN_DEFAULT` ([#953])

--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs1"
-version = "0.7.2"
+version = "0.7.3"
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #1:
 RSA Cryptography Specifications Version 2.2 (RFC 8017)


### PR DESCRIPTION
### Added
- Provide functions to construct `RsaPss` and `RsaOaepParams` ([#1010])

### Changed
- Use `NULL` parameters for SHA `AlgorithmIdentifier`s ([#1010])

[#1010]: https://github.com/RustCrypto/formats/pull/1010