### PR TITLE
RFC5083 - AuthEnvelopedData

### DIFF
--- a/cms/src/authenveloped_data.rs
+++ b/cms/src/authenveloped_data.rs
@@ -1,0 +1,60 @@
+//! AuthEnvelopedData-related types
+
+use der::{asn1::SetOfVec, Sequence};
+use x509_cert::attr::Attribute;
+
+use crate::{authenticated_data::MessageAuthenticationCode, content_info::CmsVersion, enveloped_data::{EncryptedContentInfo, OriginatorInfo, RecipientInfos}};
+
+/// The `AuthEnvelopedData` type is defined in [RFC 5083 Section 4].
+/// 
+/// ```text
+/// AuthEnvelopedData ::= SEQUENCE {
+///     version CMSVersion,
+///     originatorInfo [0] IMPLICIT OriginatorInfo OPTIONAL,
+///     recipientInfos RecipientInfos,
+///     authEncryptedContentInfo EncryptedContentInfo,
+///     authAttrs [1] IMPLICIT AuthAttributes OPTIONAL,
+///     mac MessageAuthenticationCode,
+///     unauthAttrs [2] IMPLICIT UnauthAttributes OPTIONAL }
+/// ```
+/// 
+/// [RFC 5083 Section 4]: https://www.rfc-editor.org/rfc/rfc5083#section-4
+#[derive(Clone, Debug, Sequence)]
+#[allow(missing_docs)]
+pub struct AuthEnvelopedData {
+    pub version: CmsVersion,
+    #[asn1(
+        context_specific = "0",
+        tag_mode = "IMPLICIT",
+        constructed = "true",
+        optional = "true"
+    )]
+    pub originator_info: Option<OriginatorInfo>,
+    pub recip_infos: RecipientInfos,
+    pub auth_encrypted_content_info: EncryptedContentInfo,
+    #[asn1(
+        context_specific = "1",
+        tag_mode = "IMPLICIT",
+        constructed = "true",
+        optional = "true"
+    )]
+    pub auth_attrs: Option<AuthAttributes>,
+    pub mac: MessageAuthenticationCode,
+    #[asn1(
+        context_specific = "2",
+        tag_mode = "IMPLICIT",
+        constructed = "true",
+        optional = "true"
+    )]
+    pub unauth_attrs: Option<UnauthAttributes>
+}
+
+/// ```text
+/// AuthAttributes ::= SET SIZE (1..MAX) OF Attribute
+/// ```
+pub type AuthAttributes = SetOfVec<Attribute>;
+
+/// ```text
+/// UnauthAttributes ::= SET SIZE (1..MAX) OF Attribute
+/// ```
+pub type UnauthAttributes = SetOfVec<Attribute>;

--- a/cms/src/authenveloped_data.rs
+++ b/cms/src/authenveloped_data.rs
@@ -3,10 +3,14 @@
 use der::{asn1::SetOfVec, Sequence};
 use x509_cert::attr::Attribute;
 
-use crate::{authenticated_data::MessageAuthenticationCode, content_info::CmsVersion, enveloped_data::{EncryptedContentInfo, OriginatorInfo, RecipientInfos}};
+use crate::{
+    authenticated_data::MessageAuthenticationCode,
+    content_info::CmsVersion,
+    enveloped_data::{EncryptedContentInfo, OriginatorInfo, RecipientInfos},
+};
 
 /// The `AuthEnvelopedData` type is defined in [RFC 5083 Section 4].
-/// 
+///
 /// ```text
 /// AuthEnvelopedData ::= SEQUENCE {
 ///     version CMSVersion,
@@ -17,7 +21,7 @@ use crate::{authenticated_data::MessageAuthenticationCode, content_info::CmsVers
 ///     mac MessageAuthenticationCode,
 ///     unauthAttrs [2] IMPLICIT UnauthAttributes OPTIONAL }
 /// ```
-/// 
+///
 /// [RFC 5083 Section 4]: https://www.rfc-editor.org/rfc/rfc5083#section-4
 #[derive(Clone, Debug, Sequence)]
 #[allow(missing_docs)]
@@ -46,7 +50,7 @@ pub struct AuthEnvelopedData {
         constructed = "true",
         optional = "true"
     )]
-    pub unauth_attrs: Option<UnauthAttributes>
+    pub unauth_attrs: Option<UnauthAttributes>,
 }
 
 /// ```text

--- a/cms/src/lib.rs
+++ b/cms/src/lib.rs
@@ -28,6 +28,7 @@ extern crate alloc;
 extern crate std;
 
 pub mod attr;
+pub mod authenveloped_data;
 pub mod authenticated_data;
 pub mod builder;
 pub mod cert;

--- a/cms/src/lib.rs
+++ b/cms/src/lib.rs
@@ -28,8 +28,8 @@ extern crate alloc;
 extern crate std;
 
 pub mod attr;
-pub mod authenveloped_data;
 pub mod authenticated_data;
+pub mod authenveloped_data;
 pub mod builder;
 pub mod cert;
 pub mod compressed_data;


### PR DESCRIPTION
Saw the issue #1171  regarding this missing CMS data type, most of the types were already implemented so it should be safe to include.