### PR TITLE
tls_codec: Make constants generated during trait derivation upper case

### DIFF
--- a/tls_codec/derive/src/lib.rs
+++ b/tls_codec/derive/src/lib.rs
@@ -541,11 +541,7 @@ fn make_n_ids(n: usize) -> Vec<Ident> {
 
 /// Returns identifier to define a constant equal to the discriminant of a variant
 fn discriminant_id(variant: &Ident) -> Ident {
-    let variant_string = variant.to_string().to_uppercase();
-    Ident::new(
-        &format!("__TLS_CODEC_{}", variant_string),
-        Span::call_site(),
-    )
+    Ident::new(&format!("__TLS_CODEC_{}", variant), Span::call_site())
 }
 
 /// Returns definitions of constants equal to the discriminants of each variant

--- a/tls_codec/derive/src/lib.rs
+++ b/tls_codec/derive/src/lib.rs
@@ -618,6 +618,7 @@ fn define_discriminant_constants(
                 );
             } else {
                 quote! {
+                    #[allow(non_upper_case_globals)]
                     const #constant_id: #repr = {
                         if #implicit_discriminant > #repr::MAX as usize {
                             panic!("The value corresponding to that expression is outside the bounds of the enum representation");

--- a/tls_codec/derive/src/lib.rs
+++ b/tls_codec/derive/src/lib.rs
@@ -769,6 +769,7 @@ fn impl_serialize(parsed_ast: TlsStruct, svariant: SerializeVariant) -> TokenStr
                 SerializeVariant::Bytes => {
                     quote! {
                         impl #impl_generics tls_codec::SerializeBytes for #ident #ty_generics #where_clause {
+                            #[allow(non_upper_case_globals)]
                             fn tls_serialize(&self) -> core::result::Result<Vec<u8>, tls_codec::Error> {
                                 let expected_out = tls_codec::Size::tls_serialized_len(&self);
                                 let mut out = Vec::with_capacity(expected_out);
@@ -850,6 +851,7 @@ fn impl_serialize(parsed_ast: TlsStruct, svariant: SerializeVariant) -> TokenStr
                 SerializeVariant::Write => {
                     quote! {
                         impl #impl_generics tls_codec::Serialize for #ident #ty_generics #where_clause {
+                            #[allow(non_upper_case_globals)]
                             fn tls_serialize<W: std::io::Write>(&self, writer: &mut W) -> core::result::Result<usize, tls_codec::Error> {
                                 #discriminant_constants
                                 match self {
@@ -868,6 +870,7 @@ fn impl_serialize(parsed_ast: TlsStruct, svariant: SerializeVariant) -> TokenStr
                 SerializeVariant::Bytes => {
                     quote! {
                         impl #impl_generics tls_codec::SerializeBytes for #ident #ty_generics #where_clause {
+                            #[allow(non_upper_case_globals)]
                             fn tls_serialize(&self) -> core::result::Result<Vec<u8>, tls_codec::Error> {
                                 #discriminant_constants
                                 match self {

--- a/tls_codec/derive/src/lib.rs
+++ b/tls_codec/derive/src/lib.rs
@@ -568,6 +568,7 @@ fn define_discriminant_constants(
                     ))
                 } else {
                     Ok(quote! {
+                        #[allow(non_upper_case_globals)]
                         const #constant_id: #repr = #enum_ident::#variant_id as #repr;
                     })
                 }
@@ -585,6 +586,7 @@ fn define_discriminant_constants(
                     DiscriminantValue::Literal(value) => {
                         implicit_discriminant = value;
                         quote! {
+                            #[allow(non_upper_case_globals)]
                             const #constant_id: #repr = {
                                 if #value < #repr::MIN as usize || #value > #repr::MAX as usize {
                                     panic!("The value corresponding to that expression is outside the bounds of the enum representation");
@@ -596,7 +598,7 @@ fn define_discriminant_constants(
                     DiscriminantValue::Path(pathexpr) => {
                         discriminant_has_paths = true;
                         quote! {
-                            #[allow(clippy::unnecessary_cast)]
+                            #[allow(clippy::unnecessary_cast, non_upper_case_globals)]
                             const #constant_id: #repr = {
                                 let pathexpr_usize = #pathexpr as usize;
                                 if pathexpr_usize < #repr::MIN as usize || pathexpr_usize > #repr::MAX as usize {
@@ -771,7 +773,6 @@ fn impl_serialize(parsed_ast: TlsStruct, svariant: SerializeVariant) -> TokenStr
                 SerializeVariant::Bytes => {
                     quote! {
                         impl #impl_generics tls_codec::SerializeBytes for #ident #ty_generics #where_clause {
-                            #[allow(non_upper_case_globals)]
                             fn tls_serialize(&self) -> core::result::Result<Vec<u8>, tls_codec::Error> {
                                 let expected_out = tls_codec::Size::tls_serialized_len(&self);
                                 let mut out = Vec::with_capacity(expected_out);
@@ -854,7 +855,6 @@ fn impl_serialize(parsed_ast: TlsStruct, svariant: SerializeVariant) -> TokenStr
                     quote! {
                         impl #impl_generics tls_codec::Serialize for #ident #ty_generics #where_clause {
                             #[cfg(feature = "std")]
-                            #[allow(non_upper_case_globals)]
                             fn tls_serialize<W: std::io::Write>(&self, writer: &mut W) -> core::result::Result<usize, tls_codec::Error> {
                                 #discriminant_constants
                                 match self {
@@ -874,7 +874,6 @@ fn impl_serialize(parsed_ast: TlsStruct, svariant: SerializeVariant) -> TokenStr
                 SerializeVariant::Bytes => {
                     quote! {
                         impl #impl_generics tls_codec::SerializeBytes for #ident #ty_generics #where_clause {
-                            #[allow(non_upper_case_globals)]
                             fn tls_serialize(&self) -> core::result::Result<Vec<u8>, tls_codec::Error> {
                                 #discriminant_constants
                                 match self {
@@ -955,7 +954,6 @@ fn impl_deserialize(parsed_ast: TlsStruct) -> TokenStream2 {
             let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
             quote! {
                 impl #impl_generics tls_codec::Deserialize for #ident #ty_generics #where_clause {
-                    #[allow(non_upper_case_globals)]
                     #[cfg(feature = "std")]
                     fn tls_deserialize<R: std::io::Read>(bytes: &mut R) -> core::result::Result<Self, tls_codec::Error> {
                         #discriminant_constants
@@ -1060,7 +1058,6 @@ fn impl_deserialize_bytes(parsed_ast: TlsStruct) -> TokenStream2 {
             let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
             quote! {
                 impl #impl_generics tls_codec::DeserializeBytes for #ident #ty_generics #where_clause {
-                    #[allow(non_upper_case_globals)]
                     fn tls_deserialize(bytes: &[u8]) -> core::result::Result<(Self, &[u8]), tls_codec::Error> {
                         #discriminant_constants
                         let (discriminant, remainder) = <#repr as tls_codec::DeserializeBytes>::tls_deserialize(bytes)?;

--- a/tls_codec/derive/src/lib.rs
+++ b/tls_codec/derive/src/lib.rs
@@ -541,7 +541,11 @@ fn make_n_ids(n: usize) -> Vec<Ident> {
 
 /// Returns identifier to define a constant equal to the discriminant of a variant
 fn discriminant_id(variant: &Ident) -> Ident {
-    Ident::new(&format!("__TLS_CODEC_{}", variant), Span::call_site())
+    let variant_string = variant.to_string().to_uppercase();
+    Ident::new(
+        &format!("__TLS_CODEC_{}", variant_string),
+        Span::call_site(),
+    )
 }
 
 /// Returns definitions of constants equal to the discriminants of each variant


### PR DESCRIPTION
This PR makes generated constants strictly upper case. This is one way to avoid clippy warnings that occur, when deriving TlsSerialize and others. Another way would be to allow lower case constants selectively.

EDIT: I just realized that the solution in this PR doesn't work in edge cases, where an enum has, for example, an `Ok` and an `OK` variant. A better solution might be to just `allow` non-snake-case constants.