### PR TITLE
spki: adds a public key to SubjectPublicKeyInfoOwned helper

### DIFF
--- a/spki/src/spki.rs
+++ b/spki/src/spki.rs
@@ -181,6 +181,7 @@ impl<Params, Key> PemLabel for SubjectPublicKeyInfo<Params, Key> {
 #[cfg(feature = "alloc")]
 mod allocating {
     use super::*;
+    use crate::EncodePublicKey;
     use der::referenced::*;
 
     impl<'a> RefToOwned<'a> for SubjectPublicKeyInfoRef<'a> {
@@ -200,6 +201,17 @@ mod allocating {
                 algorithm: self.algorithm.owned_to_ref(),
                 subject_public_key: self.subject_public_key.owned_to_ref(),
             }
+        }
+    }
+
+    impl SubjectPublicKeyInfoOwned {
+        /// Create a [`SubjectPublicKeyInfoOwned`] from any object that implements
+        /// [`EncodePublicKey`].
+        pub fn from_key<T>(source: T) -> Result<Self>
+        where
+            T: EncodePublicKey,
+        {
+            Ok(source.to_public_key_der()?.decode_msg::<Self>()?)
         }
     }
 }


### PR DESCRIPTION
This adds a `SubjectPublicKeyInfoOwned::from_key` helper that will accept any public key (an object implementing `EncodePublicKey`).