### PR TITLE
Add custom error types to the Decode and DecodeValue traits.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,8 +562,7 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.17.0-pre.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7e045ee5c360512162782f3d4cb07d2f4ce8c4ef9bf7c77ec16d1cf60b3d5ca"
+source = "git+https://github.com/turbocool3r/signatures?branch=custom-errors#d9d394ad7a87de8943a0eb39b85f316149ebb025"
 dependencies = [
  "der",
  "digest 0.11.0-pre.8",
@@ -1272,8 +1271,7 @@ checksum = "c707298afce11da2efef2f600116fa93ffa7a032b5d7b628aa17711ec81383ca"
 [[package]]
 name = "rfc6979"
 version = "0.5.0-pre.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "045972f2f66b9467a2f6834b7fd0f9b23ca214b4a8700b880c36edb726e96da6"
+source = "git+https://github.com/turbocool3r/signatures?branch=custom-errors#d9d394ad7a87de8943a0eb39b85f316149ebb025"
 dependencies = [
  "hmac 0.13.0-pre.3",
  "subtle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,3 +64,7 @@ x509-ocsp         = { path = "./x509-ocsp" }
 p256 = { git = "https://github.com/RustCrypto/elliptic-curves.git" }
 # Pending a release of 0.11.0-pre.2
 whirlpool = { git = "https://github.com/RustCrypto/hashes.git" }
+
+# https://github.com/RustCrypto/formats/pull/1055
+# https://github.com/RustCrypto/signatures/pull/809
+ecdsa = { git = "https://github.com/turbocool3r/signatures", branch = "custom-errors" }

--- a/crmf/src/pop.rs
+++ b/crmf/src/pop.rs
@@ -231,6 +231,8 @@ impl<'a> ::der::Choice<'a> for EncKeyWithIdChoice<'a> {
     }
 }
 impl<'a> ::der::Decode<'a> for EncKeyWithIdChoice<'a> {
+    type Error = ::der::Error;
+
     fn decode<R: ::der::Reader<'a>>(reader: &mut R) -> ::der::Result<Self> {
         let t = reader.peek_tag()?;
         if t == <Utf8StringRef<'a> as ::der::FixedTag>::TAG {

--- a/der/derive/src/choice.rs
+++ b/der/derive/src/choice.rs
@@ -96,6 +96,8 @@ impl DeriveChoice {
             }
 
             impl<#lifetime> ::der::Decode<#lifetime> for #ident<#lt_params> {
