### PR TITLE
Add notes about `UTCTime` range being 1970-2049

### DIFF
--- a/der/src/asn1/utc_time.rs
+++ b/der/src/asn1/utc_time.rs
@@ -25,6 +25,9 @@ use std::time::SystemTime;
 /// >   interpreted as `19YY`; and
 /// > - Where `YY` is less than 50, the year SHALL be interpreted as `20YY`.
 ///
+/// Note: Due to common operations working on `UNIX_EPOCH` [`UtcTime`]s are 
+/// only supported for the years 1970-2049.
+///
 /// [1]: https://tools.ietf.org/html/rfc5280#section-4.1.2.5.1
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct UtcTime(DateTime);

--- a/der/src/asn1/utc_time.rs
+++ b/der/src/asn1/utc_time.rs
@@ -25,7 +25,7 @@ use std::time::SystemTime;
 /// >   interpreted as `19YY`; and
 /// > - Where `YY` is less than 50, the year SHALL be interpreted as `20YY`.
 ///
-/// Note: Due to common operations working on `UNIX_EPOCH` [`UtcTime`]s are 
+/// Note: Due to common operations working on `UNIX_EPOCH` [`UtcTime`]s are
 /// only supported for the years 1970-2049.
 ///
 /// [1]: https://tools.ietf.org/html/rfc5280#section-4.1.2.5.1

--- a/x509-cert/src/time.rs
+++ b/x509-cert/src/time.rs
@@ -24,7 +24,10 @@ use std::time::SystemTime;
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Choice, Copy, Clone, Debug, Eq, PartialEq, ValueOrd)]
 pub enum Time {
-    /// Legacy UTC time (has 2-digit year, valid only through 2050).
+    /// Legacy UTC time (has 2-digit year, valid from 1970 to 2049).
+    ///
+    /// Note: RFC 5280 specifies 1950-2049, however due to common operations working on
+    /// `UNIX_EPOCH` this implementation's lower bound is 1970.
     #[asn1(type = "UTCTime")]
     UtcTime(UtcTime),
 


### PR DESCRIPTION
It looks like `UtcTime` currently has a lower bound of 1970.
I'm very open to wording tweaks IFF a documentation change ends up being the way to address this.

RFC 5280 says that `UTCTime` is 1950-2049, however due the common use of
computer times being based off of `UNIX_EPOCH` the implementation of
[`UtcTime`](https://docs.rs/der/latest/der/asn1/struct.UtcTime.html) is limited to 1970.

This limitation is due to the `MIN_YEAR` bounding valid
[`DateTime`](https://docs.rs/der/latest/der/struct.DateTime.html)
structs.
The `DateTime` struct is the underlying implementation of `UTCTime`.

Thanks!