### PR TITLE
der: fix handling of non-unique items in `SetOf`(Vec)

### DIFF
--- a/der/src/error.rs
+++ b/der/src/error.rs
@@ -227,6 +227,9 @@ pub enum ErrorKind {
         oid: ObjectIdentifier,
     },
 
+    /// `SET` cannot contain duplicates.
+    SetDuplicate,
+
     /// `SET` ordering error: items not in canonical order.
     SetOrdering,
 
@@ -329,6 +332,7 @@ impl fmt::Display for ErrorKind {
             ErrorKind::OidUnknown { oid } => {
                 write!(f, "unknown/unsupported OID: {}", oid)
             }
+            ErrorKind::SetDuplicate => write!(f, "SET OF contains duplicate"),
             ErrorKind::SetOrdering => write!(f, "SET OF ordering error"),
             ErrorKind::Overflow => write!(f, "integer overflow"),
             ErrorKind::Overlength => write!(f, "ASN.1 DER message is too long"),

--- a/der/tests/set_of.rs
+++ b/der/tests/set_of.rs
@@ -4,15 +4,21 @@
 
 use der::{asn1::SetOfVec, DerOrd};
 use proptest::{prelude::*, string::*};
+use std::collections::BTreeSet;
 
 proptest! {
     #[test]
     fn sort_equiv(bytes in bytes_regex(".{0,64}").unwrap()) {
-        let mut expected = bytes.clone();
-        expected.sort_by(|a, b| a.der_cmp(b).unwrap());
+        let mut uniq = BTreeSet::new();
 
-        let set = SetOfVec::try_from(bytes).unwrap();
-        prop_assert_eq!(expected.as_slice(), set.as_slice());
+        // Ensure there are no duplicates
+        if bytes.iter().copied().all(move |x| uniq.insert(x)) {
+            let mut expected = bytes.clone();
+            expected.sort_by(|a, b| a.der_cmp(b).unwrap());
+
+            let set = SetOfVec::try_from(bytes).unwrap();
+            prop_assert_eq!(expected.as_slice(), set.as_slice());
+        }
     }
 }
 


### PR DESCRIPTION
The `TryFrom` constructors were not properly tested for the handling of duplicate items and allowed them to be inserted.

This commit fixes the handling and adds tests. In the event there are duplicates in a set, a newly added `ErrorKind::SetDuplicate` variant is returned with the error type.