### PR TITLE
der: add `SetOfVec::{extend, from_iter}`

### DIFF
--- a/der/src/asn1/set_of.rs
+++ b/der/src/asn1/set_of.rs
@@ -214,6 +214,19 @@ where
         }
     }
 
+    /// Create a new [`SetOfVec`] from the given iterator.
+    ///
+    /// Note: this is an inherent method instead of an impl of the
+    /// [`FromIterator`] trait in order to be fallible.
+    pub fn from_iter<I>(iter: I) -> Result<Self>
+    where
+        I: IntoIterator<Item = T>,
+    {
+        let mut ret = Self::new();
+        ret.extend(iter)?;
+        Ok(ret)
+    }
+
     /// Add an element to this [`SetOfVec`].
     ///
     /// Items MUST be added in lexicographical order according to the
@@ -228,6 +241,18 @@ where
 
         self.inner.push(new_elem);
         Ok(())
+    }
+
+    /// Extend a [`SetOfVec`] using an iterator.
+    ///
+    /// Note: this is an inherent method instead of an impl of the
+    /// [`Extend`] trait in order to be fallible.
+    pub fn extend<I>(&mut self, iter: I) -> Result<()>
+    where
+        I: IntoIterator<Item = T>,
+    {
+        self.inner.extend(iter);
+        der_sort(&mut self.inner)
     }
 
     /// Borrow the elements of this [`SetOfVec`] as a slice.


### PR DESCRIPTION
Adds inherent methods to `SetOfVec` shaped like the `Extend` and `FromIterator` traits.

However, the methods are fallible, so they don't quite fit the existing traits, hence why inherent methods are used instead.