### PR TITLE
const-oid v0.9.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "arbitrary"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e90af4de65aa7b293ef2d09daff88501eb254f58edde2e1ac02c82d873eadad"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -218,8 +227,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
+ "arbitrary",
  "hex-literal",
 ]
 
@@ -342,6 +352,17 @@ name = "der_derive"
 version = "0.6.0"
 dependencies = [
  "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8beee4701e2e229e8098bbdecdca12449bc3e322f137d269182fa1291e20bd00"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "arbitrary",
  "hex-literal",

--- a/const-oid/CHANGELOG.md
+++ b/const-oid/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.3 (2023-06-29)
+### Added
+- `Database::find_names_for_oid` ([#1129])
+
+[#1129]: https://github.com/RustCrypto/formats/pull/1129
+
+## 0.9.2 (2023-02-26)
+### Added
+- Implement `Arbitrary` trait ([#761])
+
+[#761]: https://github.com/RustCrypto/formats/pull/761
+
 ## 0.9.1 (2022-11-12)
 ### Added
 - clippy lints for checked arithmetic and panics ([#561])

--- a/const-oid/Cargo.toml
+++ b/const-oid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "const-oid"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """

--- a/const-oid/Cargo.toml
+++ b/const-oid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "const-oid"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """
@@ -15,6 +15,9 @@ keywords = ["iso", "iec", "itu", "oid"]
 readme = "README.md"
 edition = "2021"
 rust-version = "1.57"
+
+[dependencies]
+arbitrary = { version = "1.2", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/const-oid/src/db.rs
+++ b/const-oid/src/db.rs
@@ -127,7 +127,7 @@ impl<'a> Iterator for Names<'a> {
         while i < self.database.0.len() {
             let lhs = self.database.0[i].0;
 
-            if lhs.buffer.eq(&self.oid.buffer) {
+            if lhs.as_bytes().eq(self.oid.as_bytes()) {
                 self.position = i + 1;
                 return Some(self.database.0[i].1);
             }

--- a/const-oid/src/db.rs
+++ b/const-oid/src/db.rs
@@ -54,6 +54,7 @@ const fn eq_case(lhs: &[u8], rhs: &[u8]) -> bool {
 }
 
 /// A query interface for OIDs/Names.
+#[derive(Copy, Clone)]
 pub struct Database<'a>(&'a [(&'a ObjectIdentifier, &'a str)]);
 
 impl<'a> Database<'a> {
@@ -92,6 +93,43 @@ impl<'a> Database<'a> {
             let lhs = self.0[i].1;
             if eq_case(lhs.as_bytes(), name.as_bytes()) {
                 return Some(self.0[i].0);
+            }
+
+            i += 1;
+        }
+
+        None
+    }
+
+    /// Return the list of matched name for the OID.
+    pub const fn find_names_for_oid(&self, oid: ObjectIdentifier) -> Names<'a> {
+        Names {
+            database: *self,
+            oid,
+            position: 0,
+        }
+    }
+}
+
+/// Iterator returning the multiple names that may be associated with an OID.
+pub struct Names<'a> {
+    database: Database<'a>,
+    oid: ObjectIdentifier,
+    position: usize,
+}
+
+impl<'a> Iterator for Names<'a> {
+    type Item = &'a str;
+
+    fn next(&mut self) -> Option<&'a str> {
+        let mut i = self.position;
+
+        while i < self.database.0.len() {
+            let lhs = self.database.0[i].0;
+
+            if lhs.buffer.eq(&self.oid.buffer) {
+                self.position = i + 1;
+                return Some(self.database.0[i].1);
             }
 
             i += 1;


### PR DESCRIPTION
Backport release which includes changes from #1129, which added the `Database::find_names_for_oid` method.

NOT FOR MERGE: this just keeps a historical record of what was in this release.