### PR TITLE
Fix TlsByteVecUX deserialization

### DIFF
--- a/tls_codec/src/tls_vec.rs
+++ b/tls_codec/src/tls_vec.rs
@@ -74,7 +74,9 @@ macro_rules! impl_byte_deserialize {
                     u16::MAX
                 )));
             }
-            let vec = bytes.get(..len).ok_or(Error::EndOfStream)?;
+            let vec = bytes
+                .get($len_len..len + $len_len)
+                .ok_or(Error::EndOfStream)?;
             let result = Self { vec: vec.to_vec() };
             Ok((result, &remainder.get(len..).ok_or(Error::EndOfStream)?))
         }

--- a/tls_codec/tests/decode_bytes.rs
+++ b/tls_codec/tests/decode_bytes.rs
@@ -1,0 +1,28 @@
+use tls_codec::{DeserializeBytes, TlsByteVecU16, TlsByteVecU32, TlsByteVecU8};
+
+#[test]
+fn deserialize_tls_byte_vec_u8() {
+    let bytes = [3, 2, 1, 0];
+    let (result, rest) = TlsByteVecU8::tls_deserialize(&bytes).unwrap();
+    let expected_result = [2, 1, 0];
+    assert_eq!(result.as_slice(), expected_result);
+    assert_eq!(rest, []);
+}
+
+#[test]
+fn deserialize_tls_byte_vec_u16() {
+    let bytes = [0, 3, 2, 1, 0];
+    let (result, rest) = TlsByteVecU16::tls_deserialize(&bytes).unwrap();
+    let expected_result = [2, 1, 0];
+    assert_eq!(result.as_slice(), expected_result);
+    assert_eq!(rest, []);
+}
+
+#[test]
+fn deserialize_tls_byte_vec_u32() {
+    let bytes = [0, 0, 0, 3, 2, 1, 0];
+    let (result, rest) = TlsByteVecU32::tls_deserialize(&bytes).unwrap();
+    let expected_result = [2, 1, 0];
+    assert_eq!(result.as_slice(), expected_result);
+    assert_eq!(rest, []);
+}


### PR DESCRIPTION
This PR fixes the bug found in #1109. It adds a `DeserializeBytes::tls_deserialize` test for each of the `TlsByteVecUX` types and fixes the bug.