### PR TITLE
der_derive: fix doc typo and use a valid tag number

### DIFF
--- a/der/derive/src/lib.rs
+++ b/der/derive/src/lib.rs
@@ -55,7 +55,7 @@
 //! This attribute can be added to associate a particular `CONTEXT-SPECIFIC`
 //! tag number with a given enum variant or struct field.
 //!
-//! The value must be quoted and contain a number, e.g. `#[asn1(context_specific = "42"]`.
+//! The value must be quoted and contain a number, e.g. `#[asn1(context_specific = "29")]`.
 //!
 //! ### `#[asn1(default = "...")]` attribute: `DEFAULT` support
 //!


### PR DESCRIPTION
Add the missing close-parenthesis.

Also change the number in the example, because 42 isn't a valid tag, and will result in a vague compile-time error if the reader pastes this example into their code.