+                type Error = ::der::Error;
+
                 fn decode<R: ::der::Reader<#lifetime>>(reader: &mut R) -> ::der::Result<Self> {
                     use der::Reader as _;
                     match reader.peek_tag()? {

--- a/der/derive/src/enumerated.rs
+++ b/der/derive/src/enumerated.rs
@@ -117,6 +117,8 @@ impl DeriveEnumerated {
 
         quote! {
             impl<#default_lifetime> ::der::DecodeValue<#default_lifetime> for #ident {
+                type Error = ::der::Error;
+
                 fn decode_value<R: ::der::Reader<#default_lifetime>>(
                     reader: &mut R,
                     header: ::der::Header

--- a/der/derive/src/sequence.rs
+++ b/der/derive/src/sequence.rs
@@ -86,6 +86,8 @@ impl DeriveSequence {
 
         quote! {
             impl #impl_generics ::der::DecodeValue<#lifetime> for #ident #ty_generics #where_clause {
+                type Error = ::der::Error;
+
                 fn decode_value<R: ::der::Reader<#lifetime>>(
                     reader: &mut R,
                     header: ::der::Header,

--- a/der/src/asn1/bit_string.rs
+++ b/der/src/asn1/bit_string.rs
@@ -120,6 +120,8 @@ impl<'a> BitStringRef<'a> {
 impl_any_conversions!(BitStringRef<'a>, 'a);
 
 impl<'a> DecodeValue<'a> for BitStringRef<'a> {
+    type Error = Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         let header = Header {
             tag: header.tag,
@@ -309,6 +311,8 @@ mod allocating {
     impl_any_conversions!(BitString);
 
     impl<'a> DecodeValue<'a> for BitString {
+        type Error = Error;
+
         fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
             let inner_len = (header.length - Length::ONE)?;
             let unused_bits = reader.read_byte()?;
@@ -442,6 +446,8 @@ where
     T::Type: From<bool>,
     T::Type: core::ops::Shl<usize, Output = T::Type>,
 {
+    type Error = Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         let position = reader.position();
         let bits = BitStringRef::decode_value(reader, header)?;

--- a/der/src/asn1/bmp_string.rs
+++ b/der/src/asn1/bmp_string.rs
@@ -90,6 +90,8 @@ impl AsRef<[u8]> for BmpString {
 }
 
 impl<'a> DecodeValue<'a> for BmpString {
+    type Error = Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         Self::from_ucs2(reader.read_vec(header.length)?)
     }

--- a/der/src/asn1/boolean.rs
+++ b/der/src/asn1/boolean.rs
@@ -15,6 +15,8 @@ const TRUE_OCTET: u8 = 0b11111111;
 const FALSE_OCTET: u8 = 0b00000000;
 
 impl<'a> DecodeValue<'a> for bool {
+    type Error = Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         if header.length != Length::ONE {
             return Err(reader.error(ErrorKind::Length { tag: Self::TAG }));

--- a/der/src/asn1/generalized_time.rs
+++ b/der/src/asn1/generalized_time.rs
@@ -4,15 +4,13 @@
 use crate::{
     datetime::{self, DateTime},
     ord::OrdIsValueOrd,
-    DecodeValue, EncodeValue, ErrorKind, FixedTag, Header, Length, Reader, Result, Tag, Writer,
+    DecodeValue, EncodeValue, Error, ErrorKind, FixedTag, Header, Length, Reader, Result, Tag,
+    Writer,
 };
 use core::time::Duration;
 
 #[cfg(feature = "std")]
-use {
-    crate::{asn1::AnyRef, Error},
-    std::time::SystemTime,
-};
+use {crate::asn1::AnyRef, std::time::SystemTime};
 
 #[cfg(feature = "time")]
 use time::PrimitiveDateTime;
@@ -77,6 +75,8 @@ impl GeneralizedTime {
 impl_any_conversions!(GeneralizedTime);
 
 impl<'a> DecodeValue<'a> for GeneralizedTime {
+    type Error = Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         if Self::LENGTH != usize::try_from(header.length)? {
             return Err(Self::TAG.value_error());
@@ -166,6 +166,8 @@ impl From<&DateTime> for GeneralizedTime {
 }
 
 impl<'a> DecodeValue<'a> for DateTime {
+    type Error = Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         Ok(GeneralizedTime::decode_value(reader, header)?.into())
     }
@@ -189,6 +191,8 @@ impl OrdIsValueOrd for DateTime {}
 
 #[cfg(feature = "std")]
 impl<'a> DecodeValue<'a> for SystemTime {
+    type Error = Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         Ok(GeneralizedTime::decode_value(reader, header)?.into())
     }
@@ -256,6 +260,8 @@ impl OrdIsValueOrd for SystemTime {}
 
 #[cfg(feature = "time")]
 impl<'a> DecodeValue<'a> for PrimitiveDateTime {
+    type Error = Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         GeneralizedTime::decode_value(reader, header)?.try_into()
     }

--- a/der/src/asn1/integer/int.rs
+++ b/der/src/asn1/integer/int.rs
@@ -14,7 +14,9 @@ macro_rules! impl_encoding_traits {
     ($($int:ty => $uint:ty),+) => {
         $(
             impl<'a> DecodeValue<'a> for $int {
-                fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
+                type Error = $crate::Error;
+
+                fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> $crate::Result<Self> {
                     let mut buf = [0u8; Self::BITS as usize / 8];
                     let max_length = u32::from(header.length) as usize;
 
@@ -122,6 +124,8 @@ impl<'a> IntRef<'a> {
 impl_any_conversions!(IntRef<'a>, 'a);
 
 impl<'a> DecodeValue<'a> for IntRef<'a> {
+    type Error = Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         let bytes = BytesRef::decode_value(reader, header)?;
         validate_canonical(bytes.as_slice())?;
@@ -167,8 +171,8 @@ mod allocating {
         asn1::Uint,
         ord::OrdIsValueOrd,
         referenced::{OwnedToRef, RefToOwned},
-        BytesOwned, DecodeValue, EncodeValue, ErrorKind, FixedTag, Header, Length, Reader, Result,
-        Tag, Writer,
+        BytesOwned, DecodeValue, EncodeValue, Error, ErrorKind, FixedTag, Header, Length, Reader,
+        Result, Tag, Writer,
     };
     use alloc::vec::Vec;
 
@@ -214,6 +218,8 @@ mod allocating {
     impl_any_conversions!(Int);
 
     impl<'a> DecodeValue<'a> for Int {
+        type Error = Error;
+
         fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
             let bytes = BytesOwned::decode_value(reader, header)?;
             validate_canonical(bytes.as_slice())?;

--- a/der/src/asn1/integer/uint.rs
+++ b/der/src/asn1/integer/uint.rs
@@ -14,6 +14,8 @@ macro_rules! impl_encoding_traits {
     ($($uint:ty),+) => {
         $(
             impl<'a> DecodeValue<'a> for $uint {
+                type Error = $crate::Error;
+
                 fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
                     // Integers always encodes as a signed value, unsigned gets a leading 0x00 that
                     // needs to be stripped off. We need to provide room for it.
@@ -114,6 +116,8 @@ impl<'a> UintRef<'a> {
 impl_any_conversions!(UintRef<'a>, 'a);
 
 impl<'a> DecodeValue<'a> for UintRef<'a> {
+    type Error = Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         let bytes = BytesRef::decode_value(reader, header)?.as_slice();
         let result = Self::new(decode_to_slice(bytes)?)?;
@@ -160,8 +164,8 @@ mod allocating {
     use crate::{
         ord::OrdIsValueOrd,
         referenced::{OwnedToRef, RefToOwned},
-        BytesOwned, DecodeValue, EncodeValue, ErrorKind, FixedTag, Header, Length, Reader, Result,
-        Tag, Writer,
+        BytesOwned, DecodeValue, EncodeValue, Error, ErrorKind, FixedTag, Header, Length, Reader,
+        Result, Tag, Writer,
     };
 
     /// Unsigned arbitrary precision ASN.1 `INTEGER` type.
@@ -206,6 +210,8 @@ mod allocating {
     impl_any_conversions!(Uint);
 
     impl<'a> DecodeValue<'a> for Uint {
+        type Error = Error;
+
         fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
             let bytes = BytesOwned::decode_value(reader, header)?;
             let result = Self::new(decode_to_slice(bytes.as_slice())?)?;

--- a/der/src/asn1/internal_macros.rs
+++ b/der/src/asn1/internal_macros.rs
@@ -6,7 +6,7 @@ macro_rules! impl_any_conversions {
         impl<'__der: $($li),*, $($li),*> TryFrom<$crate::AnyRef<'__der>> for $type {
             type Error = $crate::Error;
 
-            fn try_from(any: $crate::AnyRef<'__der>) -> Result<$type> {
+            fn try_from(any: $crate::AnyRef<'__der>) -> $crate::Result<$type> {
                 any.decode_as()
             }
         }
@@ -15,7 +15,7 @@ macro_rules! impl_any_conversions {
         impl<'__der: $($li),*, $($li),*> TryFrom<&'__der $crate::Any> for $type {
             type Error = $crate::Error;
 
-            fn try_from(any: &'__der $crate::Any) -> Result<$type> {
+            fn try_from(any: &'__der $crate::Any) -> $crate::Result<$type> {
                 any.decode_as()
             }
         }
@@ -48,7 +48,9 @@ macro_rules! impl_string_type {
             }
 
             impl<'__der: $($li),*, $($li),*> DecodeValue<'__der> for $type {
-                fn decode_value<R: Reader<'__der>>(reader: &mut R, header: Header) -> Result<Self> {
+                type Error = $crate::Error;
+
+                fn decode_value<R: Reader<'__der>>(reader: &mut R, header: Header) -> $crate::Result<Self> {
                     Self::new(BytesRef::decode_value(reader, header)?.as_slice())
                 }
             }

--- a/der/src/asn1/null.rs
+++ b/der/src/asn1/null.rs
@@ -12,6 +12,8 @@ pub struct Null;
 impl_any_conversions!(Null);
 
 impl<'a> DecodeValue<'a> for Null {
+    type Error = Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         if header.length.is_zero() {
             Ok(Null)
@@ -58,6 +60,8 @@ impl<'a> From<()> for AnyRef<'a> {
 }
 
 impl<'a> DecodeValue<'a> for () {
+    type Error = Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         Null::decode_value(reader, header)?;
         Ok(())

--- a/der/src/asn1/oid.rs
+++ b/der/src/asn1/oid.rs
@@ -10,6 +10,8 @@ use const_oid::ObjectIdentifier;
 use super::Any;
 
 impl<'a> DecodeValue<'a> for ObjectIdentifier {
+    type Error = Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         let mut buf = [0u8; ObjectIdentifier::MAX_SIZE];
         let slice = buf

--- a/der/src/asn1/real.rs
+++ b/der/src/asn1/real.rs
@@ -8,13 +8,15 @@
 )]
 
 use crate::{
-    BytesRef, DecodeValue, EncodeValue, FixedTag, Header, Length, Reader, Result, StrRef, Tag,
-    Writer,
+    BytesRef, DecodeValue, EncodeValue, Error, FixedTag, Header, Length, Reader, Result, StrRef,
+    Tag, Writer,
 };
 
 use super::integer::uint::strip_leading_zeroes;
 
 impl<'a> DecodeValue<'a> for f64 {
+    type Error = Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         let bytes = BytesRef::decode_value(reader, header)?.as_slice();
 

--- a/der/src/asn1/sequence.rs
+++ b/der/src/asn1/sequence.rs
@@ -2,7 +2,8 @@
 //! `SEQUENCE`s to Rust structs.
 
 use crate::{
-    BytesRef, DecodeValue, EncodeValue, FixedTag, Header, Length, Reader, Result, Tag, Writer,
+    BytesRef, DecodeValue, EncodeValue, Error, FixedTag, Header, Length, Reader, Result, Tag,
+    Writer,
 };
 
 #[cfg(feature = "alloc")]
@@ -33,6 +34,8 @@ pub struct SequenceRef<'a> {
 }
 
 impl<'a> DecodeValue<'a> for SequenceRef<'a> {
+    type Error = Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         Ok(Self {
             body: BytesRef::decode_value(reader, header)?,

--- a/der/src/asn1/utc_time.rs
+++ b/der/src/asn1/utc_time.rs
@@ -82,6 +82,8 @@ impl UtcTime {
 impl_any_conversions!(UtcTime);
 
 impl<'a> DecodeValue<'a> for UtcTime {
+    type Error = Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         if Self::LENGTH != usize::try_from(header.length)? {
             return Err(Self::TAG.value_error());

--- a/der/src/asn1/utf8_string.rs
+++ b/der/src/asn1/utf8_string.rs
@@ -116,6 +116,8 @@ impl<'a> TryFrom<AnyRef<'a>> for String {
 
 #[cfg(feature = "alloc")]
 impl<'a> DecodeValue<'a> for String {
+    type Error = Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         Ok(String::from_utf8(reader.read_vec(header.length)?)?)
     }

--- a/der/src/bytes_owned.rs
+++ b/der/src/bytes_owned.rs
@@ -53,6 +53,8 @@ impl AsRef<[u8]> for BytesOwned {
 }
 
 impl<'a> DecodeValue<'a> for BytesOwned {
+    type Error = Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         reader.read_vec(header.length).and_then(Self::new)
     }

--- a/der/src/bytes_ref.rs
+++ b/der/src/bytes_ref.rs
@@ -58,6 +58,8 @@ impl AsRef<[u8]> for BytesRef<'_> {
 }
 
 impl<'a> DecodeValue<'a> for BytesRef<'a> {
+    type Error = Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         reader.read_slice(header.length).and_then(Self::new)
     }

--- a/der/src/decode.rs
+++ b/der/src/decode.rs
@@ -1,6 +1,6 @@
 //! Trait definition for [`Decode`].
 
-use crate::{FixedTag, Header, Reader, Result, SliceReader};
+use crate::{Error, FixedTag, Header, Reader, SliceReader};
 use core::marker::PhantomData;
 
 #[cfg(feature = "pem")]
@@ -16,23 +16,28 @@ use alloc::boxed::Box;
 ///
 /// This trait provides the core abstraction upon which all decoding operations
 /// are based.
-pub trait Decode<'a>: Sized {
+pub trait Decode<'a>: Sized + 'a {
+    /// Type returned in the event of a decoding error.
+    type Error: From<Error> + 'static;
+
     /// Attempt to decode this message using the provided decoder.
-    fn decode<R: Reader<'a>>(decoder: &mut R) -> Result<Self>;
+    fn decode<R: Reader<'a>>(decoder: &mut R) -> Result<Self, Self::Error>;
 
     /// Parse `Self` from the provided DER-encoded byte slice.
-    fn from_der(bytes: &'a [u8]) -> Result<Self> {
+    fn from_der(bytes: &'a [u8]) -> Result<Self, Self::Error> {
         let mut reader = SliceReader::new(bytes)?;
         let result = Self::decode(&mut reader)?;
-        reader.finish(result)
+        Ok(reader.finish(result)?)
     }
 }
 
 impl<'a, T> Decode<'a> for T
 where
-    T: DecodeValue<'a> + FixedTag,
+    T: DecodeValue<'a> + FixedTag + 'a,
 {
-    fn decode<R: Reader<'a>>(reader: &mut R) -> Result<T> {
+    type Error = <T as DecodeValue<'a>>::Error;
+
+    fn decode<R: Reader<'a>>(reader: &mut R) -> Result<T, <T as DecodeValue<'a>>::Error> {
         let header = Header::decode(reader)?;
         header.tag.assert_eq(T::TAG)?;
         T::decode_value(reader, header)
@@ -43,9 +48,11 @@ where
 /// implementations on structs with phantom fields.
 impl<'a, T> Decode<'a> for PhantomData<T>
 where
-    T: ?Sized,
+    T: ?Sized + 'a,
 {
-    fn decode<R: Reader<'a>>(_reader: &mut R) -> Result<PhantomData<T>> {
+    type Error = Error;
+
+    fn decode<R: Reader<'a>>(_reader: &mut R) -> Result<PhantomData<T>, Error> {
         Ok(PhantomData)
     }
 }
@@ -69,14 +76,14 @@ impl<T> DecodeOwned for T where T: for<'a> Decode<'a> {}
 #[cfg(feature = "pem")]
 pub trait DecodePem: DecodeOwned + PemLabel {
     /// Try to decode this type from PEM.
-    fn from_pem(pem: impl AsRef<[u8]>) -> Result<Self>;
+    fn from_pem(pem: impl AsRef<[u8]>) -> Result<Self, <Self as Decode<'static>>::Error>;
 }
 
 #[cfg(feature = "pem")]
-impl<T: DecodeOwned + PemLabel> DecodePem for T {
-    fn from_pem(pem: impl AsRef<[u8]>) -> Result<Self> {
+impl<T: DecodeOwned<Error = Error> + PemLabel> DecodePem for T {
+    fn from_pem(pem: impl AsRef<[u8]>) -> Result<T, Error> {
         let mut reader = PemReader::new(pem.as_ref())?;
-        Self::validate_pem_label(reader.type_label())?;
+        Self::validate_pem_label(reader.type_label()).map_err(Error::from)?;
         T::decode(&mut reader)
     }
 }
@@ -84,8 +91,11 @@ impl<T: DecodeOwned + PemLabel> DecodePem for T {
 /// Decode the value part of a Tag-Length-Value encoded field, sans the [`Tag`]
 /// and [`Length`].
 pub trait DecodeValue<'a>: Sized {
+    /// Type returned in the event of a decoding error.
+    type Error: From<Error> + 'static;
+
     /// Attempt to decode this message using the provided [`Reader`].
-    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self>;
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self, Self::Error>;
 }
 
 #[cfg(feature = "alloc")]
@@ -93,7 +103,9 @@ impl<'a, T> DecodeValue<'a> for Box<T>
 where
     T: DecodeValue<'a>,
 {
-    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
+    type Error = T::Error;
+
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self, Self::Error> {
         Ok(Box::new(T::decode_value(reader, header)?))
     }
 }

--- a/der/src/header.rs
+++ b/der/src/header.rs
@@ -1,6 +1,6 @@
 //! ASN.1 DER headers.
 
-use crate::{Decode, DerOrd, Encode, ErrorKind, Length, Reader, Result, Tag, Writer};
+use crate::{Decode, DerOrd, Encode, Error, ErrorKind, Length, Reader, Result, Tag, Writer};
 use core::cmp::Ordering;
 
 /// ASN.1 DER headers: tag + length component of TLV-encoded values
@@ -24,6 +24,8 @@ impl Header {
 }
 
 impl<'a> Decode<'a> for Header {
+    type Error = Error;
+
     fn decode<R: Reader<'a>>(reader: &mut R) -> Result<Header> {
         let tag = Tag::decode(reader)?;
 

--- a/der/src/length.rs
+++ b/der/src/length.rs
@@ -207,6 +207,8 @@ impl TryFrom<Length> for usize {
 }
 
 impl<'a> Decode<'a> for Length {
+    type Error = Error;
+
     fn decode<R: Reader<'a>>(reader: &mut R) -> Result<Length> {
         match reader.read_byte()? {
             // Note: per X.690 Section 8.1.3.6.1 the byte 0x80 encodes indefinite
@@ -356,6 +358,8 @@ impl IndefiniteLength {
 }
 
 impl<'a> Decode<'a> for IndefiniteLength {
+    type Error = Error;
+
     fn decode<R: Reader<'a>>(reader: &mut R) -> Result<IndefiniteLength> {
         if reader.peek_byte() == Some(INDEFINITE_LENGTH_OCTET) {
             // Consume the byte we already peeked at.

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -110,6 +110,8 @@
 //! }
 //!
 //! impl<'a> DecodeValue<'a> for AlgorithmIdentifier<'a> {
+//!     type Error = der::Error;
+//!
 //!     fn decode_value<R: Reader<'a>>(reader: &mut R, _header: Header) -> der::Result<Self> {
 //!        // The `der::Decoder::Decode` method can be used to decode any
 //!        // type which impls the `Decode` trait, which is impl'd for

--- a/der/src/reader.rs
+++ b/der/src/reader.rs
@@ -9,7 +9,7 @@ pub(crate) use nested::NestedReader;
 
 use crate::{
     asn1::ContextSpecific, Decode, DecodeValue, Encode, EncodingRules, Error, ErrorKind, FixedTag,
-    Header, Length, Result, Tag, TagMode, TagNumber,
+    Header, Length, Tag, TagMode, TagNumber,
 };
 
 #[cfg(feature = "alloc")]
@@ -30,7 +30,7 @@ pub trait Reader<'r>: Sized {
     /// the data at the current position in the decoder.
     ///
     /// Does not modify the decoder's state.
-    fn peek_header(&self) -> Result<Header>;
+    fn peek_header(&self) -> Result<Header, Error>;
 
     /// Get the position within the buffer.
     fn position(&self) -> Length;
@@ -42,13 +42,17 @@ pub trait Reader<'r>: Sized {
     /// - `Ok(slice)` on success
     /// - `Err(ErrorKind::Incomplete)` if there is not enough data
     /// - `Err(ErrorKind::Reader)` if the reader can't borrow from the input
-    fn read_slice(&mut self, len: Length) -> Result<&'r [u8]>;
+    fn read_slice(&mut self, len: Length) -> Result<&'r [u8], Error>;
 
     /// Attempt to decode an ASN.1 `CONTEXT-SPECIFIC` field with the
     /// provided [`TagNumber`].
-    fn context_specific<T>(&mut self, tag_number: TagNumber, tag_mode: TagMode) -> Result<Option<T>>
+    fn context_specific<T>(
+        &mut self,
+        tag_number: TagNumber,
+        tag_mode: TagMode,
+    ) -> Result<Option<T>, T::Error>
     where
-        T: DecodeValue<'r> + FixedTag,
+        T: DecodeValue<'r> + FixedTag + 'r,
     {
         Ok(match tag_mode {
             TagMode::Explicit => ContextSpecific::<T>::decode_explicit(self, tag_number)?,
@@ -58,8 +62,8 @@ pub trait Reader<'r>: Sized {
     }
 
     /// Decode a value which impls the [`Decode`] trait.
-    fn decode<T: Decode<'r>>(&mut self) -> Result<T> {
-        T::decode(self).map_err(|e| e.nested(self.position()))
+    fn decode<T: Decode<'r>>(&mut self) -> Result<T, T::Error> {
+        T::decode(self)
     }
 
     /// Return an error with the given [`ErrorKind`], annotating it with
@@ -70,7 +74,7 @@ pub trait Reader<'r>: Sized {
 
     /// Finish decoding, returning the given value if there is no
     /// remaining data, or an error otherwise
-    fn finish<T>(self, value: T) -> Result<T> {
+    fn finish<T>(self, value: T) -> Result<T, Error> {
         if !self.is_finished() {
             Err(ErrorKind::TrailingData {
                 decoded: self.position(),
@@ -100,7 +104,7 @@ pub trait Reader<'r>: Sized {
     /// [`Tag`] value.
     ///
     /// Does not modify the decoder's state.
-    fn peek_tag(&self) -> Result<Tag> {
+    fn peek_tag(&self) -> Result<Tag, Error> {
         match self.peek_byte() {
             Some(byte) => byte.try_into(),
             None => Err(Error::incomplete(self.input_len())),
@@ -108,7 +112,7 @@ pub trait Reader<'r>: Sized {
     }
 
     /// Read a single byte.
-    fn read_byte(&mut self) -> Result<u8> {
+    fn read_byte(&mut self) -> Result<u8, Error> {
         let mut buf = [0];
         self.read_into(&mut buf)?;
         Ok(buf[0])
@@ -120,25 +124,26 @@ pub trait Reader<'r>: Sized {
     /// # Returns
     /// - `Ok(slice)` if there is sufficient data
     /// - `Err(ErrorKind::Incomplete)` if there is not enough data
-    fn read_into<'o>(&mut self, buf: &'o mut [u8]) -> Result<&'o [u8]> {
+    fn read_into<'o>(&mut self, buf: &'o mut [u8]) -> Result<&'o [u8], Error> {
         let input = self.read_slice(buf.len().try_into()?)?;
         buf.copy_from_slice(input);
         Ok(buf)
     }
 
     /// Read nested data of the given length.
-    fn read_nested<'n, T, F>(&'n mut self, len: Length, f: F) -> Result<T>
+    fn read_nested<'n, T, F, E>(&'n mut self, len: Length, f: F) -> Result<T, E>
     where
-        F: FnOnce(&mut NestedReader<'n, Self>) -> Result<T>,
+        F: FnOnce(&mut NestedReader<'n, Self>) -> Result<T, E>,
+        E: From<Error>,
     {
         let mut reader = NestedReader::new(self, len)?;
         let ret = f(&mut reader)?;
-        reader.finish(ret)
+        Ok(reader.finish(ret)?)
     }
 
     /// Read a byte vector of the given length.
     #[cfg(feature = "alloc")]
-    fn read_vec(&mut self, len: Length) -> Result<Vec<u8>> {
+    fn read_vec(&mut self, len: Length) -> Result<Vec<u8>, Error> {
         let mut bytes = vec![0u8; usize::try_from(len)?];
         self.read_into(&mut bytes)?;
         Ok(bytes)
@@ -152,9 +157,10 @@ pub trait Reader<'r>: Sized {
 
     /// Read an ASN.1 `SEQUENCE`, creating a nested [`Reader`] for the body and
     /// calling the provided closure with it.
-    fn sequence<'n, F, T>(&'n mut self, f: F) -> Result<T>
+    fn sequence<'n, F, T, E>(&'n mut self, f: F) -> Result<T, E>
     where
-        F: FnOnce(&mut NestedReader<'n, Self>) -> Result<T>,
+        F: FnOnce(&mut NestedReader<'n, Self>) -> Result<T, E>,
+        E: From<Error>,
     {
         let header = Header::decode(self)?;
         header.tag.assert_eq(Tag::Sequence)?;
@@ -162,7 +168,7 @@ pub trait Reader<'r>: Sized {
     }
 
     /// Obtain a slice of bytes contain a complete TLV production suitable for parsing later.
-    fn tlv_bytes(&mut self) -> Result<&'r [u8]> {
+    fn tlv_bytes(&mut self) -> Result<&'r [u8], Error> {
         let header = self.peek_header()?;
         let header_len = header.encoded_len()?;
         self.read_slice((header_len + header.length)?)

--- a/der/src/reader/slice.rs
+++ b/der/src/reader/slice.rs
@@ -1,8 +1,6 @@
 //! Slice reader.
 
-use crate::{
-    BytesRef, Decode, EncodingRules, Error, ErrorKind, Header, Length, Reader, Result, Tag,
-};
+use crate::{BytesRef, Decode, EncodingRules, Error, ErrorKind, Header, Length, Reader, Tag};
 
 /// [`Reader`] which consumes an input byte slice.
 #[derive(Clone, Debug)]
@@ -22,7 +20,7 @@ pub struct SliceReader<'a> {
 
 impl<'a> SliceReader<'a> {
     /// Create a new slice reader for the given byte slice.
-    pub fn new(bytes: &'a [u8]) -> Result<Self> {
+    pub fn new(bytes: &'a [u8]) -> Result<Self, Error> {
         Ok(Self {
             bytes: BytesRef::new(bytes)?,
             encoding_rules: EncodingRules::default(),
@@ -50,7 +48,7 @@ impl<'a> SliceReader<'a> {
 
     /// Obtain the remaining bytes in this slice reader from the current cursor
     /// position.
-    fn remaining(&self) -> Result<&'a [u8]> {
+    fn remaining(&self) -> Result<&'a [u8], Error> {
         if self.is_failed() {
             Err(ErrorKind::Failed.at(self.position))
         } else {
@@ -77,7 +75,7 @@ impl<'a> Reader<'a> for SliceReader<'a> {
             .and_then(|bytes| bytes.first().cloned())
     }
 
-    fn peek_header(&self) -> Result<Header> {
+    fn peek_header(&self) -> Result<Header, Error> {
         Header::decode(&mut self.clone())
     }
 
@@ -85,7 +83,7 @@ impl<'a> Reader<'a> for SliceReader<'a> {
         self.position
     }
 
-    fn read_slice(&mut self, len: Length) -> Result<&'a [u8]> {
+    fn read_slice(&mut self, len: Length) -> Result<&'a [u8], Error> {
         if self.is_failed() {
             return Err(self.error(ErrorKind::Failed));
         }
@@ -102,14 +100,14 @@ impl<'a> Reader<'a> for SliceReader<'a> {
         }
     }
 
-    fn decode<T: Decode<'a>>(&mut self) -> Result<T> {
+    fn decode<T: Decode<'a>>(&mut self) -> Result<T, T::Error> {
         if self.is_failed() {
-            return Err(self.error(ErrorKind::Failed));
+            return Err(self.error(ErrorKind::Failed).into());
         }
 
         T::decode(self).map_err(|e| {
             self.failed = true;
-            e.nested(self.position)
+            e
         })
     }
 
@@ -118,7 +116,7 @@ impl<'a> Reader<'a> for SliceReader<'a> {
         kind.at(self.position)
     }
 
-    fn finish<T>(self, value: T) -> Result<T> {
+    fn finish<T>(self, value: T) -> Result<T, Error> {
         if self.is_failed() {
             Err(ErrorKind::Failed.at(self.position))
         } else if !self.is_finished() {

--- a/der/src/str_owned.rs
+++ b/der/src/str_owned.rs
@@ -2,8 +2,8 @@
 //! library-level length limitation i.e. `Length::max()`.
 
 use crate::{
-    referenced::OwnedToRef, BytesRef, DecodeValue, EncodeValue, Header, Length, Reader, Result,
-    StrRef, Writer,
+    referenced::OwnedToRef, BytesRef, DecodeValue, EncodeValue, Error, Header, Length, Reader,
+    Result, StrRef, Writer,
 };
 use alloc::string::String;
 use core::str;
@@ -69,6 +69,8 @@ impl AsRef<[u8]> for StrOwned {
 }
 
 impl<'a> DecodeValue<'a> for StrOwned {
+    type Error = Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         Self::from_bytes(BytesRef::decode_value(reader, header)?.as_slice())
     }

--- a/der/src/str_ref.rs
+++ b/der/src/str_ref.rs
@@ -1,7 +1,7 @@
 //! Common handling for types backed by `str` slices with enforcement of a
 //! library-level length limitation i.e. `Length::max()`.
 
-use crate::{BytesRef, DecodeValue, EncodeValue, Header, Length, Reader, Result, Writer};
+use crate::{BytesRef, DecodeValue, EncodeValue, Error, Header, Length, Reader, Result, Writer};
 use core::str;
 
 /// String slice newtype which respects the [`Length::max`] limit.
@@ -63,6 +63,8 @@ impl AsRef<[u8]> for StrRef<'_> {
 }
 
 impl<'a> DecodeValue<'a> for StrRef<'a> {
+    type Error = Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         Self::from_bytes(BytesRef::decode_value(reader, header)?.as_slice())
     }

--- a/der/src/tag.rs
+++ b/der/src/tag.rs
@@ -315,6 +315,8 @@ impl From<&Tag> for u8 {
 }
 
 impl<'a> Decode<'a> for Tag {
+    type Error = Error;
+
     fn decode<R: Reader<'a>>(reader: &mut R) -> Result<Self> {
         reader.read_byte().and_then(Self::try_from)
     }

--- a/gss-api/src/lib.rs
+++ b/gss-api/src/lib.rs
@@ -62,6 +62,8 @@ impl<'a> FixedTag for InitialContextToken<'a> {
 }
 
 impl<'a> DecodeValue<'a> for InitialContextToken<'a> {
+    type Error = der::Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, _header: der::Header) -> der::Result<Self> {
         Ok(Self {
             this_mech: reader.decode()?,

--- a/pkcs1/src/params.rs
+++ b/pkcs1/src/params.rs
@@ -37,6 +37,8 @@ impl Default for TrailerField {
 }
 
 impl<'a> DecodeValue<'a> for TrailerField {
+    type Error = der::Error;
+
     fn decode_value<R: Reader<'a>>(decoder: &mut R, header: der::Header) -> der::Result<Self> {
         match u8::decode_value(decoder, header)? {
             1 => Ok(TrailerField::BC),
@@ -178,6 +180,8 @@ impl<'a> Default for RsaPssParams<'a> {
 }
 
 impl<'a> DecodeValue<'a> for RsaPssParams<'a> {
+    type Error = der::Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: der::Header) -> der::Result<Self> {
         reader.read_nested(header.length, |reader| {
             Ok(Self {
@@ -342,6 +346,7 @@ impl<'a> Default for RsaOaepParams<'a> {
 }
 
 impl<'a> DecodeValue<'a> for RsaOaepParams<'a> {
+    type Error = der::Error;
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: der::Header) -> der::Result<Self> {
         reader.read_nested(header.length, |reader| {
             Ok(Self {

--- a/pkcs1/src/private_key.rs
+++ b/pkcs1/src/private_key.rs
@@ -93,6 +93,8 @@ impl<'a> RsaPrivateKey<'a> {
 }
 
 impl<'a> DecodeValue<'a> for RsaPrivateKey<'a> {
+    type Error = der::Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> der::Result<Self> {
         reader.read_nested(header.length, |reader| {
             let version = Version::decode(reader)?;
@@ -215,6 +217,8 @@ pub struct OtherPrimeInfos<'a> {
 
 #[cfg(not(feature = "alloc"))]
 impl<'a> DecodeValue<'a> for OtherPrimeInfos<'a> {
+    type Error = der::Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, _header: Header) -> der::Result<Self> {
         // Placeholder decoder that always returns an error.
         // Uses `Tag::Integer` to signal an unsupported version.

--- a/pkcs1/src/private_key/other_prime_info.rs
+++ b/pkcs1/src/private_key/other_prime_info.rs
@@ -30,6 +30,8 @@ pub struct OtherPrimeInfo<'a> {
 }
 
 impl<'a> DecodeValue<'a> for OtherPrimeInfo<'a> {
+    type Error = der::Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> der::Result<Self> {
         reader.read_nested(header.length, |reader| {
             Ok(Self {

--- a/pkcs1/src/public_key.rs
+++ b/pkcs1/src/public_key.rs
@@ -34,6 +34,7 @@ pub struct RsaPublicKey<'a> {
 }
 
 impl<'a> DecodeValue<'a> for RsaPublicKey<'a> {
+    type Error = der::Error;
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> der::Result<Self> {
         reader.read_nested(header.length, |reader| {
             Ok(Self {

--- a/pkcs1/src/version.rs
+++ b/pkcs1/src/version.rs
@@ -52,6 +52,7 @@ impl TryFrom<u8> for Version {
 }
 
 impl<'a> Decode<'a> for Version {
+    type Error = der::Error;
     fn decode<R: Reader<'a>>(decoder: &mut R) -> der::Result<Self> {
         Version::try_from(u8::decode(decoder)?).map_err(|_| Self::TAG.value_error())
     }

--- a/pkcs12/src/safe_bag.rs
+++ b/pkcs12/src/safe_bag.rs
@@ -37,6 +37,8 @@ pub struct SafeBag {
 }
 
 impl<'a> ::der::DecodeValue<'a> for SafeBag {
+    type Error = ::der::Error;
+
     fn decode_value<R: ::der::Reader<'a>>(
         reader: &mut R,
         header: ::der::Header,

--- a/pkcs5/src/lib.rs
+++ b/pkcs5/src/lib.rs
@@ -144,6 +144,8 @@ impl EncryptionScheme {
 }
 
 impl<'a> DecodeValue<'a> for EncryptionScheme {
+    type Error = der::Error;
+
     fn decode_value<R: Reader<'a>>(decoder: &mut R, header: Header) -> der::Result<Self> {
         AlgorithmIdentifierRef::decode_value(decoder, header)?.try_into()
     }

--- a/pkcs5/src/pbes1.rs
+++ b/pkcs5/src/pbes1.rs
@@ -67,6 +67,8 @@ impl Algorithm {
 }
 
 impl<'a> DecodeValue<'a> for Algorithm {
+    type Error = der::Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: der::Header) -> der::Result<Self> {
         AlgorithmIdentifierRef::decode_value(reader, header)?.try_into()
     }
@@ -125,6 +127,8 @@ pub struct Parameters {
 }
 
 impl<'a> DecodeValue<'a> for Parameters {
+    type Error = der::Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: der::Header) -> der::Result<Self> {
         AnyRef::decode_value(reader, header)?.try_into()
     }

--- a/pkcs5/src/pbes2.rs
+++ b/pkcs5/src/pbes2.rs
@@ -262,6 +262,8 @@ impl Parameters {
 }
 
 impl<'a> DecodeValue<'a> for Parameters {
+    type Error = der::Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: der::Header) -> der::Result<Self> {
         AnyRef::decode_value(reader, header)?.try_into()
     }
@@ -370,6 +372,8 @@ impl EncryptionScheme {
 }
 
 impl<'a> Decode<'a> for EncryptionScheme {
+    type Error = der::Error;
+
     fn decode<R: Reader<'a>>(reader: &mut R) -> der::Result<Self> {
         AlgorithmIdentifierRef::decode(reader).and_then(TryInto::try_into)
     }

--- a/pkcs5/src/pbes2/kdf.rs
+++ b/pkcs5/src/pbes2/kdf.rs
@@ -104,6 +104,8 @@ impl Kdf {
 }
 
 impl<'a> DecodeValue<'a> for Kdf {
+    type Error = der::Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: der::Header) -> der::Result<Self> {
         AlgorithmIdentifierRef::decode_value(reader, header)?.try_into()
     }
@@ -222,6 +224,7 @@ impl Pbkdf2Params {
 }
 
 impl<'a> DecodeValue<'a> for Pbkdf2Params {
+    type Error = der::Error;
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: der::Header) -> der::Result<Self> {
         AnyRef::decode_value(reader, header)?.try_into()
     }
@@ -419,6 +422,8 @@ impl ScryptParams {
 }
 
 impl<'a> DecodeValue<'a> for ScryptParams {
+    type Error = der::Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: der::Header) -> der::Result<Self> {
         AnyRef::decode_value(reader, header)?.try_into()
     }

--- a/pkcs5/src/pbes2/kdf/salt.rs
+++ b/pkcs5/src/pbes2/kdf/salt.rs
@@ -56,6 +56,8 @@ impl AsRef<[u8]> for Salt {
 }
 
 impl<'a> DecodeValue<'a> for Salt {
+    type Error = Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         let length = usize::try_from(header.length)?;
 

--- a/pkcs8/src/encrypted_private_key_info.rs
+++ b/pkcs8/src/encrypted_private_key_info.rs
@@ -97,6 +97,8 @@ impl<'a> EncryptedPrivateKeyInfo<'a> {
 }
 
 impl<'a> DecodeValue<'a> for EncryptedPrivateKeyInfo<'a> {
+    type Error = der::Error;
+
     fn decode_value<R: Reader<'a>>(
         reader: &mut R,
         header: Header,

--- a/pkcs8/src/private_key_info.rs
+++ b/pkcs8/src/private_key_info.rs
@@ -171,6 +171,8 @@ impl<'a> PrivateKeyInfo<'a> {
 }
 
 impl<'a> DecodeValue<'a> for PrivateKeyInfo<'a> {
+    type Error = der::Error;
+
     fn decode_value<R: Reader<'a>>(
         reader: &mut R,
         header: Header,

--- a/pkcs8/src/version.rs
+++ b/pkcs8/src/version.rs
@@ -26,6 +26,8 @@ impl Version {
 }
 
 impl<'a> Decode<'a> for Version {
+    type Error = der::Error;
+
     fn decode<R: Reader<'a>>(decoder: &mut R) -> der::Result<Self> {
         Version::try_from(u8::decode(decoder)?).map_err(|_| Self::TAG.value_error())
     }

--- a/sec1/src/parameters.rs
+++ b/sec1/src/parameters.rs
@@ -28,6 +28,8 @@ pub enum EcParameters {
 }
 
 impl<'a> DecodeValue<'a> for EcParameters {
+    type Error = der::Error;
+
     fn decode_value<R: Reader<'a>>(decoder: &mut R, header: Header) -> der::Result<Self> {
         ObjectIdentifier::decode_value(decoder, header).map(Self::NamedCurve)
     }

--- a/sec1/src/private_key.rs
+++ b/sec1/src/private_key.rs
@@ -95,6 +95,8 @@ impl<'a> EcPrivateKey<'a> {
 }
 
 impl<'a> DecodeValue<'a> for EcPrivateKey<'a> {
+    type Error = der::Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> der::Result<Self> {
         reader.read_nested(header.length, |reader| {
             if u8::decode(reader)? != VERSION {

--- a/spki/src/algorithm.rs
+++ b/spki/src/algorithm.rs
@@ -33,8 +33,10 @@ pub struct AlgorithmIdentifier<Params> {
 
 impl<'a, Params> DecodeValue<'a> for AlgorithmIdentifier<Params>
 where
-    Params: Choice<'a>,
+    Params: Choice<'a, Error = der::Error>,
 {
+    type Error = der::Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> der::Result<Self> {
         reader.read_nested(header.length, |reader| {
             Ok(Self {
@@ -60,11 +62,14 @@ where
     }
 }
 
-impl<'a, Params> Sequence<'a> for AlgorithmIdentifier<Params> where Params: Choice<'a> + Encode {}
+impl<'a, Params> Sequence<'a> for AlgorithmIdentifier<Params> where
+    Params: Choice<'a, Error = der::Error> + Encode
+{
+}
 
 impl<'a, Params> TryFrom<&'a [u8]> for AlgorithmIdentifier<Params>
 where
-    Params: Choice<'a> + Encode,
+    Params: Choice<'a, Error = der::Error> + Encode,
 {
     type Error = Error;
 

--- a/spki/src/spki.rs
+++ b/spki/src/spki.rs
@@ -51,10 +51,10 @@ pub struct SubjectPublicKeyInfo<Params, Key> {
 
 impl<'a, Params, Key> SubjectPublicKeyInfo<Params, Key>
 where
-    Params: Choice<'a> + Encode,
+    Params: Choice<'a, Error = der::Error> + Encode,
     // TODO: replace FixedTag with FixedTag<TAG = { Tag::BitString }> once
     // https://github.com/rust-lang/rust/issues/92827 is fixed
-    Key: Decode<'a> + Encode + FixedTag,
+    Key: Decode<'a, Error = der::Error> + Encode + FixedTag,
 {
     /// Calculate the SHA-256 fingerprint of this [`SubjectPublicKeyInfo`] and
     /// encode it as a Base64 string.
@@ -84,9 +84,11 @@ where
 
 impl<'a: 'k, 'k, Params, Key: 'k> DecodeValue<'a> for SubjectPublicKeyInfo<Params, Key>
 where
-    Params: Choice<'a> + Encode,
-    Key: Decode<'a>,
+    Params: Choice<'a, Error = der::Error> + Encode,
+    Key: Decode<'a, Error = der::Error>,
 {
+    type Error = der::Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> der::Result<Self> {
         reader.read_nested(header.length, |reader| {
             Ok(Self {
@@ -99,7 +101,7 @@ where
 
 impl<'a, Params, Key> EncodeValue for SubjectPublicKeyInfo<Params, Key>
 where
-    Params: Choice<'a> + Encode,
+    Params: Choice<'a, Error = der::Error> + Encode,
     Key: Encode,
 {
     fn value_len(&self) -> der::Result<Length> {
@@ -115,15 +117,15 @@ where
 
 impl<'a, Params, Key> Sequence<'a> for SubjectPublicKeyInfo<Params, Key>
 where
-    Params: Choice<'a> + Encode,
-    Key: Decode<'a> + Encode + FixedTag,
+    Params: Choice<'a, Error = der::Error> + Encode,
+    Key: Decode<'a, Error = der::Error> + Encode + FixedTag,
 {
 }
 
 impl<'a, Params, Key> TryFrom<&'a [u8]> for SubjectPublicKeyInfo<Params, Key>
 where
-    Params: Choice<'a> + Encode,
-    Key: Decode<'a> + Encode + FixedTag,
+    Params: Choice<'a, Error = der::Error> + Encode,
+    Key: Decode<'a, Error = der::Error> + Encode + FixedTag,
 {
     type Error = Error;
 
@@ -134,7 +136,7 @@ where
 
 impl<'a, Params, Key> ValueOrd for SubjectPublicKeyInfo<Params, Key>
 where
-    Params: Choice<'a> + DerOrd + Encode,
+    Params: Choice<'a, Error = der::Error> + DerOrd + Encode,
     Key: ValueOrd,
 {
     fn value_cmp(&self, other: &Self) -> der::Result<Ordering> {
@@ -148,8 +150,8 @@ where
 #[cfg(feature = "alloc")]
 impl<'a: 'k, 'k, Params, Key: 'k> TryFrom<SubjectPublicKeyInfo<Params, Key>> for Document
 where
-    Params: Choice<'a> + Encode,
-    Key: Decode<'a> + Encode + FixedTag,
+    Params: Choice<'a, Error = der::Error> + Encode,
+    Key: Decode<'a, Error = der::Error> + Encode + FixedTag,
     BitStringRef<'a>: From<&'k Key>,
 {
     type Error = Error;
@@ -162,8 +164,8 @@ where
 #[cfg(feature = "alloc")]
 impl<'a: 'k, 'k, Params, Key: 'k> TryFrom<&SubjectPublicKeyInfo<Params, Key>> for Document
 where
-    Params: Choice<'a> + Encode,
-    Key: Decode<'a> + Encode + FixedTag,
+    Params: Choice<'a, Error = der::Error> + Encode,
+    Key: Decode<'a, Error = der::Error> + Encode + FixedTag,
     BitStringRef<'a>: From<&'k Key>,
 {
     type Error = Error;

--- a/x509-cert/src/macros.rs
+++ b/x509-cert/src/macros.rs
@@ -49,6 +49,8 @@ macro_rules! impl_newtype {
         }
 
         impl<'a> ::der::DecodeValue<'a> for $newtype {
+            type Error = ::der::Error;
+
             fn decode_value<R: ::der::Reader<'a>>(
                 decoder: &mut R,
                 header: ::der::Header,

--- a/x509-cert/src/serial_number.rs
+++ b/x509-cert/src/serial_number.rs
@@ -130,6 +130,8 @@ impl<P: Profile> EncodeValue for SerialNumber<P> {
 }
 
 impl<'a, P: Profile> DecodeValue<'a> for SerialNumber<P> {
+    type Error = der::Error;
+
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         let inner = Int::decode_value(reader, header)?;
         let serial = Self {

--- a/x509-cert/tests/certificate.rs
+++ b/x509-cert/tests/certificate.rs
@@ -38,6 +38,8 @@ pub struct DeferDecodeCertificate<'a> {
 }
 
 impl<'a> DecodeValue<'a> for DeferDecodeCertificate<'a> {
+    type Error = der::Error;
+
     fn decode_value<R: Reader<'a>>(
         reader: &mut R,
         header: Header,
@@ -81,6 +83,8 @@ pub struct DeferDecodeTbsCertificate<'a> {
 }
 
 impl<'a> DecodeValue<'a> for DeferDecodeTbsCertificate<'a> {
+    type Error = der::Error;
+
     fn decode_value<R: Reader<'a>>(
         reader: &mut R,
         header: Header,


### PR DESCRIPTION
Adds support for specifying custom error types for the `Encode`, `Decode`, `EncodeValue`, `DecodeValue`, `DerOrd` and `ValueOrd` traits (see #1053).