### PR TITLE
der: 0.7.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "arbitrary",
  "bytes",

--- a/der/CHANGELOG.md
+++ b/der/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.8 (2023-08-07)
+### Added
+- `bytes` feature ([#1156])
+- impl `RefToOwned`/`OwnedToRef` for `&[u8]`/`Box<[u8]>` ([#1188])
+- `BmpString` ([#1164])
+
+### Changed
+- no-panic cleanup ([#1169])
+- Bump `der_derive` dependency to v0.7.2 ([#1192])
+
+[#1156]: https://github.com/RustCrypto/formats/pull/1156
+[#1164]: https://github.com/RustCrypto/formats/pull/1164
+[#1169]: https://github.com/RustCrypto/formats/pull/1169
+[#1188]: https://github.com/RustCrypto/formats/pull/1188
+[#1192]: https://github.com/RustCrypto/formats/pull/1192
+
 ## 0.7.7 (2023-06-29)
 ### Added
 - `TryFrom<String>` impl for strings based on `StrOwned` ([#1064])

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der"
-version = "0.7.7"
+version = "0.7.8"
 description = """
 Pure Rust embedded-friendly implementation of the Distinguished Encoding Rules
 (DER) for Abstract Syntax Notation One (ASN.1) as described in ITU X.690 with
@@ -19,7 +19,7 @@ rust-version = "1.65"
 arbitrary = { version = "1.3", features = ["derive"], optional = true }
 bytes = { version = "1", optional = true, default-features = false }
 const-oid = { version = "0.9.2", optional = true }
-der_derive = { version = "0.7.1", optional = true }
+der_derive = { version = "0.7.2", optional = true }
 flagset = { version = "0.4.3", optional = true }
 pem-rfc7468 = { version = "0.7", optional = true, features = ["alloc"] }
 time = { version = "0.3.4", optional = true, default-features = false }


### PR DESCRIPTION
Added
- `bytes` feature ([#1156])
- impl `RefToOwned`/`OwnedToRef` for `&[u8]`/`Box<[u8]>` ([#1188])
- `BmpString` ([#1164])

Changed
- no-panic cleanup ([#1169])
- Bump `der_derive` dependency to v0.7.2 ([#1192])

[#1156]: https://github.com/RustCrypto/formats/pull/1156
[#1164]: https://github.com/RustCrypto/formats/pull/1164
[#1169]: https://github.com/RustCrypto/formats/pull/1169
[#1188]: https://github.com/RustCrypto/formats/pull/1188
[#1192]: https://github.com/RustCrypto/formats/pull/1192