### PR TITLE
cms: Fixed encoding of `SubjectKeyIdentifier`

### DIFF
--- a/cms/src/signed_data.rs
+++ b/cms/src/signed_data.rs
@@ -169,7 +169,7 @@ pub type SignedAttributes = Attributes;
 pub enum SignerIdentifier {
     IssuerAndSerialNumber(IssuerAndSerialNumber),
 
-    #[asn1(context_specific = "0", tag_mode = "EXPLICIT")]
+    #[asn1(context_specific = "0", tag_mode = "IMPLICIT")]
     SubjectKeyIdentifier(SubjectKeyIdentifier),
 }
 


### PR DESCRIPTION
Fixup for `SignerIdentifier` encoding by @bkstein
ported from #1115