### PR TITLE
pkcs7 v0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs7"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "der",
  "hex-literal",

--- a/pkcs7/CHANGELOG.md
+++ b/pkcs7/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.1 (2023-05-13)
+
+🚨 DEPRECATED! 🚨
+
+Use the [`cms` crate](https://github.com/RustCrypto/formats/tree/master/cms) instead ([#1062])
+
+[#1062]: https://github.com/RustCrypto/formats/pull/1062
+
 ## 0.4.0 (2023-03-18)
 ### Added
 - `SignedData` type to ([#813])

--- a/pkcs7/Cargo.toml
+++ b/pkcs7/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs7"
-version = "0.4.0"
+version = "0.4.1"
 description = "DEPRECATED: use the `cms` crate instead"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
This release deprecates the `pkcs7` crate in favor of the `cms` crate