### PR TITLE
der v0.7.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,7 +404,7 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "arbitrary",
  "const-oid 0.9.2",

--- a/der/CHANGELOG.md
+++ b/der/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.6 (2023-05-16)
+### Added
+- `SetOfVec::{extend, from_iter}` methods ([#1065])
+- `SetOf(Vec)::{insert, insert_ordered}` methods ([#1067])
+
+### Changed
+- Deprecate `SetOf(Vec)::add` ([#1067])
+
+### Fixed
+- Off-by-one error in `BMPString` tag ([#1037])
+- Handling of non-unique items in `SetOf`(Vec) ([#1066])
+
+[#1037]: https://github.com/RustCrypto/formats/pull/1037
+[#1065]: https://github.com/RustCrypto/formats/pull/1065
+[#1066]: https://github.com/RustCrypto/formats/pull/1066
+[#1067]: https://github.com/RustCrypto/formats/pull/1067
+
 ## 0.7.5 (2023-04-24)
 ### Added
 - adds support for `DateTime::INFINITY` ([#1026])

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der"
-version = "0.7.5"
+version = "0.7.6"
 description = """
 Pure Rust embedded-friendly implementation of the Distinguished Encoding Rules
 (DER) for Abstract Syntax Notation One (ASN.1) as described in ITU X.690 with

--- a/pkcs7/Cargo.toml
+++ b/pkcs7/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-der = { version = "0.7", features = ["oid"] }
+der = { version = "0.7.6", features = ["oid"] }
 spki = { version = "0.7" }
 x509-cert = { version = "0.2", default-features = false }
 

--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.65"
 
 [dependencies]
 const-oid = { version = "0.9.2", features = ["db"] } # TODO: path = "../const-oid"
-der = { version = "0.7.5", features = ["alloc", "derive", "flagset", "oid"] }
+der = { version = "0.7.6", features = ["alloc", "derive", "flagset", "oid"] }
 spki = { version = "0.7.2", features = ["alloc"] }
 
 # optional dependencies


### PR DESCRIPTION
### Added
- `SetOfVec::{extend, from_iter}` methods ([#1065])
- `SetOf(Vec)::{insert, insert_ordered}` methods ([#1067])

### Changed
- Deprecate `SetOf(Vec)::add` ([#1067])

### Fixed
- Off-by-one error in `BMPString` tag ([#1037])
- Handling of non-unique items in `SetOf`(Vec) ([#1066])

[#1037]: https://github.com/RustCrypto/formats/pull/1037
[#1065]: https://github.com/RustCrypto/formats/pull/1065
[#1066]: https://github.com/RustCrypto/formats/pull/1066
[#1067]: https://github.com/RustCrypto/formats/pull/1067