### PR TITLE
Add Hash implementation to EncodedPoint

### DIFF
--- a/sec1/src/point.rs
+++ b/sec1/src/point.rs
@@ -10,6 +10,7 @@ use base16ct::HexDisplay;
 use core::{
     cmp::Ordering,
     fmt::{self, Debug},
+    hash::{Hash, Hasher},
     ops::Add,
     str,
 };
@@ -291,6 +292,15 @@ where
 {
     fn eq(&self, other: &Self) -> bool {
         self.as_bytes() == other.as_bytes()
+    }
+}
+
+impl<Size> Hash for EncodedPoint<Size>
+where
+    Size: ModulusSize,
+{
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.as_bytes().hash(state)
     }
 }
 


### PR DESCRIPTION
It would be nice to be able to have public ssh keys implement Hash so that they can be used as HashMap keys or be put in HashSets. 

This minimal change will in turn make it possible to do the analogous change in [ssh-key](https://github.com/RustCrypto/SSH/tree/master/ssh-key)