### PR TITLE
const-oid: Added SCEP's failInfoText oid.

### DIFF
--- a/const-oid/oiddbgen/Cargo.lock
+++ b/const-oid/oiddbgen/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.10.0-pre"
+version = "0.10.0-pre.0"
 
 [[package]]
 name = "convert_case"

--- a/const-oid/oiddbgen/rfc8894.md
+++ b/const-oid/oiddbgen/rfc8894.md
@@ -4,6 +4,7 @@ Simple Certificate Enrolment Protocol
 RFC 8894 unfortunately formatted the SCEP OIDs in a table, that can't
 be parsed easily. For this reason the definitions are repeated here
 in a parseable format.
+`id-pkix` is not contained in RFC 8894. It was added to make failInfoText parseable, too.
 
 # SCEP Secure Message Objects
 ## 3.2.  SCEP pkiMessage
@@ -18,5 +19,6 @@ id-pkiStatus          OBJECT IDENTIFIER ::= {id-attributes pkiStatus(3)}
 id-failInfo           OBJECT IDENTIFIER ::= {id-attributes failInfo(4)}
 id-senderNonce        OBJECT IDENTIFIER ::= {id-attributes senderNonce(5)}
 id-recipientNonce     OBJECT IDENTIFIER ::= {id-attributes recipientNonce(6)}
+id-pkix               OBJECT IDENTIFIER ::= {1 3 6 1 5 5 pkix(7)}
 id-scep               OBJECT IDENTIFIER ::= {id-pkix 24}
 id-scep-failInfoText  OBJECT IDENTIFIER ::= {id-scep 1}

--- a/const-oid/src/db/gen.rs
+++ b/const-oid/src/db/gen.rs
@@ -5495,10 +5495,25 @@ pub mod rfc8410 {
         ]);
 }
 pub mod rfc8894 {
+    #[doc = "1.3.6.1.5.5.7: id-pkix"]
+    pub const ID_PKIX: crate::ObjectIdentifierRef<'static> =
+        crate::ObjectIdentifierRef::from_bytes_unchecked(&[
+            49, 46, 51, 46, 54, 46, 49, 46, 53, 46, 53, 46, 55,
+        ]);
+    #[doc = "1.3.6.1.5.5.7.24: id-scep"]
+    pub const ID_SCEP: crate::ObjectIdentifierRef<'static> =
+        crate::ObjectIdentifierRef::from_bytes_unchecked(&[
+            49, 46, 51, 46, 54, 46, 49, 46, 53, 46, 53, 46, 55, 46, 50, 52,
+        ]);
     #[doc = "2.16.840.1.113733: id-VeriSign"]
     pub const ID_VERI_SIGN: crate::ObjectIdentifierRef<'static> =
         crate::ObjectIdentifierRef::from_bytes_unchecked(&[
             50, 46, 49, 54, 46, 56, 52, 48, 46, 49, 46, 49, 49, 51, 55, 51, 51,
+        ]);
+    #[doc = "1.3.6.1.5.5.7.24.1: id-scep-failInfoText"]
+    pub const ID_SCEP_FAIL_INFO_TEXT: crate::ObjectIdentifierRef<'static> =
+        crate::ObjectIdentifierRef::from_bytes_unchecked(&[
+            49, 46, 51, 46, 54, 46, 49, 46, 53, 46, 53, 46, 55, 46, 50, 52, 46, 49,
         ]);
     #[doc = "2.16.840.1.113733.1: id-pki"]
     pub const ID_PKI: crate::ObjectIdentifierRef<'static> =
@@ -7432,7 +7447,10 @@ pub const DB: super::Database<'static> = super::Database(&[
     (rfc8410::ID_X_448, "id-X448"),
     (rfc8410::ID_ED_25519, "id-Ed25519"),
     (rfc8410::ID_ED_448, "id-Ed448"),
+    (rfc8894::ID_PKIX, "id-pkix"),
+    (rfc8894::ID_SCEP, "id-scep"),
     (rfc8894::ID_VERI_SIGN, "id-VeriSign"),
+    (rfc8894::ID_SCEP_FAIL_INFO_TEXT, "id-scep-failInfoText"),
     (rfc8894::ID_PKI, "id-pki"),
     (rfc8894::ID_ATTRIBUTES, "id-attributes"),
     (rfc8894::ID_MESSAGE_TYPE, "id-messageType"),


### PR DESCRIPTION
As `id-pkix` was not explicitely noted in rfc8894.md, it was missing in the generated `gen.rs`. This PR fixes that.
Note: I recognized, that Cargo.lock was also changed, though I didn't make any changes, that could have caused that. Is this is intended?