### PR TITLE
der: bump `const-oid` to v0.10.0-pre.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,7 @@ version = "0.8.0-pre"
 dependencies = [
  "arbitrary",
  "bytes",
- "const-oid 0.9.6",
+ "const-oid 0.10.0-pre.1",
  "der_derive 0.8.0-pre",
  "flagset",
  "hex-literal 0.4.1",
@@ -1008,7 +1008,7 @@ dependencies = [
 name = "pkcs1"
 version = "0.8.0-pre"
 dependencies = [
- "const-oid 0.9.6",
+ "const-oid 0.10.0-pre.1",
  "der 0.8.0-pre",
  "hex-literal 0.4.1",
  "pkcs8 0.11.0-pre",

--- a/cmpv2/Cargo.toml
+++ b/cmpv2/Cargo.toml
@@ -21,7 +21,7 @@ spki = { version = "0.7" }
 x509-cert = { version = "0.2", default-features = false }
 
 [dev-dependencies]
-const-oid = { version = "0.9", features = ["db"] } # TODO: path = "../const-oid"
+const-oid = { version = "0.9", features = ["db"] }
 hex-literal = "0.4"
 
 [features]

--- a/cms/Cargo.toml
+++ b/cms/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.65"
 der = { version = "0.7.7", features = ["alloc", "derive", "oid", "pem"] }
 spki = { version = "0.7" }
 x509-cert = { version = "0.2.3", default-features = false, features = ["pem"] }
-const-oid = { version = "0.9.4", features = ["db"] } # TODO: path = "../const-oid"
+const-oid = { version = "0.9.4", features = ["db"] }
 
 # optional dependencies
 aes = { version = "0.8.2", optional = true }

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.65"
 [dependencies]
 arbitrary = { version = "1.3", features = ["derive"], optional = true }
 bytes = { version = "1", optional = true, default-features = false }
-const-oid = { version = "0.9.2", optional = true }
+const-oid = { version = "=0.10.0-pre.1", optional = true }
 der_derive = { version = "=0.8.0-pre", optional = true }
 flagset = { version = "0.4.4", optional = true }
 pem-rfc7468 = { version = "=1.0.0-pre", optional = true, features = ["alloc"] }

--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -22,7 +22,7 @@ spki = { version = "=0.8.0-pre" }
 pkcs8 = { version = "=0.11.0-pre", optional = true, default-features = false }
 
 [dev-dependencies]
-const-oid = { version = "0.9", features = ["db"] } # TODO: path = "../const-oid"
+const-oid = { version = "=0.10.0-pre.1", features = ["db"] }
 hex-literal = "0.4"
 tempfile = "3"
 

--- a/pkcs12/Cargo.toml
+++ b/pkcs12/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.65"
 der = { version = "0.7.8", features = ["alloc", "derive", "oid", "pem"] }
 spki = { version = "0.7" }
 x509-cert = { version = "0.2.3", default-features = false, features = ["pem"] }
-const-oid = { version = "0.9", features = ["db"] } # TODO: path = "../const-oid"
+const-oid = { version = "0.9", features = ["db"] }
 cms = "0.2.1"
 digest = { version = "0.10.7", features=["alloc"], optional = true }
 zeroize = "1.6.0"


### PR DESCRIPTION
...as sourced from this repo, as it has diverged from the crate release.

This is possible now that #1299 has landed.