### PR TITLE
const-oid: impl `AsRef<ObjectIdentifierRef>` for `ObjectIdentifier`

### DIFF
--- a/const-oid/src/lib.rs
+++ b/const-oid/src/lib.rs
@@ -191,6 +191,12 @@ impl<const MAX_SIZE: usize> AsRef<[u8]> for ObjectIdentifier<MAX_SIZE> {
     }
 }
 
+impl<const MAX_SIZE: usize> AsRef<ObjectIdentifierRef> for ObjectIdentifier<MAX_SIZE> {
+    fn as_ref(&self) -> &ObjectIdentifierRef {
+        self.as_oid_ref()
+    }
+}
+
 impl<const MAX_SIZE: usize> Borrow<ObjectIdentifierRef> for ObjectIdentifier<MAX_SIZE> {
     fn borrow(&self) -> &ObjectIdentifierRef {
         self.as_oid_ref()


### PR DESCRIPTION
`AsRef` is a convenient trait because it's in the prelude