### PR TITLE
sec1 v0.7.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1417,7 +1417,7 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "base16ct",
  "der",

--- a/sec1/CHANGELOG.md
+++ b/sec1/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.3 (2023-07-16)
+### Added
+- Impl `Hash` for `EncodedPoint` ([#1102])
+
+[#1102]: https://github.com/RustCrypto/formats/pull/1102
+
 ## 0.7.2 (2023-04-09)
 ### Added
 - Impl `ModulusSize` for `U24` ([#995])

--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sec1"
-version = "0.7.2"
+version = "0.7.3"
 description = """
 Pure Rust implementation of SEC1: Elliptic Curve Cryptography encoding formats
 including ASN.1 DER-serialized private keys as well as the


### PR DESCRIPTION
### Added
- Impl `Hash` for `EncodedPoint` ([#1102])

[#1102]: https://github.com/RustCrypto/formats/pull/1102