### PR TITLE
sec1: migrate from `generic-array` to `hybrid-array`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,6 +781,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hybrid-array"
+version = "0.2.0-pre.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27fbaf242418fe980caf09ed348d5a6aeabe71fc1bd8bebad641f4591ae0a46d"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1408,8 +1417,8 @@ version = "0.8.0-pre"
 dependencies = [
  "base16ct",
  "der 0.8.0-pre",
- "generic-array",
  "hex-literal 0.4.1",
+ "hybrid-array",
  "pkcs8 0.11.0-pre",
  "serdect",
  "subtle",

--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.70"
 [dependencies]
 base16ct = { version = "0.2", optional = true, default-features = false }
 der = { version = "=0.8.0-pre", optional = true, features = ["oid"] }
-generic-array = { version = "0.14.7", optional = true, default-features = false }
+hybrid-array = { version = "=0.2.0-pre.8", optional = true, default-features = false }
 pkcs8 = { version = "=0.11.0-pre", optional = true, default-features = false }
 serdect = { version = "=0.3.0-pre", optional = true, default-features = false, features = ["alloc"] }
 subtle = { version = "2", optional = true, default-features = false }
@@ -35,7 +35,7 @@ std = ["alloc", "der?/std"]
 
 der = ["dep:der", "zeroize"]
 pem = ["alloc", "der/pem", "pkcs8/pem"]
-point = ["dep:base16ct", "dep:generic-array"]
+point = ["dep:base16ct", "dep:hybrid-array"]
 serde = ["dep:serdect"]
 zeroize = ["dep:zeroize", "der?/zeroize"]
 

--- a/sec1/src/lib.rs
+++ b/sec1/src/lib.rs
@@ -49,7 +49,7 @@ pub use crate::error::{Error, Result};
 pub use crate::point::EncodedPoint;
 
 #[cfg(feature = "point")]
-pub use generic_array::typenum::consts;
+pub use hybrid_array::typenum::consts;
 
 #[cfg(feature = "der")]
 pub use crate::{parameters::EcParameters, private_key::EcPrivateKey, traits::DecodeEcPrivateKey};


### PR DESCRIPTION
The RustCrypto/traits crates are now using `hybrid-array`, which features a mostly safe implementation that natively leverages const generics as much as possible.