### PR TITLE
tls_codec: Fix variable length encoding

### DIFF
--- a/tls_codec/src/quic_vec.rs
+++ b/tls_codec/src/quic_vec.rs
@@ -25,11 +25,11 @@ use crate::{Deserialize, Error, Serialize, Size};
 #[cfg(not(feature = "mls"))]
 const MAX_LEN: u64 = (1 << 62) - 1;
 #[cfg(not(feature = "mls"))]
-const MAX_LEN_LEN: usize = 8;
+const MAX_LEN_LEN_LOG: usize = 3;
 #[cfg(feature = "mls")]
 const MAX_LEN: u64 = (1 << 30) - 1;
 #[cfg(feature = "mls")]
-const MAX_LEN_LEN: usize = 4;
+const MAX_LEN_LEN_LOG: usize = 2;
 
 /// Read the length of a variable-length vector.
 ///
@@ -49,14 +49,23 @@ fn read_variable_length<R: std::io::Read>(bytes: &mut R) -> Result<(usize, usize
     }
 
     let mut length: usize = (len_len_byte[0] & 0x3F).into();
-    let len_len = (len_len_byte[0] >> 6).into();
+    let len_len_log = (len_len_byte[0] >> 6).into();
     if !cfg!(fuzzing) {
-        debug_assert!(len_len <= MAX_LEN_LEN);
+        debug_assert!(len_len_log <= MAX_LEN_LEN_LOG);
     }
