### PR TITLE
Draft for remainder Deserialization trait

### DIFF
--- a/tls_codec/benches/quic_vec.rs
+++ b/tls_codec/benches/quic_vec.rs
@@ -20,7 +20,8 @@ fn vector(c: &mut Criterion) {
             },
             |serialized_long_vec| {
                 let _deserialized_long_vec =
-                    Vec::<u8>::tls_deserialize(&mut serialized_long_vec.as_slice()).unwrap();
+                    <Vec<u8> as Deserialize>::tls_deserialize(&mut serialized_long_vec.as_slice())
+                        .unwrap();
             },
             BatchSize::SmallInput,
         )
@@ -46,7 +47,8 @@ fn byte_vector(c: &mut Criterion) {
             },
             |serialized_long_vec| {
                 let _deserialized_long_vec =
-                    VLBytes::tls_deserialize(&mut serialized_long_vec.as_slice()).unwrap();
+                    <VLBytes as Deserialize>::tls_deserialize(&mut serialized_long_vec.as_slice())
+                        .unwrap();
             },
             BatchSize::SmallInput,
         )

--- a/tls_codec/derive/src/lib.rs
+++ b/tls_codec/derive/src/lib.rs
@@ -505,6 +505,16 @@ pub fn deserialize_macro_derive(input: TokenStream) -> TokenStream {
     impl_deserialize(parsed_ast).into()
 }
 
