### PR TITLE
tls_codec: Rename functions in DeserializeBytes trait

### DIFF
--- a/tls_codec/CHANGELOG.md
+++ b/tls_codec/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- [#1251](https://github.com/RustCrypto/formats/pull/1251): Add `_bytes` suffix to function names in the `DeserializeBytes` trait to avoid collisions with function names in the `Deserialize` trait
+
+### Removed
+
+- [#1251](https://github.com/RustCrypto/formats/pull/1251): Remove the `tls_deserialize_bytes` function from the `Deserialize` trait

--- a/tls_codec/benches/quic_vec.rs
+++ b/tls_codec/benches/quic_vec.rs
@@ -20,8 +20,7 @@ fn vector(c: &mut Criterion) {
             },
             |serialized_long_vec| {
                 let _deserialized_long_vec =
-                    <Vec<u8> as Deserialize>::tls_deserialize(&mut serialized_long_vec.as_slice())
-                        .unwrap();
+                    Vec::<u8>::tls_deserialize(&mut serialized_long_vec.as_slice()).unwrap();
             },
             BatchSize::SmallInput,
         )
@@ -47,8 +46,7 @@ fn byte_vector(c: &mut Criterion) {
             },
             |serialized_long_vec| {
                 let _deserialized_long_vec =
-                    <VLBytes as Deserialize>::tls_deserialize(&mut serialized_long_vec.as_slice())
-                        .unwrap();
+                    VLBytes::tls_deserialize(&mut serialized_long_vec.as_slice()).unwrap();
             },
             BatchSize::SmallInput,
         )

--- a/tls_codec/benches/tls_vec.rs
+++ b/tls_codec/benches/tls_vec.rs
@@ -19,10 +19,8 @@ fn vector(c: &mut Criterion) {
                 TlsSliceU32(&long_vector).tls_serialize_detached().unwrap()
             },
             |serialized_long_vec| {
-                let _deserialized_long_vec = <TlsVecU32<u8> as Deserialize>::tls_deserialize(
-                    &mut serialized_long_vec.as_slice(),
-                )
-                .unwrap();
+                let _deserialized_long_vec =
+                    TlsVecU32::<u8>::tls_deserialize(&mut serialized_long_vec.as_slice()).unwrap();
             },
             BatchSize::SmallInput,
         )
@@ -49,10 +47,8 @@ fn byte_vector(c: &mut Criterion) {
                     .unwrap()
             },
             |serialized_long_vec| {
-                let _deserialized_long_vec = <TlsVecU32<u8> as Deserialize>::tls_deserialize(
-                    &mut serialized_long_vec.as_slice(),
-                )
-                .unwrap();
+                let _deserialized_long_vec =
+                    TlsVecU32::<u8>::tls_deserialize(&mut serialized_long_vec.as_slice()).unwrap();
             },
             BatchSize::SmallInput,
         )

