### PR TITLE
x509-cert: ignore commonName warning

### DIFF
--- a/x509-cert/tests/builder.rs
+++ b/x509-cert/tests/builder.rs
@@ -165,6 +165,9 @@ fn leaf_certificate() {
         "e_subject_common_name_not_exactly_from_san",
         // Extended key usage needs to be added by end-user and is use-case dependent
         "e_sub_cert_eku_missing",
+        // TODO(baloo): drop this in https://github.com/RustCrypto/formats/pull/1306
+        // CABF SC-62 marked commoName (CN) as not recommended
+        "w_subject_common_name_included",
     ];
 
     zlint::check_certificate(pem.as_bytes(), &ignored);
@@ -242,6 +245,9 @@ fn pss_certificate() {
         "e_sub_cert_eku_missing",
         // zlint warns on RSAPSS signature algorithms
         "e_signature_algorithm_not_supported",
+        // TODO(baloo): drop this in https://github.com/RustCrypto/formats/pull/1306
+        // CABF SC-62 marked commoName (CN) as not recommended
+        "w_subject_common_name_included",
     ];
 
     zlint::check_certificate(pem.as_bytes(), ignored);


### PR DESCRIPTION
With the upgrade of zlint to 3.6.0 came new lints. One of them is enforcement of one of the measure from SC-62 removing commonName from the Subject.