### PR TITLE
Added adding attributes to certreq builder.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,7 +244,7 @@ checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 name = "cmpv2"
 version = "0.2.0"
 dependencies = [
- "const-oid 0.9.2",
+ "const-oid 0.9.4",
  "crmf",
  "der",
  "hex-literal",
@@ -256,7 +256,7 @@ dependencies = [
 name = "cms"
 version = "0.2.1"
 dependencies = [
- "const-oid 0.9.2",
+ "const-oid 0.9.4",
  "der",
  "ecdsa",
  "hex-literal",
@@ -274,9 +274,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
+checksum = "795bc6e66a8e340f075fcf6227e417a2dc976b92b91f3cdc778bb858778b6747"
 dependencies = [
  "arbitrary",
 ]
@@ -339,7 +339,7 @@ name = "crmf"
 version = "0.2.0"
 dependencies = [
  "cms",
- "const-oid 0.9.2",
+ "const-oid 0.9.4",
  "der",
  "spki",
  "x509-cert",
@@ -415,7 +415,7 @@ name = "der"
 version = "0.7.7"
 dependencies = [
  "arbitrary",
- "const-oid 0.9.2",
+ "const-oid 0.9.4",
  "der_derive",
  "flagset",
  "hex-literal",
@@ -462,7 +462,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
- "const-oid 0.9.2",
+ "const-oid 0.9.4",
  "crypto-common",
  "subtle",
 ]
@@ -999,7 +999,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 name = "pkcs1"
 version = "0.7.5"
 dependencies = [
- "const-oid 0.9.2",
+ "const-oid 0.9.4",
  "der",
  "hex-literal",
  "pkcs8",
@@ -1271,7 +1271,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ab43bb47d23c1a631b4b680199a45255dce26fa9ab2fa902581f624ff13e6a8"
 dependencies = [
  "byteorder",
- "const-oid 0.9.2",
+ "const-oid 0.9.4",
  "digest",
  "num-bigint-dig",
  "num-integer",
@@ -1931,7 +1931,7 @@ name = "x509-cert"
 version = "0.2.3"
 dependencies = [
  "arbitrary",
- "const-oid 0.9.2",
+ "const-oid 0.9.4",
  "der",
  "ecdsa",
  "hex-literal",
@@ -1960,7 +1960,7 @@ dependencies = [
 name = "x509-ocsp"
 version = "0.2.0-pre"
 dependencies = [
- "const-oid 0.9.2",
+ "const-oid 0.9.4",
  "der",
  "hex-literal",
  "spki",


### PR DESCRIPTION
@baloo Right after creating this PR, I saw, that you did the same thing 4 days ago. Unfortunately, I cloned my own repo, which didn't have your changes, yet.

Adding attributes using the `x509_cert::builder::RequestBuilder` was implemented. This is required, if you want to add a challenge attribute (required for SCEP `GetCert` requests) to a CSR. I also extended the `certificate_request()` test and the implementation looks correct to me:

```
Certificate Request:
    Data:
        Version: 1 (0x0)
        Subject: CN = service.domination.world
        Subject Public Key Info:
            Public Key Algorithm: id-ecPublicKey
                Public-Key: (256 bit)
                pub:
                    04:1c:ac:ff:b5:5f:2f:2c:ef:d8:9d:89:eb:37:4b:
                    26:81:15:24:52:80:2d:ee:a0:99:16:06:81:37:d8:
                    39:cf:7f:c4:81:a4:44:92:30:4d:7e:f6:6a:c1:17:
                    be:fe:83:a8:d0:8f:15:5f:2b:52:f9:f6:18:dd:44:
                    70:29:04:8e:0f
                ASN1 OID: prime256v1
                NIST CURVE: P-256
        Attributes:
            challengePassword        :Ch@113ng3 9@zzw0rd
            Requested Extensions:
                X509v3 Subject Alternative Name: 
                    IP Address:192.0.2.0
    Signature Algorithm: ecdsa-with-SHA256
    Signature Value:
        30:44:02:20:29:f5:3d:7e:94:bd:b4:f4:34:bc:be:d3:5c:6d:
        46:71:66:a2:de:80:93:b7:e6:c7:ce:17:2e:dd:41:6d:f7:07:
        02:20:5a:55:5a:ac:40:a8:e6:e9:07:2e:c0:fe:2a:a5:ac:2f:
        98:08:bb:5e:26:99:ba:24:57:4c:ce:d5:02:80:64:bd
```