### PR TITLE
x509-cert: fixup CI flakiness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1245,9 +1245,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dd2017d3e6d67384f301f8b06fbf4567afc576430a61624d845eb04d2b30a72"
+checksum = "72f1471dbb4be5de45050e8ef7040625298ccb9efe941419ac2697088715925f"
 dependencies = [
  "byteorder",
  "const-oid 0.9.2",

--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -27,7 +27,7 @@ signature = { version = "2.1.0", features = ["rand_core"], optional = true }
 [dev-dependencies]
 hex-literal = "0.4"
 rand = "0.8.5"
-rsa = { version = "0.9.0", features = ["sha2"] }
+rsa = { version = "0.9.1", features = ["sha2"] }
 ecdsa = { version = "0.16.4", features = ["digest", "pem"] }
 p256 = "0.13.0"
 rstest = "0.17"


### PR DESCRIPTION
rsa 0.9.1 provides a fix for invalid signatures sometimes generated