### PR TITLE
der_derive v0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "der_derive"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/der/derive/CHANGELOG.md
+++ b/der/derive/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.1 (2023-04-19)
+### Added
+ - Support for type generics in `Sequence` macro ([#1014])
+
+[#1014]: https://github.com/RustCrypto/formats/pull/1014
+
 ## 0.7.0 (2023-02-26)
 ### Changed
 - Eliminate dynamism from encoding ([#828])

--- a/der/derive/Cargo.toml
+++ b/der/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der_derive"
-version = "0.7.0"
+version = "0.7.1"
 description = "Custom derive support for the `der` crate's `Choice` and `Sequence` traits"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
Added
 - Support for type generics in `Sequence` macro ([#1014])

[#1014]: https://github.com/RustCrypto/formats/pull/1014