### PR TITLE
x509-cert: adds support for `Time::INFINITY`

### DIFF
--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.65"
 
 [dependencies]
 const-oid = { version = "0.9.2", features = ["db"] } # TODO: path = "../const-oid"
-der = { version = "0.7.4", features = ["alloc", "derive", "flagset", "oid"] }
+der = { version = "0.7.5", features = ["alloc", "derive", "flagset", "oid"] }
 spki = { version = "0.7.1", features = ["alloc"] }
 
 # optional dependencies

--- a/x509-cert/src/time.rs
+++ b/x509-cert/src/time.rs
@@ -34,6 +34,10 @@ pub enum Time {
 }
 
 impl Time {
+    /// Time used for Certificate who do not expire.
+    pub const INFINITY: Time =
+        Time::GeneralTime(GeneralizedTime::from_date_time(DateTime::INFINITY));
+
     /// Get duration since `UNIX_EPOCH`.
     pub fn to_unix_duration(self) -> Duration {
         match self {


### PR DESCRIPTION
When certificates are burned in hardware, the expiration date could be set to infinity.

For example with IDevID when burned to TPM:
https://trustedcomputinggroup.org/wp-content/uploads/TPM-2p0-Keys-for-Device-Identity-and-Attestation_v1_r12_pub10082021.pdf#page=55