### PR TITLE
x509-tsp: enable CI

### DIFF
--- a/.github/workflows/x509-tsp.yml
+++ b/.github/workflows/x509-tsp.yml
@@ -1,0 +1,46 @@
+name: x509-tsp
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/x509-tsp.yml"
+      - "const-oid/**"
+      - "cmpv2/**"
+      - "cms/**"
+      - "der/**"
+      - "spki/**"
+      - "x509-cert/**"
+      - "x509-tsp/**"
+      - "Cargo.*"
+  push:
+    branches: master
+
+defaults:
+  run:
+    working-directory: x509-tsp
+
+env:
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: "-Dwarnings"
+
+jobs:
+  minimal-versions:
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.65.0 # MSRV
+          - stable
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo hack test --feature-powerset

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2024,6 +2024,7 @@ dependencies = [
  "cms",
  "der",
  "hex-literal",
+ "x509-cert",
 ]
 
 [[package]]

--- a/x509-tsp/Cargo.toml
+++ b/x509-tsp/Cargo.toml
@@ -17,6 +17,7 @@ rust-version = "1.65"
 der = { version = "0.7.6", features = ["alloc", "derive", "oid", "pem"] }
 cms = { version = "0.2.1", features = ["alloc", "std"] }
 cmpv2 = { version = "0.2", features = ["alloc", "std"] }
+x509-cert = { version = "0.2.4", default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.4.1"

--- a/x509-tsp/src/lib.rs
+++ b/x509-tsp/src/lib.rs
@@ -214,10 +214,7 @@ mod tests {
             GeneralName::DirectoryName(n) => n,
             _ => panic!(),
         };
-        assert_eq!(
-            dn.to_string(),
-            "C=US,STATEORPROVINCENAME=Some-State,O=Test,CN=Test TSA"
-        );
+        assert_eq!(dn.to_string(), "CN=Test TSA,O=Test,ST=Some-State,C=US");
         assert_eq!(
             tst.message_imprint.hashed_message.as_bytes(),
             hex!("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")

--- a/x509-tsp/src/lib.rs
+++ b/x509-tsp/src/lib.rs
@@ -1,15 +1,13 @@
 use cmpv2::status::PkiStatusInfo;
-use cms::{
-    cert::x509::{
-        ext::{pkix::name::GeneralName, Extensions},
-        spki::AlgorithmIdentifier,
-    },
-    content_info::ContentInfo,
-};
+use cms::content_info::ContentInfo;
 use der::{
     asn1::{GeneralizedTime, Int, OctetString},
     oid::ObjectIdentifier,
     Any, Enumerated, Sequence,
+};
+use x509_cert::{
+    ext::{pkix::name::GeneralName, Extensions},
+    spki::AlgorithmIdentifier,
 };
 
 #[derive(Clone, Copy, Debug, Enumerated, Eq, PartialEq, PartialOrd, Ord)]


### PR DESCRIPTION
This enables CI on x509-tsp. It also fixes tests that broke with #1130

Fixes #1176