### PR TITLE
x509-cert: spki::from_key api break 

### DIFF
--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.65"
 [dependencies]
 const-oid = { version = "0.9.6", features = ["db"] }
 der = { version = "0.7.6", features = ["alloc", "derive", "flagset", "oid"] }
-spki = { version = "0.7.3", features = ["alloc"] }
+spki = { version = "0.8.0-pre", features = ["alloc"] }
 
 # optional dependencies
 arbitrary = { version = "1.3", features = ["derive"], optional = true }

--- a/x509-cert/src/builder.rs
+++ b/x509-cert/src/builder.rs
@@ -276,7 +276,7 @@ where
         cert_signer: &'s S,
     ) -> Result<Self> {
         let verifying_key = cert_signer.verifying_key();
-        let signer_pub = SubjectPublicKeyInfoOwned::from_key(verifying_key)?;
+        let signer_pub = SubjectPublicKeyInfoOwned::from_key(&verifying_key)?;
 
         let signature_alg = cert_signer.signature_algorithm_identifier()?;
         let issuer = profile.get_issuer(&subject);
@@ -368,7 +368,7 @@ where
     pub fn new(subject: Name, req_signer: &'s S) -> Result<Self> {
         let version = Default::default();
         let verifying_key = req_signer.verifying_key();
-        let public_key = SubjectPublicKeyInfoOwned::from_key(verifying_key)?;
+        let public_key = SubjectPublicKeyInfoOwned::from_key(&verifying_key)?;
         let attributes = Default::default();
         let extension_req = Default::default();
 


### PR DESCRIPTION
Blocking on:
 - #1290 
 - #1296 
 - Bump of x509-cert to 0.3.0-pre