### PR TITLE
spki: borrow the public key in `spki::from_key`

### DIFF
--- a/spki/src/spki.rs
+++ b/spki/src/spki.rs
@@ -207,7 +207,7 @@ mod allocating {
     impl SubjectPublicKeyInfoOwned {
         /// Create a [`SubjectPublicKeyInfoOwned`] from any object that implements
         /// [`EncodePublicKey`].
-        pub fn from_key<T>(source: T) -> Result<Self>
+        pub fn from_key<T>(source: &T) -> Result<Self>
         where
             T: EncodePublicKey,
         {


### PR DESCRIPTION
`SubjectPublicKeyInfoOwned` does not require the ownership of the key.

This is a breaking change.