### PR TITLE
Remove proc-macro-error dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,7 +441,6 @@ dependencies = [
 name = "der_derive"
 version = "0.7.1"
 dependencies = [
- "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn 2.0.25",
@@ -1106,30 +1105,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c2fcef82c0ec6eefcc179b978446c399b3cdf73c392c35604e399eee6df1ee3"
 dependencies = [
  "elliptic-curve",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
 ]
 
 [[package]]

--- a/der/derive/Cargo.toml
+++ b/der/derive/Cargo.toml
@@ -17,6 +17,5 @@ proc-macro = true
 
 [dependencies]
 proc-macro2 = "1"
-proc-macro-error = "1"
 quote = "1"
 syn = { version = "2", features = ["extra-traits"] }

--- a/der/derive/src/choice.rs
+++ b/der/derive/src/choice.rs
@@ -7,7 +7,6 @@ mod variant;
 use self::variant::ChoiceVariant;
 use crate::{default_lifetime, TypeAttrs};
 use proc_macro2::TokenStream;
-use proc_macro_error::abort;
 use quote::quote;
 use syn::{DeriveInput, Ident, Lifetime};
 
@@ -25,7 +24,7 @@ pub(crate) struct DeriveChoice {
 
 impl DeriveChoice {
     /// Parse [`DeriveInput`].
-    pub fn new(input: DeriveInput) -> Self {
+    pub fn new(input: DeriveInput) -> syn::Result<Self> {
         let data = match input.data {
             syn::Data::Enum(data) => data,
             _ => abort!(
@@ -41,18 +40,18 @@ impl DeriveChoice {
             .next()
             .map(|lt| lt.lifetime.clone());
 
-        let type_attrs = TypeAttrs::parse(&input.attrs);
+        let type_attrs = TypeAttrs::parse(&input.attrs)?;
         let variants = data
             .variants
             .iter()
             .map(|variant| ChoiceVariant::new(variant, &type_attrs))
-            .collect();
+            .collect::<syn::Result<_>>()?;
 
-        Self {
+        Ok(Self {
             ident: input.ident,
             lifetime,
             variants,
-        }
+        })
     }
 
     /// Lower the derived output into a [`TokenStream`].
@@ -161,7 +160,7 @@ mod tests {
             }
         };
 
-        let ir = DeriveChoice::new(input);
+        let ir = DeriveChoice::new(input).unwrap();
         assert_eq!(ir.ident, "Time");
         assert_eq!(ir.lifetime, None);
         assert_eq!(ir.variants.len(), 2);
@@ -201,7 +200,7 @@ mod tests {
             }
         };
 
-        let ir = DeriveChoice::new(input);
+        let ir = DeriveChoice::new(input).unwrap();
         assert_eq!(ir.ident, "ImplicitChoice");
         assert_eq!(ir.lifetime.unwrap().to_string(), "'a");
         assert_eq!(ir.variants.len(), 3);

--- a/der/derive/src/enumerated.rs
+++ b/der/derive/src/enumerated.rs
@@ -5,7 +5,6 @@
 use crate::attributes::AttrNameValue;
 use crate::{default_lifetime, ATTR_NAME};
 use proc_macro2::TokenStream;
-use proc_macro_error::abort;
 use quote::quote;
 use syn::{DeriveInput, Expr, ExprLit, Ident, Lit, LitInt, Variant};
 
@@ -29,7 +28,7 @@ pub(crate) struct DeriveEnumerated {
 
 impl DeriveEnumerated {
     /// Parse [`DeriveInput`].
-    pub fn new(input: DeriveInput) -> Self {
+    pub fn new(input: DeriveInput) -> syn::Result<Self> {
         let data = match input.data {
             syn::Data::Enum(data) => data,
             _ => abort!(
@@ -46,14 +45,14 @@ impl DeriveEnumerated {
             if attr.path().is_ident(ATTR_NAME) {
                 let kvs = match AttrNameValue::parse_attribute(attr) {
                     Ok(kvs) => kvs,
-                    Err(e) => abort!(attr, "{}", e),
+                    Err(e) => abort!(attr, e),
                 };
                 for anv in kvs {
                     if anv.name.is_ident("type") {
                         match anv.value.value().as_str() {
                             "ENUMERATED" => integer = false,
                             "INTEGER" => integer = true,
-                            s => abort!(anv.value, "`type = \"{}\"` is unsupported", s),
+                            s => abort!(anv.value, format_args!("`type = \"{s}\"` is unsupported")),
                         }
                     }
                 }
@@ -65,16 +64,15 @@ impl DeriveEnumerated {
                     );
                 }
 
-                let r = attr
-                    .parse_args::<Ident>()
-                    .unwrap_or_else(|_| abort!(attr, "error parsing `#[repr]` attribute"));
+                let r = attr.parse_args::<Ident>().map_err(|_| {
+                    syn::Error::new_spanned(attr, "error parsing `#[repr]` attribute")
+                })?;
 
                 // Validate
                 if !REPR_TYPES.contains(&r.to_string().as_str()) {
                     abort!(
                         attr,
-                        "invalid `#[repr]` type: allowed types are {:?}",
-                        REPR_TYPES
+                        format_args!("invalid `#[repr]` type: allowed types are {REPR_TYPES:?}"),
                     );
                 }
 
@@ -83,20 +81,23 @@ impl DeriveEnumerated {
         }
 
         // Parse enum variants
-        let variants = data.variants.iter().map(EnumeratedVariant::new).collect();
+        let variants = data
+            .variants
+            .iter()
+            .map(EnumeratedVariant::new)
+            .collect::<syn::Result<_>>()?;
 
-        Self {
+        Ok(Self {
             ident: input.ident.clone(),
-            repr: repr.unwrap_or_else(|| {
-                abort!(
+            repr: repr.ok_or_else(|| {
+                syn::Error::new_spanned(
                     &input.ident,
-                    "no `#[repr]` attribute on enum: must be one of {:?}",
-                    REPR_TYPES
+                    format_args!("no `#[repr]` attribute on enum: must be one of {REPR_TYPES:?}"),
                 )
-            }),
+            })?,
             variants,
             integer,
-        }
+        })
     }
 
     /// Lower the derived output into a [`TokenStream`].
@@ -163,7 +164,7 @@ pub struct EnumeratedVariant {
 
 impl EnumeratedVariant {
     /// Create a new [`ChoiceVariant`] from the input [`Variant`].
-    fn new(input: &Variant) -> Self {
+    fn new(input: &Variant) -> syn::Result<Self> {
         for attr in &input.attrs {
             if attr.path().is_ident(ATTR_NAME) {
                 abort!(
@@ -180,10 +181,10 @@ impl EnumeratedVariant {
                     lit: Lit::Int(discriminant),
                     ..
                 }),
-            )) => Self {
+            )) => Ok(Self {
                 ident: input.ident.clone(),
                 discriminant: discriminant.clone(),
-            },
+            }),
             Some((_, other)) => abort!(other, "invalid discriminant for `Enumerated`"),
             None => abort!(input, "`Enumerated` variant has no discriminant"),
         }
@@ -223,7 +224,7 @@ mod tests {
             }
         };
 
-        let ir = DeriveEnumerated::new(input);
+        let ir = DeriveEnumerated::new(input).unwrap();
         assert_eq!(ir.ident, "CrlReason");
         assert_eq!(ir.repr, "u32");
         assert_eq!(ir.variants.len(), 10);

--- a/der/derive/src/lib.rs
+++ b/der/derive/src/lib.rs
@@ -121,6 +121,12 @@
     unused_qualifications
 )]
 
+macro_rules! abort {
+    ( $tokens:expr, $message:expr $(,)? ) => {
+        return Err(syn::Error::new_spanned($tokens, $message))
+    };
+}
+
 mod asn1_type;
 mod attributes;
 mod choice;
@@ -140,7 +146,6 @@ use crate::{
 };
 use proc_macro::TokenStream;
 use proc_macro2::Span;
-use proc_macro_error::proc_macro_error;
 use syn::{parse_macro_input, DeriveInput, Lifetime};
 
 /// Get the default lifetime.
@@ -186,10 +191,12 @@ fn default_lifetime() -> Lifetime {
 /// [3]: https://docs.rs/der/latest/der/trait.Encode.html
 /// [4]: https://docs.rs/der_derive/
 #[proc_macro_derive(Choice, attributes(asn1))]
-#[proc_macro_error]
 pub fn derive_choice(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
-    DeriveChoice::new(input).to_tokens().into()
+    match DeriveChoice::new(input) {
+        Ok(t) => t.to_tokens().into(),
+        Err(e) => e.to_compile_error().into(),
+    }
 }
 
 /// Derive decoders and encoders for ASN.1 [`Enumerated`] types on a
@@ -222,10 +229,12 @@ pub fn derive_choice(input: TokenStream) -> TokenStream {
 /// Note that the derive macro will write a `TryFrom<...>` impl for the
 /// provided `#[repr]`, which is used by the decoder.
 #[proc_macro_derive(Enumerated, attributes(asn1))]
-#[proc_macro_error]
 pub fn derive_enumerated(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
-    DeriveEnumerated::new(input).to_tokens().into()
+    match DeriveEnumerated::new(input) {
+        Ok(t) => t.to_tokens().into(),
+        Err(e) => e.to_compile_error().into(),
+    }
 }
 
 /// Derive the [`Sequence`][1] trait on a `struct`.
@@ -262,10 +271,12 @@ pub fn derive_enumerated(input: TokenStream) -> TokenStream {
 /// [1]: https://docs.rs/der/latest/der/trait.Sequence.html
 /// [2]: https://docs.rs/der_derive/
 #[proc_macro_derive(Sequence, attributes(asn1))]
-#[proc_macro_error]
 pub fn derive_sequence(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
-    DeriveSequence::new(input).to_tokens().into()
+    match DeriveSequence::new(input) {
+        Ok(t) => t.to_tokens().into(),
+        Err(e) => e.to_compile_error().into(),
+    }
 }
 
 /// Derive the [`ValueOrd`][1] trait on a `struct`.
@@ -275,8 +286,10 @@ pub fn derive_sequence(input: TokenStream) -> TokenStream {
 ///
 /// [1]: https://docs.rs/der/latest/der/trait.ValueOrd.html
 #[proc_macro_derive(ValueOrd, attributes(asn1))]
-#[proc_macro_error]
 pub fn derive_value_ord(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
-    DeriveValueOrd::new(input).to_tokens().into()
+    match DeriveValueOrd::new(input) {
+        Ok(t) => t.to_tokens().into(),
+        Err(e) => e.to_compile_error().into(),
+    }
 }

--- a/der/derive/src/sequence.rs
+++ b/der/derive/src/sequence.rs
@@ -6,7 +6,6 @@ mod field;
 use crate::{default_lifetime, TypeAttrs};
 use field::SequenceField;
 use proc_macro2::TokenStream;
-use proc_macro_error::abort;
 use quote::quote;
 use syn::{DeriveInput, GenericParam, Generics, Ident, LifetimeParam};
 
@@ -24,7 +23,7 @@ pub(crate) struct DeriveSequence {
 
 impl DeriveSequence {
     /// Parse [`DeriveInput`].
-    pub fn new(input: DeriveInput) -> Self {
+    pub fn new(input: DeriveInput) -> syn::Result<Self> {
         let data = match input.data {
             syn::Data::Struct(data) => data,
             _ => abort!(
@@ -33,19 +32,19 @@ impl DeriveSequence {
             ),
         };
 
-        let type_attrs = TypeAttrs::parse(&input.attrs);
+        let type_attrs = TypeAttrs::parse(&input.attrs)?;
 
         let fields = data
             .fields
             .iter()
             .map(|field| SequenceField::new(field, &type_attrs))
-            .collect();
+            .collect::<syn::Result<_>>()?;
 
-        Self {
+        Ok(Self {
             ident: input.ident,
             generics: input.generics.clone(),
             fields,
-        }
+        })
     }
 
     /// Lower the derived output into a [`TokenStream`].
@@ -143,7 +142,7 @@ mod tests {
             }
         };
 
-        let ir = DeriveSequence::new(input);
+        let ir = DeriveSequence::new(input).unwrap();
         assert_eq!(ir.ident, "AlgorithmIdentifier");
         assert_eq!(
             ir.generics.lifetimes().next().unwrap().lifetime.to_string(),
@@ -177,7 +176,7 @@ mod tests {
             }
         };
 
-        let ir = DeriveSequence::new(input);
+        let ir = DeriveSequence::new(input).unwrap();
         assert_eq!(ir.ident, "SubjectPublicKeyInfo");
         assert_eq!(
             ir.generics.lifetimes().next().unwrap().lifetime.to_string(),
@@ -245,7 +244,7 @@ mod tests {
             }
         };
 
-        let ir = DeriveSequence::new(input);
+        let ir = DeriveSequence::new(input).unwrap();
         assert_eq!(ir.ident, "OneAsymmetricKey");
         assert_eq!(
             ir.generics.lifetimes().next().unwrap().lifetime.to_string(),
@@ -320,7 +319,7 @@ mod tests {
             }
         };
 
-        let ir = DeriveSequence::new(input);
+        let ir = DeriveSequence::new(input).unwrap();
         assert_eq!(ir.ident, "ImplicitSequence");
         assert_eq!(
             ir.generics.lifetimes().next().unwrap().lifetime.to_string(),


### PR DESCRIPTION
Closes #1173.

I chose to minimize the diff by introducing a minimal `abort!` macro that early-returns like `anyhow::bail!` or similar macros, which reduces the amount of code that has to change a lot.

Further refactorings are possible (in particular, I personally prefer to collect all attribute errors and emitting them individually where possible, instead of short-circuiting on the first error), but I didn't do any of that in this PR for the same reason. Let me know if you're interested in anything like that.