### PR TITLE
tls_codec: Introduce helper macro for conditional deserialization

### DIFF
--- a/tls_codec/derive/src/lib.rs
+++ b/tls_codec/derive/src/lib.rs
@@ -1012,7 +1012,7 @@ fn restrict_conditional_generic(
     let impl_generics = quote! { #impl_generics }
         .to_string()
         // Make string replacement easier by replacing newlines with spaces.
-        .replace("\n", " ")
+        .replace('\n', " ")
         .replace(" const IS_DESERIALIZABLE : bool ", "")
         .replace("<>", "")
         .parse()
@@ -1381,12 +1381,20 @@ fn impl_conditionally_deserializable(mut annotated_item: ItemStruct) -> TokenStr
         Span::call_site(),
     );
     let annotated_item_visibility = annotated_item.vis.clone();
+    let doc_string_deserializable = format!(
+        "Alias for the deserializable version of the [`{}`].",
+        annotated_item_ident
+    );
+    let doc_string_undeserializable = format!(
+        "Alias for the version of the [`{}`] that cannot be deserialized.",
+        annotated_item_ident
+    );
     quote! {
         #annotated_item
 
-        /// Alias for the deserializable version of the [`#annotated_item_ident`].
+        #[doc = #doc_string_deserializable]
         #annotated_item_visibility type #undeserializable_ident #original_ty_generics = #annotated_item_ident #undeserializable_ty_generics;
-        /// Alias for the version of the [`#annotated_item_ident`] that cannot be deserialized.
+        #[doc = #doc_string_undeserializable]
         #annotated_item_visibility type #deserializable_ident #original_ty_generics = #annotated_item_ident #deserializable_ty_generics;
 
         #deserialize_implementation

--- a/tls_codec/derive/src/lib.rs
+++ b/tls_codec/derive/src/lib.rs
@@ -234,6 +234,32 @@
 //!     DeserializableExampleStruct::tls_deserialize(&mut serialized.as_slice()).unwrap();
 //! # }
 //! ```
+//!
+//! The helper macro `#[tls_codec(cd_field)]` can be used to mark a field as
+//! conditionally deserializable, thus allowing nested conditionally
+//! deserializable structs.
+//!
+//! ```
+//! # #[cfg(all(feature = "conditional_deserialization", feature = "std"))]
+//! # {
+//! use tls_codec::{Serialize, Deserialize};
+//! use tls_codec_derive::{TlsSerialize, TlsSize, conditionally_deserializable};
+//!
+//! #[conditionally_deserializable]
+//! #[derive(TlsSize, TlsSerialize, PartialEq, Debug)]
+//! struct ExampleStruct {
+//!     a: u8,
+//!     b: u16,
+//! }
+//!
+//! #[conditionally_deserializable]
+//! #[derive(TlsSize, TlsSerialize, PartialEq, Debug)]
+//! struct NestedExampleStruct {
+//!    #[tls_codec(cd_field)]
+//!    example_struct: ExampleStruct,
+//! }
+//! # }
+//! ```
 
 extern crate proc_macro;
 extern crate proc_macro2;

--- a/tls_codec/derive/src/lib.rs
+++ b/tls_codec/derive/src/lib.rs
@@ -1334,13 +1334,6 @@ fn set_cd_fields_generic(
 
 #[cfg(feature = "conditional_deserialization")]
 fn impl_conditionally_deserializable(mut annotated_item: ItemStruct) -> TokenStream2 {
-    use core::panic;
-
-    use syn::{
-        parse::{Parse, Parser},
-        AngleBracketedGenericArguments, GenericArgument, PathArguments,
-    };
-
     let deserializable_const_generic: ConstParam = parse_quote! {const IS_DESERIALIZABLE: bool};
     // Add the DESERIALIZABLE const generic to the struct
     annotated_item

--- a/tls_codec/derive/src/lib.rs
+++ b/tls_codec/derive/src/lib.rs
@@ -1378,7 +1378,9 @@ fn impl_conditionally_deserializable(mut annotated_item: ItemStruct) -> TokenStr
     quote! {
         #annotated_item
 
+        /// Alias for the deserializable version of the [`#annotated_item_ident`].
         #annotated_item_visibility type #undeserializable_ident = #annotated_item_ident #undeserializable_ty_generics;
+        /// Alias for the version of the [`#annotated_item_ident`] that cannot be deserialized.
         #annotated_item_visibility type #deserializable_ident = #annotated_item_ident #deserializable_ty_generics;
 
         #deserialize_implementation

--- a/tls_codec/derive/src/lib.rs
+++ b/tls_codec/derive/src/lib.rs
@@ -1326,9 +1326,10 @@ fn set_cd_fields_generic(
                         let angle_bracketed = parser.parse(TokenStream::from(value.clone()));
                         let angle_bracketed = angle_bracketed.unwrap();
                         segment.arguments = PathArguments::AngleBracketed(angle_bracketed);
-                        //panic!("Path: {:?}", path);
                     }
                 }
+            } else {
+                panic!("Only simple types are supported for conditional deserialization.");
             }
         }
     });

