### PR TITLE
tls_codec: expose vlen functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1696,6 +1696,16 @@ dependencies = [
 [[package]]
 name = "tls_codec"
 version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e78c9c330f8c85b2bae7c8368f2739157db9991235123aa1b15ef9502bfb6a"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec"
+version = "0.4.2-pre.1"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -1716,7 +1726,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "tls_codec",
+ "tls_codec 0.4.2-pre.1",
  "trybuild",
 ]
 
@@ -1980,7 +1990,7 @@ dependencies = [
  "signature",
  "spki",
  "tempfile",
- "tls_codec",
+ "tls_codec 0.4.1",
  "tokio",
  "x509-cert-test-support",
 ]

--- a/tls_codec/Cargo.toml
+++ b/tls_codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tls_codec"
-version = "0.4.1"
+version = "0.4.2-pre.1"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/tls_codec/"

--- a/tls_codec/src/lib.rs
+++ b/tls_codec/src/lib.rs
@@ -48,7 +48,7 @@ pub use tls_vec::{
 };
 
 #[cfg(feature = "std")]
-pub use quic_vec::{rw::read_variable_length, write_length, SecretVLBytes};
+pub use quic_vec::{rw as vlen, SecretVLBytes};
 pub use quic_vec::{VLByteSlice, VLBytes};
 
 #[cfg(feature = "derive")]

--- a/tls_codec/src/lib.rs
+++ b/tls_codec/src/lib.rs
@@ -48,7 +48,7 @@ pub use tls_vec::{
 };
 
 #[cfg(feature = "std")]
-pub use quic_vec::SecretVLBytes;
+pub use quic_vec::{rw::read_variable_length, write_length, SecretVLBytes};
 pub use quic_vec::{VLByteSlice, VLBytes};
 
 #[cfg(feature = "derive")]

--- a/tls_codec/src/quic_vec.rs
+++ b/tls_codec/src/quic_vec.rs
@@ -105,7 +105,7 @@ fn length_encoding_bytes(length: u64) -> Result<usize, Error> {
 }
 
 #[inline(always)]
-fn write_length(content_length: usize) -> Result<Vec<u8>, Error> {
+pub fn write_length(content_length: usize) -> Result<Vec<u8>, Error> {
     let len_len = length_encoding_bytes(content_length.try_into()?)?;
     if !cfg!(fuzzing) {
         debug_assert!(len_len <= 8, "Invalid vector len_len {len_len}");
@@ -418,7 +418,7 @@ impl<'a> Size for VLByteSlice<'a> {
 }
 
 #[cfg(feature = "std")]
-mod rw {
+pub(super) mod rw {
     use super::*;
     use crate::{Deserialize, Serialize};
 
@@ -429,9 +429,7 @@ mod rw {
     ///
     /// The length and number of bytes read are returned.
     #[inline]
-    pub(super) fn read_variable_length<R: std::io::Read>(
-        bytes: &mut R,
-    ) -> Result<(usize, usize), Error> {
+    pub fn read_variable_length<R: std::io::Read>(bytes: &mut R) -> Result<(usize, usize), Error> {
         // The length is encoded in the first two bits of the first byte.
         let mut len_len_byte = [0u8; 1];
         if bytes.read(&mut len_len_byte)? == 0 {

--- a/tls_codec/src/quic_vec.rs
+++ b/tls_codec/src/quic_vec.rs
@@ -105,7 +105,7 @@ fn length_encoding_bytes(length: u64) -> Result<usize, Error> {
 }
 
 #[inline(always)]
-pub fn write_length(content_length: usize) -> Result<Vec<u8>, Error> {
+pub fn write_variable_length(content_length: usize) -> Result<Vec<u8>, Error> {
     let len_len = length_encoding_bytes(content_length.try_into()?)?;
     if !cfg!(fuzzing) {
         debug_assert!(len_len <= 8, "Invalid vector len_len {len_len}");
@@ -178,7 +178,7 @@ impl<T: SerializeBytes> SerializeBytes for &[T] {
         // This requires more computations but the other option would be to buffer
         // the entire content, which can end up requiring a lot of memory.
         let content_length = self.iter().fold(0, |acc, e| acc + e.tls_serialized_len());
-        let mut length = write_length(content_length)?;
+        let mut length = write_variable_length(content_length)?;
         let len_len = length.len();
 
         let mut out = Vec::with_capacity(content_length + len_len);
@@ -418,7 +418,7 @@ impl<'a> Size for VLByteSlice<'a> {
 }
 
 #[cfg(feature = "std")]
-pub(super) mod rw {
+pub mod rw {
     use super::*;
     use crate::{Deserialize, Serialize};
 
@@ -429,7 +429,7 @@ pub(super) mod rw {
     ///
     /// The length and number of bytes read are returned.
     #[inline]
-    pub fn read_variable_length<R: std::io::Read>(bytes: &mut R) -> Result<(usize, usize), Error> {
+    pub fn read_length<R: std::io::Read>(bytes: &mut R) -> Result<(usize, usize), Error> {
         // The length is encoded in the first two bits of the first byte.
         let mut len_len_byte = [0u8; 1];
         if bytes.read(&mut len_len_byte)? == 0 {
@@ -456,7 +456,7 @@ pub(super) mod rw {
     impl<T: Deserialize> Deserialize for Vec<T> {
         #[inline(always)]
         fn tls_deserialize<R: std::io::Read>(bytes: &mut R) -> Result<Self, Error> {
-            let (length, len_len) = read_variable_length(bytes)?;
+            let (length, len_len) = read_length(bytes)?;
 
             if length == 0 {
                 // An empty vector.
@@ -475,11 +475,11 @@ pub(super) mod rw {
     }
 
     #[inline(always)]
-    pub(super) fn write_length<W: std::io::Write>(
+    pub fn write_length<W: std::io::Write>(
         writer: &mut W,
         content_length: usize,
     ) -> Result<usize, Error> {
-        let buf = super::write_length(content_length)?;
+        let buf = super::write_variable_length(content_length)?;
         let buf_len = buf.len();
         writer.write_all(&buf)?;
         Ok(buf_len)
@@ -523,9 +523,6 @@ pub(super) mod rw {
     }
 }
 
-#[cfg(feature = "std")]
-use rw::*;
-
 /// Read/Write (std) based (de)serialization for [`VLBytes`].
 #[cfg(feature = "std")]
 mod rw_bytes {
@@ -551,7 +548,7 @@ mod rw_bytes {
             return Err(Error::InvalidVectorLength);
         }
 
-        let length_bytes = write_length(content_length)?;
+        let length_bytes = write_variable_length(content_length)?;
         let len_len = length_bytes.len();
         writer.write_all(&length_bytes)?;
 
@@ -577,7 +574,7 @@ mod rw_bytes {
 
     impl Deserialize for VLBytes {
         fn tls_deserialize<R: std::io::Read>(bytes: &mut R) -> Result<Self, Error> {
-            let (length, _) = read_variable_length(bytes)?;
+            let (length, _) = rw::read_length(bytes)?;
             if length == 0 {
                 return Ok(Self::new(vec![]));
             }


### PR DESCRIPTION
Expose functions to read and write variable-length encodings for quic vectors.
This can be useful when manual parsing of variable-length structs is required.

There are no code changes in here. This only makes two existing functions public.