### PR TITLE
der: add `Error::(set_)source`; remove `Clone` + `Copy`

### DIFF
--- a/pkcs1/src/error.rs
+++ b/pkcs1/src/error.rs
@@ -9,7 +9,7 @@ use der::pem;
 pub type Result<T> = core::result::Result<T, Error>;
 
 /// Error type
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum Error {
     /// ASN.1 DER-related errors.
@@ -92,4 +92,13 @@ impl From<pkcs8::spki::Error> for Error {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Asn1(err) => Some(err),
+            #[cfg(feature = "pkcs8")]
+            Error::Pkcs8(err) => Some(err),
+            _ => None,
+        }
+    }
+}

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -33,6 +33,8 @@ hex-literal = "0.4"
 
 [features]
 alloc = []
+std = ["alloc"]
+
 3des = ["dep:des", "pbes2"]
 des-insecure = ["dep:des", "pbes2"]
 getrandom = ["rand_core/getrandom"]

--- a/pkcs5/src/error.rs
+++ b/pkcs5/src/error.rs
@@ -54,3 +54,6 @@ impl fmt::Display for Error {
         }
     }
 }
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}

--- a/pkcs5/src/lib.rs
+++ b/pkcs5/src/lib.rs
@@ -29,6 +29,9 @@
 #[cfg(all(feature = "alloc", feature = "pbes2"))]
 extern crate alloc;
 
+#[cfg(feature = "std")]
+extern crate std;
+
 mod error;
 
 pub mod pbes1;

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -30,7 +30,7 @@ tempfile = "3"
 
 [features]
 alloc = ["der/alloc", "der/zeroize", "spki/alloc"]
-std = ["alloc", "der/std", "spki/std"]
+std = ["alloc", "der/std", "pkcs5?/std", "spki/std"]
 
 3des = ["encryption", "pkcs5/3des"]
 des-insecure = ["encryption", "pkcs5/des-insecure"]

--- a/pkcs8/src/error.rs
+++ b/pkcs8/src/error.rs
@@ -9,7 +9,7 @@ use der::pem;
 pub type Result<T> = core::result::Result<T, Error>;
 
 /// Error type
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum Error {
     /// ASN.1 DER-related errors.
@@ -48,7 +48,17 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Asn1(err) => Some(err),
+            #[cfg(feature = "pkcs5")]
+            Error::EncryptedPrivateKey(err) => Some(err),
+            Error::PublicKey(err) => Some(err),
+            _ => None,
+        }
+    }
+}
 
 impl From<der::Error> for Error {
     fn from(err: der::Error) -> Error {

--- a/pkcs8/tests/encrypted_private_key.rs
+++ b/pkcs8/tests/encrypted_private_key.rs
@@ -3,10 +3,13 @@
 #![cfg(feature = "pkcs5")]
 
 use hex_literal::hex;
-use pkcs8::{pkcs5::pbes2, EncryptedPrivateKeyInfo, PrivateKeyInfo};
+use pkcs8::{pkcs5::pbes2, EncryptedPrivateKeyInfo};
 
 #[cfg(feature = "alloc")]
 use der::Encode;
+
+#[cfg(feature = "encryption")]
+use pkcs8::PrivateKeyInfo;
 
 #[cfg(feature = "pem")]
 use der::EncodePem;

--- a/sec1/src/error.rs
+++ b/sec1/src/error.rs
@@ -9,7 +9,7 @@ use der::pem;
 pub type Result<T> = core::result::Result<T, Error>;
 
 /// Error type
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum Error {
     /// ASN.1 DER-related errors.

--- a/spki/src/error.rs
+++ b/spki/src/error.rs
@@ -10,7 +10,7 @@ pub type Result<T> = core::result::Result<T, Error>;
 use der::pem;
 
 /// Error type
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum Error {
     /// Algorithm parameters are missing.
@@ -65,4 +65,11 @@ impl From<pem::Error> for Error {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Asn1(err) => Some(err),
+            _ => None,
+        }
+    }
+}


### PR DESCRIPTION
When the `std` feature is enabled, adds support for propagating an arbitrary error source which can be set using `Error::set_source`.

The main use case is passing back an arbitrary error value in the `ErrorKind::Value` use case, to handle passing back what specifically was wrong with a given value in a DER-encoded document.

This entails removing the `Clone` + `Copy` bounds since the error is stored in a `Box`, which can't be `Copy` and can't reflect a `Clone` bound. Fortunately, nothing in this repo ever seems to clone an `Error` so it's not really an issue.

Also adds `Error::source` impls to the downstream error types in `pkcs1`, `pkcs5`, `pkcs8`, `sec1`, and `spki`.