### PR TITLE
Bump X.509-based crates to prerelease versions; MSRV 1.75

### DIFF
--- a/.github/workflows/cmpv2.yml
+++ b/.github/workflows/cmpv2.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cmpv2.yml
+++ b/.github/workflows/cmpv2.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.72.0 # MSRV
+          - 1.75.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.72.0 # MSRV
+          - 1.75.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cmpv2.yml
+++ b/.github/workflows/cmpv2.yml
@@ -42,6 +42,7 @@ jobs:
       - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features arbitrary,default,std
 
   minimal-versions:
+    if: false # TODO: temp disabled due to unpublished prerelease dependencies
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
     with:
         working-directory: ${{ github.workflow }}

--- a/.github/workflows/cms.yml
+++ b/.github/workflows/cms.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.72.0 # MSRV
+          - 1.75.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -57,7 +57,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.72.0 # MSRV
+          - 1.75.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cms.yml
+++ b/.github/workflows/cms.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -57,7 +57,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/crmf.yml
+++ b/.github/workflows/crmf.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/crmf.yml
+++ b/.github/workflows/crmf.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.72.0 # MSRV
+          - 1.75.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.72.0 # MSRV
+          - 1.75.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/crmf.yml
+++ b/.github/workflows/crmf.yml
@@ -42,6 +42,7 @@ jobs:
       - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features arbitrary,default,std
 
   minimal-versions:
+    if: false # TODO: temp disabled due to unpublished prerelease dependencies
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
     with:
         working-directory: ${{ github.workflow }}

--- a/.github/workflows/der.yml
+++ b/.github/workflows/der.yml
@@ -38,11 +38,11 @@ jobs:
       - uses: RustCrypto/actions/cargo-hack-install@master
       - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features std,arbitrary
 
-  # TODO(tarcieri): re-enable this when we're not using unpublished prerelease dependencies
-  #  minimal-versions:
-  #    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
-  #    with:
-  #        working-directory: ${{ github.workflow }}
+  minimal-versions:
+    if: false # TODO: temp disabled due to unpublished prerelease dependencies
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     strategy:

--- a/.github/workflows/gss-api.yml
+++ b/.github/workflows/gss-api.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/gss-api.yml
+++ b/.github/workflows/gss-api.yml
@@ -42,6 +42,7 @@ jobs:
       - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features default,std
 
   minimal-versions:
+    if: false # TODO: temp disabled due to unpublished prerelease dependencies
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
     with:
         working-directory: ${{ github.workflow }}

--- a/.github/workflows/gss-api.yml
+++ b/.github/workflows/gss-api.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.72.0 # MSRV
+          - 1.75.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.72.0 # MSRV
+          - 1.75.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pkcs1.yml
+++ b/.github/workflows/pkcs1.yml
@@ -41,11 +41,11 @@ jobs:
       - uses: RustCrypto/actions/cargo-hack-install@master
       - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features std
 
-  # TODO(tarcieri): re-enable this when we're not using unpublished prerelease dependencies
-  #  minimal-versions:
-  #    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
-  #    with:
-  #        working-directory: ${{ github.workflow }}
+  minimal-versions:
+    if: false # TODO: temp disabled due to unpublished prerelease dependencies
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/pkcs12.yml
+++ b/.github/workflows/pkcs12.yml
@@ -43,12 +43,10 @@ jobs:
       - run: cargo hack build --target ${{ matrix.target }} --feature-powerset
 
   minimal-versions:
+    if: false # TODO: temp disabled due to unpublished prerelease dependencies
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
     with:
         working-directory: ${{ github.workflow }}
-        # TODO: re-enable benches build when min version of proc-macro2
-        # will be updated to 1.0.60+
-        nightly-cmd:
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/pkcs12.yml
+++ b/.github/workflows/pkcs12.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -55,7 +55,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pkcs12.yml
+++ b/.github/workflows/pkcs12.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.72.0 # MSRV
+          - 1.75.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.72.0 # MSRV
+          - 1.75.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pkcs5.yml
+++ b/.github/workflows/pkcs5.yml
@@ -40,11 +40,11 @@ jobs:
       - uses: RustCrypto/actions/cargo-hack-install@master
       - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features getrandom,std
 
-# TODO(tarcieri): re-enable this when we're not using unpublished prerelease dependencies
-#  minimal-versions:
-#    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
-#    with:
-#        working-directory: ${{ github.workflow }}
+  minimal-versions:
+    if: false # TODO: temp disabled due to unpublished prerelease dependencies
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/sec1.yml
+++ b/.github/workflows/sec1.yml
@@ -41,11 +41,11 @@ jobs:
       - uses: RustCrypto/actions/cargo-hack-install@master
       - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features std
 
-# TODO(tarcieri): re-enable this when we're not using unpublished prerelease dependencies
-#  minimal-versions:
-#    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
-#    with:
-#        working-directory: ${{ github.workflow }}
+  minimal-versions:
+    if: false # TODO: temp disabled due to unpublished prerelease dependencies
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/spki.yml
+++ b/.github/workflows/spki.yml
@@ -40,11 +40,12 @@ jobs:
       - uses: RustCrypto/actions/cargo-hack-install@master
       - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features arbitrary,std
 
-# TODO(tarcieri): re-enable this when we're not using unpublished prerelease dependencies
-#  minimal-versions:
-#    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
-#    with:
-#        working-directory: ${{ github.workflow }}
+
+  minimal-versions:
+    if: false # TODO: temp disabled due to unpublished prerelease dependencies
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.73.0
+          toolchain: 1.75.0
           components: clippy
       - run: cargo clippy --all --all-features --tests
 

--- a/.github/workflows/x509-cert.yml
+++ b/.github/workflows/x509-cert.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/x509-cert.yml
+++ b/.github/workflows/x509-cert.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.72.0 # MSRV
+          - 1.75.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.72.0 # MSRV
+          - 1.75.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/x509-cert.yml
+++ b/.github/workflows/x509-cert.yml
@@ -41,6 +41,7 @@ jobs:
       - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features arbitrary,builder,default,std
 
   minimal-versions:
+    if: false # TODO: temp disabled due to unpublished prerelease dependencies
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
     with:
         working-directory: ${{ github.workflow }}
@@ -55,7 +56,6 @@ jobs:
           - stable
     steps:
       - uses: actions/checkout@v4
-      
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}

--- a/.github/workflows/x509-ocsp.yml
+++ b/.github/workflows/x509-ocsp.yml
@@ -41,12 +41,10 @@ jobs:
       - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features std
 
   minimal-versions:
+    if: false # TODO: temp disabled due to unpublished prerelease dependencies
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
     with:
         working-directory: ${{ github.workflow }}
