### PR TITLE
base64ct: pin rustix to 0.37 to preserve MSRV 1.60

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,7 @@ version = "1.6.0"
 dependencies = [
  "base64",
  "proptest",
+ "rustix 0.37.23",
 ]
 
 [[package]]

--- a/base64ct/Cargo.toml
+++ b/base64ct/Cargo.toml
@@ -19,6 +19,7 @@ rust-version = "1.60"
 [dev-dependencies]
 base64 = "0.21"
 proptest = "1"
+rustix = "0.37" # Pinned to preserve MSRV 1.60
 
 [features]
 alloc = []


### PR DESCRIPTION
Otherwise we get test failures on newer versions which are MSRV 1.63