### PR TITLE
x509-cert: fixup `Arbitrary` for certificates

### DIFF
--- a/x509-cert/src/certificate.rs
+++ b/x509-cert/src/certificate.rs
@@ -31,6 +31,7 @@ pub trait Profile: PartialEq + Debug + Eq + Clone {
     }
 }
 
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Debug, PartialEq, Eq, Clone)]
 /// Parse certificates with rfc5280-compliant checks
 pub struct Rfc5280;
@@ -38,6 +39,7 @@ pub struct Rfc5280;
 impl Profile for Rfc5280 {}
 
 #[cfg(feature = "hazmat")]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Debug, PartialEq, Eq, Clone)]
 /// Parse raw x509 certificate and disable all the checks
 pub struct Raw;

--- a/x509-cert/tests/certificate.rs
+++ b/x509-cert/tests/certificate.rs
@@ -446,3 +446,22 @@ fn load_certificate_chains() {
 
     assert_eq!(chain.len(), 4, "4 certificates are expected in this chain");
 }
+
+#[cfg(feature = "arbitrary")]
+#[test]
+// Purpose of this check is to ensure the arbitraty trait is provided for certificate variants
+#[allow(unused)]
+fn certificate_arbitrary() {
+    fn check_arbitrary<'a>(_arbitrary: impl arbitrary::Arbitrary<'a>) {}
+
+    fn check_certificate(certificate: x509_cert::Certificate) {
+        check_arbitrary(certificate);
+    }
+
+    #[cfg(feature = "hazmat")]
+    fn check_raw_certificate(
+        certificate: x509_cert::certificate::CertificateInner<x509_cert::certificate::Raw>,
+    ) {
+        check_arbitrary(certificate);
+    }
+}


### PR DESCRIPTION
Fixes #1149

This broke with the parsing profiles (#987)