### PR TITLE
const-oid: add `ObjectIdentifierRef`

### DIFF
--- a/const-oid/src/arcs.rs
+++ b/const-oid/src/arcs.rs
@@ -58,7 +58,8 @@ impl<'a> Arcs<'a> {
         match self.cursor {
             // Indicates we're on the root arc
             None => {
-                let root = RootArcs::try_from(self.bytes[0])?;
+                let root_byte = *self.bytes.first().ok_or(Error::Empty)?;
+                let root = RootArcs::try_from(root_byte)?;
                 self.cursor = Some(0);
                 Ok(Some(root.first_arc()))
             }

--- a/const-oid/src/db.rs
+++ b/const-oid/src/db.rs
@@ -58,7 +58,7 @@ impl<'a> Database<'a> {
         while i < self.0.len() {
             let lhs = self.0[i].0;
 
-            if lhs.buffer.eq(&oid.buffer) {
+            if lhs.ber.eq(&oid.ber) {
                 return Some(self.0[i].1);
             }
 
@@ -110,7 +110,7 @@ impl<'a> Iterator for Names<'a> {
         while i < self.database.0.len() {
             let lhs = self.database.0[i].0;
 
-            if lhs.buffer.eq(&self.oid.buffer) {
+            if lhs.ber.eq(&self.oid.ber) {
                 self.position = i + 1;
                 return Some(self.database.0[i].1);
             }

--- a/const-oid/src/encoder.rs
+++ b/const-oid/src/encoder.rs
@@ -5,29 +5,29 @@ use crate::{
     Arc, Buffer, Error, ObjectIdentifier, Result,
 };
 
-/// BER/DER encoder
+/// BER/DER encoder.
 #[derive(Debug)]
 pub(crate) struct Encoder<const MAX_SIZE: usize> {
-    /// Current state
+    /// Current state.
     state: State,
 
-    /// Bytes of the OID being encoded in-progress
+    /// Bytes of the OID being BER-encoded in-progress.
     bytes: [u8; MAX_SIZE],
 
-    /// Current position within the byte buffer
+    /// Current position within the byte buffer.
     cursor: usize,
 }
 
-/// Current state of the encoder
+/// Current state of the encoder.
 #[derive(Debug)]
 enum State {
-    /// Initial state - no arcs yet encoded
+    /// Initial state - no arcs yet encoded.
     Initial,
 
-    /// First arc parsed
+    /// First arc parsed.
     FirstArc(Arc),
 
-    /// Encoding base 128 body of the OID
+    /// Encoding base 128 body of the OID.
     Body,
 }
 
@@ -45,8 +45,8 @@ impl<const MAX_SIZE: usize> Encoder<MAX_SIZE> {
     pub(crate) const fn extend(oid: ObjectIdentifier<MAX_SIZE>) -> Self {
         Self {
             state: State::Body,
-            bytes: oid.buffer.bytes,
-            cursor: oid.buffer.length as usize,
+            bytes: oid.ber.bytes,
+            cursor: oid.ber.length as usize,
         }
     }
 
@@ -100,16 +100,16 @@ impl<const MAX_SIZE: usize> Encoder<MAX_SIZE> {
 
     /// Finish encoding an OID.
     pub(crate) const fn finish(self) -> Result<ObjectIdentifier<MAX_SIZE>> {
-        if self.cursor >= 2 {
-            let bytes = Buffer {
-                bytes: self.bytes,
-                length: self.cursor as u8,
-            };
-
-            Ok(ObjectIdentifier { buffer: bytes })
-        } else {
-            Err(Error::NotEnoughArcs)
+        if self.cursor == 0 {
+            return Err(Error::Empty);
         }
+
+        let ber = Buffer {
+            bytes: self.bytes,
+            length: self.cursor as u8,
+        };
+
+        Ok(ObjectIdentifier { ber })
     }
 
     /// Encode a single byte of a Base 128 value.

--- a/const-oid/src/error.rs
+++ b/const-oid/src/error.rs
@@ -37,9 +37,6 @@ pub enum Error {
     /// OID length is invalid (too short or too long).
     Length,
 
-    /// Minimum 3 arcs required.
-    NotEnoughArcs,
-
     /// Trailing `.` character at end of input.
     TrailingDot,
 }
@@ -56,7 +53,6 @@ impl Error {
             Error::DigitExpected { .. } => panic!("OID expected to start with digit"),
             Error::Empty => panic!("OID value is empty"),
             Error::Length => panic!("OID length invalid"),
-            Error::NotEnoughArcs => panic!("OID requires minimum of 3 arcs"),
             Error::TrailingDot => panic!("OID ends with invalid trailing '.'"),
         }
     }
@@ -73,7 +69,6 @@ impl fmt::Display for Error {
             }
             Error::Empty => f.write_str("OID value is empty"),
             Error::Length => f.write_str("OID length invalid"),
-            Error::NotEnoughArcs => f.write_str("OID requires minimum of 3 arcs"),
             Error::TrailingDot => f.write_str("OID ends with invalid trailing '.'"),
         }
     }

--- a/const-oid/tests/oid.rs
+++ b/const-oid/tests/oid.rs
@@ -1,4 +1,4 @@
-//! `const-oid` crate tests
+//! Tests for `ObjectIdentifier`.
 
 // TODO(tarcieri): test full set of OID encoding constraints specified here:
 // <https://misc.daniel-marschall.de/asn.1/oid_facts.html>
@@ -62,16 +62,6 @@ fn from_bytes() {
 
     // Empty
     assert_eq!(ObjectIdentifier::from_bytes(&[]), Err(Error::Empty));
-
-    // Truncated
-    assert_eq!(
-        ObjectIdentifier::from_bytes(&[42]),
-        Err(Error::NotEnoughArcs)
-    );
-    assert_eq!(
-        ObjectIdentifier::from_bytes(&[42, 134]),
-        Err(Error::NotEnoughArcs)
-    );
 }
 
 #[test]
@@ -102,9 +92,6 @@ fn from_str() {
     assert_eq!(oid3.arc(5).unwrap(), 1);
     assert_eq!(oid3.arc(6).unwrap(), 1);
     assert_eq!(oid3, EXAMPLE_OID_LARGE_ARC);
-
-    // Too short
-    assert_eq!("1.2".parse::<ObjectIdentifier>(), Err(Error::NotEnoughArcs));
 
     // Truncated
     assert_eq!(
@@ -145,12 +132,6 @@ fn try_from_u32_slice() {
     assert_eq!(oid2.arc(1).unwrap(), 16);
     assert_eq!(EXAMPLE_OID_2, oid2);
 
-    // Too short
-    assert_eq!(
-        ObjectIdentifier::from_arcs([1, 2]),
-        Err(Error::NotEnoughArcs)
-    );
-
     // Invalid first arc
     assert_eq!(
         ObjectIdentifier::from_arcs([3, 2, 840, 10045, 3, 1, 7]),
@@ -171,13 +152,16 @@ fn as_bytes() {
 }
 
 #[test]
-fn parse_empty() {
-    assert_eq!(ObjectIdentifier::new(""), Err(Error::Empty));
+fn as_oid_ref() {
+    assert_eq!(
+        EXAMPLE_OID_0.as_bytes(),
+        EXAMPLE_OID_0.as_oid_ref().as_bytes()
+    );
 }
 
 #[test]
-fn parse_not_enough_arcs() {
-    assert_eq!(ObjectIdentifier::new("1.2"), Err(Error::NotEnoughArcs));
+fn parse_empty() {
+    assert_eq!(ObjectIdentifier::new(""), Err(Error::Empty));
 }
 
 #[test]
@@ -201,6 +185,9 @@ fn parent() {
     let child = oid("1.2.3.4");
     let parent = child.parent().unwrap();
     assert_eq!(parent, oid("1.2.3"));
+
+    let parent = parent.parent().unwrap();
+    assert_eq!(parent, oid("1.2"));
     assert_eq!(parent.parent(), None);
 }
 

--- a/const-oid/tests/oid_ref.rs
+++ b/const-oid/tests/oid_ref.rs
@@ -1,0 +1,71 @@
+//! Tests for `ObjectIdentifierRef`.
+
+use const_oid::{Error, ObjectIdentifier, ObjectIdentifierRef};
+use hex_literal::hex;
+
+/// Example OID value with a root arc of `0` (and large arc).
+const EXAMPLE_OID_0_STR: &str = "0.9.2342.19200300.100.1.1";
+const EXAMPLE_OID_0_BER: &[u8] = &hex!("0992268993F22C640101");
+const EXAMPLE_OID_0: ObjectIdentifier = ObjectIdentifier::new_unwrap(EXAMPLE_OID_0_STR);
+
+/// Example OID value with a root arc of `1`.
+const EXAMPLE_OID_1_STR: &str = "1.2.840.10045.2.1";
+const EXAMPLE_OID_1_BER: &[u8] = &hex!("2A8648CE3D0201");
+const EXAMPLE_OID_1: ObjectIdentifier = ObjectIdentifier::new_unwrap(EXAMPLE_OID_1_STR);
+
+/// Example OID value with a root arc of `2`.
+const EXAMPLE_OID_2_STR: &str = "2.16.840.1.101.3.4.1.42";
+const EXAMPLE_OID_2_BER: &[u8] = &hex!("60864801650304012A");
+const EXAMPLE_OID_2: ObjectIdentifier = ObjectIdentifier::new_unwrap(EXAMPLE_OID_2_STR);
+
+/// Example OID value with a large arc
+const EXAMPLE_OID_LARGE_ARC_STR: &str = "0.9.2342.19200300.100.1.1";
+const EXAMPLE_OID_LARGE_ARC_BER: &[u8] = &hex!("0992268993F22C640101");
+const EXAMPLE_OID_LARGE_ARC: ObjectIdentifier =
+    ObjectIdentifier::new_unwrap("0.9.2342.19200300.100.1.1");
+
+#[test]
+fn from_bytes() {
+    let oid0 = ObjectIdentifierRef::from_bytes(EXAMPLE_OID_0_BER).unwrap();
+    assert_eq!(oid0.arc(0).unwrap(), 0);
+    assert_eq!(oid0.arc(1).unwrap(), 9);
+    assert_eq!(oid0, &EXAMPLE_OID_0);
+
+    let oid1 = ObjectIdentifierRef::from_bytes(EXAMPLE_OID_1_BER).unwrap();
+    assert_eq!(oid1.arc(0).unwrap(), 1);
+    assert_eq!(oid1.arc(1).unwrap(), 2);
+    assert_eq!(oid1, &EXAMPLE_OID_1);
+
+    let oid2 = ObjectIdentifierRef::from_bytes(EXAMPLE_OID_2_BER).unwrap();
+    assert_eq!(oid2.arc(0).unwrap(), 2);
+    assert_eq!(oid2.arc(1).unwrap(), 16);
+    assert_eq!(oid2, &EXAMPLE_OID_2);
+
+    let oid3 = ObjectIdentifierRef::from_bytes(EXAMPLE_OID_LARGE_ARC_BER).unwrap();
+    assert_eq!(oid3.arc(0).unwrap(), 0);
+    assert_eq!(oid3.arc(1).unwrap(), 9);
+    assert_eq!(oid3.arc(2).unwrap(), 2342);
+    assert_eq!(oid3.arc(3).unwrap(), 19200300);
+    assert_eq!(oid3.arc(4).unwrap(), 100);
+    assert_eq!(oid3.arc(5).unwrap(), 1);
+    assert_eq!(oid3.arc(6).unwrap(), 1);
+    assert_eq!(oid3, &EXAMPLE_OID_LARGE_ARC);
+
+    // Empty
+    assert_eq!(ObjectIdentifierRef::from_bytes(&[]), Err(Error::Empty));
+}
+
+#[test]
+fn display() {
+    let oid0 = ObjectIdentifierRef::from_bytes(EXAMPLE_OID_0_BER).unwrap();
+    assert_eq!(oid0.to_string(), EXAMPLE_OID_0_STR);
+
+    let oid1 = ObjectIdentifierRef::from_bytes(EXAMPLE_OID_1_BER).unwrap();
+    assert_eq!(oid1.to_string(), EXAMPLE_OID_1_STR);
+
+    let oid2 = ObjectIdentifierRef::from_bytes(EXAMPLE_OID_2_BER).unwrap();
+    assert_eq!(oid2.to_string(), EXAMPLE_OID_2_STR);
+
+    let oid3 = ObjectIdentifierRef::from_bytes(EXAMPLE_OID_LARGE_ARC_BER).unwrap();
+    assert_eq!(oid3.to_string(), EXAMPLE_OID_LARGE_ARC_STR);
+}


### PR DESCRIPTION
Adds a `repr(transparent)` newtype for a `[u8]` which is guaranteed to contain a valid BER serialization of an OID. This is a similar approach to how `Path`/`PathBuf` or `OsStr`/`OsString` work (except with `ObjectIdentifier` being stack-allocated instead of heap allocated).

An unsafe pointer cast is required to go from `&[u8]` to `&ObjectIdentifierRef`, so unfortunately this means the crate is no longer `forbid(unsafe_code)`, however it's been lowered to `deny(unsafe_code)` to ensure contributors think twice before adding more.

`Borrow` and `Deref` impls have been added to the owned `ObjectIdentifier` type, allowing common functionality to be moved to `ObjectIdentifierRef`, allowing both types to exist while eliminating code duplication.

A `PartialEq` impl allows them to be compared.

The `db` module continues to use `ObjectIdentifier` for now, however hopefully this approach would allow #1212 to be reinstated and for `ObjectIdentifierRef`s to be used for the database eventually (i.e. revert the revert in #1299)

NOTE: this PR also relaxes the previous requirement that an OID have at least three arcs. It is now allowed to only have two. It also removes the `Error::NotEnoughArcs` variant that covered that particular case.