### PR TITLE
const-oid: fix `Encoder` size check and off-by-one error

### DIFF
--- a/const-oid/src/encoder.rs
+++ b/const-oid/src/encoder.rs
@@ -80,7 +80,7 @@ impl<const MAX_SIZE: usize> Encoder<MAX_SIZE> {
                 let nbytes = base128_len(arc);
 
                 // Shouldn't overflow on any 16-bit+ architectures
-                if self.cursor + nbytes + 1 >= ObjectIdentifier::MAX_SIZE {
+                if self.cursor + nbytes + 1 > MAX_SIZE {
                     return Err(Error::Length);
                 }
 


### PR DESCRIPTION
The `Encoder` previously returned `Error::Length` even when there was one remaining byte in the buffer.

This fixes that error and adds an edge case test.