### PR TITLE
Forward feature flags to the spki crate

### DIFF
--- a/.github/workflows/x509-cert.yml
+++ b/.github/workflows/x509-cert.yml
@@ -38,7 +38,8 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
       - uses: RustCrypto/actions/cargo-hack-install@master
-      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features arbitrary,builder,default,std
+      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features fingerprint,base64,default,arbitrary,builder,std
+      - run: cargo hack check --target ${{ matrix.target }} --feature-powerset --include-features fingerprint,base64 --exclude-features default,std
 
   minimal-versions:
     if: false # TODO: temp disabled due to unpublished prerelease dependencies
@@ -62,7 +63,7 @@ jobs:
       - uses: RustCrypto/actions/cargo-hack-install@master
       - name: Install zlint
         uses: RustCrypto/actions/zlint-install@master
-      - run: cargo hack test --feature-powerset
+      - run: cargo hack test --feature-powerset --exclude-features base64
 
   fuzz:
     runs-on: ubuntu-latest

--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -47,6 +47,8 @@ builder = ["async-signature", "std", "sha1/default", "signature"]
 hazmat = []
 pem = ["der/pem", "spki/pem"]
 sct = ["dep:tls_codec"]
+fingerprint = ["spki/fingerprint"]
+base64 = ["spki/base64"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Allows creation of spki fingerprints without having to add the `spki` crate separately and keep versions in sync.