--- a/tls_codec/derive/src/lib.rs
+++ b/tls_codec/derive/src/lib.rs
@@ -1061,7 +1061,7 @@ fn impl_deserialize_bytes(parsed_ast: TlsStruct) -> TokenStream2 {
                 impl #impl_generics tls_codec::DeserializeBytes for #ident #ty_generics #where_clause {
                     fn tls_deserialize_bytes(bytes: &[u8]) -> core::result::Result<(Self, &[u8]), tls_codec::Error> {
                         #discriminant_constants
-                        let (discriminant, remainder) = <#repr as tls_codec::DeserializeBytes>::tls_deserialize_bytes(bytes)?;
+                        let (discriminant, remainder) = #repr::tls_deserialize_bytes(bytes)?;
                         match discriminant {
                             #(#arms)*
                             _ => {

--- a/tls_codec/derive/src/lib.rs
+++ b/tls_codec/derive/src/lib.rs
@@ -1005,8 +1005,8 @@ fn impl_deserialize_bytes(parsed_ast: TlsStruct) -> TokenStream2 {
             let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
             quote! {
                 impl #impl_generics tls_codec::DeserializeBytes for #ident #ty_generics #where_clause {
-                    fn tls_deserialize(bytes: &[u8]) -> core::result::Result<(Self, &[u8]), tls_codec::Error> {
-                        #(let (#members_values, bytes) = #prefixes::tls_deserialize(bytes)?;)*
+                    fn tls_deserialize_bytes(bytes: &[u8]) -> core::result::Result<(Self, &[u8]), tls_codec::Error> {
+                        #(let (#members_values, bytes) = #prefixes::tls_deserialize_bytes(bytes)?;)*
                         Ok((Self {
                             #(#members: #members_values,)*
                             #(#members_default: Default::default(),)*
@@ -1049,7 +1049,7 @@ fn impl_deserialize_bytes(parsed_ast: TlsStruct) -> TokenStream2 {
                         .collect::<Vec<_>>();
                     quote! {
                         #discriminant => {
-                            #(let (#member_values, remainder) = #prefixes::tls_deserialize(remainder)?;)*
+                            #(let (#member_values, remainder) = #prefixes::tls_deserialize_bytes(remainder)?;)*
                             let result = #ident::#variant_id { #(#members: #member_values,)* };
                             Ok((result, remainder))
                         },
@@ -1059,9 +1059,9 @@ fn impl_deserialize_bytes(parsed_ast: TlsStruct) -> TokenStream2 {
             let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
             quote! {
                 impl #impl_generics tls_codec::DeserializeBytes for #ident #ty_generics #where_clause {
-                    fn tls_deserialize(bytes: &[u8]) -> core::result::Result<(Self, &[u8]), tls_codec::Error> {
+                    fn tls_deserialize_bytes(bytes: &[u8]) -> core::result::Result<(Self, &[u8]), tls_codec::Error> {
                         #discriminant_constants
-                        let (discriminant, remainder) = <#repr as tls_codec::DeserializeBytes>::tls_deserialize(bytes)?;
+                        let (discriminant, remainder) = <#repr as tls_codec::DeserializeBytes>::tls_deserialize_bytes(bytes)?;
                         match discriminant {
                             #(#arms)*
                             _ => {

--- a/tls_codec/derive/tests/decode.rs
+++ b/tls_codec/derive/tests/decode.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "std")]
 use tls_codec::{
-    Deserialize, Error, Serialize, Size, TlsSliceU16, TlsVecU16, TlsVecU32, TlsVecU8, VLBytes,
+    Deserialize, DeserializeBytes, Error, Serialize, Size, TlsSliceU16, TlsVecU16, TlsVecU32,
+    TlsVecU8, VLBytes,
 };
 use tls_codec_derive::{TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize};
 
@@ -58,10 +59,7 @@ fn tuple_struct() {
     let serialized_t1 = t1.tls_serialize_detached().unwrap();
     let deserialized_t1 = TupleStruct1::tls_deserialize(&mut serialized_t1.as_slice()).unwrap();
     let (deserialized_bytes_t1, _remainder) =
-        <TupleStruct1 as tls_codec::DeserializeBytes>::tls_deserialize_bytes(
-            serialized_t1.as_slice(),
-        )
-        .unwrap();
+        TupleStruct1::tls_deserialize_bytes(serialized_t1.as_slice()).unwrap();
     assert_eq!(t1, deserialized_t1);
     assert_eq!(t1, deserialized_bytes_t1);
     assert_eq!(
@@ -77,10 +75,7 @@ fn tuple_struct() {
     let serialized_t2 = t2.tls_serialize_detached().unwrap();
     let deserialized_t2 = TupleStruct::tls_deserialize(&mut serialized_t2.as_slice()).unwrap();
     let (deserialized_bytes_t2, _remainder) =
-        <TupleStruct as tls_codec::DeserializeBytes>::tls_deserialize_bytes(
-            serialized_t2.as_slice(),
-        )
-        .unwrap();
+        TupleStruct::tls_deserialize_bytes(serialized_t2.as_slice()).unwrap();
     assert_eq!(t2, deserialized_t2);
     assert_eq!(t2, deserialized_bytes_t2);
     assert_eq!(
@@ -98,8 +93,7 @@ fn simple_enum() {
     let b = &[0u8, 5] as &[u8];
     let mut b_reader = b;
     let deserialized = ExtensionType::tls_deserialize(&mut b_reader).unwrap();
-    let (deserialized_bytes, _remainder) =
-        <ExtensionType as tls_codec::DeserializeBytes>::tls_deserialize_bytes(b).unwrap();
+    let (deserialized_bytes, _remainder) = ExtensionType::tls_deserialize_bytes(b).unwrap();
     assert_eq!(ExtensionType::RatchetTree, deserialized);
     assert_eq!(ExtensionType::RatchetTree, deserialized_bytes);
 
@@ -113,8 +107,7 @@ fn simple_enum() {
     for variant in variants.iter() {
         let deserialized = ExtensionType::tls_deserialize(&mut b_reader).unwrap();
         assert_eq!(variant, &deserialized);
-        let (deserialized_bytes, remainder) =
-            <ExtensionType as tls_codec::DeserializeBytes>::tls_deserialize_bytes(b).unwrap();
+        let (deserialized_bytes, remainder) = ExtensionType::tls_deserialize_bytes(b).unwrap();
         b = remainder;
         assert_eq!(variant, &deserialized_bytes);
     }
@@ -133,11 +126,9 @@ fn deserialize_tls_vec() {
     assert_eq!(long_vector.len(), deserialized_long_vec.len());
     assert_eq!(long_vector, deserialized_long_vec);
     let (deserialized_long_vec_bytes, _remainder): (Vec<ExtensionStruct>, &[u8]) =
-        <TlsVecU16<ExtensionStruct> as tls_codec::DeserializeBytes>::tls_deserialize_bytes(
-            serialized_long_vec.as_slice(),
-        )
-        .map(|(v, r)| (v.into(), r))
-        .unwrap();
+        TlsVecU16::<ExtensionStruct>::tls_deserialize_bytes(serialized_long_vec.as_slice())
+            .map(|(v, r)| (v.into(), r))
+            .unwrap();
     assert_eq!(long_vector.len(), deserialized_long_vec_bytes.len());
     assert_eq!(long_vector, deserialized_long_vec_bytes);
 }

--- a/tls_codec/derive/tests/decode.rs
+++ b/tls_codec/derive/tests/decode.rs
@@ -308,8 +308,8 @@ mod custom_bytes {
         TlsByteSliceU32(v).tls_serialize(writer)
     }
 
-    pub fn tls_deserialize(bytes: &[u8]) -> Result<(Vec<u8>, &[u8]), tls_codec::Error> {
-        let (vec, remainder) = TlsByteVecU32::tls_deserialize(bytes)?;
+    pub fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Vec<u8>, &[u8]), tls_codec::Error> {
+        let (vec, remainder) = TlsByteVecU32::tls_deserialize_bytes(bytes)?;
         Ok((vec.into_vec(), remainder))
     }
 }

--- a/tls_codec/derive/tests/decode.rs
+++ b/tls_codec/derive/tests/decode.rs
@@ -58,8 +58,10 @@ fn tuple_struct() {
     let serialized_t1 = t1.tls_serialize_detached().unwrap();
     let deserialized_t1 = TupleStruct1::tls_deserialize(&mut serialized_t1.as_slice()).unwrap();
     let (deserialized_bytes_t1, _remainder) =
-        <TupleStruct1 as tls_codec::DeserializeBytes>::tls_deserialize(serialized_t1.as_slice())
-            .unwrap();
+        <TupleStruct1 as tls_codec::DeserializeBytes>::tls_deserialize_bytes(
+            serialized_t1.as_slice(),
+        )
+        .unwrap();
     assert_eq!(t1, deserialized_t1);
     assert_eq!(t1, deserialized_bytes_t1);
     assert_eq!(
@@ -75,8 +77,10 @@ fn tuple_struct() {
     let serialized_t2 = t2.tls_serialize_detached().unwrap();
     let deserialized_t2 = TupleStruct::tls_deserialize(&mut serialized_t2.as_slice()).unwrap();
     let (deserialized_bytes_t2, _remainder) =
-        <TupleStruct as tls_codec::DeserializeBytes>::tls_deserialize(serialized_t2.as_slice())
-            .unwrap();
+        <TupleStruct as tls_codec::DeserializeBytes>::tls_deserialize_bytes(
+            serialized_t2.as_slice(),
+        )
+        .unwrap();
     assert_eq!(t2, deserialized_t2);
     assert_eq!(t2, deserialized_bytes_t2);
     assert_eq!(
@@ -95,7 +99,7 @@ fn simple_enum() {
     let mut b_reader = b;
     let deserialized = ExtensionType::tls_deserialize(&mut b_reader).unwrap();
     let (deserialized_bytes, _remainder) =
-        <ExtensionType as tls_codec::DeserializeBytes>::tls_deserialize(b).unwrap();
+        <ExtensionType as tls_codec::DeserializeBytes>::tls_deserialize_bytes(b).unwrap();
     assert_eq!(ExtensionType::RatchetTree, deserialized);
     assert_eq!(ExtensionType::RatchetTree, deserialized_bytes);
 
@@ -110,7 +114,7 @@ fn simple_enum() {
         let deserialized = ExtensionType::tls_deserialize(&mut b_reader).unwrap();
         assert_eq!(variant, &deserialized);
         let (deserialized_bytes, remainder) =
-            <ExtensionType as tls_codec::DeserializeBytes>::tls_deserialize(b).unwrap();
+            <ExtensionType as tls_codec::DeserializeBytes>::tls_deserialize_bytes(b).unwrap();
         b = remainder;
         assert_eq!(variant, &deserialized_bytes);
     }
@@ -129,7 +133,7 @@ fn deserialize_tls_vec() {
     assert_eq!(long_vector.len(), deserialized_long_vec.len());
     assert_eq!(long_vector, deserialized_long_vec);
     let (deserialized_long_vec_bytes, _remainder): (Vec<ExtensionStruct>, &[u8]) =
-        <TlsVecU16<ExtensionStruct> as tls_codec::DeserializeBytes>::tls_deserialize(
+        <TlsVecU16<ExtensionStruct> as tls_codec::DeserializeBytes>::tls_deserialize_bytes(
             serialized_long_vec.as_slice(),
         )
         .map(|(v, r)| (v.into(), r))

--- a/tls_codec/derive/tests/decode_bytes.rs
+++ b/tls_codec/derive/tests/decode_bytes.rs
@@ -71,8 +71,7 @@ fn tuple_struct() {
 fn byte_arrays() {
     let x = [0u8, 1, 2, 3];
     let serialized = x.tls_serialize().unwrap();
-    let (deserialized, rest) =
-        <[u8; 4] as DeserializeBytes>::tls_deserialize_bytes(&serialized).unwrap();
+    let (deserialized, rest) = <[u8; 4]>::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, x);
     assert!(rest.is_empty());
 }

--- a/tls_codec/derive/tests/decode_bytes.rs
+++ b/tls_codec/derive/tests/decode_bytes.rs
@@ -33,11 +33,11 @@ fn simple_enum() {
     let serialized = ExtensionType::KeyId.tls_serialize().unwrap();
     let (deserialized, rest) = ExtensionType::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, ExtensionType::KeyId);
-    assert_eq!(rest, []);
+    assert!(rest.is_empty());
     let serialized = ExtensionType::SomethingElse.tls_serialize().unwrap();
     let (deserialized, rest) = ExtensionType::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, ExtensionType::SomethingElse);
-    assert_eq!(rest, []);
+    assert!(rest.is_empty());
 }
 
 #[test]
@@ -50,7 +50,7 @@ fn simple_struct() {
     let serialized = extension.tls_serialize().unwrap();
     let (deserialized, rest) = ExtensionStruct::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, extension);
-    assert_eq!(rest, []);
+    assert!(rest.is_empty());
 }
 
 #[test]
@@ -64,7 +64,7 @@ fn tuple_struct() {
     let serialized = x.tls_serialize().unwrap();
     let (deserialized, rest) = TupleStruct::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, x);
-    assert_eq!(rest, []);
+    assert!(rest.is_empty());
 }
 
 #[test]
@@ -74,7 +74,7 @@ fn byte_arrays() {
     let (deserialized, rest) =
         <[u8; 4] as DeserializeBytes>::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, x);
-    assert_eq!(rest, []);
+    assert!(rest.is_empty());
 }
 
 #[derive(TlsSerializeBytes, TlsDeserializeBytes, TlsSize, Debug, PartialEq)]
@@ -95,7 +95,7 @@ mod custom {
         v.tls_serialize()
     }
 
-    pub fn tls_deserialize<T: DeserializeBytes>(
+    pub fn tls_deserialize_bytes<T: DeserializeBytes>(
         bytes: &[u8],
     ) -> Result<(T, &[u8]), tls_codec::Error> {
         T::tls_deserialize_bytes(bytes)
@@ -112,7 +112,7 @@ fn custom() {
     assert_eq!(vec![3, 0, 1, 2, 3], serialized);
     let (deserialized, rest) = Custom::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, x);
-    assert_eq!(rest, []);
+    assert!(rest.is_empty());
 }
 
 #[derive(TlsSerializeBytes, TlsDeserializeBytes, TlsSize, Debug, PartialEq)]
@@ -127,7 +127,7 @@ fn enum_with_tuple_variant() {
     let serialized = x.tls_serialize().unwrap();
     let (deserialized, rest) = EnumWithTupleVariant::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, x);
-    assert_eq!(rest, []);
+    assert!(rest.is_empty());
 }
 
 #[derive(TlsSerializeBytes, TlsDeserializeBytes, TlsSize, Debug, PartialEq)]
@@ -142,7 +142,7 @@ fn enum_with_struct_variant() {
     let serialized = x.tls_serialize().unwrap();
     let (deserialized, rest) = EnumWithStructVariant::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, x);
-    assert_eq!(rest, []);
+    assert!(rest.is_empty());
 }
 
 #[derive(TlsSerializeBytes, TlsDeserializeBytes, TlsSize, Debug, PartialEq)]
@@ -161,7 +161,7 @@ fn enum_with_data_and_discriminant() {
     let (deserialized, rest) =
         EnumWithDataAndDiscriminant::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, x);
-    assert_eq!(rest, []);
+    assert!(rest.is_empty());
 }
 
 #[test]
@@ -171,7 +171,7 @@ fn discriminant_is_incremented_implicitly() {
     let (deserialized, rest) =
         EnumWithDataAndDiscriminant::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, x);
-    assert_eq!(rest, []);
+    assert!(rest.is_empty());
 }
 
 mod discriminant {
@@ -206,21 +206,21 @@ fn enum_with_data_and_const_discriminant() {
     let (deserialized, rest) =
         EnumWithDataAndConstDiscriminant::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, x);
-    assert_eq!(rest, []);
+    assert!(rest.is_empty());
 
     let x = EnumWithDataAndConstDiscriminant::B;
     let serialized = x.tls_serialize().unwrap();
     let (deserialized, rest) =
         EnumWithDataAndConstDiscriminant::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, x);
-    assert_eq!(rest, []);
+    assert!(rest.is_empty());
 
     let x = EnumWithDataAndConstDiscriminant::C;
     let serialized = x.tls_serialize().unwrap();
     let (deserialized, rest) =
         EnumWithDataAndConstDiscriminant::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, x);
-    assert_eq!(rest, []);
+    assert!(rest.is_empty());
 }
 
 #[derive(TlsSerializeBytes, TlsDeserializeBytes, TlsSize, Debug, PartialEq)]
@@ -236,7 +236,7 @@ fn enum_with_custom_serialized_field() {
     let (deserialized, rest) =
         EnumWithCustomSerializedField::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, x);
-    assert_eq!(rest, []);
+    assert!(rest.is_empty());
 }
 
 #[test]
@@ -248,7 +248,7 @@ fn that_skip_attribute_on_struct_works() {
         let serialized = test.tls_serialize().unwrap();
         let (deserialized, rest) = T::tls_deserialize_bytes(&serialized).unwrap();
         assert_eq!(deserialized, expected);
-        assert_eq!(rest, []);
+        assert!(rest.is_empty());
     }
 
     #[derive(Debug, PartialEq, TlsSerializeBytes, TlsDeserializeBytes, TlsSize)]

--- a/tls_codec/derive/tests/decode_bytes.rs
+++ b/tls_codec/derive/tests/decode_bytes.rs
@@ -32,12 +32,12 @@ struct SomeValue {
 fn simple_enum() {
     let serialized = ExtensionType::KeyId.tls_serialize().unwrap();
     let (deserialized, rest) =
-        <ExtensionType as DeserializeBytes>::tls_deserialize(&serialized).unwrap();
+        <ExtensionType as DeserializeBytes>::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, ExtensionType::KeyId);
     assert_eq!(rest, []);
     let serialized = ExtensionType::SomethingElse.tls_serialize().unwrap();
     let (deserialized, rest) =
-        <ExtensionType as DeserializeBytes>::tls_deserialize(&serialized).unwrap();
+        <ExtensionType as DeserializeBytes>::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, ExtensionType::SomethingElse);
     assert_eq!(rest, []);
 }
@@ -51,7 +51,7 @@ fn simple_struct() {
     };
     let serialized = extension.tls_serialize().unwrap();
     let (deserialized, rest) =
-        <ExtensionStruct as DeserializeBytes>::tls_deserialize(&serialized).unwrap();
+        <ExtensionStruct as DeserializeBytes>::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, extension);
     assert_eq!(rest, []);
 }
@@ -66,7 +66,7 @@ fn tuple_struct() {
     let x = TupleStruct(ext, 6);
     let serialized = x.tls_serialize().unwrap();
     let (deserialized, rest) =
-        <TupleStruct as DeserializeBytes>::tls_deserialize(&serialized).unwrap();
+        <TupleStruct as DeserializeBytes>::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, x);
     assert_eq!(rest, []);
 }
@@ -75,7 +75,8 @@ fn tuple_struct() {
 fn byte_arrays() {
     let x = [0u8, 1, 2, 3];
     let serialized = x.tls_serialize().unwrap();
-    let (deserialized, rest) = <[u8; 4] as DeserializeBytes>::tls_deserialize(&serialized).unwrap();
+    let (deserialized, rest) =
+        <[u8; 4] as DeserializeBytes>::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, x);
     assert_eq!(rest, []);
 }
@@ -101,7 +102,7 @@ mod custom {
     pub fn tls_deserialize<T: DeserializeBytes>(
         bytes: &[u8],
     ) -> Result<(T, &[u8]), tls_codec::Error> {
-        <T as DeserializeBytes>::tls_deserialize(bytes)
+        <T as DeserializeBytes>::tls_deserialize_bytes(bytes)
     }
 }
 
@@ -113,7 +114,8 @@ fn custom() {
     };
     let serialized = x.tls_serialize().unwrap();
     assert_eq!(vec![3, 0, 1, 2, 3], serialized);
-    let (deserialized, rest) = <Custom as DeserializeBytes>::tls_deserialize(&serialized).unwrap();
+    let (deserialized, rest) =
+        <Custom as DeserializeBytes>::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, x);
     assert_eq!(rest, []);
 }
@@ -129,7 +131,7 @@ fn enum_with_tuple_variant() {
     let x = EnumWithTupleVariant::A(3, 4);
     let serialized = x.tls_serialize().unwrap();
     let (deserialized, rest) =
-        <EnumWithTupleVariant as DeserializeBytes>::tls_deserialize(&serialized).unwrap();
+        <EnumWithTupleVariant as DeserializeBytes>::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, x);
     assert_eq!(rest, []);
 }
@@ -145,7 +147,7 @@ fn enum_with_struct_variant() {
     let x = EnumWithStructVariant::A { foo: 3, bar: 4 };
     let serialized = x.tls_serialize().unwrap();
     let (deserialized, rest) =
-        <EnumWithStructVariant as DeserializeBytes>::tls_deserialize(&serialized).unwrap();
+        <EnumWithStructVariant as DeserializeBytes>::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, x);
     assert_eq!(rest, []);
 }
@@ -164,7 +166,8 @@ fn enum_with_data_and_discriminant() {
     let serialized = x.tls_serialize().unwrap();
 
     let (deserialized, rest) =
-        <EnumWithDataAndDiscriminant as DeserializeBytes>::tls_deserialize(&serialized).unwrap();
+        <EnumWithDataAndDiscriminant as DeserializeBytes>::tls_deserialize_bytes(&serialized)
+            .unwrap();
     assert_eq!(deserialized, x);
     assert_eq!(rest, []);
 }
@@ -174,7 +177,8 @@ fn discriminant_is_incremented_implicitly() {
     let x = EnumWithDataAndDiscriminant::B;
     let serialized = x.tls_serialize().unwrap();
     let (deserialized, rest) =
-        <EnumWithDataAndDiscriminant as DeserializeBytes>::tls_deserialize(&serialized).unwrap();
+        <EnumWithDataAndDiscriminant as DeserializeBytes>::tls_deserialize_bytes(&serialized)
+            .unwrap();
     assert_eq!(deserialized, x);
     assert_eq!(rest, []);
 }
@@ -209,7 +213,7 @@ fn enum_with_data_and_const_discriminant() {
     let serialized = x.tls_serialize().unwrap();
     assert_eq!(vec![0, 3, 4], serialized);
     let (deserialized, rest) =
-        <EnumWithDataAndConstDiscriminant as DeserializeBytes>::tls_deserialize(&serialized)
+        <EnumWithDataAndConstDiscriminant as DeserializeBytes>::tls_deserialize_bytes(&serialized)
             .unwrap();
     assert_eq!(deserialized, x);
     assert_eq!(rest, []);
@@ -217,7 +221,7 @@ fn enum_with_data_and_const_discriminant() {
     let x = EnumWithDataAndConstDiscriminant::B;
     let serialized = x.tls_serialize().unwrap();
     let (deserialized, rest) =
-        <EnumWithDataAndConstDiscriminant as DeserializeBytes>::tls_deserialize(&serialized)
+        <EnumWithDataAndConstDiscriminant as DeserializeBytes>::tls_deserialize_bytes(&serialized)
             .unwrap();
     assert_eq!(deserialized, x);
     assert_eq!(rest, []);
@@ -225,7 +229,7 @@ fn enum_with_data_and_const_discriminant() {
     let x = EnumWithDataAndConstDiscriminant::C;
     let serialized = x.tls_serialize().unwrap();
     let (deserialized, rest) =
-        <EnumWithDataAndConstDiscriminant as DeserializeBytes>::tls_deserialize(&serialized)
+        <EnumWithDataAndConstDiscriminant as DeserializeBytes>::tls_deserialize_bytes(&serialized)
             .unwrap();
     assert_eq!(deserialized, x);
     assert_eq!(rest, []);
@@ -242,7 +246,8 @@ fn enum_with_custom_serialized_field() {
     let x = EnumWithCustomSerializedField::A(vec![1, 2, 3]);
     let serialized = x.tls_serialize().unwrap();
     let (deserialized, rest) =
-        <EnumWithCustomSerializedField as DeserializeBytes>::tls_deserialize(&serialized).unwrap();
+        <EnumWithCustomSerializedField as DeserializeBytes>::tls_deserialize_bytes(&serialized)
+            .unwrap();
     assert_eq!(deserialized, x);
     assert_eq!(rest, []);
 }
@@ -254,7 +259,8 @@ fn that_skip_attribute_on_struct_works() {
         T: std::fmt::Debug + PartialEq + SerializeBytes + Size,
     {
         let serialized = test.tls_serialize().unwrap();
-        let (deserialized, rest) = <T as DeserializeBytes>::tls_deserialize(&serialized).unwrap();
+        let (deserialized, rest) =
+            <T as DeserializeBytes>::tls_deserialize_bytes(&serialized).unwrap();
         assert_eq!(deserialized, expected);
         assert_eq!(rest, []);
     }

--- a/tls_codec/derive/tests/decode_bytes.rs
+++ b/tls_codec/derive/tests/decode_bytes.rs
@@ -31,13 +31,11 @@ struct SomeValue {
 #[test]
 fn simple_enum() {
     let serialized = ExtensionType::KeyId.tls_serialize().unwrap();
-    let (deserialized, rest) =
-        <ExtensionType as DeserializeBytes>::tls_deserialize_bytes(&serialized).unwrap();
+    let (deserialized, rest) = ExtensionType::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, ExtensionType::KeyId);
     assert_eq!(rest, []);
     let serialized = ExtensionType::SomethingElse.tls_serialize().unwrap();
-    let (deserialized, rest) =
-        <ExtensionType as DeserializeBytes>::tls_deserialize_bytes(&serialized).unwrap();
+    let (deserialized, rest) = ExtensionType::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, ExtensionType::SomethingElse);
     assert_eq!(rest, []);
 }
@@ -50,8 +48,7 @@ fn simple_struct() {
         additional_data: None,
     };
     let serialized = extension.tls_serialize().unwrap();
-    let (deserialized, rest) =
-        <ExtensionStruct as DeserializeBytes>::tls_deserialize_bytes(&serialized).unwrap();
+    let (deserialized, rest) = ExtensionStruct::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, extension);
     assert_eq!(rest, []);
 }
@@ -65,8 +62,7 @@ fn tuple_struct() {
     };
     let x = TupleStruct(ext, 6);
     let serialized = x.tls_serialize().unwrap();
-    let (deserialized, rest) =
-        <TupleStruct as DeserializeBytes>::tls_deserialize_bytes(&serialized).unwrap();
+    let (deserialized, rest) = TupleStruct::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, x);
     assert_eq!(rest, []);
 }
@@ -102,7 +98,7 @@ mod custom {
     pub fn tls_deserialize<T: DeserializeBytes>(
         bytes: &[u8],
     ) -> Result<(T, &[u8]), tls_codec::Error> {
-        <T as DeserializeBytes>::tls_deserialize_bytes(bytes)
+        T::tls_deserialize_bytes(bytes)
     }
 }
 
@@ -114,8 +110,7 @@ fn custom() {
     };
     let serialized = x.tls_serialize().unwrap();
     assert_eq!(vec![3, 0, 1, 2, 3], serialized);
-    let (deserialized, rest) =
-        <Custom as DeserializeBytes>::tls_deserialize_bytes(&serialized).unwrap();
+    let (deserialized, rest) = Custom::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, x);
     assert_eq!(rest, []);
 }
@@ -130,8 +125,7 @@ enum EnumWithTupleVariant {
 fn enum_with_tuple_variant() {
     let x = EnumWithTupleVariant::A(3, 4);
     let serialized = x.tls_serialize().unwrap();
-    let (deserialized, rest) =
-        <EnumWithTupleVariant as DeserializeBytes>::tls_deserialize_bytes(&serialized).unwrap();
+    let (deserialized, rest) = EnumWithTupleVariant::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, x);
     assert_eq!(rest, []);
 }
@@ -146,8 +140,7 @@ enum EnumWithStructVariant {
 fn enum_with_struct_variant() {
     let x = EnumWithStructVariant::A { foo: 3, bar: 4 };
     let serialized = x.tls_serialize().unwrap();
-    let (deserialized, rest) =
-        <EnumWithStructVariant as DeserializeBytes>::tls_deserialize_bytes(&serialized).unwrap();
+    let (deserialized, rest) = EnumWithStructVariant::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, x);
     assert_eq!(rest, []);
 }
@@ -166,8 +159,7 @@ fn enum_with_data_and_discriminant() {
     let serialized = x.tls_serialize().unwrap();
 
     let (deserialized, rest) =
-        <EnumWithDataAndDiscriminant as DeserializeBytes>::tls_deserialize_bytes(&serialized)
-            .unwrap();
+        EnumWithDataAndDiscriminant::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, x);
     assert_eq!(rest, []);
 }
@@ -177,8 +169,7 @@ fn discriminant_is_incremented_implicitly() {
     let x = EnumWithDataAndDiscriminant::B;
     let serialized = x.tls_serialize().unwrap();
     let (deserialized, rest) =
-        <EnumWithDataAndDiscriminant as DeserializeBytes>::tls_deserialize_bytes(&serialized)
-            .unwrap();
+        EnumWithDataAndDiscriminant::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, x);
     assert_eq!(rest, []);
 }
@@ -213,24 +204,21 @@ fn enum_with_data_and_const_discriminant() {
     let serialized = x.tls_serialize().unwrap();
     assert_eq!(vec![0, 3, 4], serialized);
     let (deserialized, rest) =
-        <EnumWithDataAndConstDiscriminant as DeserializeBytes>::tls_deserialize_bytes(&serialized)
-            .unwrap();
+        EnumWithDataAndConstDiscriminant::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, x);
     assert_eq!(rest, []);
 
     let x = EnumWithDataAndConstDiscriminant::B;
     let serialized = x.tls_serialize().unwrap();
     let (deserialized, rest) =
-        <EnumWithDataAndConstDiscriminant as DeserializeBytes>::tls_deserialize_bytes(&serialized)
-            .unwrap();
+        EnumWithDataAndConstDiscriminant::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, x);
     assert_eq!(rest, []);
 
     let x = EnumWithDataAndConstDiscriminant::C;
     let serialized = x.tls_serialize().unwrap();
     let (deserialized, rest) =
-        <EnumWithDataAndConstDiscriminant as DeserializeBytes>::tls_deserialize_bytes(&serialized)
-            .unwrap();
+        EnumWithDataAndConstDiscriminant::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, x);
     assert_eq!(rest, []);
 }
@@ -246,8 +234,7 @@ fn enum_with_custom_serialized_field() {
     let x = EnumWithCustomSerializedField::A(vec![1, 2, 3]);
     let serialized = x.tls_serialize().unwrap();
     let (deserialized, rest) =
-        <EnumWithCustomSerializedField as DeserializeBytes>::tls_deserialize_bytes(&serialized)
-            .unwrap();
+        EnumWithCustomSerializedField::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, x);
     assert_eq!(rest, []);
 }
