### PR TITLE
Derive Zeroize and ZeroizeOnDrop for VLBytes

### DIFF
--- a/tls_codec/Cargo.toml
+++ b/tls_codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tls_codec"
-version = "0.3.0-pre.2"
+version = "0.3.0-pre.3"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/tls_codec/"

--- a/tls_codec/Cargo.toml
+++ b/tls_codec/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 rust-version = "1.60"
 
 [dependencies]
-zeroize = { version = "1", default-features = false, features = ["alloc"] }
+zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
 
 # optional dependencies
 arbitrary = { version = "1", features = ["derive"], optional = true }

--- a/tls_codec/Cargo.toml
+++ b/tls_codec/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 rust-version = "1.60"
 
 [dependencies]
-zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
+zeroize = { version = "1.6", default-features = false, features = ["alloc", "zeroize_derive"] }
 
 # optional dependencies
 arbitrary = { version = "1", features = ["derive"], optional = true }

--- a/tls_codec/src/lib.rs
+++ b/tls_codec/src/lib.rs
@@ -51,7 +51,7 @@ pub use tls_vec::{
 };
 
 #[cfg(feature = "std")]
-pub use quic_vec::{VLByteSlice, VLBytes};
+pub use quic_vec::{SecretVLBytes, VLByteSlice, VLBytes};
 
 #[cfg(feature = "derive")]
 pub use tls_codec_derive::{TlsDeserialize, TlsSerialize, TlsSize};

--- a/tls_codec/src/quic_vec.rs
+++ b/tls_codec/src/quic_vec.rs
@@ -13,6 +13,7 @@
 //! up to 62-bit length values.
 use alloc::vec::Vec;
 use core::fmt;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
@@ -214,7 +215,7 @@ fn write_hex(f: &mut fmt::Formatter<'_>, data: &[u8]) -> fmt::Result {
 /// Use this struct if bytes are encoded.
 /// This is faster than the generic version.
 #[cfg_attr(feature = "serde", derive(SerdeSerialize, SerdeDeserialize))]
-#[derive(Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
+#[derive(Clone, PartialEq, Eq, Hash, Ord, PartialOrd, Zeroize, ZeroizeOnDrop)]
 pub struct VLBytes {
     vec: Vec<u8>,
 }
@@ -281,7 +282,7 @@ impl AsRef<[u8]> for VLBytes {
 
 impl From<VLBytes> for Vec<u8> {
     fn from(b: VLBytes) -> Self {
-        b.vec
+        b.vec.clone()
     }
 }
 

--- a/tls_codec/src/quic_vec.rs
+++ b/tls_codec/src/quic_vec.rs
@@ -545,7 +545,7 @@ impl<'a> Arbitrary<'a> for VLBytes {
 
 #[cfg(test)]
 mod test {
-    use crate::{VLByteSlice, VLBytes};
+    use crate::{SecretVLBytes, VLByteSlice, VLBytes};
     use std::println;
 
     #[test]
@@ -573,6 +573,11 @@ mod test {
             let got = format!("{:?}", VLBytes::new(test.clone()));
             println!("{got}");
             assert_eq!(expected_vl_bytes, got);
+
+            let expected_secret_vl_bytes = format!("SecretVLBytes {{ {expected} }}");
+            let got = format!("{:?}", SecretVLBytes::new(test.clone()));
+            println!("{got}");
+            assert_eq!(expected_secret_vl_bytes, got);
         }
     }
 }


### PR DESCRIPTION
In contrast to the generic tls_vec implementations, there is no `Secret...` variant for VLBytes. Since the overhead is relatively low, this PR blanket-implements ZeriozeOnDrop for VLBytes. In the future, it might be worth exposing a dedicated `SecretVLBytes` struct.