### PR TITLE
Added RFC 8894 (SCEP) OIDs

### DIFF
--- a/const-oid/oiddbgen/rfc8894.md
+++ b/const-oid/oiddbgen/rfc8894.md
@@ -1,0 +1,22 @@
+Simple Certificate Enrolment Protocol
+-------------------------------------
+
+RFC 8894 unfortunately formatted the SCEP OIDs in a table, that can't
+be parsed easily. For this reason the definitions are repeated here
+in a parseable format.
+
+# SCEP Secure Message Objects
+## 3.2.  SCEP pkiMessage
+### 3.2.1.  Signed Transaction Attributes
+
+id-VeriSign           OBJECT IDENTIFIER ::= {2 16 US(840) 1 VeriSign(113733)}
+id-pki                OBJECT IDENTIFIER ::= {id-VeriSign pki(1)}
+id-attributes         OBJECT IDENTIFIER ::= {id-pki attributes(9)}
+id-transactionID      OBJECT IDENTIFIER ::= {id-attributes transactionID(7)}
+id-messageType        OBJECT IDENTIFIER ::= {id-attributes messageType(2)}
+id-pkiStatus          OBJECT IDENTIFIER ::= {id-attributes pkiStatus(3)}
+id-failInfo           OBJECT IDENTIFIER ::= {id-attributes failInfo(4)}
+id-senderNonce        OBJECT IDENTIFIER ::= {id-attributes senderNonce(5)}
+id-recipientNonce     OBJECT IDENTIFIER ::= {id-attributes recipientNonce(6)}
+id-scep               OBJECT IDENTIFIER ::= {id-pkix 24}
+id-scep-failInfoText  OBJECT IDENTIFIER ::= {id-scep 1}

--- a/const-oid/oiddbgen/src/main.rs
+++ b/const-oid/oiddbgen/src/main.rs
@@ -18,9 +18,12 @@ const RFCS: &[(&str, &str)] = &[
     ("rfc8410", include_str!("../rfc8410.txt")),
 ];
 
-// Created from:
-// https://csrc.nist.gov/projects/computer-security-objects-register/algorithm-registration
-const FIPS202: &str = include_str!("../fips202.md");
+const MDS: &[(&str, &str)] = &[
+    // Created from:
+    // https://csrc.nist.gov/projects/computer-security-objects-register/algorithm-registration
+    ("fips202", include_str!("../fips202.md")),
+    ("rfc8894", include_str!("../rfc8894.md")),
+];
 
 // Bases defined in other places.
 const BASES: &[(&str, &str)] = &[("id-ad-ocsp", "1.3.6.1.5.5.7.48.1")];
@@ -39,8 +42,10 @@ fn main() {
         }
     }
 
-    for (name, obid) in Asn1Parser::new(FIPS202, NO_BASES).iter() {
-        root.add("fips202", &name, &obid);
+    for (spec, body) in MDS {
+        for (name, obid) in Asn1Parser::new(body, NO_BASES).iter() {
+            root.add(spec, &name, &obid);
+        }
     }
 
     println!("{}", root.module());

--- a/const-oid/src/db/gen.rs
+++ b/const-oid/src/db/gen.rs
@@ -2285,6 +2285,26 @@ pub mod rfc8410 {
     pub const ID_ED_448: crate::ObjectIdentifier =
         crate::ObjectIdentifier::new_unwrap("1.3.101.113");
 }
+pub mod rfc8894 {
+    pub const ID_VERI_SIGN: crate::ObjectIdentifier =
+        crate::ObjectIdentifier::new_unwrap("2.16.840.1.113733");
+    pub const ID_PKI: crate::ObjectIdentifier =
+        crate::ObjectIdentifier::new_unwrap("2.16.840.1.113733.1");
+    pub const ID_ATTRIBUTES: crate::ObjectIdentifier =
+        crate::ObjectIdentifier::new_unwrap("2.16.840.1.113733.1.9");
+    pub const ID_MESSAGE_TYPE: crate::ObjectIdentifier =
+        crate::ObjectIdentifier::new_unwrap("2.16.840.1.113733.1.9.2");
+    pub const ID_PKI_STATUS: crate::ObjectIdentifier =
+        crate::ObjectIdentifier::new_unwrap("2.16.840.1.113733.1.9.3");
+    pub const ID_FAIL_INFO: crate::ObjectIdentifier =
+        crate::ObjectIdentifier::new_unwrap("2.16.840.1.113733.1.9.4");
+    pub const ID_SENDER_NONCE: crate::ObjectIdentifier =
+        crate::ObjectIdentifier::new_unwrap("2.16.840.1.113733.1.9.5");
+    pub const ID_RECIPIENT_NONCE: crate::ObjectIdentifier =
+        crate::ObjectIdentifier::new_unwrap("2.16.840.1.113733.1.9.6");
+    pub const ID_TRANSACTION_ID: crate::ObjectIdentifier =
+        crate::ObjectIdentifier::new_unwrap("2.16.840.1.113733.1.9.7");
+}
 pub const DB: super::Database<'static> = super::Database(&[
     (&fips202::NIST_ALGORITHMS, "nistAlgorithms"),
     (&fips202::HASH_ALGS, "hashAlgs"),
@@ -4242,4 +4262,13 @@ pub const DB: super::Database<'static> = super::Database(&[
     (&rfc8410::ID_X_448, "id-X448"),
     (&rfc8410::ID_ED_25519, "id-Ed25519"),
     (&rfc8410::ID_ED_448, "id-Ed448"),
+    (&rfc8894::ID_VERI_SIGN, "id-VeriSign"),
+    (&rfc8894::ID_PKI, "id-pki"),
+    (&rfc8894::ID_ATTRIBUTES, "id-attributes"),
+    (&rfc8894::ID_MESSAGE_TYPE, "id-messageType"),
+    (&rfc8894::ID_PKI_STATUS, "id-pkiStatus"),
+    (&rfc8894::ID_FAIL_INFO, "id-failInfo"),
+    (&rfc8894::ID_SENDER_NONCE, "id-senderNonce"),
+    (&rfc8894::ID_RECIPIENT_NONCE, "id-recipientNonce"),
+    (&rfc8894::ID_TRANSACTION_ID, "id-transactionID"),
 ]);


### PR DESCRIPTION
RFC 8894 can't be easily parsed, as the OID definitions were formatted in an ASCII table with line breaks. Thus, I created a new markdown file for these OIDs.