### PR TITLE
x509-cert: v0.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1960,7 +1960,7 @@ dependencies = [
 
 [[package]]
 name = "x509-cert"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "arbitrary",
  "const-oid 0.9.2",

--- a/x509-cert/CHANGELOG.md
+++ b/x509-cert/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.3 (2023-05-30)
+
+### Added
+- Added `TryFrom` for `RelativeDistinguishedName` ([#1092])
+- Load a chain of certificates from a slice ([#1081])
+
+[#1092]: https://github.com/RustCrypto/formats/pull/1092
+[#1081]: https://github.com/RustCrypto/formats/pull/1081
+
 ## 0.2.2 (2023-05-19)
 
 ### Added

--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x509-cert"
-version = "0.2.2"
+version = "0.2.3"
 description = """
 Pure Rust implementation of the X.509 Public Key Infrastructure Certificate
 format as described in RFC 5280


### PR DESCRIPTION
Added
- Added `TryFrom` for `RelativeDistinguishedName` ([#1092])
- Load a chain of certificates from a slice ([#1081])