### PR TITLE
spki: Adds a `SignatureBitStringEncoding` trait

### DIFF
--- a/spki/src/lib.rs
+++ b/spki/src/lib.rs
@@ -61,6 +61,7 @@ pub use {
         spki::SubjectPublicKeyInfoOwned,
         traits::{
             DynAssociatedAlgorithmIdentifier, DynSignatureAlgorithmIdentifier, EncodePublicKey,
+            SignatureBitStringEncoding,
         },
     },
     der::Document,

--- a/spki/src/traits.rs
+++ b/spki/src/traits.rs
@@ -6,7 +6,7 @@ use der::{EncodeValue, Tagged};
 #[cfg(feature = "alloc")]
 use {
     crate::AlgorithmIdentifierOwned,
-    der::{Any, Document},
+    der::{asn1::BitString, Any, Document},
 };
 
 #[cfg(feature = "pem")]
@@ -172,4 +172,13 @@ where
                 .transpose()?,
         })
     }
+}
+
+/// Returns the `BitString` encoding of the signature.
+///
+/// X.509 and CSR structures require signatures to be BitString encoded.
+#[cfg(feature = "alloc")]
+pub trait SignatureBitStringEncoding {
+    /// `BitString` encoding for this signature.
+    fn to_bitstring(&self) -> der::Result<BitString>;
 }


### PR DESCRIPTION
This is used to differentiate the different encoding for signatures as x509 related structures rely on `BitString` encoding of the various signatures.

This is mostly used as a marker trait to ensure misuse resistance of the API.

See #1043 #1041