### PR TITLE
const-oid: make `ObjectIdentifier::as_bytes` a `const fn`

### DIFF
--- a/.github/workflows/const-oid.yml
+++ b/.github/workflows/const-oid.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.71.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.71.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/der.yml
+++ b/.github/workflows/der.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.71.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -51,7 +51,7 @@ jobs:
           # 32-bit Linux
           - targets: i686-unknown-linux-gnu
             platform: ubuntu-latest
-            rust: 1.65.0 # MSRV
+            rust: 1.71.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - targets: i686-unknown-linux-gnu
             platform: ubuntu-latest
@@ -61,7 +61,7 @@ jobs:
           # 64-bit Linux
           - targets: x86_64-unknown-linux-gnu
             platform: ubuntu-latest
-            rust: 1.65.0 # MSRV
+            rust: 1.71.0 # MSRV
           - targets: x86_64-unknown-linux-gnu
             platform: ubuntu-latest
             rust: stable
@@ -70,7 +70,7 @@ jobs:
           # 64-bit Windows
           #- targets: x86_64-pc-windows-msvc
           #  platform: windows-latest
-          #  rust: 1.65.0 # MSRV
+          #  rust: 1.71.0 # MSRV
           #- targets: x86_64-pc-windows-msvc
           #  platform: windows-latest
           #  rust: stable
