### PR TITLE
const_oid: add RFC 6962 OIDs

### DIFF
--- a/const-oid/oiddbgen/rfc6962.txt
+++ b/const-oid/oiddbgen/rfc6962.txt
@@ -1,0 +1,17 @@
+Object Identifiers (OID) for Certificate Transparency
+-----------------------------------------------------
+This document lists the OIDs for
+- Precertificate signed certificate timestamps extension,
+- Precertificate poison extension, and
+- Precertificate signing certificate,
+
+This file was manually created, as there exists no offical document that is easily parsable.
+RFC 6962 publishes the following OIDs:
+
+google OBJECT IDENTIFIER ::= { iso(1) org(3) dod(6) internet(1) private(4) enterprise(1) google(11129) }
+
+ct-precert-scts OBJECT IDENTIFIER ::= { google 2 4 2 }
+
+ct-precert-poison OBJECT IDENTIFIER ::= {google 2 4 3 }
+
+ct-precert-signing-cert OBJECT IDENTIFIER ::= { google 2 4 4 }

--- a/const-oid/oiddbgen/src/main.rs
+++ b/const-oid/oiddbgen/src/main.rs
@@ -12,6 +12,7 @@ const RFCS: &[(&str, &str)] = &[
     ("rfc5912", include_str!("../rfc5912.txt")),
     ("rfc6268", include_str!("../rfc6268.txt")),
     ("rfc6960", include_str!("../rfc6960.txt")),
+    ("rfc6962", include_str!("../rfc6962.txt")),
     ("rfc7107", include_str!("../rfc7107.txt")),
     ("rfc7299", include_str!("../rfc7299.txt")),
     ("rfc8410", include_str!("../rfc8410.txt")),
@@ -23,7 +24,7 @@ const FIPS202: &str = include_str!("../fips202.md");
 
 // Bases defined in other places.
 const BASES: &[(&str, &str)] = &[("id-ad-ocsp", "1.3.6.1.5.5.7.48.1")];
-const NO_BASES: &[(&str, &str)] = &[("","")];
+const NO_BASES: &[(&str, &str)] = &[("", "")];
 
 fn main() {
     let mut root = Root::default();

--- a/const-oid/src/db/gen.rs
+++ b/const-oid/src/db/gen.rs
@@ -2062,6 +2062,16 @@ pub mod rfc6960 {
     pub const ID_PKIX_OCSP_EXTENDED_REVOKE: crate::ObjectIdentifier =
         crate::ObjectIdentifier::new_unwrap("1.3.6.1.5.5.7.48.1.9");
 }
+pub mod rfc6962 {
+    pub const GOOGLE: crate::ObjectIdentifier =
+        crate::ObjectIdentifier::new_unwrap("1.3.6.1.4.1.11129");
+    pub const CT_PRECERT_SCTS: crate::ObjectIdentifier =
+        crate::ObjectIdentifier::new_unwrap("1.3.6.1.4.1.11129.2.4.2");
+    pub const CT_PRECERT_POISON: crate::ObjectIdentifier =
+        crate::ObjectIdentifier::new_unwrap("1.3.6.1.4.1.11129.2.4.3");
+    pub const CT_PRECERT_SIGNING_CERT: crate::ObjectIdentifier =
+        crate::ObjectIdentifier::new_unwrap("1.3.6.1.4.1.11129.2.4.4");
+}
 pub mod rfc7107 {
     pub const ID_SMIME: crate::ObjectIdentifier =
         crate::ObjectIdentifier::new_unwrap("1.2.840.113549.1.9.16");
@@ -4115,6 +4125,10 @@ pub const DB: super::Database<'static> = super::Database(&[
         &rfc6960::ID_PKIX_OCSP_EXTENDED_REVOKE,
         "id-pkix-ocsp-extended-revoke",
     ),
+    (&rfc6962::GOOGLE, "google"),
+    (&rfc6962::CT_PRECERT_SCTS, "ct-precert-scts"),
+    (&rfc6962::CT_PRECERT_POISON, "ct-precert-poison"),
+    (&rfc6962::CT_PRECERT_SIGNING_CERT, "ct-precert-signing-cert"),
     (&rfc7107::ID_SMIME, "id-smime"),
     (&rfc7107::ID_MOD, "id-mod"),
     (&rfc7107::ID_CT, "id-ct"),


### PR DESCRIPTION
This PR adds OIDs from [RFC 6962](https://www.rfc-editor.org/rfc/rfc6962).