### PR TITLE
x509-cert v0.2.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1599,17 +1599,7 @@ dependencies = [
  "criterion",
  "regex",
  "serde",
- "tls_codec_derive 0.3.0",
- "zeroize",
-]
-
-[[package]]
-name = "tls_codec"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38a1d5fcfa859f0ec2b5e111dc903890bd7dac7f34713232bf9aa4fd7cad7b2"
-dependencies = [
- "tls_codec_derive 0.4.0",
+ "tls_codec_derive",
  "zeroize",
 ]
 
@@ -1620,19 +1610,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "tls_codec 0.3.1",
+ "tls_codec",
  "trybuild",
-]
-
-[[package]]
-name = "tls_codec_derive"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e00e3e7a54e0f1c8834ce72ed49c8487fbd3f801d8cfe1a0ad0640382f8e15"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1856,7 +1835,7 @@ dependencies = [
 
 [[package]]
 name = "x509-cert"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "arbitrary",
  "const-oid 0.9.5",
@@ -1872,7 +1851,7 @@ dependencies = [
  "signature",
  "spki",
  "tempfile",
- "tls_codec 0.4.0",
+ "tls_codec",
  "x509-cert-test-support",
 ]
 

--- a/x509-cert/CHANGELOG.md
+++ b/x509-cert/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.5 (2023-12-23)
+
+### Added
+- Signed Certificate Timestamp (SCT) extension support ([#1134])
+
+### Changed
+- Relax dependencies ([#1179])
+- Use `SubjectPublicKeyInfoOwned::from_key` ([#1271])
+
+[#1134]: https://github.com/RustCrypto/formats/pull/1134
+[#1179]: https://github.com/RustCrypto/formats/pull/1179
+[#1271]: https://github.com/RustCrypto/formats/pull/1271
+
 ## 0.2.4 (2023-07-25)
 
 ### Added

--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x509-cert"
-version = "0.2.4"
+version = "0.2.5"
 description = """
 Pure Rust implementation of the X.509 Public Key Infrastructure Certificate
 format as described in RFC 5280


### PR DESCRIPTION
### Added
- Signed Certificate Timestamp (SCT) extension support ([#1134])

### Changed
- Relax dependencies ([#1179])
- Use `SubjectPublicKeyInfoOwned::from_key` ([#1271])

[#1134]: https://github.com/RustCrypto/formats/pull/1134
[#1179]: https://github.com/RustCrypto/formats/pull/1179
[#1271]: https://github.com/RustCrypto/formats/pull/1271