### PR TITLE
der_derive: handle type generics in sequence

### DIFF
--- a/der/derive/src/choice.rs
+++ b/der/derive/src/choice.rs
@@ -61,7 +61,10 @@ impl DeriveChoice {
 
         let lifetime = match self.lifetime {
             Some(ref lifetime) => quote!(#lifetime),
-            None => default_lifetime(),
+            None => {
+                let lifetime = default_lifetime();
+                quote!(#lifetime)
+            }
         };
 
         // Lifetime parameters

--- a/der/derive/src/lib.rs
+++ b/der/derive/src/lib.rs
@@ -141,13 +141,11 @@ use crate::{
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use proc_macro_error::proc_macro_error;
-use quote::quote;
 use syn::{parse_macro_input, DeriveInput, Lifetime};
 
 /// Get the default lifetime.
-fn default_lifetime() -> proc_macro2::TokenStream {
-    let lifetime = Lifetime::new("'__der_lifetime", Span::call_site());
-    quote!(#lifetime)
+fn default_lifetime() -> Lifetime {
+    Lifetime::new("'__der_lifetime", Span::call_site())
 }
 
 /// Derive the [`Choice`][1] trait on an `enum`.

--- a/der/derive/src/sequence.rs
+++ b/der/derive/src/sequence.rs
@@ -8,7 +8,7 @@ use field::SequenceField;
 use proc_macro2::TokenStream;
 use proc_macro_error::abort;
 use quote::quote;
-use syn::{DeriveInput, GenericParam, Generics, Ident, Lifetime, LifetimeParam};
+use syn::{DeriveInput, GenericParam, Generics, Ident, LifetimeParam};
 
 /// Derive the `Sequence` trait for a struct
 pub(crate) struct DeriveSequence {
@@ -55,16 +55,17 @@ impl DeriveSequence {
 
         // Use the first lifetime parameter as lifetime for Decode/Encode lifetime
         // if none found, add one.
-        let lifetime: Lifetime = if let Some(lt) = generics.lifetimes().next() {
-            lt.lifetime.clone()
-        } else {
-            let lifetime = default_lifetime();
-            generics.params.insert(
-                0,
-                GenericParam::Lifetime(LifetimeParam::new(lifetime.clone())),
-            );
-            lifetime
-        };
+        let lifetime = generics
+            .lifetimes()
+            .next()
+            .map(|lt| lt.lifetime.clone())
+            .unwrap_or_else(|| {
+                let lt = default_lifetime();
+                generics
+                    .params
+                    .insert(0, GenericParam::Lifetime(LifetimeParam::new(lt.clone())));
+                lt
+            });
 
         // We may or may not have inserted a lifetime.
         let (_impl_generics, ty_generics, where_clause) = self.generics.split_for_impl();

--- a/der/derive/src/sequence.rs
+++ b/der/derive/src/sequence.rs
@@ -68,8 +68,8 @@ impl DeriveSequence {
             });
 
         // We may or may not have inserted a lifetime.
-        let (_impl_generics, ty_generics, where_clause) = self.generics.split_for_impl();
-        let (impl_generics, _ty_generics, _where_clause) = generics.split_for_impl();
+        let (_, ty_generics, where_clause) = self.generics.split_for_impl();
+        let (impl_generics, _, _) = generics.split_for_impl();
 
         let mut decode_body = Vec::new();
         let mut decode_result = Vec::new();


### PR DESCRIPTION
this is required for #987 to have parsing profiles like:
```rust
#[derive(Clone, Debug, Eq, PartialEq, Sequence, ValueOrd)]
pub struct CertificateInner<P: Profile = Rfc5280> {
    pub tbs_certificate: TbsCertificate<P>,
    pub signature_algorithm: AlgorithmIdentifierOwned,
    pub signature: BitString,
}
```