### PR TITLE
cms v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,7 +254,7 @@ dependencies = [
 
 [[package]]
 name = "cms"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "const-oid 0.9.2",
  "der",

--- a/cms/CHANGELOG.md
+++ b/cms/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.1 (2023-05-04)
+### Added
+- Convenience functions for converting cert(s) to certs-only `SignedData` message ([#1032])
+
+[#1032]: https://github.com/RustCrypto/formats/pull/1032
+
 ## 0.2.0 (2023-03-18)
 - Initial RustCrypto release
 

--- a/cms/Cargo.toml
+++ b/cms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cms"
-version = "0.2.0"
+version = "0.2.1"
 description = """
 Pure Rust implementation of the Cryptographic Message Syntax (CMS) as described in RFC 5652 and RFC 3274.
 """

--- a/cms/src/cert.rs
+++ b/cms/src/cert.rs
@@ -1,5 +1,7 @@
 //! Certificate-related types
 
+pub use x509_cert as x509;
+
 use core::cmp::Ordering;
 use der::{asn1::ObjectIdentifier, Any, Choice, Sequence, ValueOrd};
 use x509_cert::name::Name;

--- a/cms/src/lib.rs
+++ b/cms/src/lib.rs
@@ -13,6 +13,15 @@
     unused_qualifications
 )]
 
+//! # `p7b` support
+//!
+//! This crate can be used to convert an X.509 certificate into a certs-only
+//! [`signed_data::SignedData`] message, a.k.a `.p7b` file.
+//!
+//! Use a [`TryFrom`] conversion between [`cert::x509::Certificate`] and
+//! [`content_info::ContentInfo`] to generate the data structures, then use
+//! `to_der` to serialize it.
+
 extern crate alloc;
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
### Added
- Convenience functions for converting cert(s) to certs-only `SignedData` message ([#1032])

[#1032]: https://github.com/RustCrypto/formats/pull/1032