@@ -90,7 +90,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.71.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pkcs1.yml
+++ b/.github/workflows/pkcs1.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.71.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.71.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pkcs5.yml
+++ b/.github/workflows/pkcs5.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.71.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.71.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pkcs8.yml
+++ b/.github/workflows/pkcs8.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.71.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.71.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/sec1.yml
+++ b/.github/workflows/sec1.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.70.0 # MSRV
+          - 1.71.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.70.0 # MSRV
+          - 1.71.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/spki.yml
+++ b/.github/workflows/spki.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.71.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.71.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/const-oid/Cargo.toml
+++ b/const-oid/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["cryptography", "data-structures", "encoding", "no-std", "parser-i
 keywords = ["iso", "iec", "itu", "oid"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.71"
 
 [dependencies]
 arbitrary = { version = "1.2", optional = true, features = ["derive"] }

--- a/const-oid/README.md
+++ b/const-oid/README.md
@@ -57,7 +57,7 @@ well as a runtime OID library.
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.65** at a minimum.
+This crate requires **Rust 1.71** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -84,7 +84,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/const-oid/badge.svg
 [docs-link]: https://docs.rs/const-oid/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.71+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 [build-image]: https://github.com/RustCrypto/formats/workflows/const-oid/badge.svg?branch=master&event=push

--- a/const-oid/src/buffer.rs
+++ b/const-oid/src/buffer.rs
@@ -12,8 +12,8 @@ pub struct Buffer<const SIZE: usize> {
 
 impl<const SIZE: usize> Buffer<SIZE> {
     /// Borrow the inner byte slice.
-    pub fn as_bytes(&self) -> &[u8] {
-        &self.bytes[..self.length as usize]
+    pub const fn as_bytes(&self) -> &[u8] {
+        self.bytes.split_at(self.length as usize).0
     }
 
     /// Get the length of the BER message.

--- a/const-oid/src/encoder.rs
+++ b/const-oid/src/encoder.rs
@@ -7,12 +7,12 @@ use crate::{
 
 /// BER/DER encoder
 #[derive(Debug)]
-pub(crate) struct Encoder {
+pub(crate) struct Encoder<const MAX_SIZE: usize> {
     /// Current state
     state: State,
 
     /// Bytes of the OID being encoded in-progress
-    bytes: [u8; ObjectIdentifier::MAX_SIZE],
+    bytes: [u8; MAX_SIZE],
 
     /// Current position within the byte buffer
     cursor: usize,
@@ -31,18 +31,18 @@ enum State {
     Body,
 }
 
-impl Encoder {
+impl<const MAX_SIZE: usize> Encoder<MAX_SIZE> {
     /// Create a new encoder initialized to an empty default state.
     pub(crate) const fn new() -> Self {
         Self {
             state: State::Initial,
-            bytes: [0u8; ObjectIdentifier::MAX_SIZE],
+            bytes: [0u8; MAX_SIZE],
             cursor: 0,
         }
     }
 
     /// Extend an existing OID.
-    pub(crate) const fn extend(oid: ObjectIdentifier) -> Self {
+    pub(crate) const fn extend(oid: ObjectIdentifier<MAX_SIZE>) -> Self {
         Self {
             state: State::Body,
             bytes: oid.buffer.bytes,
@@ -99,7 +99,7 @@ impl Encoder {
     }
 
     /// Finish encoding an OID.
-    pub(crate) const fn finish(self) -> Result<ObjectIdentifier> {
+    pub(crate) const fn finish(self) -> Result<ObjectIdentifier<MAX_SIZE>> {
         if self.cursor >= 2 {
             let bytes = Buffer {
                 bytes: self.bytes,
@@ -156,7 +156,7 @@ mod tests {
 
     #[test]
     fn encode() {
-        let encoder = Encoder::new();
+        let encoder = Encoder::<7>::new();
         let encoder = encoder.arc(1).unwrap();
         let encoder = encoder.arc(2).unwrap();
         let encoder = encoder.arc(840).unwrap();

--- a/const-oid/src/parser.rs
+++ b/const-oid/src/parser.rs
@@ -11,7 +11,7 @@ pub(crate) struct Parser {
     current_arc: Arc,
 
     /// BER/DER encoder
-    encoder: Encoder,
+    encoder: Encoder<{ ObjectIdentifier::MAX_SIZE }>,
 }
 
 impl Parser {

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "data-structures", "encoding", "no-std", "parser-i
 keywords = ["asn1", "crypto", "itu", "pkcs"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.71"
 
 [dependencies]
 arbitrary = { version = "1.3", features = ["derive"], optional = true }

--- a/der/README.md
+++ b/der/README.md
@@ -18,15 +18,15 @@ This crate provides a `no_std`-friendly implementation of a subset of ASN.1 DER
 necessary for decoding/encoding the following cryptography-related formats
 implemented as crates maintained by the [RustCrypto] project:
 
+- [`cms`]: Cryptographic Message Syntax
 - [`pkcs1`]: RSA Cryptography Specifications
 - [`pkcs5`]: Password-Based Cryptography Specification
-- [`pkcs7`]: Cryptographic Message Syntax
 - [`pkcs8`]: Private-Key Information Syntax Specification
-- [`pkcs10`]: Certification Request Syntax Specification
+- [`pkcs12`]: Personal Information Exchange Syntax
 - [`sec1`]: Elliptic Curve Cryptography
 - [`spki`]: X.509 Subject Public Key Info
-- [`x501`]: Directory Services Types
-- [`x509`]: Public Key Infrastructure Certificate
+- [`x509-cert`]: Public Key Infrastructure Certificate
+- [`x509-ocsp`]: Online Certificate Status Protocol
 
 The core implementation avoids any heap usage (with convenience methods
 that allocate gated under the off-by-default `alloc` feature).
@@ -49,7 +49,7 @@ encountered. There is currently no way to disable these checks.
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.65** at a minimum.
+This crate requires **Rust 1.71** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -78,19 +78,19 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/formats/actions/workflows/der.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/formats/actions/workflows/der.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.71+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 
 [//]: # (links)
 
 [RustCrypto]: https://github.com/rustcrypto
+[`cms`]: https://github.com/RustCrypto/formats/tree/master/cms
 [`pkcs1`]: https://github.com/RustCrypto/formats/tree/master/pkcs1
 [`pkcs5`]: https://github.com/RustCrypto/formats/tree/master/pkcs5
-[`pkcs7`]: https://github.com/RustCrypto/formats/tree/master/pkcs7
 [`pkcs8`]: https://github.com/RustCrypto/formats/tree/master/pkcs8
-[`pkcs10`]: https://github.com/RustCrypto/formats/tree/master/pkcs10
+[`pkcs12`]: https://github.com/RustCrypto/formats/tree/master/pkcs12
 [`sec1`]: https://github.com/RustCrypto/formats/tree/master/sec1
 [`spki`]: https://github.com/RustCrypto/formats/tree/master/spki
-[`x501`]: https://github.com/RustCrypto/formats/tree/master/x501
-[`x509`]: https://github.com/RustCrypto/formats/tree/master/x509
+[`x509-cert`]: https://github.com/RustCrypto/formats/tree/master/x509-cert
+[`x509-ocsp`]: https://github.com/RustCrypto/formats/tree/master/x509-ocsp

--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "data-structures", "encoding", "no-std", "parser-i
 keywords = ["crypto", "key", "pem", "pkcs", "rsa"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.71"
 
 [dependencies]
 der = { version = "=0.8.0-pre", features = ["oid"] }

--- a/pkcs1/README.md
+++ b/pkcs1/README.md
@@ -31,7 +31,7 @@ PEM encoded RSA public keys begin with:
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.65** at a minimum.
+This crate requires **Rust 1.71** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -58,7 +58,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/pkcs1/badge.svg
 [docs-link]: https://docs.rs/pkcs1/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.71+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 [build-image]: https://github.com/RustCrypto/formats/workflows/pkcs1/badge.svg?branch=master&event=push

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "data-structures", "encoding", "no-std"]
 keywords = ["crypto", "key", "pkcs", "password"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.71"
 
 [dependencies]
 der = { version = "=0.8.0-pre", features = ["oid"] }

--- a/pkcs5/README.md
+++ b/pkcs5/README.md
@@ -14,7 +14,7 @@ Password-Based Cryptography Specification Version 2.1 ([RFC 8018]).
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.65** at a minimum.
+This crate requires **Rust 1.71** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -43,7 +43,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/formats/actions/workflows/pkcs5.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/formats/actions/workflows/pkcs5.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.71+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "data-structures", "encoding", "no-std", "parser-i
 keywords = ["crypto", "key", "pkcs", "private"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.71"
 
 [dependencies]
 der = { version = "=0.8.0-pre", features = ["oid"] }

--- a/pkcs8/README.md
+++ b/pkcs8/README.md
@@ -54,7 +54,7 @@ algorithm, including the ones listed above or other algorithms.
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.65** at a minimum.
+This crate requires **Rust 1.71** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -81,7 +81,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/pkcs8/badge.svg
 [docs-link]: https://docs.rs/pkcs8/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.71+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 [build-image]: https://github.com/RustCrypto/formats/workflows/pkcs8/badge.svg?branch=master&event=push

--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "data-structures", "encoding", "no-std", "parser-i
 keywords = ["crypto", "key", "elliptic-curve", "secg"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.71"
 
 [dependencies]
 base16ct = { version = "0.2", optional = true, default-features = false }

--- a/sec1/README.md
+++ b/sec1/README.md
@@ -18,7 +18,7 @@ formats including ASN.1 DER-serialized private keys (also described in
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.70** at a minimum.
+This crate requires **Rust 1.71** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -45,7 +45,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/sec1/badge.svg
 [docs-link]: https://docs.rs/sec1/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.70+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.71+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 [build-image]: https://github.com/RustCrypto/formats/workflows/sec1/badge.svg?branch=master&event=push

--- a/spki/README.md
+++ b/spki/README.md
@@ -16,7 +16,7 @@ Specified in [RFC 5280 § 4.1].
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.65** at a minimum.
+This crate requires **Rust 1.71** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -45,7 +45,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/formats/actions/workflows/spki.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/formats/actions/workflows/spki.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.71+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 


### PR DESCRIPTION
Also bumps MSRV to 1.71 due to the const use of `[u8]::split_at`.

Additionally makes the internal `Encoder` type const generic around the size of the output buffer.