### PR TITLE
der: adds support for `DateTime::INFINITY`

### DIFF
--- a/der/src/asn1/generalized_time.rs
+++ b/der/src/asn1/generalized_time.rs
@@ -37,7 +37,7 @@ impl GeneralizedTime {
     const LENGTH: usize = 15;
 
     /// Create a [`GeneralizedTime`] from a [`DateTime`].
-    pub fn from_date_time(datetime: DateTime) -> Self {
+    pub const fn from_date_time(datetime: DateTime) -> Self {
         Self(datetime)
     }
 

--- a/der/src/datetime.rs
+++ b/der/src/datetime.rs
@@ -56,6 +56,18 @@ pub struct DateTime {
 }
 
 impl DateTime {
+    /// This is the maximum date represented by the [`DateTime`]
+    /// This corresponds to: 9999-12-31T23:59:59Z
+    pub const INFINITY: DateTime = DateTime {
+        year: 9999,
+        month: 12,
+        day: 31,
+        hour: 23,
+        minutes: 59,
+        seconds: 59,
+        unix_duration: MAX_UNIX_DURATION,
+    };
+
     /// Create a new [`DateTime`] from the given UTC time components.
     // TODO(tarcieri): checked arithmetic
     #[allow(clippy::integer_arithmetic)]


### PR DESCRIPTION
When certificates are burned in hardware, the expiration date could be set to infinity.

For example with IDevID when burned to TPM:
https://trustedcomputinggroup.org/wp-content/uploads/TPM-2p0-Keys-for-Device-Identity-and-Attestation_v1_r12_pub10082021.pdf#page=55

Part1 of #1024 