--- a/tls_codec/derive/src/lib.rs
+++ b/tls_codec/derive/src/lib.rs
@@ -396,6 +396,7 @@ impl TlsAttr {
                     if let Some(ident) = path.get_ident() {
                         match ident.to_string().to_ascii_lowercase().as_ref() {
                             "skip" => Ok(TlsAttr::Skip),
+                            #[cfg(feature = "conditional_deserialization")]
                             "cd_field" => Ok(TlsAttr::CdField),
                             _ => Err(syn::Error::new_spanned(
                                 ident,
@@ -461,6 +462,7 @@ fn function_skip(field: &Field) -> Result<bool> {
 
 /// Process all attributes of a field and return a single, true or false, `cd_field` value.
 /// This function will return an error in the case of multiple `cd` attributes.
+#[cfg(feature = "conditional_deserialization")]
 fn function_cd(field: &Field) -> Result<bool> {
     let skip = TlsAttr::parse_multi(&field.attrs)?
         .into_iter()
@@ -1299,6 +1301,7 @@ pub fn conditionally_deserializable(
     impl_conditionally_deserializable(annotated_item).into()
 }
 
+#[cfg(feature = "conditional_deserialization")]
 fn set_cd_fields_generic(
     mut item_struct: ItemStruct,
     value: proc_macro2::TokenStream,

--- a/tls_codec/derive/tests/decode.rs
+++ b/tls_codec/derive/tests/decode.rs
@@ -530,7 +530,7 @@ fn type_with_unknowns() {
 
 #[cfg(feature = "conditional_deserialization")]
 mod conditional_deserialization {
-    use tls_codec::{Deserialize, Serialize};
+    use tls_codec::{Deserialize, DeserializeBytes, Serialize, Size};
     use tls_codec_derive::{conditionally_deserializable, TlsSerialize, TlsSize};
 
     #[test]
@@ -572,11 +572,42 @@ mod conditional_deserialization {
             a: u8,
             b: u16,
         }
+
         let undeserializable_struct = UndeserializableExampleStruct { a: 1, b: 2 };
         let serialized = undeserializable_struct.tls_serialize_detached().unwrap();
         let deserializable_struct =
             DeserializableExampleStruct::tls_deserialize_exact(&*serialized).unwrap();
         assert_eq!(deserializable_struct.a, undeserializable_struct.a);
         assert_eq!(deserializable_struct.b, undeserializable_struct.b);
+    }
+
+    #[test]
+    fn nested_conditionally_deserializable() {
+        #[conditionally_deserializable]
+        #[derive(TlsSize, TlsSerialize, PartialEq, Debug)]
+        struct ExampleStruct {
+            a: u8,
+            b: u16,
+        }
+
+        #[conditionally_deserializable]
+        #[derive(TlsSize, TlsSerialize, PartialEq, Debug)]
+        struct NestedExampleStruct {
+            #[tls_codec(cd_field)]
+            nested_field: ExampleStruct,
+        }
+
+        #[conditionally_deserializable]
+        #[derive(TlsSize, TlsSerialize, PartialEq, Debug)]
+        struct GenericExampleStruct<T: Serialize + Size + Deserialize + DeserializeBytes> {
+            a: T,
+        }
+
+        #[conditionally_deserializable]
+        #[derive(TlsSize, TlsSerialize, PartialEq, Debug)]
+        struct NestedGenericExampleStruct<T: Serialize + Size + Deserialize + DeserializeBytes> {
+            #[tls_codec(cd_field)]
+            nested_field: GenericExampleStruct<T>,
+        }
     }
 }

--- a/tls_codec/derive/tests/decode.rs
+++ b/tls_codec/derive/tests/decode.rs
@@ -551,6 +551,13 @@ mod conditional_deserialization {
 
         #[conditionally_deserializable]
         #[derive(TlsSize, TlsSerialize, PartialEq, Debug)]
+        struct NestedExampleStruct {
+            #[tls_codec(cd_field)]
+            nested_field: ExampleStruct,
+        }
+
+        #[conditionally_deserializable]
+        #[derive(TlsSize, TlsSerialize, PartialEq, Debug)]
         struct SecondExampleStruct {
             a: u8,
             b: u16,


### PR DESCRIPTION
This PR introduces the `#[tls_codec(cd_field)]` macro. It can be used alongside the `#[conditionally_deserializable]` macro to mark fields that are also conditionally deserializable and that internally need to have the const generic added.