### PR TITLE
der_derive: support re-exports for proc-macros

### DIFF
--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -327,6 +327,9 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
+// Necessary for the derive macros and re-exports
+extern crate self as der;
+
 pub mod asn1;
 pub mod referenced;
 


### PR DESCRIPTION
Previously, deriving via der_derive would fail if you didn't include `der`, but one of the crates that re-exports it. Following the `extern crate` trick mentioned in: https://users.rust-lang.org/t/how-to-express-crate-path-in-procedural-macros/91274/17.

Closes #1107. Maybe?