### PR TITLE
.cargo/audit.toml: ignore RUSTSEC-2023-0071

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,4 +1,5 @@
 [advisories]
 ignore = [
     "RUSTSEC-2021-0127", # serde_cbor is unmaintained
+    "RUSTSEC-2023-0071", # rsa: Marvin Attack: potential key recovery
 ]


### PR DESCRIPTION
It's not actionable until a new release of the `rsa` crate is available