### PR TITLE
x509-cert v0.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1977,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "x509-cert"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "arbitrary",
  "const-oid 0.9.3",

--- a/x509-cert/CHANGELOG.md
+++ b/x509-cert/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.4 (2023-07-25)
+
+### Added
+- `add_attribute` to `RequestBuilder` ([#1137])
+
+### Changed
+- bump `serde_json` from 1.0.97 to 1.0.99 ([#1122])
+- use the shortest name when looking attr OID ([#1130])
+- bump `serde_json` from 1.0.100 to 1.0.103 ([#1158])
+
+### Fixed
+- RDN string representation ([#1126])
+- `Arbitrary` for certificates ([#1150])
+
+[#1122]: https://github.com/RustCrypto/formats/pull/1122
+[#1126]: https://github.com/RustCrypto/formats/pull/1126
+[#1130]: https://github.com/RustCrypto/formats/pull/1130
+[#1137]: https://github.com/RustCrypto/formats/pull/1137
+[#1150]: https://github.com/RustCrypto/formats/pull/1150
+[#1158]: https://github.com/RustCrypto/formats/pull/1158
+
 ## 0.2.3 (2023-05-30)
 
 ### Added

--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x509-cert"
-version = "0.2.3"
+version = "0.2.4"
 description = """
 Pure Rust implementation of the X.509 Public Key Infrastructure Certificate
 format as described in RFC 5280


### PR DESCRIPTION
Added
- `add_attribute` to `RequestBuilder` ([#1137])

Changed
- bump `serde_json` from 1.0.97 to 1.0.99 ([#1122])
- use the shortest name when looking attr OID ([#1130])
- bump `serde_json` from 1.0.100 to 1.0.103 ([#1158])

Fixed
- RDN string representation ([#1126])
- `Arbitrary` for certificates ([#1150])

[#1122]: https://github.com/RustCrypto/formats/pull/1122
[#1126]: https://github.com/RustCrypto/formats/pull/1126
[#1130]: https://github.com/RustCrypto/formats/pull/1130
[#1137]: https://github.com/RustCrypto/formats/pull/1137
[#1150]: https://github.com/RustCrypto/formats/pull/1150
[#1158]: https://github.com/RustCrypto/formats/pull/1158