-        # TODO: re-enable benches build when min version of proc-macro2
-        # will be updated to 1.0.60+
-        nightly-cmd:
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/x509-ocsp.yml
+++ b/.github/workflows/x509-ocsp.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.72.0 # MSRV
+          - 1.75.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.72.0 # MSRV
+          - 1.75.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/x509-ocsp.yml
+++ b/.github/workflows/x509-ocsp.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/x509-tsp.yml
+++ b/.github/workflows/x509-tsp.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.72.0 # MSRV
+          - 1.75.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -54,7 +54,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.72.0 # MSRV
+          - 1.75.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/x509-tsp.yml
+++ b/.github/workflows/x509-tsp.yml
@@ -44,12 +44,10 @@ jobs:
       - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features arbitrary,builder,default,std
 
   minimal-versions:
+    if: false # TODO: temp disabled due to unpublished prerelease dependencies
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
     with:
         working-directory: ${{ github.workflow }}
-        # TODO: re-enable benches build when min version of proc-macro2
-        # will be updated to 1.0.60+
-        nightly-cmd:
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/x509-tsp.yml
+++ b/.github/workflows/x509-tsp.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -56,7 +56,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.11.0-pre.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0edadbde8e0243b49d434f9a23ec0590af201f400a34d7d51049284e4a77c568"
+dependencies = [
+ "crypto-common 0.2.0-pre.4",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,7 +262,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "inout",
 ]
 
@@ -286,38 +295,38 @@ checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "cmpv2"
-version = "0.2.0"
+version = "0.3.0-pre"
 dependencies = [
- "const-oid 0.9.6",
+ "const-oid",
  "crmf",
- "der 0.7.8",
- "hex-literal 0.4.1",
- "spki 0.7.3",
+ "der",
+ "hex-literal",
+ "spki",
  "x509-cert",
 ]
 
 [[package]]
 name = "cms"
-version = "0.2.3"
+version = "0.3.0-pre"
 dependencies = [
  "aes",
  "cbc",
  "cipher",
- "const-oid 0.9.6",
- "der 0.7.8",
+ "const-oid",
+ "der",
  "ecdsa",
  "getrandom",
- "hex-literal 0.4.1",
+ "hex-literal",
  "p256",
- "pem-rfc7468 0.7.0",
- "pkcs5 0.7.1",
+ "pem-rfc7468",
+ "pkcs5",
  "rand",
  "rsa",
- "sha1",
- "sha2",
+ "sha1 0.11.0-pre.2",
+ "sha2 0.11.0-pre.2",
  "sha3",
  "signature",
- "spki 0.7.3",
+ "spki",
  "x509-cert",
  "zeroize",
 ]
@@ -330,19 +339,10 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-dependencies = [
- "arbitrary",
-]
-
-[[package]]
-name = "const-oid"
 version = "0.10.0-pre.2"
 dependencies = [
  "arbitrary",
- "hex-literal 0.4.1",
+ "hex-literal",
 ]
 
 [[package]]
@@ -390,22 +390,23 @@ dependencies = [
 
 [[package]]
 name = "crmf"
-version = "0.2.0"
+version = "0.3.0-pre"
 dependencies = [
  "cms",
- "const-oid 0.9.6",
- "der 0.7.8",
- "spki 0.7.3",
+ "const-oid",
+ "der",
+ "spki",
  "x509-cert",
 ]
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.5"
+version = "0.6.0-pre.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+checksum = "1943d7beadd9ce2b25f3bae73b9e9336fccc1edf38bdec1ed58d3aa183989e11"
 dependencies = [
- "generic-array",
+ "hybrid-array",
+ "num-traits",
  "rand_core",
  "subtle",
  "zeroize",
@@ -423,17 +424,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "der"
-version = "0.7.8"
+name = "crypto-common"
+version = "0.2.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
+checksum = "806e4e3731d44f1340b069551225b44c2056c105cad9e67f0c46266db8a3a6b9"
 dependencies = [
- "arbitrary",
- "const-oid 0.9.6",
- "der_derive 0.7.2",
- "flagset",
- "pem-rfc7468 0.7.0",
- "zeroize",
+ "getrandom",
+ "hybrid-array",
+ "rand_core",
 ]
 
 [[package]]
@@ -442,25 +440,14 @@ version = "0.8.0-pre.0"
 dependencies = [
  "arbitrary",
  "bytes",
- "const-oid 0.10.0-pre.2",
- "der_derive 0.8.0-pre.0",
+ "const-oid",
+ "der_derive",
  "flagset",
- "hex-literal 0.4.1",
- "pem-rfc7468 1.0.0-pre.0",
+ "hex-literal",
+ "pem-rfc7468",
  "proptest",
  "time",
  "zeroize",
-]
-
-[[package]]
-name = "der_derive"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe87ce4529967e0ba1dcf8450bab64d97dfd5010a6256187ffe2e43e6f0e049"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -507,24 +494,35 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid 0.9.6",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.6",
+ "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.0-pre.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957713a19ffdda287c63772e607f848512f67ba948f17d8e42cb8d50fd98a786"
+dependencies = [
+ "block-buffer 0.11.0-pre.4",
+ "const-oid",
+ "crypto-common 0.2.0-pre.4",
  "subtle",
 ]
 
 [[package]]
 name = "ecdsa"
-version = "0.16.9"
+version = "0.17.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+checksum = "12cc615703dcff86386153ad5dabbf2544f2ed8fbacb881e1ea440410220660f"
 dependencies = [
- "der 0.7.8",
- "digest",
+ "der",
+ "digest 0.11.0-pre.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
- "spki 0.7.3",
+ "spki",
 ]
 
 [[package]]
@@ -535,20 +533,20 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.8"
+version = "0.14.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+checksum = "b5a28b26e8b4a94186ac649acffa41ba13ca853bd33e44b00fc1c3bd30bfeebe"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.11.0-pre.7",
  "ff",
- "generic-array",
  "group",
- "pem-rfc7468 0.7.0",
- "pkcs8 0.10.2",
+ "hybrid-array",
+ "pem-rfc7468",
+ "pkcs8",
  "rand_core",
- "sec1 0.7.3",
+ "sec1",
  "subtle",
  "zeroize",
 ]
@@ -700,7 +698,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
@@ -733,11 +730,11 @@ dependencies = [
 
 [[package]]
 name = "gss-api"
-version = "0.1.0"
+version = "0.2.0-pre"
 dependencies = [
- "der 0.7.8",
- "hex-literal 0.4.1",
- "spki 0.7.3",
+ "der",
+ "hex-literal",
+ "spki",
  "x509-cert",
 ]
 
@@ -761,12 +758,6 @@ checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "hex-literal"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
-
-[[package]]
-name = "hex-literal"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
@@ -777,16 +768,26 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0-pre.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fac01891f12d968a2737928c9af2532abdc750e56a890fdbcafdfff17017678"
+dependencies = [
+ "digest 0.11.0-pre.7",
 ]
 
 [[package]]
 name = "hybrid-array"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c5517ac29f08e88170b9647d85cc5f21c2596de177b4867232e20b214b8da1"
+checksum = "7b700a69c9d992339e82b6cda619873ee17768be06e80ed5ef07c50c50d499ab"
 dependencies = [
  "typenum",
+ "zeroize",
 ]
 
 [[package]]
@@ -837,9 +838,9 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "keccak"
-version = "0.1.4"
+version = "0.2.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
+checksum = "a7cdd4f0dc5807b9a2b25dd48a3f58e862606fe7bd47f41ecde36e97422d7e90"
 dependencies = [
  "cpufeatures",
 ]
@@ -939,14 +940,14 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "p256"
-version = "0.13.2"
+version = "0.14.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+checksum = "00a9c7e3fe894f553af8fb20c69c66ecc35d27f8f30a420ecb59a7ab2d3b43d7"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.11.0-pre.2",
 ]
 
 [[package]]
@@ -961,17 +962,8 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
- "hmac",
-]
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
+ "digest 0.10.7",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -995,41 +987,29 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der 0.7.8",
- "pkcs8 0.10.2",
- "spki 0.7.3",
-]
-
-[[package]]
-name = "pkcs1"
 version = "0.8.0-pre.0"
 dependencies = [
- "const-oid 0.10.0-pre.2",
- "der 0.8.0-pre.0",
- "hex-literal 0.4.1",
- "pkcs8 0.11.0-pre.0",
- "spki 0.8.0-pre.0",
+ "const-oid",
+ "der",
+ "hex-literal",
+ "pkcs8",
+ "spki",
  "tempfile",
 ]
 
 [[package]]
 name = "pkcs12"
