### PR TITLE
tls_codec: fix deserialization of `Option<T>`

### DIFF
--- a/tls_codec/src/primitives.rs
+++ b/tls_codec/src/primitives.rs
@@ -95,13 +95,13 @@ impl<T: Deserialize> Deserialize for Option<T> {
 impl<T: DeserializeBytes> DeserializeBytes for Option<T> {
     #[inline]
     fn tls_deserialize(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
-        let some_or_none = bytes.first().ok_or(Error::EndOfStream)?;
+        let (some_or_none, remainder) = <u8 as DeserializeBytes>::tls_deserialize(bytes)?;
         match some_or_none {
             0 => {
-                Ok((None, bytes.get(1..).ok_or(Error::EndOfStream)?))
+                Ok((None, remainder))
             },
             1 => {
-                let (element, remainder) = T::tls_deserialize(bytes)?;
+                let (element, remainder) = T::tls_deserialize(remainder)?;
                 Ok((Some(element), remainder))
             },
             _ => Err(Error::DecodingError(alloc::format!("Trying to decode Option<T> with {} for option. It must be 0 for None and 1 for Some.", some_or_none)))

--- a/tls_codec/tests/decode.rs
+++ b/tls_codec/tests/decode.rs
@@ -25,6 +25,20 @@ fn deserialize_primitives() {
 }
 
 #[test]
+fn deserialize_option_bytes() {
+    use tls_codec::DeserializeBytes;
+    for b in [Some(0u8), None] {
+        let b_encoded = b.tls_serialize_detached().expect("Unable to tls_serialize");
+        let (b_decoded, remainder) = Option::<u8>::tls_deserialize(&mut b_encoded.as_slice())
+            .expect("Unable to tls_deserialize");
+
+        assert!(remainder.is_empty());
+
+        assert_eq!(b_decoded, b);
+    }
+}
+
+#[test]
 fn deserialize_bytes_primitives() {
     use tls_codec::DeserializeBytes;
     let b = &[77u8, 88, 1, 99] as &[u8];


### PR DESCRIPTION
The implementation of `Option<T>` had a small bug, where the remainder was not returned correctly. This PR fixes that bug and adds a small test to test for its presence.