-    if len_len > MAX_LEN_LEN {
+    if len_len_log > MAX_LEN_LEN_LOG {
         return Err(Error::InvalidVectorLength);
     }
-    for _ in 0..len_len {
+
+    let len_len = match len_len_log {
+        0 => 1,
+        1 => 2,
+        2 => 4,
+        3 => 8,
+        _ => unreachable!(),
+    };
+
+    for _ in 1..len_len {
         let mut next = [0u8; 1];
         bytes.read_exact(&mut next)?;
         length = (length << 8) + usize::from(next[0]);
@@ -76,9 +85,9 @@ fn length_encoding_bytes(length: u64) -> Result<usize, Error> {
 
     Ok(if length < 0x40 {
         1
-    } else if length < 0x3fff {
+    } else if length < 0x4000 {
         2
-    } else if length < 0x3fff_ffff {
+    } else if length < 0x4000_0000 {
         4
     } else {
         8
@@ -135,8 +144,8 @@ fn write_length<W: std::io::Write>(writer: &mut W, content_length: usize) -> Res
     match len_len {
         1 => length_bytes[0] = 0x00,
         2 => length_bytes[0] = 0x40,
-        4 => length_bytes[0] = 0xc0,
-        8 => length_bytes[0] = 0x80,
+        4 => length_bytes[0] = 0x80,
+        8 => length_bytes[0] = 0xc0,
         _ => {
             if !cfg!(fuzzing) {
                 debug_assert!(false, "Invalid vector len_len {len_len}");

--- a/tls_codec/src/quic_vec.rs
+++ b/tls_codec/src/quic_vec.rs
@@ -71,6 +71,12 @@ fn read_variable_length<R: std::io::Read>(bytes: &mut R) -> Result<(usize, usize
         length = (length << 8) + usize::from(next[0]);
     }
 
+    // ensure that len_len is minimal for the given length
+    let min_len_len = length_encoding_bytes(length as u64)?;
+    if min_len_len != len_len {
+        return Err(Error::InvalidVectorLength);
+    }
+
     Ok((length, len_len))
 }
 

--- a/tls_codec/src/quic_vec.rs
+++ b/tls_codec/src/quic_vec.rs
@@ -83,11 +83,11 @@ fn length_encoding_bytes(length: u64) -> Result<usize, Error> {
         return Err(Error::InvalidVectorLength);
     }
 
-    Ok(if length < 0x40 {
+    Ok(if length <= 0x3f {
         1
-    } else if length < 0x4000 {
+    } else if length <= 0x3fff {
         2
-    } else if length < 0x4000_0000 {
+    } else if length <= 0x3fff_ffff {
         4
     } else {
         8

--- a/tls_codec/src/quic_vec.rs
+++ b/tls_codec/src/quic_vec.rs
@@ -71,10 +71,12 @@ fn read_variable_length<R: std::io::Read>(bytes: &mut R) -> Result<(usize, usize
         length = (length << 8) + usize::from(next[0]);
     }
 
-    // ensure that len_len is minimal for the given length
-    let min_len_len = length_encoding_bytes(length as u64)?;
-    if min_len_len != len_len {
-        return Err(Error::InvalidVectorLength);
+    if cfg!(feature = "mls") {
+        // ensure that len_len is minimal for the given length
+        let min_len_len = length_encoding_bytes(length as u64)?;
+        if min_len_len != len_len {
+            return Err(Error::InvalidVectorLength);
+        }
     }
 
     Ok((length, len_len))

--- a/tls_codec/tests/decode.rs
+++ b/tls_codec/tests/decode.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "std")]
 
 use tls_codec::{
-    Deserialize, Serialize, Size, TlsByteSliceU16, TlsByteVecU16, TlsByteVecU8, TlsSliceU16,
+    Deserialize, Error, Serialize, Size, TlsByteSliceU16, TlsByteVecU16, TlsByteVecU8, TlsSliceU16,
     TlsVecU16, TlsVecU32, TlsVecU8, VLByteSlice, VLBytes,
 };
 
@@ -160,6 +160,15 @@ fn deserialize_tls_vl_bytes() {
     );
     assert_eq!(long_vector.len(), deserialized_long_vec.as_slice().len());
     assert_eq!(long_vector.as_slice(), deserialized_long_vec.as_slice());
+}
+
+#[test]
+fn deserialize_tls_vl_invalid_length() {
+    let mut b = &[0x40u8, 3, 10, 20, 30] as &[u8];
+    assert_eq!(
+        VLBytes::tls_deserialize(&mut b),
+        Err(Error::InvalidVectorLength)
+    );
 }
 
 #[test]

--- a/tls_codec/tests/decode.rs
+++ b/tls_codec/tests/decode.rs
@@ -165,10 +165,13 @@ fn deserialize_tls_vl_bytes() {
 #[test]
 fn deserialize_tls_vl_invalid_length() {
     let mut b = &[0x40u8, 3, 10, 20, 30] as &[u8];
-    assert_eq!(
-        VLBytes::tls_deserialize(&mut b),
-        Err(Error::InvalidVectorLength)
-    );
+    let result = VLBytes::tls_deserialize(&mut b);
+    if cfg!(feature = "mls") {
+        assert_eq!(result, Err(Error::InvalidVectorLength));
+    } else {
+        let deserialized = result.expect("Unable to tls_deserialize");
+        assert_eq!(deserialized.as_slice(), [10, 20, 30]);
+    }
 }
 
 #[test]

--- a/tls_codec/tests/decode.rs
+++ b/tls_codec/tests/decode.rs
@@ -151,7 +151,7 @@ fn deserialize_tls_vl_bytes() {
 
     let long_vector = vec![77u8; 65535];
     let serialized_long_vec = VLByteSlice(&long_vector).tls_serialize_detached().unwrap();
-    std::println!("bytes: {:x?}", &serialized_long_vec[0..5]);
+    assert_eq!(serialized_long_vec[0], 0x80);
     let deserialized_long_vec =
         VLBytes::tls_deserialize(&mut serialized_long_vec.as_slice()).unwrap();
     assert_eq!(

--- a/tls_codec/tests/encode.rs
+++ b/tls_codec/tests/encode.rs
@@ -58,3 +58,22 @@ fn serialize_var_len_bytes() {
         .expect("Error encoding vector");
     assert_eq!(serialized, vec![0x00]);
 }
+
+#[test]
+fn serialize_var_len_boundaries() {
+    let v = VLBytes::new(vec![99u8; 63]);
+    let serialized = v.tls_serialize_detached().expect("Error encoding vector");
+    assert_eq!(&serialized[0..5], &[63, 99, 99, 99, 99]);
+
+    let v = VLBytes::new(vec![99u8; 64]);
+    let serialized = v.tls_serialize_detached().expect("Error encoding vector");
+    assert_eq!(&serialized[0..5], &[0x40, 64, 99, 99, 99]);
+
+    let v = VLBytes::new(vec![99u8; 16383]);
+    let serialized = v.tls_serialize_detached().expect("Error encoding vector");
+    assert_eq!(&serialized[0..5], &[0x7f, 0xff, 99, 99, 99]);
+
+    let v = VLBytes::new(vec![99u8; 16384]);
+    let serialized = v.tls_serialize_detached().expect("Error encoding vector");
+    assert_eq!(&serialized[0..5], &[0x80, 0, 0x40, 0, 99]);
+}


### PR DESCRIPTION
- Lengths over 2 bytes were serialised with an incorrect prefix
- Fixed off-by-one errors on encoding length boundaries
- Length prefix should be the logarithm of the number of bytes to read to extract the length