### PR TITLE
pkcs12: Cargo.toml cleanups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,7 +1019,6 @@ dependencies = [
 name = "pkcs12"
 version = "0.0.0"
 dependencies = [
- "cfg-if",
  "digest",
  "hex-literal",
  "sha2",

--- a/pkcs12/Cargo.toml
+++ b/pkcs12/Cargo.toml
@@ -8,15 +8,14 @@ Personal Information Exchange Syntax v1.1 (RFC7292)
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/formats/tree/master/pkcs12"
-categories = ["cryptography", "data-structures", "encoding", "no-std", "parser-implementations"]
+categories = ["cryptography", "encoding", "no-std", "parser-implementations"]
 keywords = ["crypto", "key", "pkcs", "private"]
 readme = "README.md"
 edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-cfg-if = "1.0.0"
-digest = { version = "0.10.7", features=["alloc"], optional = true }
+digest = { version = "0.10.7", features = ["alloc"], optional = true }
 zeroize = "1.6.0"
 
 [dev-dependencies]
@@ -24,10 +23,9 @@ hex-literal = "0.4"
 sha2 = "0.10.7"
 whirlpool = "0.10.4"
 
-[package.metadata.docs.rs]
-all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-
 [features]
 kdf = ["dep:digest"]
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
- Remove unused `cfg-if` dependency
- Whitespace fixups
- Move features before docs.rs metadata
- Remove category `data-structures` which is more for data structure algorithms than data format decoders/encoders