### PR TITLE
x509-cert: adds a `CertReq` builder

### DIFF
--- a/x509-cert/src/ext.rs
+++ b/x509-cert/src/ext.rs
@@ -1,6 +1,5 @@
 //! Standardized X.509 Certificate Extensions
 
-use crate::certificate;
 use const_oid::AssociatedOid;
 use der::{asn1::OctetString, Sequence, ValueOrd};
 use spki::ObjectIdentifier;
@@ -49,15 +48,19 @@ pub type Extensions = alloc::vec::Vec<Extension>;
 /// builder.
 pub trait AsExtension: AssociatedOid + der::Encode {
     /// Should the extension be marked critical
-    fn critical(&self, tbs: &certificate::TbsCertificate) -> bool;
+    fn critical(&self, subject: &crate::name::Name, extensions: &[Extension]) -> bool;
 
     /// Returns the Extension with the content encoded.
-    fn to_extension(&self, tbs: &certificate::TbsCertificate) -> Result<Extension, der::Error> {
+    fn to_extension(
+        &self,
+        subject: &crate::name::Name,
+        extensions: &[Extension],
+    ) -> Result<Extension, der::Error> {
         let content = OctetString::new(<Self as der::Encode>::to_der(self)?)?;
 
         Ok(Extension {
             extn_id: <Self as AssociatedOid>::OID,
-            critical: self.critical(tbs),
+            critical: self.critical(subject, extensions),
             extn_value: content,
         })
     }

--- a/x509-cert/src/ext/pkix.rs
+++ b/x509-cert/src/ext/pkix.rs
@@ -71,7 +71,7 @@ impl AssociatedOid for SubjectAltName {
 impl_newtype!(SubjectAltName, name::GeneralNames);
 
 impl crate::ext::AsExtension for SubjectAltName {
-    fn critical(&self, tbs: &crate::certificate::TbsCertificate) -> bool {
+    fn critical(&self, subject: &crate::name::Name, _extensions: &[super::Extension]) -> bool {
         // https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.6
         //   Further, if the only subject identity included in the certificate is
         //   an alternative name form (e.g., an electronic mail address), then the
@@ -83,7 +83,7 @@ impl crate::ext::AsExtension for SubjectAltName {
         //   subject distinguished name, conforming CAs SHOULD mark the
         //   subjectAltName extension as non-critical.
 
-        tbs.subject.is_empty()
+        subject.is_empty()
     }
 }
 

--- a/x509-cert/src/ext/pkix/constraints/basic.rs
+++ b/x509-cert/src/ext/pkix/constraints/basic.rs
@@ -24,7 +24,11 @@ impl AssociatedOid for BasicConstraints {
 }
 
 impl crate::ext::AsExtension for BasicConstraints {
-    fn critical(&self, _tbs: &crate::certificate::TbsCertificate) -> bool {
+    fn critical(
+        &self,
+        _subject: &crate::name::Name,
+        _extensions: &[crate::ext::Extension],
+    ) -> bool {
         // https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.9
         //   Conforming CAs MUST include this extension in all CA certificates
         //   that contain public keys used to validate digital signatures on

--- a/x509-cert/src/ext/pkix/keyusage.rs
+++ b/x509-cert/src/ext/pkix/keyusage.rs
@@ -139,7 +139,11 @@ impl AssociatedOid for ExtendedKeyUsage {
 impl_newtype!(ExtendedKeyUsage, Vec<ObjectIdentifier>);
 
 impl crate::ext::AsExtension for ExtendedKeyUsage {
-    fn critical(&self, _tbs: &crate::certificate::TbsCertificate) -> bool {
+    fn critical(
+        &self,
+        _subject: &crate::name::Name,
+        _extensions: &[crate::ext::Extension],
+    ) -> bool {
         // https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.12
         //   This extension MAY, at the option of the certificate issuer, be
         //   either critical or non-critical.

--- a/x509-cert/src/macros.rs
+++ b/x509-cert/src/macros.rs
@@ -86,7 +86,11 @@ macro_rules! impl_extension {
     };
     ($newtype:ty, critical = $critical:expr) => {
         impl crate::ext::AsExtension for $newtype {
-            fn critical(&self, _tbs: &crate::certificate::TbsCertificate) -> bool {
+            fn critical(
+                &self,
+                _subject: &crate::name::Name,
+                _extensions: &[crate::ext::Extension],
+            ) -> bool {
                 $critical
             }
         }

--- a/x509-cert/test-support/src/openssl.rs
+++ b/x509-cert/test-support/src/openssl.rs
@@ -5,7 +5,7 @@ use std::{
 };
 use tempfile::tempdir;
 
-pub fn check_certificate(pem: &[u8]) -> String {
+fn check_openssl_output(command: &str, pem: &[u8]) -> String {
     let tmp_dir = tempdir().expect("create tempdir");
     let cert_path = tmp_dir.path().join("cert.pem");
 
@@ -13,7 +13,7 @@ pub fn check_certificate(pem: &[u8]) -> String {
     cert_file.write_all(pem).expect("Create pem file");
 
     let mut child = Command::new("openssl")
-        .arg("x509")
+        .arg(command)
         .arg("-in")
         .arg(&cert_path)
         .arg("-noout")
@@ -32,4 +32,12 @@ pub fn check_certificate(pem: &[u8]) -> String {
         .expect("read openssl output");
 
     String::from_utf8(output_buf.clone()).unwrap()
+}
+
+pub fn check_certificate(pem: &[u8]) -> String {
+    check_openssl_output("x509", pem)
+}
+
+pub fn check_request(pem: &[u8]) -> String {
+    check_openssl_output("req", pem)
 }

--- a/x509-cert/tests/builder.rs
+++ b/x509-cert/tests/builder.rs
@@ -8,7 +8,7 @@ use sha2::Sha256;
 use spki::SubjectPublicKeyInfoOwned;
 use std::{str::FromStr, time::Duration};
 use x509_cert::{
-    builder::{CertificateBuilder, Profile, RequestBuilder},
+    builder::{Builder, CertificateBuilder, Profile, RequestBuilder},
     ext::pkix::{name::GeneralName, SubjectAltName},
     name::Name,
     serial_number::SerialNumber,


### PR DESCRIPTION
Fixes https://github.com/RustCrypto/formats/issues/1031


Generates CSR like:
```
---- certificate_request stdout ----
Certificate Request:
    Data:
        Version: 1 (0x0)
        Subject: CN = service.domination.world
        Subject Public Key Info:
            Public Key Algorithm: id-ecPublicKey
                Public-Key: (256 bit)
                pub:
                    04:1c:ac:ff:b5:5f:2f:2c:ef:d8:9d:89:eb:37:4b:
                    26:81:15:24:52:80:2d:ee:a0:99:16:06:81:37:d8:
                    39:cf:7f:c4:81:a4:44:92:30:4d:7e:f6:6a:c1:17:
                    be:fe:83:a8:d0:8f:15:5f:2b:52:f9:f6:18:dd:44:
                    70:29:04:8e:0f
                ASN1 OID: prime256v1
                NIST CURVE: P-256
        Attributes:
            Requested Extensions:
                X509v3 Subject Alternative Name:
                    IP Address:192.0.2.0
    Signature Algorithm: ecdsa-with-SHA256
    Signature Value:
        73:29:74:17:23:a1:12:f4:94:82:3e:b8:8b:eb:f4:21:f4:80:
        7e:ba:1a:0e:63:b4:ea:03:5e:6c:87:43:f1:01:6d:19:34:3c:
        1c:f8:e7:0f:d0:1b:c4:5b:20:b5:80:46:dd:73:0a:84:b4:94:
        00:5e:a3:31:81:21:70:3b:57:a5
-----BEGIN CERTIFICATE REQUEST-----
MIH5MIGnAgEAMCMxITAfBgNVBAMMGHNlcnZpY2UuZG9taW5hdGlvbi53b3JsZDBZ
MBMGByqGSM49AgEGCCqGSM49AwEHA0IABBys/7VfLyzv2J2J6zdLJoEVJFKALe6g
mRYGgTfYOc9/xIGkRJIwTX72asEXvv6DqNCPFV8rUvn2GN1EcCkEjg+gIjAgBgkq
hkiG9w0BCQ4xEzARMA8GA1UdEQQIMAaHBMAAAgAwCgYIKoZIzj0EAwIDQQBzKXQX
I6ES9JSCPriL6/Qh9IB+uhoOY7TqA15sh0PxAW0ZNDwc+OcP0BvEWyC1gEbdcwqE
tJQAXqMxgSFwO1el
-----END CERTIFICATE REQUEST-----
```