### PR TITLE
Set min version of serde to 1.0.184

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "305fe645edc1442a0fa8b6726ba61d422798d37a52e12eaecf4b022ebbb88f01"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
  "libc",
 ]
@@ -451,9 +451,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7684a49fb1af197853ef7b2ee694bc1f5b4179556f1e5710e1760c5db6f5e929"
+checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
 
 [[package]]
 name = "derive_arbitrary"
@@ -1402,9 +1402,9 @@ checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.171"
+version = "1.0.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
+checksum = "be9b6f69f1dfd54c3b568ffa45c310d6973a5e5148fd40cf515acaf38cf5bc31"
 dependencies = [
  "serde_derive",
 ]
@@ -1421,9 +1421,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.171"
+version = "1.0.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
+checksum = "dc59dfdcbad1437773485e0367fea4b090a2e0a16d9ffc46af47764536a298ec"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1616,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "tls_codec"
-version = "0.3.1"
+version = "0.3.0"
 dependencies = [
  "arbitrary",
  "criterion",

--- a/serdect/CHANGELOG.md
+++ b/serdect/CHANGELOG.md
@@ -4,13 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.1 (2023-08-19)
-### Changed
-- Pin upper version of `serde` to <1.0.172 to work around [serde-rs/serde#2538] ([#1201])
-
-[#1201]: https://github.com/RustCrypto/formats/pull/1201
-[serde-rs/serde#2538]: https://github.com/serde-rs/serde/issues/2538
-
 ## 0.2.0 (2023-02-26)
 ### Changed
 - MSRV 1.60 ([#802])

--- a/serdect/Cargo.toml
+++ b/serdect/Cargo.toml
@@ -16,8 +16,7 @@ rust-version = "1.60"
 
 [dependencies]
 base16ct = { version = "0.2", default-features = false }
-# Pin upper version of serde to work around https://github.com/serde-rs/serde/issues/2538
-serde = { version = "1.0.96, <1.0.172", default-features = false }
+serde = { version = "1.0.184", default-features = false }
 
 # optional features
 zeroize = { version = "1", optional = true, default-features = false }
@@ -27,7 +26,7 @@ bincode = "1"
 ciborium = "0.2"
 hex-literal = "0.4"
 proptest = "1"
-serde = { version = "1.0.119", default-features = false, features = ["derive"] }
+serde = { version = "1.0.184", default-features = false, features = ["derive"] }
 serde_json = "1"
 serde-json-core = { version = "0.5", default-features = false, features = ["std"] }
 toml = "0.7"

--- a/tls_codec/Cargo.toml
+++ b/tls_codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tls_codec"
-version = "0.3.1"
+version = "0.3.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/tls_codec/"
@@ -19,8 +19,7 @@ zeroize = { version = "1.6", default-features = false, features = [
 # optional dependencies
 arbitrary = { version = "1", features = ["derive"], optional = true }
 tls_codec_derive = { version = "=0.3.0", path = "./derive", optional = true }
-# Pin upper version of serde to work around https://github.com/serde-rs/serde/issues/2538
-serde = { version = "1.0.144, <1.0.172", features = ["derive"], optional = true }
+serde = { version = "1.0.184", features = ["derive"], optional = true }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/x509-cert/test-support/Cargo.toml
+++ b/x509-cert/test-support/Cargo.toml
@@ -13,6 +13,6 @@ readme = "README.md"
 
 [dependencies]
 # Pin upper version of serde to work around https://github.com/serde-rs/serde/issues/2538
-serde = { version = "1, <1.0.172", features = ["derive"] }
+serde = { version = "1.0.184", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"


### PR DESCRIPTION
In 1.0.184 `serde` was [un-blobbed](https://github.com/serde-rs/serde/releases/tag/v1.0.184). To prevent accidental pulling of the blobbed versions 1.0.184 will be used as a min version.

Relevant PR: #1201 