### PR TITLE
der: `bytes` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,6 +157,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "bytes"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,6 +426,7 @@ name = "der"
 version = "0.7.7"
 dependencies = [
  "arbitrary",
+ "bytes",
  "const-oid 0.9.3",
  "der_derive",
  "flagset",

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -17,7 +17,8 @@ rust-version = "1.65"
 
 [dependencies]
 arbitrary = { version = "1.3", features = ["derive"], optional = true }
-const-oid = { version = "0.9.2", optional = true } # TODO: path = "../const-oid"
+bytes = { version = "1", optional = true, default-features = false }
+const-oid = { version = "0.9.2", optional = true }
 der_derive = { version = "0.7.1", optional = true }
 flagset = { version = "0.4.3", optional = true }
 pem-rfc7468 = { version = "0.7", optional = true, features = ["alloc"] }
@@ -33,6 +34,7 @@ alloc = ["zeroize?/alloc"]
 std = ["alloc"]
 
 arbitrary = ["dep:arbitrary", "const-oid?/arbitrary", "std"]
+bytes = ["dep:bytes", "alloc"]
 derive = ["dep:der_derive"]
 oid = ["dep:const-oid"]
 pem = ["dep:pem-rfc7468", "alloc", "zeroize"]


### PR DESCRIPTION
Adds (optional) support for using `bytes::Bytes` as an `OctetString`.