### PR TITLE
Change RKeyId enum variant to use constructed encoding

### DIFF
--- a/cms/src/enveloped_data.rs
+++ b/cms/src/enveloped_data.rs
@@ -299,7 +299,7 @@ pub struct RecipientEncryptedKey {
 #[allow(missing_docs)]
 pub enum KeyAgreeRecipientIdentifier {
     IssuerAndSerialNumber(IssuerAndSerialNumber),
-    #[asn1(context_specific = "0", tag_mode = "IMPLICIT")]
+    #[asn1(context_specific = "0", tag_mode = "IMPLICIT", constructed = "true")]
     RKeyId(RecipientKeyIdentifier),
 }
 


### PR DESCRIPTION
The type `RecipientKeyIdentifier` is a SEQUENCE, so it should use constructed encoding in the enum variant `KeyAgreeRecipientIdentifier::RKeyId(RecipientKeyIdentifier)`

I discovered this because of the error in this code snippet.
```Rust
use cms::{
    cert::x509::ext::pkix::SubjectKeyIdentifier,
    enveloped_data::{KeyAgreeRecipientIdentifier, RecipientKeyIdentifier},
};
use der::{asn1::OctetString, Decode, Encode};

fn main() {
    let kari = KeyAgreeRecipientIdentifier::RKeyId(RecipientKeyIdentifier {
        subject_key_identifier: SubjectKeyIdentifier(OctetString::new([0]).unwrap()),
        date: None,
        other: None,
    });
    
    let encoded = kari.to_der().unwrap();
    let decoded = KeyAgreeRecipientIdentifier::from_der(&encoded).unwrap();
    // Error { kind: Noncanonical { tag: Tag(0x80: CONTEXT-SPECIFIC [0] (primitive)) }, position: None }

    assert_eq!(kari, decoded);
}
```