-version = "0.1.0"
+version = "0.2.0-pre"
 dependencies = [
  "cms",
- "const-oid 0.9.6",
- "der 0.7.8",
- "digest",
- "hex-literal 0.3.4",
- "pkcs5 0.7.1",
- "pkcs8 0.10.2",
- "sha2",
- "spki 0.7.3",
- "subtle-encoding",
+ "const-oid",
+ "der",
+ "digest 0.11.0-pre.7",
+ "hex-literal",
+ "pkcs5",
+ "pkcs8",
+ "sha2 0.11.0-pre.2",
+ "spki",
  "whirlpool",
  "x509-cert",
  "zeroize",
@@ -1037,58 +1017,30 @@ dependencies = [
 
 [[package]]
 name = "pkcs5"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
-dependencies = [
- "aes",
- "cbc",
- "der 0.7.8",
- "des",
- "pbkdf2",
- "scrypt",
- "sha2",
- "spki 0.7.3",
-]
-
-[[package]]
-name = "pkcs5"
 version = "0.8.0-pre.0"
 dependencies = [
  "aes",
  "cbc",
- "der 0.8.0-pre.0",
+ "der",
  "des",
- "hex-literal 0.4.1",
+ "hex-literal",
  "pbkdf2",
  "rand_core",
  "scrypt",
- "sha1",
- "sha2",
- "spki 0.8.0-pre.0",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der 0.7.8",
- "pkcs5 0.7.1",
- "rand_core",
- "spki 0.7.3",
+ "sha1 0.10.6",
+ "sha2 0.10.8",
+ "spki",
 ]
 
 [[package]]
 name = "pkcs8"
 version = "0.11.0-pre.0"
 dependencies = [
- "der 0.8.0-pre.0",
- "hex-literal 0.4.1",
- "pkcs5 0.8.0-pre.0",
+ "der",
+ "hex-literal",
+ "pkcs5",
  "rand_core",
- "spki 0.8.0-pre.0",
+ "spki",
  "subtle",
  "tempfile",
 ]
@@ -1107,9 +1059,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "primeorder"
-version = "0.13.6"
+version = "0.14.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+checksum = "896702506434e6dd77119b240a2b347a25d985f230d014fb1a04207df9434fa6"
 dependencies = [
  "elliptic-curve",
 ]
@@ -1249,11 +1201,11 @@ checksum = "c707298afce11da2efef2f600116fa93ffa7a032b5d7b628aa17711ec81383ca"
 
 [[package]]
 name = "rfc6979"
-version = "0.4.0"
+version = "0.5.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+checksum = "5ca433f6da88ec508578cac524a1602a437964cf049ffb39f1509e8696d43e79"
 dependencies = [
- "hmac",
+ "hmac 0.13.0-pre.2",
  "subtle",
 ]
 
@@ -1281,21 +1233,21 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.6"
+version = "0.10.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e5124fcb30e76a7e79bfee683a2746db83784b86289f6251b54b7950a0dfc"
+checksum = "5eb33a74436b840d3c82469b8b31fadcf2acd8c26ea09ba3ec99ff09ba0c2c20"
 dependencies = [
- "const-oid 0.9.6",
- "digest",
+ "const-oid",
+ "digest 0.11.0-pre.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
- "pkcs1 0.7.5",
- "pkcs8 0.10.2",
+ "pkcs1",
+ "pkcs8",
  "rand_core",
- "sha2",
+ "sha2 0.11.0-pre.2",
  "signature",
- "spki 0.7.3",
+ "spki",
  "subtle",
  "zeroize",
 ]
@@ -1395,21 +1347,7 @@ checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
 dependencies = [
  "pbkdf2",
  "salsa20",
- "sha2",
-]
-
-[[package]]
-name = "sec1"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
-dependencies = [
- "base16ct",
- "der 0.7.8",
- "generic-array",
- "pkcs8 0.10.2",
- "subtle",
- "zeroize",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -1417,10 +1355,10 @@ name = "sec1"
 version = "0.8.0-pre.1"
 dependencies = [
  "base16ct",
- "der 0.8.0-pre.0",
- "hex-literal 0.4.1",
+ "der",
+ "hex-literal",
  "hybrid-array",
- "pkcs8 0.11.0-pre.0",
+ "pkcs8",
  "serdect",
  "subtle",
  "tempfile",
@@ -1490,7 +1428,7 @@ dependencies = [
  "base16ct",
  "bincode",
  "ciborium",
- "hex-literal 0.4.1",
+ "hex-literal",
  "proptest",
  "rmp-serde",
  "serde",
@@ -1508,7 +1446,18 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0-pre.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301ed48dd873557d86a1843ebcdd511b628f13ec5401a0efa7007dc5a595eb1f"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.11.0-pre.7",
 ]
 
 [[package]]
@@ -1519,26 +1468,37 @@ checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0-pre.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e18b939d4051b69874cbdb8f55de6a14ae44b357ccb94bdbd0a2122f8f875a46"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.11.0-pre.7",
 ]
 
 [[package]]
 name = "sha3"
-version = "0.10.8"
+version = "0.11.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+checksum = "9cecb44e361133b3304a1b3e325a1d8c999339fec8c19762b55e1509a17d6806"
 dependencies = [
- "digest",
+ "digest 0.11.0-pre.7",
  "keccak",
 ]
 
 [[package]]
 name = "signature"
-version = "2.2.0"
+version = "2.3.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+checksum = "017ea2f120415e4bf9c6177425b40386f207284147564e19d196c7bc90483c08"
 dependencies = [
- "digest",
+ "digest 0.11.0-pre.7",
  "rand_core",
 ]
 
@@ -1565,24 +1525,13 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "arbitrary",
- "base64ct",
- "der 0.7.8",
-]
-
-[[package]]
-name = "spki"
 version = "0.8.0-pre.0"
 dependencies = [
  "arbitrary",
  "base64ct",
- "der 0.8.0-pre.0",
- "hex-literal 0.4.1",
- "sha2",
+ "der",
+ "hex-literal",
+ "sha2 0.10.8",
  "tempfile",
 ]
 
@@ -1597,15 +1546,6 @@ name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
-
-[[package]]
-name = "subtle-encoding"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dcb1ed7b8330c5eed5441052651dd7a12c75e2ed88f2ec024ae1fa3a5e59945"
-dependencies = [
- "zeroize",
-]
 
 [[package]]
 name = "syn"
@@ -1808,11 +1748,11 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "whirlpool"
-version = "0.10.4"
+version = "0.11.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1ae50671d985c15b3214c7d969b8b520759fb3c8682444bec15ef775335a05c"
+checksum = "cec642e8edbd0e3208e65839cb886fe230e084bdc17d9d660c77556fe2f7d1ff"
 dependencies = [
- "digest",
+ "digest 0.11.0-pre.7",
 ]
 
 [[package]]
@@ -1923,21 +1863,21 @@ dependencies = [
 
 [[package]]
 name = "x509-cert"
-version = "0.2.5"
+version = "0.3.0-pre"
 dependencies = [
  "arbitrary",
- "const-oid 0.9.6",
- "der 0.7.8",
+ "const-oid",
+ "der",
  "ecdsa",
- "hex-literal 0.4.1",
+ "hex-literal",
  "p256",
  "rand",
  "rsa",
  "rstest",
- "sha1",
- "sha2",
+ "sha1 0.11.0-pre.2",
+ "sha2 0.11.0-pre.2",
  "signature",
- "spki 0.7.3",
+ "spki",
  "tempfile",
  "tls_codec",
  "x509-cert-test-support",
@@ -1954,31 +1894,31 @@ dependencies = [
 
 [[package]]
 name = "x509-ocsp"
-version = "0.2.1"
+version = "0.3.0-pre"
 dependencies = [
- "const-oid 0.9.6",
- "der 0.7.8",
- "digest",
- "hex-literal 0.4.1",
+ "const-oid",
+ "der",
+ "digest 0.11.0-pre.7",
+ "hex-literal",
  "lazy_static",
  "rand",
  "rand_core",
  "rsa",
- "sha1",
- "sha2",
+ "sha1 0.11.0-pre.2",
+ "sha2 0.11.0-pre.2",
  "signature",
- "spki 0.7.3",
+ "spki",
  "x509-cert",
 ]
 
 [[package]]
 name = "x509-tsp"
-version = "0.1.0"
+version = "0.2.0-pre"
 dependencies = [
  "cmpv2",
  "cms",
- "der 0.7.8",
- "hex-literal 0.4.1",
+ "der",
+ "hex-literal",
  "x509-cert",
 ]
 

--- a/cmpv2/Cargo.toml
+++ b/cmpv2/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "data-structures", "encoding", "no-std"]
 keywords = ["crypto"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.72"
+rust-version = "1.75"
 
 [dependencies]
 crmf = "=0.3.0-pre"

--- a/cmpv2/Cargo.toml
+++ b/cmpv2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cmpv2"
-version = "0.2.0"
+version = "0.3.0-pre"
 description = """
 Pure Rust implementation of the Certificate Management Protocol (CMP) as
 described in RFC 4210
@@ -12,16 +12,16 @@ categories = ["cryptography", "data-structures", "encoding", "no-std"]
 keywords = ["crypto"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.72"
 
 [dependencies]
-crmf = "0.2"
-der = { version = "0.7", features = ["alloc", "derive", "flagset", "oid"] }
-spki = { version = "0.7" }
-x509-cert = { version = "0.2", default-features = false }
+crmf = "=0.3.0-pre"
+der = { version = "=0.8.0-pre.0", features = ["alloc", "derive", "flagset", "oid"] }
+spki = { version = "=0.8.0-pre.0" }
+x509-cert = { version = "=0.3.0-pre", default-features = false }
 
 [dev-dependencies]
-const-oid = { version = "0.9", features = ["db"] }
+const-oid = { version = "=0.10.0-pre.2", features = ["db"] }
 hex-literal = "0.4"
 
 [features]

--- a/cmpv2/README.md
+++ b/cmpv2/README.md
@@ -13,7 +13,7 @@ Pure Rust implementation of the Certificate Management Protocol (CMP) as describ
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.72** at a minimum.
+This crate requires **Rust 1.75** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -42,7 +42,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/formats/actions/workflows/cmpv2.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/formats/actions/workflows/cmpv2.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.72+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.75+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 

--- a/cmpv2/README.md
+++ b/cmpv2/README.md
@@ -13,7 +13,7 @@ Pure Rust implementation of the Certificate Management Protocol (CMP) as describ
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.65** at a minimum.
+This crate requires **Rust 1.72** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -42,7 +42,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/formats/actions/workflows/cmpv2.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/formats/actions/workflows/cmpv2.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.72+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 

--- a/cms/Cargo.toml
+++ b/cms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cms"
-version = "0.2.3"
+version = "0.3.0-pre"
 description = """
 Pure Rust implementation of the Cryptographic Message Syntax (CMS) as described in RFC 5652 and RFC 3274.
 """
@@ -11,34 +11,34 @@ categories = ["cryptography", "encoding", "no-std", "parser-implementations"]
 keywords = ["crypto", "pkcs7", "signing"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.72"
 
 [dependencies]
-der = { version = "0.7.7", features = ["alloc", "derive", "oid", "pem"] }
-spki = { version = "0.7" }
-x509-cert = { version = "0.2.3", default-features = false, features = ["pem"] }
-const-oid = { version = "0.9.4", features = ["db"] }
+der = { version = "=0.8.0-pre.0", features = ["alloc", "derive", "oid", "pem"] }
+spki = { version = "=0.8.0-pre.0" }
+x509-cert = { version = "=0.3.0-pre", default-features = false, features = ["pem"] }
+const-oid = { version = "=0.10.0-pre.2", features = ["db"] }
 
 # optional dependencies
 aes = { version = "0.8.2", optional = true }
 cbc = { version = "0.1.2", optional = true }
 cipher = { version = "0.4.4", features = ["alloc", "block-padding", "rand_core"], optional = true }
-rsa = { version = "0.9.6", optional = true }
-sha1 = { version = "0.10", optional = true }
-sha2 = { version = "0.10", optional = true }
-sha3 = { version = "0.10", optional = true }
-signature = { version = "2.1.0", features = ["digest", "alloc"], optional = true }
+rsa = { version = "=0.10.0-pre.0", optional = true }
+sha1 = { version = "=0.11.0-pre.2", optional = true }
+sha2 = { version = "=0.11.0-pre.2", optional = true }
+sha3 = { version = "=0.11.0-pre.2", optional = true }
+signature = { version = "=2.3.0-pre.2", features = ["digest", "alloc"], optional = true }
 zeroize = { version = "1.6.0", optional = true }
 
 [dev-dependencies]
 getrandom = "0.2"
 hex-literal = "0.4"
-pem-rfc7468 = "0.7.0"
-pkcs5 = "0.7"
+pem-rfc7468 = "=1.0.0-pre.0"
+pkcs5 = "=0.8.0-pre.0"
 rand = "0.8.5"
-rsa = { version = "0.9.6", features = ["sha2"] }
-ecdsa = { version = "0.16.8", features = ["digest", "pem"] }
-p256 = "0.13.0"
+rsa = { version = "=0.10.0-pre.0", features = ["sha2"] }
+ecdsa = { version = "=0.17.0-pre.4", features = ["digest", "pem"] }
+p256 = "=0.14.0-pre.0"
 
 [features]
 alloc = ["der/alloc"]

--- a/cms/Cargo.toml
+++ b/cms/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["cryptography", "encoding", "no-std", "parser-implementations"]
 keywords = ["crypto", "pkcs7", "signing"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.72"
+rust-version = "1.75"
 
 [dependencies]
 der = { version = "=0.8.0-pre.0", features = ["alloc", "derive", "oid", "pem"] }

--- a/cms/README.md
+++ b/cms/README.md
@@ -27,7 +27,7 @@ RFC 3161 digital timestamping protocol.
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.65** at a minimum.
+This crate requires **Rust 1.72** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -56,7 +56,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/formats/actions/workflows/cms.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/formats/actions/workflows/cms.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.72+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 

--- a/cms/README.md
+++ b/cms/README.md
@@ -27,7 +27,7 @@ RFC 3161 digital timestamping protocol.
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.72** at a minimum.
+This crate requires **Rust 1.75** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -56,7 +56,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/formats/actions/workflows/cms.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/formats/actions/workflows/cms.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.72+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.75+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 

--- a/cms/tests/enveloped_data.rs
+++ b/cms/tests/enveloped_data.rs
@@ -217,7 +217,7 @@ fn reencode_enveloped_data_pwri_test() {
                 );
                 let enc_pbkdf2 = kdf_alg.parameters.as_ref().unwrap().to_der().unwrap();
                 let pbkdf2 = Pbkdf2Params::from_der(enc_pbkdf2.as_slice()).unwrap();
-                assert_eq!(hex!("7F EE A8 FD 56 8E 8F 07"), pbkdf2.salt);
+                assert_eq!(hex!("7F EE A8 FD 56 8E 8F 07"), pbkdf2.salt.as_ref());
                 assert_eq!(2048, pbkdf2.iteration_count);
                 assert_eq!(
                     ObjectIdentifier::new_unwrap("1.2.840.113549.1.9.16.3.9"),
@@ -431,7 +431,7 @@ fn reencode_enveloped_data_multi_test() {
                 );
                 let enc_pbkdf2 = kdf_alg.parameters.as_ref().unwrap().to_der().unwrap();
                 let pbkdf2 = Pbkdf2Params::from_der(enc_pbkdf2.as_slice()).unwrap();
-                assert_eq!(hex!("39 04 A7 33 A0 6A 1B 27"), pbkdf2.salt);
+                assert_eq!(hex!("39 04 A7 33 A0 6A 1B 27"), pbkdf2.salt.as_ref());
                 assert_eq!(2048, pbkdf2.iteration_count);
                 assert_eq!(
                     ObjectIdentifier::new_unwrap("1.2.840.113549.1.9.16.3.9"),

--- a/cms/tests/tests_from_pkcs7_crate.rs
+++ b/cms/tests/tests_from_pkcs7_crate.rs
@@ -40,7 +40,7 @@ fn cms_decode_encrypted_key_example() {
         .to_der()
         .unwrap();
     let pbkdf2 = Pbkdf2Params::from_der(enc_pbkdf2.as_slice()).unwrap();
-    assert_eq!(hex!("ad2d4b4e87b34d67"), pbkdf2.salt);
+    assert_eq!(hex!("ad2d4b4e87b34d67"), pbkdf2.salt.as_ref());
     assert_eq!(2048, pbkdf2.iteration_count);
     assert_eq!(
         552u32,

--- a/crmf/Cargo.toml
+++ b/crmf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crmf"
-version = "0.2.0"
+version = "0.3.0-pre"
 description = """
 Pure Rust implementation of the Certificate Request Message Format (CRMF) as
 described in RFC 4211
@@ -12,16 +12,16 @@ categories = ["cryptography", "data-structures", "encoding", "no-std"]
 keywords = ["crypto"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.72"
 
 [dependencies]
-cms = "0.2"
-der = { version = "0.7", features = ["alloc", "derive"] }
-spki = "0.7"
-x509-cert = { version = "0.2", default-features = false }
+cms = "=0.3.0-pre"
+der = { version = "=0.8.0-pre.0", features = ["alloc", "derive"] }
+spki = "=0.8.0-pre.0"
+x509-cert = { version = "=0.3.0-pre", default-features = false }
 
 [dev-dependencies]
-const-oid = "0.9"
+const-oid = "=0.10.0-pre.2"
 
 [features]
 alloc = ["der/alloc"]

--- a/crmf/Cargo.toml
+++ b/crmf/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "data-structures", "encoding", "no-std"]
 keywords = ["crypto"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.72"
+rust-version = "1.75"
 
 [dependencies]
 cms = "=0.3.0-pre"

--- a/crmf/README.md
+++ b/crmf/README.md
@@ -13,7 +13,7 @@ Pure Rust implementation of the Certificate Request Message Format (CRMF) as des
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.65** at a minimum.
+This crate requires **Rust 1.72** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -42,7 +42,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/formats/actions/workflows/crmf.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/formats/actions/workflows/crmf.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.72+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 

--- a/crmf/README.md
+++ b/crmf/README.md
@@ -13,7 +13,7 @@ Pure Rust implementation of the Certificate Request Message Format (CRMF) as des
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.72** at a minimum.
+This crate requires **Rust 1.75** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -42,7 +42,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/formats/actions/workflows/crmf.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/formats/actions/workflows/crmf.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.72+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.75+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 

--- a/der/derive/Cargo.toml
+++ b/der/derive/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["cryptography", "data-structures", "encoding", "no-std", "parser-i
 keywords = ["asn1", "der", "crypto", "itu", "pkcs"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.71"
 
 [lib]
 proc-macro = true

--- a/der/derive/README.md
+++ b/der/derive/README.md
@@ -15,7 +15,7 @@ Custom derive support for the `der` crate's `Choice` and `Sequence` traits:
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.65** at a minimum.
+This crate requires **Rust 1.71** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -37,14 +37,14 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/der_derive.svg
+[crate-image]: https://buildstats.info/crate/der_derive
 [crate-link]: https://crates.io/crates/der_derive
 [docs-image]: https://docs.rs/der_derive/badge.svg
 [docs-link]: https://docs.rs/der_derive/
 [build-image]: https://github.com/RustCrypto/formats/actions/workflows/der.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/formats/actions/workflows/der.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.71+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 

--- a/gss-api/Cargo.toml
+++ b/gss-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gss-api"
-version = "0.1.0"
+version = "0.2.0-pre"
 description = """
 Pure Rust implementation for Generic Security Service Application Program
 Interface (GSS-API)
@@ -12,17 +12,17 @@ categories = ["cryptography", "authentication", "encoding", "no-std", "parser-im
 keywords = ["crypto", "gssapi", "kerberos", "krb5"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.72"
 
 [dependencies]
-der = { version = "0.7", features = ["oid", "alloc"] }
-spki = { version = "0.7" }
-x509-cert = { version = "0.2", default-features = false }
+der = { version = "=0.8.0-pre.0", features = ["oid", "alloc"] }
+spki = { version = "=0.8.0-pre.0" }
+x509-cert = { version = "=0.3.0-pre", default-features = false }
 
 [dev-dependencies]
-der = { version = "0.7", features = ["oid", "pem", "alloc"] }
+der = { version = "=0.8.0-pre.0", features = ["oid", "pem", "alloc"] }
 hex-literal = "0.4"
-x509-cert = { version = "0.2", default-features = false, features = ["pem"] }
+x509-cert = { version = "=0.3.0-pre", default-features = false, features = ["pem"] }
 
 [features]
 rfc2478 = []

--- a/gss-api/Cargo.toml
+++ b/gss-api/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "authentication", "encoding", "no-std", "parser-im
 keywords = ["crypto", "gssapi", "kerberos", "krb5"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.72"
+rust-version = "1.75"
 
 [dependencies]
 der = { version = "=0.8.0-pre.0", features = ["oid", "alloc"] }

--- a/gss-api/README.md
+++ b/gss-api/README.md
@@ -46,7 +46,7 @@ guarantees about the identity of the remote user or remote host.
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.72** at a minimum.
+This crate requires **Rust 1.75** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -73,7 +73,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/gss-api/badge.svg
 [docs-link]: https://docs.rs/gss-api/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.72+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.75+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 [build-image]: https://github.com/RustCrypto/formats/actions/workflows/gss-api.yml/badge.svg

--- a/gss-api/README.md
+++ b/gss-api/README.md
@@ -46,7 +46,7 @@ guarantees about the identity of the remote user or remote host.
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.65** at a minimum.
+This crate requires **Rust 1.72** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -73,7 +73,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/gss-api/badge.svg
 [docs-link]: https://docs.rs/gss-api/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.72+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 [build-image]: https://github.com/RustCrypto/formats/actions/workflows/gss-api.yml/badge.svg

--- a/pkcs12/Cargo.toml
+++ b/pkcs12/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "encoding", "no-std", "parser-implementations"]
 keywords = ["crypto", "key", "pkcs", "private"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.72"
+rust-version = "1.75"
 
 [dependencies]
 der = { version = "=0.8.0-pre.0", features = ["alloc", "derive", "oid", "pem"] }

--- a/pkcs12/Cargo.toml
+++ b/pkcs12/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs12"
-version = "0.1.0"
+version = "0.2.0-pre"
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #12:
 Personal Information Exchange Syntax v1.1 (RFC7292)
@@ -12,24 +12,23 @@ categories = ["cryptography", "encoding", "no-std", "parser-implementations"]
 keywords = ["crypto", "key", "pkcs", "private"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.72"
 
 [dependencies]
-der = { version = "0.7.8", features = ["alloc", "derive", "oid", "pem"] }
-spki = { version = "0.7" }
-x509-cert = { version = "0.2.3", default-features = false, features = ["pem"] }
-const-oid = { version = "0.9", features = ["db"] }
-cms = "0.2.1"
-digest = { version = "0.10.7", features=["alloc"], optional = true }
+der = { version = "=0.8.0-pre.0", features = ["alloc", "derive", "oid", "pem"] }
+spki = { version = "=0.8.0-pre.0" }
+x509-cert = { version = "=0.3.0-pre", default-features = false, features = ["pem"] }
+const-oid = { version = "=0.10.0-pre.2", features = ["db"] }
+cms = "=0.3.0-pre"
+digest = { version = "0.11.0-pre.7", features=["alloc"], optional = true }
 zeroize = "1.6.0"
 
 [dev-dependencies]
-hex-literal = "0.3.3"
-pkcs8 = { version = "0.10.2", features = ["pkcs5", "getrandom"] }
-pkcs5 = {version = "0.7.1", features = ["pbes2", "3des"]}
-subtle-encoding = "0.5.1"
-sha2 = "0.10.8"
-whirlpool = "0.10.4"
+hex-literal = "0.4"
+pkcs8 = { version = "=0.11.0-pre.0", features = ["pkcs5", "getrandom"] }
+pkcs5 = {version = "=0.8.0-pre.0", features = ["pbes2", "3des"]}
+sha2 = "=0.11.0-pre.2"
+whirlpool = "=0.11.0-pre.2"
 
 [features]
 kdf = ["dep:digest"]

--- a/pkcs12/README.md
+++ b/pkcs12/README.md
@@ -14,7 +14,7 @@ Personal Information Exchange Syntax v1.1 ([RFC7292]).
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.65** at a minimum.
+This crate requires **Rust 1.72** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -41,7 +41,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/pkcs12/badge.svg
 [docs-link]: https://docs.rs/pkcs12/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.72+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 [build-image]: https://github.com/RustCrypto/formats/workflows/pkcs12/badge.svg?branch=master&event=push

--- a/pkcs12/README.md
+++ b/pkcs12/README.md
@@ -14,7 +14,7 @@ Personal Information Exchange Syntax v1.1 ([RFC7292]).
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.72** at a minimum.
+This crate requires **Rust 1.75** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -41,7 +41,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/pkcs12/badge.svg
 [docs-link]: https://docs.rs/pkcs12/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.72+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.75+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 [build-image]: https://github.com/RustCrypto/formats/workflows/pkcs12/badge.svg?branch=master&event=push

--- a/spki/Cargo.toml
+++ b/spki/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "data-structures", "encoding", "no-std"]
 keywords = ["crypto", "x509"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.71"
 
 [dependencies]
 der = { version = "=0.8.0-pre.0", features = ["oid"] }

--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "data-structures", "encoding", "no-std"]
 keywords = ["crypto"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.72"
+rust-version = "1.75"
 
 [dependencies]
 const-oid = { version = "=0.10.0-pre.2", features = ["db"] }

--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x509-cert"
-version = "0.2.5"
+version = "0.3.0-pre"
 description = """
 Pure Rust implementation of the X.509 Public Key Infrastructure Certificate
 format as described in RFC 5280
@@ -12,27 +12,27 @@ categories = ["cryptography", "data-structures", "encoding", "no-std"]
 keywords = ["crypto"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.72"
 
 [dependencies]
-const-oid = { version = "0.9.6", features = ["db"] }
-der = { version = "0.7.6", features = ["alloc", "derive", "flagset", "oid"] }
-spki = { version = "0.7.3", features = ["alloc"] }
+const-oid = { version = "=0.10.0-pre.2", features = ["db"] }
+der = { version = "=0.8.0-pre.0", features = ["alloc", "derive", "flagset", "oid"] }
+spki = { version = "=0.8.0-pre.0", features = ["alloc"] }
 
 # optional dependencies
 arbitrary = { version = "1.3", features = ["derive"], optional = true }
-sha1 = { version = "0.10.6", optional = true }
-signature = { version = "2.1.0", features = ["rand_core"], optional = true }
+sha1 = { version = "0.11.0-pre.2", optional = true }
+signature = { version = "=2.3.0-pre.2", features = ["rand_core"], optional = true }
 tls_codec = { version = "0.4.0", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
 hex-literal = "0.4"
 rand = "0.8.5"
-rsa = { version = "0.9.6", features = ["sha2"] }
-ecdsa = { version = "0.16.8", features = ["digest", "pem"] }
-p256 = "0.13.0"
+rsa = { version = "=0.10.0-pre.0", features = ["sha2"] }
+ecdsa = { version = "=0.17.0-pre.4", features = ["digest", "pem"] }
+p256 = "=0.14.0-pre.0"
 rstest = "0.18"
-sha2 = { version = "0.10", features = ["oid"] }
+sha2 = { version = "=0.11.0-pre.2", features = ["oid"] }
 tempfile = "3.5.0"
 x509-cert-test-support = { path = "./test-support" }
 

--- a/x509-cert/README.md
+++ b/x509-cert/README.md
@@ -14,7 +14,7 @@ format as described in [RFC 5280].
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.72** at a minimum.
+This crate requires **Rust 1.75** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -43,7 +43,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/formats/actions/workflows/x509-cert.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/formats/actions/workflows/x509-cert.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.72+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.75+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 

--- a/x509-cert/README.md
+++ b/x509-cert/README.md
@@ -14,7 +14,7 @@ format as described in [RFC 5280].
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.65** at a minimum.
+This crate requires **Rust 1.72** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -43,7 +43,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/formats/actions/workflows/x509-cert.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/formats/actions/workflows/x509-cert.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.72+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 

--- a/x509-cert/src/builder.rs
+++ b/x509-cert/src/builder.rs
@@ -276,7 +276,7 @@ where
         cert_signer: &'s S,
     ) -> Result<Self> {
         let verifying_key = cert_signer.verifying_key();
-        let signer_pub = SubjectPublicKeyInfoOwned::from_key(verifying_key)?;
+        let signer_pub = SubjectPublicKeyInfoOwned::from_key(&verifying_key)?;
 
         let signature_alg = cert_signer.signature_algorithm_identifier()?;
         let issuer = profile.get_issuer(&subject);
@@ -368,7 +368,7 @@ where
     pub fn new(subject: Name, req_signer: &'s S) -> Result<Self> {
         let version = Default::default();
         let verifying_key = req_signer.verifying_key();
-        let public_key = SubjectPublicKeyInfoOwned::from_key(verifying_key)?;
+        let public_key = SubjectPublicKeyInfoOwned::from_key(&verifying_key)?;
         let attributes = Default::default();
         let extension_req = Default::default();
 

--- a/x509-ocsp/Cargo.toml
+++ b/x509-ocsp/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "data-structures", "encoding", "no-std"]
 keywords = ["crypto", "x509"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.72"
+rust-version = "1.75"
 
 [dependencies]
 const-oid = { version = "=0.10.0-pre.2", default-features = false, features = ["db"] }

--- a/x509-ocsp/Cargo.toml
+++ b/x509-ocsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x509-ocsp"
-version = "0.2.1"
+version = "0.3.0-pre"
 description = """
 Pure Rust implementation of the X.509 Internet Public Key Infrastructure
 Online Certificate Status Protocol - OCSP formats as described in RFC 6960
@@ -12,26 +12,26 @@ categories = ["cryptography", "data-structures", "encoding", "no-std"]
 keywords = ["crypto", "x509"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.72"
 
 [dependencies]
-const-oid = { version = "0.9.5", default-features = false, features = ["db"] }
-der = { version = "0.7.8", features = ["alloc", "derive", "oid"] }
-spki = { version = "0.7.2", features = ["alloc"] }
-x509-cert = { version = "0.2.4", default-features = false }
+const-oid = { version = "=0.10.0-pre.2", default-features = false, features = ["db"] }
+der = { version = "=0.8.0-pre.0", features = ["alloc", "derive", "oid"] }
+spki = { version = "=0.8.0-pre.0", features = ["alloc"] }
+x509-cert = { version = "=0.3.0-pre", default-features = false }
 
 # Optional
-digest = { version = "0.10.7", optional = true, default-features = false, features = ["oid"] }
+digest = { version = "=0.11.0-pre.7", optional = true, default-features = false, features = ["oid"] }
 rand_core = { version = "0.6.4", optional = true, default-features = false }
-signature = { version = "2.1.0", optional = true, default-features = false, features = ["digest", "rand_core"] }
+signature = { version = "=2.3.0-pre.2", optional = true, default-features = false, features = ["digest", "rand_core"] }
 
 [dev-dependencies]
 hex-literal = "0.4.1"
 lazy_static = "1.4.0"
 rand = "0.8.5"
-rsa = { version = "0.9.2", default-features = false, features = ["sha2"] }
-sha1 = { version = "0.10.6", default-features = false, features = ["oid"] }
-sha2 = { version = "0.10.8", default-features = false, features = ["oid"] }
+rsa = { version = "=0.10.0-pre.0", default-features = false, features = ["sha2"] }
+sha1 = { version = "=0.11.0-pre.2", default-features = false, features = ["oid"] }
+sha2 = { version = "=0.11.0-pre.2", default-features = false, features = ["oid"] }
 
 [features]
 rand = ["rand_core"]

--- a/x509-ocsp/README.md
+++ b/x509-ocsp/README.md
@@ -14,7 +14,7 @@ Online Certificate Status Protocol - OCSP formats as described in [RFC 6960].
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.72** at a minimum.
+This crate requires **Rust 1.75** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -43,7 +43,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/formats/actions/workflows/x509-ocsp.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/formats/actions/workflows/x509-ocsp.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.72+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.75+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 

--- a/x509-ocsp/README.md
+++ b/x509-ocsp/README.md
@@ -14,7 +14,7 @@ Online Certificate Status Protocol - OCSP formats as described in [RFC 6960].
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.65** at a minimum.
+This crate requires **Rust 1.72** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -43,7 +43,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/formats/actions/workflows/x509-ocsp.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/formats/actions/workflows/x509-ocsp.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.72+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 

--- a/x509-tsp/Cargo.toml
+++ b/x509-tsp/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/RustCrypto/formats/tree/master/x509-tsp"
 categories = ["cryptography", "encoding", "no-std", "parser-implementations"]
 keywords = ["crypto", "tsp", "timestamp"]
 readme = "README.md"
-rust-version = "1.72"
+rust-version = "1.75"
 
 [dependencies]
 der = { version = "=0.8.0-pre.0", features = ["alloc", "derive", "oid", "pem"] }

--- a/x509-tsp/Cargo.toml
+++ b/x509-tsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x509-tsp"
-version = "0.1.0"
+version = "0.2.0-pre"
 edition = "2021"
 description = """
 Pure Rust implementation of the Timestamping Protocol as described in RFC 3161.
@@ -11,13 +11,13 @@ repository = "https://github.com/RustCrypto/formats/tree/master/x509-tsp"
 categories = ["cryptography", "encoding", "no-std", "parser-implementations"]
 keywords = ["crypto", "tsp", "timestamp"]
 readme = "README.md"
-rust-version = "1.65"
+rust-version = "1.72"
 
 [dependencies]
-der = { version = "0.7.6", features = ["alloc", "derive", "oid", "pem"] }
-cms = { version = "0.2.1", features = ["alloc"] }
-cmpv2 = { version = "0.2", features = ["alloc"] }
-x509-cert = { version = "0.2.4", default-features = false }
+der = { version = "=0.8.0-pre.0", features = ["alloc", "derive", "oid", "pem"] }
+cms = { version = "=0.3.0-pre", features = ["alloc"] }
+cmpv2 = { version = "=0.3.0-pre", features = ["alloc"] }
+x509-cert = { version = "=0.3.0-pre", default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.4.1"

--- a/x509-tsp/README.md
+++ b/x509-tsp/README.md
@@ -11,7 +11,7 @@ Pure Rust implementation of the Timestamping Protocol as described in [RFC 3161]
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.72** at a minimum.
+This crate requires **Rust 1.75** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -40,7 +40,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/formats/actions/workflows/x509-tsp.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/formats/actions/workflows/x509-tsp.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.72+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.75+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 

--- a/x509-tsp/README.md
+++ b/x509-tsp/README.md
@@ -1,10 +1,17 @@
 # [RustCrypto]: TimeStamp Protocol
 
+[![crate][crate-image]][crate-link]
+[![Docs][docs-image]][docs-link]
+[![Build Status][build-image]][build-link]
+![Apache2/MIT licensed][license-image]
+![Rust Version][rustc-image]
+[![Project Chat][chat-image]][chat-link]
+
 Pure Rust implementation of the Timestamping Protocol as described in [RFC 3161].
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.65** at a minimum.
+This crate requires **Rust 1.72** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -24,6 +31,18 @@ Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
 
+[//]: # (badges)
+
+[crate-image]: https://buildstats.info/crate/x509-tsp
+[crate-link]: https://crates.io/crates/x509-tsp
+[docs-image]: https://docs.rs/x509-tsp/badge.svg
+[docs-link]: https://docs.rs/x509-tsp/
+[build-image]: https://github.com/RustCrypto/formats/actions/workflows/x509-tsp.yml/badge.svg
+[build-link]: https://github.com/RustCrypto/formats/actions/workflows/x509-tsp.yml
+[license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.72+-blue.svg
+[chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
+[chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 
 [//]: # (links)
 


### PR DESCRIPTION
For next release cycle, as was started in #1296. Due to circular dependencies (on e.g. digital signature libraries) this wasn't possible at that time, but is now that we've made prereleases of all of the requisite dependencies.

MSRV is bumped to 1.75 in anticipation of using TAIT, and due to dependency MSRV bumps.

This bumps the following crates to prerelease versions (not intended for release, just to signal we're making breaking changes):

- `cmpv2` v0.3.0-pre
- `cms` v0.3.0-pre
- `crmf` v0.3.0-pre
- `gss-api` v0.2.0-pre
- `pkcs12` v0.2.0-pre
- `x509-cert` v0.3.0-pre
- `x509-ocsp` v0.3.0-pre
- `x509-tsp` v0.2.0-pre

See also: #1289