### PR TITLE
x509-cert: consume the `SignatureBitStringEncoding` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,15 +461,16 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.16.6"
+version = "0.16.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a48e5d537b8a30c0b023116d981b16334be1485af7ca68db3a2b7024cbc957fd"
+checksum = "0997c976637b606099b9985693efa3581e84e41f5c11ba5255f88711058ad428"
 dependencies = [
  "der",
  "digest",
  "elliptic-curve",
  "rfc6979",
  "signature",
+ "spki",
 ]
 
 [[package]]

--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.65"
 [dependencies]
 const-oid = { version = "0.9.2", features = ["db"] } # TODO: path = "../const-oid"
 der = { version = "0.7.5", features = ["alloc", "derive", "flagset", "oid"] }
-spki = { version = "0.7.1", features = ["alloc"] }
+spki = { version = "0.7.2", features = ["alloc"] }
 
 # optional dependencies
 arbitrary = { version = "1.3", features = ["derive"], optional = true }
@@ -28,7 +28,7 @@ signature = { version = "2.1.0", features = ["rand_core"], optional = true }
 hex-literal = "0.4"
 rand = "0.8.5"
 rsa = { version = "0.9.2", features = ["sha2"] }
-ecdsa = { version = "0.16.4", features = ["digest", "pem"] }
+ecdsa = { version = "0.16.7", features = ["digest", "pem"] }
 p256 = "0.13.0"
 rstest = "0.17"
 sha2 = { version = "0.10", features = ["oid"] }

--- a/x509-cert/src/builder.rs
+++ b/x509-cert/src/builder.rs
@@ -3,10 +3,10 @@
 use alloc::vec;
 use core::fmt;
 use der::{asn1::BitString, referenced::OwnedToRef, Encode};
-use signature::{rand_core::CryptoRngCore, Keypair, RandomizedSigner, SignatureEncoding, Signer};
+use signature::{rand_core::CryptoRngCore, Keypair, RandomizedSigner, Signer};
 use spki::{
-    DynSignatureAlgorithmIdentifier, EncodePublicKey, SubjectPublicKeyInfoOwned,
-    SubjectPublicKeyInfoRef,
+    DynSignatureAlgorithmIdentifier, EncodePublicKey, SignatureBitStringEncoding,
+    SubjectPublicKeyInfoOwned, SubjectPublicKeyInfoRef,
 };
 
 use crate::{
@@ -421,12 +421,11 @@ pub trait Builder: Sized {
     fn build<Signature>(mut self) -> Result<Self::Output>
     where
         Self::Signer: Signer<Signature>,
-        Signature: SignatureEncoding,
+        Signature: SignatureBitStringEncoding,
     {
         let blob = self.finalize()?;
 
-        let signature = self.signer().try_sign(&blob)?;
-        let signature = BitString::from_bytes(signature.to_bytes().as_ref())?;
+        let signature = self.signer().try_sign(&blob)?.to_bitstring()?;
 
         self.assemble(signature)
     }
@@ -435,12 +434,14 @@ pub trait Builder: Sized {
     fn build_with_rng<Signature>(mut self, rng: &mut impl CryptoRngCore) -> Result<Self::Output>
     where
         Self::Signer: RandomizedSigner<Signature>,
-        Signature: SignatureEncoding,
+        Signature: SignatureBitStringEncoding,
     {
         let blob = self.finalize()?;
 
-        let signature = self.signer().try_sign_with_rng(rng, &blob)?;
-        let signature = BitString::from_bytes(signature.to_bytes().as_ref())?;
+        let signature = self
+            .signer()
+            .try_sign_with_rng(rng, &blob)?
+            .to_bitstring()?;
 
         self.assemble(signature)
     }


### PR DESCRIPTION
This shows the use of #1047

This uses:
 - https://github.com/RustCrypto/signatures/pull/716
 - https://github.com/RustCrypto/RSA/pull/328