### PR TITLE
sec1: bump `hybrid-array` to v0.2.0-rc.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,9 +782,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.2.0-pre.8"
+version = "0.2.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27fbaf242418fe980caf09ed348d5a6aeabe71fc1bd8bebad641f4591ae0a46d"
+checksum = "b8c5517ac29f08e88170b9647d85cc5f21c2596de177b4867232e20b214b8da1"
 dependencies = [
  "typenum",
 ]
@@ -1414,7 +1414,7 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.8.0-pre.0"
+version = "0.8.0-pre.1"
 dependencies = [
  "base16ct",
  "der 0.8.0-pre.0",

--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sec1"
-version = "0.8.0-pre.0"
+version = "0.8.0-pre.1"
 description = """
 Pure Rust implementation of SEC1: Elliptic Curve Cryptography encoding formats
 including ASN.1 DER-serialized private keys as well as the
@@ -18,7 +18,7 @@ rust-version = "1.71"
 [dependencies]
 base16ct = { version = "0.2", optional = true, default-features = false }
 der = { version = "=0.8.0-pre.0", optional = true, features = ["oid"] }
-hybrid-array = { version = "=0.2.0-pre.8", optional = true, default-features = false }
+hybrid-array = { version = "0.2.0-rc.0", optional = true, default-features = false }
 pkcs8 = { version = "=0.11.0-pre.0", optional = true, default-features = false }
 serdect = { version = "=0.3.0-pre.0", optional = true, default-features = false, features = ["alloc"] }
 subtle = { version = "2", optional = true, default-features = false }

--- a/sec1/src/point.rs
+++ b/sec1/src/point.rs
@@ -210,7 +210,7 @@ where
         }
 
         let (x_bytes, y_bytes) = self.bytes[1..].split_at(Size::to_usize());
-        let x = Array::ref_from_slice(x_bytes);
+        let x = Array::from_slice(x_bytes);
 
         if self.is_compressed() {
             Coordinates::Compressed {
@@ -222,7 +222,7 @@ where
         } else {
             Coordinates::Uncompressed {
                 x,
-                y: Array::ref_from_slice(y_bytes),
+                y: Array::from_slice(y_bytes),
             }
         }
     }


### PR DESCRIPTION
Also cuts a `sec1` v0.8.0-pre.1 release