### PR TITLE
serdect: bump version to v0.3.0-pre

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1345,7 +1345,7 @@ dependencies = [
  "generic-array",
  "hex-literal 0.4.1",
  "pkcs8",
- "serdect",
+ "serdect 0.2.0",
  "subtle",
  "tempfile",
  "zeroize",
@@ -1409,7 +1409,17 @@ dependencies = [
 
 [[package]]
 name = "serdect"
-version = "0.2.1"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
+name = "serdect"
+version = "0.3.0-pre"
 dependencies = [
  "base16ct",
  "bincode",

--- a/serdect/Cargo.toml
+++ b/serdect/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Constant-time serde serializer/deserializer helpers for data that potentially
 contains secrets (e.g. cryptographic keys)
 """
-version = "0.2.1"
+version = "0.3.0-pre"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/formats/tree/master/serdect"


### PR DESCRIPTION
PR #1112 contained breaking changes. To reflect that, this bumps the `serdect` version to a prerelease.

Note that there is not a crate release associated with this bump. If there is a prerelease, it will be `v0.3.0-pre.0`.