### PR TITLE
pkcs7: deprecate in favor of `cms`

### DIFF
--- a/cms/Cargo.toml
+++ b/cms/Cargo.toml
@@ -7,8 +7,8 @@ Pure Rust implementation of the Cryptographic Message Syntax (CMS) as described 
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/formats/tree/master/cms"
-categories = ["cryptography", "data-structures", "encoding", "no-std"]
-keywords = ["crypto"]
+categories = ["cryptography", "encoding", "no-std", "parser-implementations"]
+keywords = ["crypto", "pkcs7", "signing"]
 readme = "README.md"
 edition = "2021"
 rust-version = "1.65"

--- a/cms/README.md
+++ b/cms/README.md
@@ -7,16 +7,23 @@
 ![Rust Version][rustc-image]
 [![Project Chat][chat-image]][chat-link]
 
-Pure Rust implementation of the Cryptographic Message Syntax (CMS) as described in [RFC 5652] and in [RFC 3274].
+Pure Rust implementation of the Cryptographic Message Syntax (CMS) as described
+in [RFC 5652], [RFC 5911], and in [RFC 3274].
 
 [Documentation][docs-link]
 
-## Status
+## About
 
-tl;dr: not ready to use.
+Cryptographic Message Syntax (CMS) is an IETF standard for encrypted messages,
+and can be used to sign and/or encrypt data.  It uses a certificate-based
+architecture for authenticating principals who can exchange encrypted and/or
+signed messages.
 
-This is a work-in-progress implementation which is at an early stage of
-development.
+CMS is based on the syntax of PKCS #7, itself based on the Privacy-Enhanced
+Mail (PEM) standard.
+
+It's used in many cryptographic standards, such as S/MIME, PKCS#12 and the
+RFC 3161 digital timestamping protocol.
 
 ## Minimum Supported Rust Version
 
@@ -56,5 +63,6 @@ dual licensed as above, without any additional terms or conditions.
 [//]: # (links)
 
 [RustCrypto]: https://github.com/rustcrypto
-[RFC 5652]: https://datatracker.ietf.org/doc/html/rfc5652
 [RFC 3274]: https://datatracker.ietf.org/doc/html/rfc3274
+[RFC 5652]: https://datatracker.ietf.org/doc/html/rfc5652
+[RFC 5911]: https://datatracker.ietf.org/doc/html/rfc5652

--- a/pkcs7/Cargo.toml
+++ b/pkcs7/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "pkcs7"
 version = "0.4.0"
-description = """
-Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #7:
-PKCS #7: Cryptographic Message Syntax Version 1.5 (RFC 5652)
-"""
+description = "DEPRECATED: use the `cms` crate instead"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/formats/tree/master/pkcs7"

--- a/pkcs7/README.md
+++ b/pkcs7/README.md
@@ -12,6 +12,17 @@ Cryptographic Message Syntax v1.5 ([RFC 5652] and [RFC 8933]).
 
 [Documentation][docs-link]
 
+## 🚨 DEPRECATED! 🚨
+
+The `pkcs7` crate is deprecated and will not receive further releases.
+
+Please migrate to the following instead:
+
+- For Cryptographic Message Syntax (CMS): use the [`cms` crate](https://github.com/RustCrypto/formats/tree/master/cms).
+- For PKCS#7 block padding: use [`block_padding::Pkcs7`](https://docs.rs/block-padding/latest/block_padding/struct.Pkcs7.html)
+
+See [#1045] for more information.
+
 ## Minimum Supported Rust Version
 
 This crate requires **Rust 1.65** at a minimum.
@@ -52,3 +63,4 @@ dual licensed as above, without any additional terms or conditions.
 [RustCrypto]: https://github.com/rustcrypto
 [RFC 5652]: https://datatracker.ietf.org/doc/html/rfc5652
 [RFC 8933]: https://datatracker.ietf.org/doc/html/rfc8933
+[#1045]: https://github.com/RustCrypto/formats/issues/1045


### PR DESCRIPTION
This commit adds a deprecation notice to README.md for the `pkcs7` crate announcing `cms` as its official successor.

Notably `pkcs7` predates many of the other format-related crates and uses entirely reference-based conventions which we migrated away from in the `x509-cert` crate. `cms` uses the newer conventions, and is more complete as a Cryptographic Message Syntax implementation.

We will not be accepting pull requests for `pkcs7` and are leaving its source code for now only to aid in porting functionality not yet present in the `cms` crate.

When the next breaking release of `der` occurs, we will delete the `pkcs7` source code from the repository, leaving only the deprecation notice to help assist people migrating.

Closes #1045.