### PR TITLE
Fix feature `alloc` and `pem` in `pkcs1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -977,7 +977,6 @@ dependencies = [
  "pkcs8",
  "spki",
  "tempfile",
- "zeroize",
 ]
 
 [[package]]

--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -20,7 +20,6 @@ spki = { version = "0.7" }
 
 # optional dependencies
 pkcs8 = { version = "0.10", optional = true, default-features = false }
-zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
 const-oid = { version = "0.9", features = ["db"] } # TODO: path = "../const-oid"
@@ -28,8 +27,9 @@ hex-literal = "0.4"
 tempfile = "3"
 
 [features]
-alloc = ["der/alloc", "pkcs8/alloc", "zeroize/alloc"]
-pem = ["alloc", "der/pem", "pkcs8/pem"]
+zeroize = ["der/zeroize"]
+alloc = ["der/alloc", "zeroize", "pkcs8?/alloc"]
+pem = ["alloc", "der/pem", "pkcs8?/pem"]
 std = ["der/std", "alloc"]
 
 [package.metadata.docs.rs]

--- a/pkcs1/src/traits.rs
+++ b/pkcs1/src/traits.rs
@@ -3,10 +3,7 @@
 use crate::Result;
 
 #[cfg(feature = "alloc")]
-use {
-    crate::{RsaPrivateKey, RsaPublicKey},
-    der::SecretDocument,
-};
+use der::{Document, SecretDocument};
 
 #[cfg(feature = "pem")]
 use {
@@ -24,8 +21,11 @@ use {
 #[cfg(feature = "std")]
 use std::path::Path;
 
+#[cfg(all(feature = "alloc", feature = "pem"))]
+use crate::{RsaPrivateKey, RsaPublicKey};
+
 #[cfg(all(feature = "alloc", feature = "pkcs8"))]
-use der::{Decode, Document};
+use der::Decode;
 
 /// Parse an [`RsaPrivateKey`] from a PKCS#1-encoded document.
 pub trait DecodeRsaPrivateKey: Sized {


### PR DESCRIPTION
Avoid pulling in dep `pkcs8` or `zeroize` just because feature `alloc` or `pem` is enabled.