+#[proc_macro_derive(TlsDeserializeRemainder, attributes(tls_codec))]
+pub fn deserialize_remainder_macro_derive(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    let parsed_ast = match parse_ast(ast) {
+        Ok(ast) => ast,
+        Err(err_ts) => return err_ts.into_compile_error().into(),
+    };
+    impl_deserialize_remainder(parsed_ast).into()
+}
+
 /// Returns identifiers to use as bindings in generated code
 fn make_n_ids(n: usize) -> Vec<Ident> {
     (0..n)
@@ -845,6 +855,82 @@ fn impl_deserialize(parsed_ast: TlsStruct) -> TokenStream2 {
                     fn tls_deserialize<R: std::io::Read>(bytes: &mut R) -> core::result::Result<Self, tls_codec::Error> {
                         #discriminant_constants
                         let discriminant = <#repr as tls_codec::Deserialize>::tls_deserialize(bytes)?;
+                        match discriminant {
+                            #(#arms)*
+                            _ => {
+                                Err(tls_codec::Error::UnknownValue(discriminant.into()))
+                            },
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[allow(unused_variables)]
+fn impl_deserialize_remainder(parsed_ast: TlsStruct) -> TokenStream2 {
+    match parsed_ast {
+        TlsStruct::Struct(Struct {
+            call_site,
+            ident,
+            generics,
+            members,
+            member_prefixes,
+            member_skips,
+        }) => {
+            let ((members, member_prefixes), (members_default, member_prefixes_default)) =
+                partition_skipped(members, member_prefixes, member_skips);
+
+            let prefixes = member_prefixes
+                .iter()
+                .map(|p| p.for_trait("DeserializeRemainder"))
+                .collect::<Vec<_>>();
+            let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+            quote! {
+                impl #impl_generics tls_codec::DeserializeRemainder for #ident #ty_generics #where_clause {
+                    fn tls_deserialize(bytes: &mut [u8]) -> core::result::Result<(Self, &[u8]), tls_codec::Error> {
+                        Ok(Self {
+                            #(#members: #prefixes::tls_deserialize(bytes)?,)*
+                            #(#members_default: Default::default(),)*
+                        })
+                    }
+                }
+            }
+        }
+        TlsStruct::Enum(Enum {
+            call_site,
+            ident,
+            generics,
+            repr,
+            variants,
+            discriminant_constants,
+        }) => {
+            let arms = variants
+                .iter()
+                .map(|variant| {
+                    let variant_id = &variant.ident;
+                    let discriminant = discriminant_id(variant_id);
+                    let members = &variant.members;
+                    let prefixes = variant
+                        .member_prefixes
+                        .iter()
+                        .map(|p| p.for_trait("DeserializeRemainder"))
+                        .collect::<Vec<_>>();
+                    quote! {
+                        #discriminant => Ok(#ident::#variant_id {
+                            #(#members: #prefixes::tls_deserialize(bytes)?,)*
+                        }),
+                    }
+                })
+                .collect::<Vec<_>>();
+            let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+            quote! {
+                impl #impl_generics tls_codec::DeserializeRemainder for #ident #ty_generics #where_clause {
+                    #[allow(non_upper_case_globals)]
+                    fn tls_deserialize(bytes: &mut [u8]) -> core::result::Result<(Self, &[u8]), tls_codec::Error> {
+                        #discriminant_constants
+                        let discriminant = <#repr as tls_codec::DeserializeRemainder>::tls_deserialize(bytes)?;
                         match discriminant {
                             #(#arms)*
                             _ => {

--- a/tls_codec/src/arrays.rs
+++ b/tls_codec/src/arrays.rs
@@ -1,6 +1,6 @@
 //! Implement the TLS codec for some byte arrays.
 
-use crate::{Deserialize, Serialize, Size};
+use crate::{Deserialize, DeserializeRemainder, Serialize, Size};
 
 #[cfg(feature = "std")]
 use {
@@ -30,6 +30,14 @@ impl<const LEN: usize> Deserialize for [u8; LEN] {
         let mut out = [0u8; LEN];
         bytes.read_exact(&mut out)?;
         Ok(out)
+    }
+}
+
+impl<const LEN: usize> DeserializeRemainder for [u8; LEN] {
+    #[inline]
+    fn tls_deserialize(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
+        let out = bytes[..LEN].try_into().map_err(|_| Error::EndOfStream)?;
+        Ok((out, &bytes[LEN..]))
     }
 }
 

--- a/tls_codec/src/lib.rs
+++ b/tls_codec/src/lib.rs
@@ -196,3 +196,37 @@ pub trait Deserialize: Size {
         Self::tls_deserialize(&mut bytes.as_ref())
     }
 }
+
+/// The `DeserializeRemainder` trait defines functions to deserialize a byte slice to a
+/// struct or enum and return the remaining byte slice.
+pub trait DeserializeRemainder: Size {
+    /// This function deserializes the `bytes` from the provided a `&[u8]`
+    /// and returns the populated struct, as well as the remaining slice.
+    ///
+    /// In order to get the amount of bytes read, use [`Size::tls_serialized_len`].
+    ///
+    /// Returns an error if occurs during deserialization.
+    #[cfg(feature = "std")]
+    fn tls_deserialize(bytes: &[u8]) -> Result<(Self, &[u8]), Error>
+    where
+        Self: Sized;
+
+    /// This function deserializes the provided `bytes` and returns the populated
+    /// struct. All bytes must be consumed.
+    ///
+    /// Returns an error if not all bytes are read from the input, or if an error
+    /// occurs during deserialization.
+    #[cfg(feature = "std")]
+    fn tls_deserialize_exact(bytes: &[u8]) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        let (out, remainder) = Self::tls_deserialize(bytes)?;
+
+        if !remainder.is_empty() {
+            return Err(Error::TrailingData);
+        }
+
+        Ok(out)
+    }
+}

--- a/tls_codec/src/quic_vec.rs
+++ b/tls_codec/src/quic_vec.rs
@@ -20,7 +20,7 @@ use arbitrary::{Arbitrary, Unstructured};
 #[cfg(feature = "serde")]
 use serde::{Deserialize as SerdeDeserialize, Serialize as SerdeSerialize};
 
-use crate::{Deserialize, Error, Serialize, Size};
+use crate::{Deserialize, DeserializeRemainder, Error, Serialize, Size};
 
 #[cfg(not(feature = "mls"))]
 const MAX_LEN: u64 = (1 << 62) - 1;
@@ -63,6 +63,33 @@ fn read_variable_length<R: std::io::Read>(bytes: &mut R) -> Result<(usize, usize
     }
 
     Ok((length, len_len))
+}
+
+fn read_variable_length_remainder(bytes: &[u8]) -> Result<((usize, usize), &[u8]), Error> {
+    // The length is encoded in the first two bits of the first byte.
+    let (len_len_byte, mut remainder) = <u8 as DeserializeRemainder>::tls_deserialize(bytes)?;
+    if len_len_byte == 0u8 {
+        // There must be at least one byte for the length.
+        // If we don't even have a length byte, this is not a valid
+        // variable-length encoded vector.
+        return Err(Error::InvalidVectorLength);
+    }
+
+    let mut length: usize = (len_len_byte & 0x3F).into();
+    let len_len = (len_len_byte >> 6).into();
+    if !cfg!(fuzzing) {
+        debug_assert!(len_len <= MAX_LEN_LEN);
+    }
+    if len_len > MAX_LEN_LEN {
+        return Err(Error::InvalidVectorLength);
+    }
+    for _ in 0..len_len {
+        let (next, next_remainder) = <u8 as DeserializeRemainder>::tls_deserialize(remainder)?;
+        remainder = next_remainder;
+        length = (length << 8) + usize::from(next);
+    }
+
+    Ok(((length, len_len), remainder))
 }
 
 #[inline]
@@ -119,6 +146,28 @@ impl<T: Deserialize> Deserialize for Vec<T> {
             result.push(element);
         }
         Ok(result)
+    }
+}
+
+impl<T: DeserializeRemainder> DeserializeRemainder for Vec<T> {
+    #[inline(always)]
+    fn tls_deserialize(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
+        let ((length, len_len), mut remainder) = read_variable_length_remainder(bytes)?;
+
+        if length == 0 {
+            // An empty vector.
+            return Ok((Vec::new(), remainder));
+        }
+
+        let mut result = Vec::new();
+        let mut read = len_len;
+        while (read - len_len) < length {
+            let (element, next_remainder) = T::tls_deserialize(remainder)?;
+            remainder = next_remainder;
+            read += element.tls_serialized_len();
+            result.push(element);
+        }
+        Ok((result, remainder))
     }
 }
 
@@ -420,6 +469,42 @@ impl Deserialize for VLBytes {
     }
 }
 
+impl DeserializeRemainder for VLBytes {
+    fn tls_deserialize(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
+        let ((length, _), remainder) = read_variable_length_remainder(bytes)?;
+        if length == 0 {
+            return Ok((Self::new(vec![]), remainder));
+        }
+
+        if !cfg!(fuzzing) {
+            debug_assert!(
+                length <= MAX_LEN as usize,
+                "Trying to allocate {length} bytes. Only {MAX_LEN} allowed.",
+            );
+        }
+        if length > MAX_LEN as usize {
+            return Err(Error::DecodingError(format!(
+                "Trying to allocate {length} bytes. Only {MAX_LEN} allowed.",
+            )));
+        }
+        match remainder.get(..length).ok_or(Error::EndOfStream) {
+            Ok(vec) => Ok((Self { vec: vec.to_vec() }, &remainder[length..])),
+            Err(_e) => {
+                let remaining_len = remainder.len();
+                if !cfg!(fuzzing) {
+                    debug_assert_eq!(
+                        remaining_len, length,
+                        "Expected to read {length} bytes but {remaining_len} were read.",
+                    );
+                }
+                Err(Error::DecodingError(format!(
+                    "{remaining_len} bytes were read but {length} were expected",
+                )))
+            }
+        }
+    }
+}
+
 impl Serialize for &VLBytes {
     #[inline(always)]
     fn tls_serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, Error> {
@@ -451,7 +536,17 @@ impl Deserialize for SecretVLBytes {
     where
         Self: Sized,
     {
-        Ok(Self(VLBytes::tls_deserialize(bytes)?))
+        Ok(Self(<VLBytes as Deserialize>::tls_deserialize(bytes)?))
+    }
+}
+
+impl DeserializeRemainder for SecretVLBytes {
+    fn tls_deserialize(bytes: &[u8]) -> Result<(Self, &[u8]), Error>
+    where
+        Self: Sized,
+    {
+        let (bytes, remainder) = <VLBytes as DeserializeRemainder>::tls_deserialize(bytes)?;
+        Ok((Self(bytes), remainder))
     }
 }
 


### PR DESCRIPTION
This PR adds a new `DeserializeRemainder` Trait for `tls_codec` that takes a byte slice as input and returns the deserialized variable, as well as the remaining part of the byte slice.

TODO:
- [ ] Move to `get(..)` notation instead of `slice[..]` and handle errors.
- [ ] Adapt more/all tests to handle both deserialization traits.
- [ ] Derive the trait for tls_vecs in addition to quic_vecs