### PR TITLE
cms v0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,7 +259,7 @@ dependencies = [
 
 [[package]]
 name = "cms"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "const-oid 0.9.3",
  "der",

--- a/cms/CHANGELOG.md
+++ b/cms/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.2 (2023-07-14)
+### Added
+- `SignedData` builder ([#1051])
+
+### Changed
+- Deprecate `pkcs7` in favor of `cms` ([#1062])
+- der: add `SetOf(Vec)::insert(_ordered)`; deprecate `add` ([#1067])
+- Re-enable all minimal-versions checks ([#1071])
+
+### Fixed
+- Don't insert signing time attribute by default ([#1148])
+- Fixed encoding of `SubjectKeyIdentifier` ([#1152])
+
+[#1051]: https://github.com/RustCrypto/formats/pull/1051
+[#1062]: https://github.com/RustCrypto/formats/pull/1062
+[#1067]: https://github.com/RustCrypto/formats/pull/1067
+[#1071]: https://github.com/RustCrypto/formats/pull/1071
+[#1148]: https://github.com/RustCrypto/formats/pull/1148
+[#1152]: https://github.com/RustCrypto/formats/pull/1152
+
 ## 0.2.1 (2023-05-04)
 ### Added
 - Convenience functions for converting cert(s) to certs-only `SignedData` message ([#1032])

--- a/cms/Cargo.toml
+++ b/cms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cms"
-version = "0.2.1"
+version = "0.2.2"
 description = """
 Pure Rust implementation of the Cryptographic Message Syntax (CMS) as described in RFC 5652 and RFC 3274.
 """


### PR DESCRIPTION
Added
- `SignedData` builder ([#1051])

Changed
- Deprecate `pkcs7` in favor of `cms` ([#1062])
- der: add `SetOf(Vec)::insert(_ordered)`; deprecate `add` ([#1067])
- Re-enable all minimal-versions checks ([#1071])

Fixed
- Don't insert signing time attribute by default ([#1148])
- Fixed encoding of `SubjectKeyIdentifier` ([#1152])

[#1051]: https://github.com/RustCrypto/formats/pull/1051
[#1062]: https://github.com/RustCrypto/formats/pull/1062
[#1067]: https://github.com/RustCrypto/formats/pull/1067
[#1071]: https://github.com/RustCrypto/formats/pull/1071
[#1148]: https://github.com/RustCrypto/formats/pull/1148
[#1152]: https://github.com/RustCrypto/formats/pull/1152