### PR TITLE
der v0.7.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,7 +404,7 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "arbitrary",
  "const-oid 0.9.2",

--- a/der/CHANGELOG.md
+++ b/der/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.4 (2023-04-19)
+### Added
+- `Decode` and `Encode` impls for `PhantomData` ([#1009])
+- `ValueOrd` and `DerOrd` impls for `PhantomData` ([#1012])
+
+### Changed
+- Bump `hex-literal` dependency to v0.4.1 ([#999])
+- Bump `der_derive` dependency to v0.7.1 ([#1016])
+
+[#1009]: https://github.com/RustCrypto/formats/pull/1009
+[#1012]: https://github.com/RustCrypto/formats/pull/1012
+[#1016]: https://github.com/RustCrypto/formats/pull/1016
+
 ## 0.7.3 (2023-04-06)
 ### Added
 - `UtcTime::MAX_YEAR` associated constant ([#989])

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der"
-version = "0.7.3"
+version = "0.7.4"
 description = """
 Pure Rust embedded-friendly implementation of the Distinguished Encoding Rules
 (DER) for Abstract Syntax Notation One (ASN.1) as described in ITU X.690 with
@@ -18,7 +18,7 @@ rust-version = "1.65"
 [dependencies]
 arbitrary = { version = "1.3", features = ["derive"], optional = true }
 const-oid = { version = "0.9.2", optional = true } # TODO: path = "../const-oid"
-der_derive = { version = "0.7", optional = true }
+der_derive = { version = "0.7.1", optional = true }
 flagset = { version = "0.4.3", optional = true }
 pem-rfc7468 = { version = "0.7", optional = true, features = ["alloc"] }
 time = { version = "0.3.4", optional = true, default-features = false }


### PR DESCRIPTION
Added
- `Decode` and `Encode` impls for `PhantomData` (#1009)
- `ValueOrd` and `DerOrd` impls for `PhantomData` (#1012)

Changed
- Bump `hex-literal` dependency to v0.4.1 (#999)
- Bump `der_derive` dependency to v0.7.1 (#1016)