@@ -259,8 +246,7 @@ fn that_skip_attribute_on_struct_works() {
         T: std::fmt::Debug + PartialEq + SerializeBytes + Size,
     {
         let serialized = test.tls_serialize().unwrap();
-        let (deserialized, rest) =
-            <T as DeserializeBytes>::tls_deserialize_bytes(&serialized).unwrap();
+        let (deserialized, rest) = T::tls_deserialize_bytes(&serialized).unwrap();
         assert_eq!(deserialized, expected);
         assert_eq!(rest, []);
     }

--- a/tls_codec/src/arrays.rs
+++ b/tls_codec/src/arrays.rs
@@ -34,7 +34,7 @@ impl<const LEN: usize> Deserialize for [u8; LEN] {
 
 impl<const LEN: usize> DeserializeBytes for [u8; LEN] {
     #[inline]
-    fn tls_deserialize(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
         let out = bytes
             .get(..LEN)
             .ok_or(Error::EndOfStream)?

--- a/tls_codec/src/lib.rs
+++ b/tls_codec/src/lib.rs
@@ -192,17 +192,6 @@ pub trait Deserialize: Size {
 
         Ok(out)
     }
-    /// This function deserializes the provided `bytes` and returns the populated
-    /// struct.
-    ///
-    /// Returns an error if one occurs during deserialization.
-    #[cfg(feature = "std")]
-    fn tls_deserialize_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, Error>
-    where
-        Self: Sized,
-    {
-        Self::tls_deserialize(&mut bytes.as_ref())
-    }
 }
 
 pub trait DeserializeBytes: Size {

--- a/tls_codec/src/lib.rs
+++ b/tls_codec/src/lib.rs
@@ -212,7 +212,7 @@ pub trait DeserializeBytes: Size {
     /// In order to get the amount of bytes read, use [`Size::tls_serialized_len`].
     ///
     /// Returns an error if one occurs during deserialization.
-    fn tls_deserialize(bytes: &[u8]) -> Result<(Self, &[u8]), Error>
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error>
     where
         Self: Sized;
 
@@ -221,11 +221,11 @@ pub trait DeserializeBytes: Size {
     ///
     /// Returns an error if not all bytes are read from the input, or if an error
     /// occurs during deserialization.
-    fn tls_deserialize_exact(bytes: &[u8]) -> Result<Self, Error>
+    fn tls_deserialize_exact_bytes(bytes: &[u8]) -> Result<Self, Error>
     where
         Self: Sized,
     {
-        let (out, remainder) = Self::tls_deserialize(bytes)?;
+        let (out, remainder) = Self::tls_deserialize_bytes(bytes)?;
 
         if !remainder.is_empty() {
             return Err(Error::TrailingData);

--- a/tls_codec/src/primitives.rs
+++ b/tls_codec/src/primitives.rs
@@ -95,7 +95,7 @@ impl<T: Deserialize> Deserialize for Option<T> {
 impl<T: DeserializeBytes> DeserializeBytes for Option<T> {
     #[inline]
     fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
-        let (some_or_none, remainder) = <u8 as DeserializeBytes>::tls_deserialize_bytes(bytes)?;
+        let (some_or_none, remainder) = <u8>::tls_deserialize_bytes(bytes)?;
         match some_or_none {
             0 => {
                 Ok((None, remainder))

--- a/tls_codec/src/primitives.rs
+++ b/tls_codec/src/primitives.rs
@@ -94,14 +94,14 @@ impl<T: Deserialize> Deserialize for Option<T> {
 
 impl<T: DeserializeBytes> DeserializeBytes for Option<T> {
     #[inline]
-    fn tls_deserialize(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
-        let (some_or_none, remainder) = <u8 as DeserializeBytes>::tls_deserialize(bytes)?;
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
+        let (some_or_none, remainder) = <u8 as DeserializeBytes>::tls_deserialize_bytes(bytes)?;
         match some_or_none {
             0 => {
                 Ok((None, remainder))
             },
             1 => {
-                let (element, remainder) = T::tls_deserialize(remainder)?;
+                let (element, remainder) = T::tls_deserialize_bytes(remainder)?;
                 Ok((Some(element), remainder))
             },
             _ => Err(Error::DecodingError(alloc::format!("Trying to decode Option<T> with {} for option. It must be 0 for None and 1 for Some.", some_or_none)))
@@ -123,7 +123,7 @@ macro_rules! impl_unsigned {
 
         impl DeserializeBytes for $t {
             #[inline]
-            fn tls_deserialize(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
+            fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
                 let len = core::mem::size_of::<$t>();
                 let out = bytes
                     .get(..len)
@@ -215,9 +215,9 @@ where
     U: DeserializeBytes,
 {
     #[inline(always)]
-    fn tls_deserialize(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
-        let (first_element, remainder) = T::tls_deserialize(bytes)?;
-        let (second_element, remainder) = U::tls_deserialize(remainder)?;
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
+        let (first_element, remainder) = T::tls_deserialize_bytes(bytes)?;
+        let (second_element, remainder) = U::tls_deserialize_bytes(remainder)?;
         Ok(((first_element, second_element), remainder))
     }
 }
@@ -270,10 +270,10 @@ where
     V: DeserializeBytes,
 {
     #[inline(always)]
-    fn tls_deserialize(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
-        let (first_element, remainder) = T::tls_deserialize(bytes)?;
-        let (second_element, remainder) = U::tls_deserialize(remainder)?;
-        let (third_element, remainder) = V::tls_deserialize(remainder)?;
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
+        let (first_element, remainder) = T::tls_deserialize_bytes(bytes)?;
+        let (second_element, remainder) = U::tls_deserialize_bytes(remainder)?;
+        let (third_element, remainder) = V::tls_deserialize_bytes(remainder)?;
         Ok(((first_element, second_element, third_element), remainder))
     }
 }
@@ -322,7 +322,7 @@ impl Deserialize for () {
 
 impl DeserializeBytes for () {
     #[inline(always)]
-    fn tls_deserialize(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
         Ok(((), bytes))
     }
 }
@@ -351,7 +351,7 @@ impl<T> Deserialize for PhantomData<T> {
 
 impl<T> DeserializeBytes for PhantomData<T> {
     #[inline(always)]
-    fn tls_deserialize(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
         Ok((PhantomData, bytes))
     }
 }

--- a/tls_codec/src/quic_vec.rs
+++ b/tls_codec/src/quic_vec.rs
@@ -69,12 +69,12 @@ fn calculate_length(len_len_byte: u8) -> Result<(usize, usize), Error> {
 fn read_variable_length_bytes(bytes: &[u8]) -> Result<((usize, usize), &[u8]), Error> {
     // The length is encoded in the first two bits of the first byte.
 
-    let (len_len_byte, mut remainder) = <u8 as DeserializeBytes>::tls_deserialize_bytes(bytes)?;
+    let (len_len_byte, mut remainder) = u8::tls_deserialize_bytes(bytes)?;
 
     let (mut length, len_len) = calculate_length(len_len_byte)?;
 
     for _ in 1..len_len {
-        let (next, next_remainder) = <u8 as DeserializeBytes>::tls_deserialize_bytes(remainder)?;
+        let (next, next_remainder) = u8::tls_deserialize_bytes(remainder)?;
         remainder = next_remainder;
         length = (length << 8) + usize::from(next);
     }

--- a/tls_codec/src/quic_vec.rs
+++ b/tls_codec/src/quic_vec.rs
@@ -680,7 +680,7 @@ mod secret_bytes {
         where
             Self: Sized,
         {
-            let (bytes, remainder) = <VLBytes as DeserializeBytes>::tls_deserialize_bytes(bytes)?;
+            let (bytes, remainder) = VLBytes::tls_deserialize_bytes(bytes)?;
             Ok((Self(bytes), remainder))
         }
     }
@@ -696,7 +696,7 @@ mod secret_bytes {
         where
             Self: Sized,
         {
-            Ok(Self(<VLBytes as Deserialize>::tls_deserialize(bytes)?))
+            Ok(Self(VLBytes::tls_deserialize(bytes)?))
         }
     }
 }

--- a/tls_codec/src/tls_vec.rs
+++ b/tls_codec/src/tls_vec.rs
@@ -62,7 +62,7 @@ macro_rules! impl_byte_deserialize {
 
         #[inline(always)]
         fn deserialize_bytes_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
-            let (type_len, remainder) = <$size as DeserializeBytes>::tls_deserialize(bytes)?;
+            let (type_len, remainder) = <$size as DeserializeBytes>::tls_deserialize_bytes(bytes)?;
             let len = type_len as usize;
             // When fuzzing we limit the maximum size to allocate.
             // XXX: We should think about a configurable limit for the allocation
@@ -107,12 +107,12 @@ macro_rules! impl_deserialize_bytes {
         #[inline(always)]
         fn deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
             let mut result = Self { vec: Vec::new() };
-            let (len, mut remainder) = <$size as DeserializeBytes>::tls_deserialize(bytes)?;
+            let (len, mut remainder) = <$size as DeserializeBytes>::tls_deserialize_bytes(bytes)?;
             let mut read = len.tls_serialized_len();
             let len_len = read;
             while (read - len_len) < len as usize {
                 let (element, next_remainder) =
-                    <T as DeserializeBytes>::tls_deserialize(remainder)?;
+                    <T as DeserializeBytes>::tls_deserialize_bytes(remainder)?;
                 remainder = next_remainder;
                 read += element.tls_serialized_len();
                 result.push(element);
@@ -261,7 +261,7 @@ macro_rules! impl_tls_vec_codec_generic {
         }
 
         impl<T: $($bounds + )* DeserializeBytes> DeserializeBytes for $name<T> {
-            fn tls_deserialize(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
+            fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
                 Self::deserialize_bytes(bytes)
             }
         }
@@ -306,7 +306,7 @@ macro_rules! impl_tls_vec_codec_bytes {
         }
 
         impl DeserializeBytes for $name {
-            fn tls_deserialize(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
+            fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
                 Self::deserialize_bytes_bytes(bytes)
             }
         }

--- a/tls_codec/src/tls_vec.rs
+++ b/tls_codec/src/tls_vec.rs
@@ -42,7 +42,7 @@ macro_rules! impl_byte_deserialize {
         #[cfg(feature = "std")]
         #[inline(always)]
         fn deserialize_bytes<R: Read>(bytes: &mut R) -> Result<Self, Error> {
-            let len = <$size as Deserialize>::tls_deserialize(bytes)? as usize;
+            let len = <$size>::tls_deserialize(bytes)? as usize;
             // When fuzzing we limit the maximum size to allocate.
             // XXX: We should think about a configurable limit for the allocation
             //      here.
@@ -62,7 +62,7 @@ macro_rules! impl_byte_deserialize {
 
         #[inline(always)]
         fn deserialize_bytes_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
-            let (type_len, remainder) = <$size as DeserializeBytes>::tls_deserialize_bytes(bytes)?;
+            let (type_len, remainder) = <$size>::tls_deserialize_bytes(bytes)?;
             let len = type_len as usize;
             // When fuzzing we limit the maximum size to allocate.
             // XXX: We should think about a configurable limit for the allocation
@@ -89,7 +89,7 @@ macro_rules! impl_deserialize {
         #[inline(always)]
         fn deserialize<R: Read>(bytes: &mut R) -> Result<Self, Error> {
             let mut result = Self { vec: Vec::new() };
-            let len = <$size as Deserialize>::tls_deserialize(bytes)?;
+            let len = <$size>::tls_deserialize(bytes)?;
             let mut read = len.tls_serialized_len();
             let len_len = read;
             while (read - len_len) < len as usize {
@@ -107,12 +107,11 @@ macro_rules! impl_deserialize_bytes {
         #[inline(always)]
         fn deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
             let mut result = Self { vec: Vec::new() };
-            let (len, mut remainder) = <$size as DeserializeBytes>::tls_deserialize_bytes(bytes)?;
+            let (len, mut remainder) = <$size>::tls_deserialize_bytes(bytes)?;
             let mut read = len.tls_serialized_len();
             let len_len = read;
             while (read - len_len) < len as usize {
-                let (element, next_remainder) =
-                    <T as DeserializeBytes>::tls_deserialize_bytes(remainder)?;
+                let (element, next_remainder) = T::tls_deserialize_bytes(remainder)?;
                 remainder = next_remainder;
                 read += element.tls_serialized_len();
                 result.push(element);

--- a/tls_codec/tests/decode.rs
+++ b/tls_codec/tests/decode.rs
@@ -171,10 +171,8 @@ fn deserialize_tuples() {
     {
         use tls_codec::DeserializeBytes;
         let (deserialized_bytes, _remainder) =
-            <(TlsVecU16<u8>, TlsVecU32<u16>) as DeserializeBytes>::tls_deserialize_bytes(
-                bytes.as_slice(),
-            )
-            .expect("Error deserializing tuple.");
+            <(TlsVecU16<u8>, TlsVecU32<u16>)>::tls_deserialize_bytes(bytes.as_slice())
+                .expect("Error deserializing tuple.");
         assert_eq!(deserialized_bytes, t);
     }
 
@@ -199,7 +197,7 @@ fn deserialize_var_len_vec() {
             use tls_codec::DeserializeBytes;
             let serialized = v.tls_serialize_detached().expect("Error encoding vector");
             let (deserialized, _remainder): (Vec<T>, &[u8]) =
-                <Vec<T> as DeserializeBytes>::tls_deserialize_bytes(serialized.as_slice())
+                Vec::<T>::tls_deserialize_bytes(serialized.as_slice())
                     .expect("Error deserializing vector");
             assert_eq!(deserialized, v);
         }

--- a/tls_codec/tests/decode.rs
+++ b/tls_codec/tests/decode.rs
@@ -29,8 +29,8 @@ fn deserialize_option_bytes() {
     use tls_codec::DeserializeBytes;
     for b in [Some(0u8), None] {
         let b_encoded = b.tls_serialize_detached().expect("Unable to tls_serialize");
-        let (b_decoded, remainder) =
-            Option::<u8>::tls_deserialize(b_encoded.as_slice()).expect("Unable to tls_deserialize");
+        let (b_decoded, remainder) = Option::<u8>::tls_deserialize_bytes(b_encoded.as_slice())
+            .expect("Unable to tls_deserialize");
 
         assert!(remainder.is_empty());
 
@@ -43,19 +43,19 @@ fn deserialize_bytes_primitives() {
     use tls_codec::DeserializeBytes;
     let b = &[77u8, 88, 1, 99] as &[u8];
 
-    let (a, remainder) = u8::tls_deserialize(b).expect("Unable to tls_deserialize");
+    let (a, remainder) = u8::tls_deserialize_bytes(b).expect("Unable to tls_deserialize");
     assert_eq!(1, a.tls_serialized_len());
     assert_eq!(77, a);
-    let (a, remainder) = u8::tls_deserialize(remainder).expect("Unable to tls_deserialize");
+    let (a, remainder) = u8::tls_deserialize_bytes(remainder).expect("Unable to tls_deserialize");
     assert_eq!(1, a.tls_serialized_len());
     assert_eq!(88, a);
-    let (a, remainder) = u16::tls_deserialize(remainder).expect("Unable to tls_deserialize");
+    let (a, remainder) = u16::tls_deserialize_bytes(remainder).expect("Unable to tls_deserialize");
     assert_eq!(2, a.tls_serialized_len());
     assert_eq!(355, a);
 
     // It's empty now.
     assert!(remainder.is_empty());
-    assert!(u8::tls_deserialize(remainder).is_err())
+    assert!(u8::tls_deserialize_bytes(remainder).is_err())
 }
 
 #[test]
@@ -91,22 +91,22 @@ fn deserialize_bytes_tls_vec() {
     use tls_codec::DeserializeBytes;
     let b = &[1u8, 4, 77, 88, 1, 99] as &[u8];
 
-    let (a, remainder) = u8::tls_deserialize(b).expect("Unable to tls_deserialize");
+    let (a, remainder) = u8::tls_deserialize_bytes(b).expect("Unable to tls_deserialize");
     assert_eq!(1, a);
     assert_eq!(1, a.tls_serialized_len());
     println!("b: {b:?}");
     let (v, remainder) =
-        TlsVecU8::<u8>::tls_deserialize(remainder).expect("Unable to tls_deserialize");
+        TlsVecU8::<u8>::tls_deserialize_bytes(remainder).expect("Unable to tls_deserialize");
     assert_eq!(5, v.tls_serialized_len());
     assert_eq!(&[77, 88, 1, 99], v.as_slice());
 
     // It's empty now.
-    assert!(u8::tls_deserialize(remainder).is_err());
+    assert!(u8::tls_deserialize_bytes(remainder).is_err());
 
     let long_vector = vec![77u8; 65535];
     let serialized_long_vec = TlsSliceU16(&long_vector).tls_serialize_detached().unwrap();
     let (deserialized_long_vec, _remainder) =
-        TlsVecU16::<u8>::tls_deserialize(serialized_long_vec.as_slice()).unwrap();
+        TlsVecU16::<u8>::tls_deserialize_bytes(serialized_long_vec.as_slice()).unwrap();
     assert_eq!(
         deserialized_long_vec.tls_serialized_len(),
         long_vector.len() + 2
@@ -171,7 +171,7 @@ fn deserialize_tuples() {
     {
         use tls_codec::DeserializeBytes;
         let (deserialized_bytes, _remainder) =
-            <(TlsVecU16<u8>, TlsVecU32<u16>) as DeserializeBytes>::tls_deserialize(
+            <(TlsVecU16<u8>, TlsVecU32<u16>) as DeserializeBytes>::tls_deserialize_bytes(
                 bytes.as_slice(),
             )
             .expect("Error deserializing tuple.");
@@ -199,7 +199,7 @@ fn deserialize_var_len_vec() {
             use tls_codec::DeserializeBytes;
             let serialized = v.tls_serialize_detached().expect("Error encoding vector");
             let (deserialized, _remainder): (Vec<T>, &[u8]) =
-                <Vec<T> as DeserializeBytes>::tls_deserialize(serialized.as_slice())
+                <Vec<T> as DeserializeBytes>::tls_deserialize_bytes(serialized.as_slice())
                     .expect("Error deserializing vector");
             assert_eq!(deserialized, v);
         }
@@ -258,7 +258,7 @@ fn deserialize_bytes_tls_vl_bytes() {
     use tls_codec::DeserializeBytes;
     let b = &[4u8, 77, 88, 1, 99];
 
-    let (v, remainder) = VLBytes::tls_deserialize(b).expect("Unable to tls_deserialize");
+    let (v, remainder) = VLBytes::tls_deserialize_bytes(b).expect("Unable to tls_deserialize");
     assert_eq!(5, v.tls_serialized_len());
     assert_eq!(&[77, 88, 1, 99], v.as_slice());
 
@@ -269,7 +269,7 @@ fn deserialize_bytes_tls_vl_bytes() {
     let serialized_long_vec = VLByteSlice(&long_vector).tls_serialize_detached().unwrap();
     std::println!("bytes: {:x?}", &serialized_long_vec[0..5]);
     let (deserialized_long_vec, remainder) =
-        VLBytes::tls_deserialize(serialized_long_vec.as_slice()).unwrap();
+        VLBytes::tls_deserialize_bytes(serialized_long_vec.as_slice()).unwrap();
     assert_eq!(
         deserialized_long_vec.tls_serialized_len(),
         long_vector.len() + 4
@@ -296,7 +296,7 @@ fn deserialize_tls_vl_invalid_length() {
 fn deserialize_bytes_tls_vl_invalid_length() {
     use tls_codec::DeserializeBytes;
     let b = &[0x40u8, 3, 10, 20, 30] as &[u8];
-    let result = VLBytes::tls_deserialize(b);
+    let result = VLBytes::tls_deserialize_bytes(b);
     if cfg!(feature = "mls") {
         assert_eq!(result, Err(Error::InvalidVectorLength));
     } else {
@@ -319,8 +319,8 @@ fn deserialize_empty_vl_bytes() {
 fn deserialize_bytes_empty_vl_bytes() {
     use tls_codec::DeserializeBytes;
     let b: &[u8] = &[0x00];
-    VLBytes::tls_deserialize(b).expect("Error parsing empty bytes");
+    VLBytes::tls_deserialize_bytes(b).expect("Error parsing empty bytes");
 
     let b: &[u8] = &[];
-    VLBytes::tls_deserialize(b).expect_err("Empty bytes were parsed successfully");
+    VLBytes::tls_deserialize_bytes(b).expect_err("Empty bytes were parsed successfully");
 }

--- a/tls_codec/tests/decode_bytes.rs
+++ b/tls_codec/tests/decode_bytes.rs
@@ -3,7 +3,7 @@ use tls_codec::{DeserializeBytes, TlsByteVecU16, TlsByteVecU32, TlsByteVecU8};
 #[test]
 fn deserialize_tls_byte_vec_u8() {
     let bytes = [3, 2, 1, 0];
-    let (result, rest) = TlsByteVecU8::tls_deserialize(&bytes).unwrap();
+    let (result, rest) = TlsByteVecU8::tls_deserialize_bytes(&bytes).unwrap();
     let expected_result = [2, 1, 0];
     assert_eq!(result.as_slice(), expected_result);
     assert_eq!(rest, []);
@@ -12,7 +12,7 @@ fn deserialize_tls_byte_vec_u8() {
 #[test]
 fn deserialize_tls_byte_vec_u16() {
     let bytes = [0, 3, 2, 1, 0];
-    let (result, rest) = TlsByteVecU16::tls_deserialize(&bytes).unwrap();
+    let (result, rest) = TlsByteVecU16::tls_deserialize_bytes(&bytes).unwrap();
     let expected_result = [2, 1, 0];
     assert_eq!(result.as_slice(), expected_result);
     assert_eq!(rest, []);
@@ -21,7 +21,7 @@ fn deserialize_tls_byte_vec_u16() {
 #[test]
 fn deserialize_tls_byte_vec_u32() {
     let bytes = [0, 0, 0, 3, 2, 1, 0];
-    let (result, rest) = TlsByteVecU32::tls_deserialize(&bytes).unwrap();
+    let (result, rest) = TlsByteVecU32::tls_deserialize_bytes(&bytes).unwrap();
     let expected_result = [2, 1, 0];
     assert_eq!(result.as_slice(), expected_result);
     assert_eq!(rest, []);


### PR DESCRIPTION
This is a breaking change renaming the functions in the `DeserializeBytes` trait to avoid collisions with the functions in the `Deserialize` trait. The functions are renamed by appending a `_bytes` suffix.