### PR TITLE
Implement `SerializeBytes` for `TlsByteVecUX` types

### DIFF
--- a/tls_codec/src/tls_vec.rs
+++ b/tls_codec/src/tls_vec.rs
@@ -95,7 +95,7 @@ macro_rules! impl_byte_deserialize {
             }
 
             let mut vec = Vec::<u8>::with_capacity(tls_serialized_len);
-            let mut written =  <$size as $crate::Serialize>::tls_serialize(&(byte_length as $size), &mut vec)?;
+            let mut written =  <$size as Serialize>::tls_serialize(&(byte_length as $size), &mut vec)?;
 
             let bytes = $self.as_slice();
             vec.extend_from_slice(bytes);
@@ -178,7 +178,7 @@ macro_rules! impl_serialize {
                 return Err(Error::InvalidVectorLength);
             }
 
-            let mut written =  <$size as $crate::Serialize>::tls_serialize(&(byte_length as $size), writer)?;
+            let mut written =  <$size as Serialize>::tls_serialize(&(byte_length as $size), writer)?;
 
             // Now serialize the elements
             for e in $self.as_slice().iter() {
@@ -222,7 +222,7 @@ macro_rules! impl_byte_serialize {
                 return Err(Error::InvalidVectorLength);
             }
 
-            let mut written = <$size as $crate::Serialize>::tls_serialize(&(byte_length as $size), writer)?;
+            let mut written = <$size as Serialize>::tls_serialize(&(byte_length as $size), writer)?;
 
             // Now serialize the elements
             written += writer.write($self.as_slice())?;

--- a/tls_codec/src/tls_vec.rs
+++ b/tls_codec/src/tls_vec.rs
@@ -162,8 +162,8 @@ macro_rules! impl_byte_serialize {
     };
 }
 macro_rules! impl_serialize_common {
-    ($self:ident, $size:ty, $name:ident, $len_len:literal $(,#[$attr:meta])?) => {
-        $(#[$attr])?
+    ($self:ident, $size:ty, $name:ident, $len_len:literal $(,#[$std_enabled:meta])?) => {
+        $(#[$std_enabled])?
         fn get_content_lengths(&$self) -> Result<(usize, usize), Error> {
             let tls_serialized_len = $self.tls_serialized_len();
             let byte_length = tls_serialized_len - $len_len;
@@ -181,7 +181,7 @@ macro_rules! impl_serialize_common {
             Ok((tls_serialized_len, byte_length))
         }
 
-        $(#[$attr])?
+        $(#[$std_enabled])?
         fn assert_written_bytes(&$self, tls_serialized_len: usize, written: usize) -> Result<(), Error> {
             debug_assert_eq!(
                 written, tls_serialized_len,

--- a/tls_codec/src/tls_vec.rs
+++ b/tls_codec/src/tls_vec.rs
@@ -161,6 +161,7 @@ macro_rules! impl_byte_serialize {
         }
     };
 }
+
 macro_rules! impl_serialize_common {
     ($self:ident, $size:ty, $name:ident, $len_len:literal $(,#[$std_enabled:meta])?) => {
         $(#[$std_enabled])?

--- a/tls_codec/src/tls_vec.rs
+++ b/tls_codec/src/tls_vec.rs
@@ -78,45 +78,6 @@ macro_rules! impl_byte_deserialize {
             let result = Self { vec: vec.to_vec() };
             Ok((result, &remainder.get(len..).ok_or(Error::EndOfStream)?))
         }
-
-        fn serialize_bytes_bytes(&$self) -> Result<Vec<u8>, Error> {
-            let tls_serialized_len = $self.tls_serialized_len();
-            let byte_length = tls_serialized_len - $len_len;
-
-            let max_len = <$size>::MAX as usize;
-            debug_assert!(
-                byte_length <= max_len,
-                "Vector length can't be encoded in the vector length a {} >= {}",
-                byte_length,
-                max_len
-            );
-            if byte_length > max_len {
-                return Err(Error::InvalidVectorLength);
-            }
-
-            let mut vec = Vec::<u8>::with_capacity(tls_serialized_len);
-            let length_vec =  <$size as SerializeBytes>::tls_serialize(&(byte_length as $size))?;
-            let mut written = length_vec.len();
-            vec.extend_from_slice(&length_vec);
-
-            let bytes = $self.as_slice();
-            vec.extend_from_slice(bytes);
-            written += bytes.len();
-
-            debug_assert_eq!(
-                written, tls_serialized_len,
-                "{} bytes should have been serialized but {} were written",
-                tls_serialized_len, written
-            );
-            if written != tls_serialized_len {
-                return Err(Error::EncodingError(format!(
-                    "{} bytes should have been serialized but {} were written",
-                    tls_serialized_len, written
-                )));
-            }
-
-            Ok(vec)
-        }
     };
 }
 
@@ -166,19 +127,7 @@ macro_rules! impl_serialize {
         fn serialize<W: Write>(&$self, writer: &mut W) -> Result<usize, Error> {
             // Get the byte length of the content, make sure it's not too
             // large and write it out.
-            let tls_serialized_len = $self.tls_serialized_len();
-            let byte_length = tls_serialized_len - $len_len;
-
-            let max_len = <$size>::MAX as usize;
-            debug_assert!(
-                byte_length <= max_len,
-                "Vector length can't be encoded in the vector length a {} >= {}",
-                byte_length,
-                max_len
-            );
-            if byte_length > max_len {
-                return Err(Error::InvalidVectorLength);
-            }
+            let (tls_serialized_len, byte_length) = $self.get_content_lengths()?;
 
             let mut written =  <$size as Serialize>::tls_serialize(&(byte_length as $size), writer)?;
 
@@ -187,17 +136,7 @@ macro_rules! impl_serialize {
                 written += e.tls_serialize(writer)?;
             }
 
-            debug_assert_eq!(
-                written, tls_serialized_len,
-                "{} bytes should have been serialized but {} were written",
-                tls_serialized_len, written
-            );
-            if written != tls_serialized_len {
-                return Err(Error::EncodingError(format!(
-                    "{} bytes should have been serialized but {} were written",
-                    tls_serialized_len, written
-                )));
-            }
+            $self.assert_written_bytes(tls_serialized_len, written)?;
             Ok(written)
         }
     };
@@ -210,6 +149,22 @@ macro_rules! impl_byte_serialize {
         fn serialize_bytes<W: Write>(&$self, writer: &mut W) -> Result<usize, Error> {
             // Get the byte length of the content, make sure it's not too
             // large and write it out.
+            let (tls_serialized_len, byte_length) = $self.get_content_lengths()?;
+
+            let mut written = <$size as Serialize>::tls_serialize(&(byte_length as $size), writer)?;
+
+            // Now serialize the elements
+            written += writer.write($self.as_slice())?;
+
+            $self.assert_written_bytes(tls_serialized_len, written)?;
+            Ok(written)
+        }
+    };
+}
+macro_rules! impl_serialize_common {
+    ($self:ident, $size:ty, $name:ident, $len_len:literal $(,#[$attr:meta])?) => {
+        $(#[$attr])?
+        fn get_content_lengths(&$self) -> Result<(usize, usize), Error> {
             let tls_serialized_len = $self.tls_serialized_len();
             let byte_length = tls_serialized_len - $len_len;
 
@@ -223,12 +178,11 @@ macro_rules! impl_byte_serialize {
             if byte_length > max_len {
                 return Err(Error::InvalidVectorLength);
             }
+            Ok((tls_serialized_len, byte_length))
+        }
 
-            let mut written = <$size as Serialize>::tls_serialize(&(byte_length as $size), writer)?;
-
-            // Now serialize the elements
-            written += writer.write($self.as_slice())?;
-
+        $(#[$attr])?
+        fn assert_written_bytes(&$self, tls_serialized_len: usize, written: usize) -> Result<(), Error> {
             debug_assert_eq!(
                 written, tls_serialized_len,
                 "{} bytes should have been serialized but {} were written",
@@ -240,7 +194,28 @@ macro_rules! impl_byte_serialize {
                     tls_serialized_len, written
                 )));
             }
-            Ok(written)
+            Ok(())
+        }
+    };
+}
+
+macro_rules! impl_serialize_bytes_bytes {
+    ($self:ident, $size:ty, $name:ident, $len_len:literal) => {
+        fn serialize_bytes_bytes(&$self) -> Result<Vec<u8>, Error> {
+            let (tls_serialized_len, byte_length) = $self.get_content_lengths()?;
+
+            let mut vec = Vec::<u8>::with_capacity(tls_serialized_len);
+            let length_vec =  <$size as SerializeBytes>::tls_serialize(&(byte_length as $size))?;
+            let mut written = length_vec.len();
+            vec.extend_from_slice(&length_vec);
+
+            let bytes = $self.as_slice();
+            vec.extend_from_slice(bytes);
+            written += bytes.len();
+
+            $self.assert_written_bytes(tls_serialized_len, written)?;
+
+            Ok(vec)
         }
     };
 }
@@ -834,6 +809,7 @@ macro_rules! impl_secret_tls_vec {
         impl_tls_vec_codec_generic!($size, $name, $len_len, Zeroize);
 
         impl<T: Serialize + Zeroize> $name<T> {
+            impl_serialize_common!(self, $size, $name, $len_len, #[cfg(feature = "std")]);
             impl_serialize!(self, $size, $name, $len_len);
         }
 
@@ -870,6 +846,7 @@ macro_rules! impl_public_tls_vec {
         impl_tls_vec_codec_generic!($size, $name, $len_len);
 
         impl<T: Serialize> $name<T> {
+            impl_serialize_common!(self, $size, $name, $len_len, #[cfg(feature = "std")]);
             impl_serialize!(self, $size, $name, $len_len);
         }
 
@@ -893,7 +870,9 @@ macro_rules! impl_tls_byte_vec {
 
         impl $name {
             // This implements serialize and size for all versions
+            impl_serialize_common!(self, $size, $name, $len_len);
             impl_byte_serialize!(self, $size, $name, $len_len);
+            impl_serialize_bytes_bytes!(self, $size, $name, $len_len);
             impl_byte_size!(self, $size, $name, $len_len);
             impl_byte_deserialize!(self, $size, $name, $len_len);
         }
@@ -930,6 +909,7 @@ macro_rules! impl_tls_byte_slice {
         }
 
         impl<'a> $name<'a> {
+            impl_serialize_common!(self, $size, $name, $len_len, #[cfg(feature = "std")]);
             impl_byte_serialize!(self, $size, $name, $len_len);
             impl_byte_size!(self, $size, $name, $len_len);
         }
@@ -985,6 +965,7 @@ macro_rules! impl_tls_slice {
         }
 
         impl<'a, T: Serialize> $name<'a, T> {
+            impl_serialize_common!(self, $size, $name, $len_len, #[cfg(feature = "std")]);
             impl_serialize!(self, $size, $name, $len_len);
         }
 

--- a/tls_codec/src/tls_vec.rs
+++ b/tls_codec/src/tls_vec.rs
@@ -95,7 +95,9 @@ macro_rules! impl_byte_deserialize {
             }
 
             let mut vec = Vec::<u8>::with_capacity(tls_serialized_len);
-            let mut written =  <$size as Serialize>::tls_serialize(&(byte_length as $size), &mut vec)?;
+            let length_vec =  <$size as SerializeBytes>::tls_serialize(&(byte_length as $size))?;
+            let mut written = length_vec.len();
+            vec.extend_from_slice(&length_vec);
 
             let bytes = $self.as_slice();
             vec.extend_from_slice(bytes);

--- a/tls_codec/src/tls_vec.rs
+++ b/tls_codec/src/tls_vec.rs
@@ -95,7 +95,7 @@ macro_rules! impl_byte_deserialize {
             }
 
             let mut vec = Vec::<u8>::with_capacity(tls_serialized_len);
-            let mut written =  <$size as Serialize>::tls_serialize(&(byte_length as $size), &mut vec)?;
+            let mut written =  <$size as $crate::Serialize>::tls_serialize(&(byte_length as $size), &mut vec)?;
 
             let bytes = $self.as_slice();
             vec.extend_from_slice(bytes);
@@ -178,7 +178,7 @@ macro_rules! impl_serialize {
                 return Err(Error::InvalidVectorLength);
             }
 
-            let mut written =  <$size as Serialize>::tls_serialize(&(byte_length as $size), writer)?;
+            let mut written =  <$size as $crate::Serialize>::tls_serialize(&(byte_length as $size), writer)?;
 
             // Now serialize the elements
             for e in $self.as_slice().iter() {
@@ -222,7 +222,7 @@ macro_rules! impl_byte_serialize {
                 return Err(Error::InvalidVectorLength);
             }
 
-            let mut written = <$size as Serialize>::tls_serialize(&(byte_length as $size), writer)?;
+            let mut written = <$size as $crate::Serialize>::tls_serialize(&(byte_length as $size), writer)?;
 
             // Now serialize the elements
             written += writer.write($self.as_slice())?;

--- a/tls_codec/src/tls_vec.rs
+++ b/tls_codec/src/tls_vec.rs
@@ -83,9 +83,6 @@ macro_rules! impl_byte_deserialize {
             let tls_serialized_len = $self.tls_serialized_len();
             let byte_length = tls_serialized_len - $len_len;
 
-            let ll = $len_len;
-            std::println!("serialize_bytes_bytes: tls_serialized_len: {tls_serialized_len}, $len_len: {ll}, byte_length: {byte_length}");
-
             let max_len = <$size>::MAX as usize;
             debug_assert!(
                 byte_length <= max_len,
@@ -170,9 +167,6 @@ macro_rules! impl_serialize {
             let tls_serialized_len = $self.tls_serialized_len();
             let byte_length = tls_serialized_len - $len_len;
 
-            let ll = $len_len;
-            std::println!("serialize: tls_serialized_len: {tls_serialized_len}, $len_len: {ll}, byte_length: {byte_length}");
-
             let max_len = <$size>::MAX as usize;
             debug_assert!(
                 byte_length <= max_len,
@@ -216,9 +210,6 @@ macro_rules! impl_byte_serialize {
             // large and write it out.
             let tls_serialized_len = $self.tls_serialized_len();
             let byte_length = tls_serialized_len - $len_len;
-
-            let ll = $len_len;
-            std::println!("serialize_bytes: tls_serialized_len: {tls_serialized_len}, $len_len: {ll}, byte_length: {byte_length}");
 
             let max_len = <$size>::MAX as usize;
             debug_assert!(

--- a/tls_codec/tests/encode_bytes.rs
+++ b/tls_codec/tests/encode_bytes.rs
@@ -1,4 +1,4 @@
-use tls_codec::SerializeBytes;
+use tls_codec::{SerializeBytes, TlsByteVecU16, TlsByteVecU32, TlsByteVecU8};
 
 #[test]
 fn serialize_primitives() {
@@ -39,4 +39,31 @@ fn serialize_var_len_boundaries() {
     let v = vec![99u8; 16384];
     let serialized = v.tls_serialize().expect("Error encoding vector");
     assert_eq!(&serialized[0..5], &[0x80, 0, 0x40, 0, 99]);
+}
+
+#[test]
+fn serialize_tls_byte_vec_u8() {
+    let byte_vec = TlsByteVecU8::from_slice(&[1, 2, 3]);
+    let actual_result = byte_vec
+        .tls_serialize()
+        .expect("Error encoding byte vector");
+    assert_eq!(actual_result, vec![3, 1, 2, 3]);
+}
+
+#[test]
+fn serialize_tls_byte_vec_u16() {
+    let byte_vec = TlsByteVecU16::from_slice(&[1, 2, 3]);
+    let actual_result = byte_vec
+        .tls_serialize()
+        .expect("Error encoding byte vector");
+    assert_eq!(actual_result, vec![0, 3, 1, 2, 3]);
+}
+
+#[test]
+fn serialize_tls_byte_vec_u32() {
+    let byte_vec = TlsByteVecU32::from_slice(&[1, 2, 3]);
+    let actual_result = byte_vec
+        .tls_serialize()
+        .expect("Error encoding byte vector");
+    assert_eq!(actual_result, vec![0, 0, 0, 3, 1, 2, 3]);
 }


### PR DESCRIPTION
This PR implements the `SerializeBytes` trait for all the `TlsByteVecUX` types. It also adds tests for serializing them using the `SerializeBytes` trait.