### PR TITLE
pkcs8: eagerly decode PEM labels

### DIFF
--- a/pem-rfc7468/src/error.rs
+++ b/pem-rfc7468/src/error.rs
@@ -45,7 +45,7 @@ pub enum Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
+        match *self {
             Error::Base64(err) => write!(f, "PEM Base64 error: {}", err),
             Error::CharacterEncoding => f.write_str("PEM character encoding error"),
             Error::EncapsulatedText => f.write_str("PEM error in encapsulated text"),
@@ -60,7 +60,11 @@ impl fmt::Display for Error {
                 f.write_str("PEM error in post-encapsulation boundary")
             }
             Error::UnexpectedTypeLabel { expected } => {
-                write!(f, "unexpected PEM type label: expecting \"{}\"", expected)
+                write!(
+                    f,
+                    "unexpected PEM type label: expecting \"BEGIN {}\"",
+                    expected
+                )
             }
         }
     }

--- a/pkcs8/src/traits.rs
+++ b/pkcs8/src/traits.rs
@@ -12,10 +12,14 @@ use {
 };
 
 #[cfg(feature = "pem")]
-use {crate::LineEnding, alloc::string::String, der::zeroize::Zeroizing};
-
-#[cfg(feature = "pem")]
-use der::pem::PemLabel;
+use {
+    crate::LineEnding,
+    alloc::string::String,
+    der::{
+        pem::{self, PemLabel},
+        zeroize::Zeroizing,
+    },
+};
 
 #[cfg(feature = "std")]
 use std::path::Path;
@@ -43,8 +47,11 @@ pub trait DecodePrivateKey: Sized {
     /// ```
     #[cfg(feature = "pem")]
     fn from_pkcs8_pem(s: &str) -> Result<Self> {
-        let (label, doc) = SecretDocument::from_pem(s)?;
+        // Validate PEM label
+        let label = pem::decode_label(s.as_bytes())?;
         PrivateKeyInfo::validate_pem_label(label)?;
+
+        let doc = SecretDocument::from_pem(s)?.1;
         Self::from_pkcs8_der(doc.as_bytes())
     }
 


### PR DESCRIPTION
This should give better errors for invalid PEM type labels even if there are subsequent Base64 processing errors, which might occur if e.g. Base64 is wrapped at a nonstandard width.

Notably such errors will include the expected PEM type label.