### PR TITLE
Revert "der: add `Error::(set_)source`; remove `Clone` + `Copy` (#1328)"

### DIFF
--- a/der/src/error.rs
+++ b/der/src/error.rs
@@ -11,24 +11,17 @@ use crate::asn1::ObjectIdentifier;
 #[cfg(feature = "pem")]
 use crate::pem;
 
-#[cfg(feature = "std")]
-use alloc::boxed::Box;
-
 /// Result type.
 pub type Result<T> = core::result::Result<T, Error>;
 
 /// Error type.
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Error {
     /// Kind of error.
     kind: ErrorKind,
 
     /// Position inside of message where error occurred.
     position: Option<Length>,
-
-    /// Source of the error.
-    #[cfg(feature = "std")]
-    source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
 }
 
 impl Error {
@@ -37,8 +30,6 @@ impl Error {
         Error {
             kind,
             position: Some(position),
-            #[cfg(feature = "std")]
-            source: None,
         }
     }
 
@@ -57,25 +48,13 @@ impl Error {
     }
 
     /// Get the [`ErrorKind`] which occurred.
-    pub fn kind(&self) -> ErrorKind {
+    pub fn kind(self) -> ErrorKind {
         self.kind
     }
 
     /// Get the position inside of the message where the error occurred.
-    pub fn position(&self) -> Option<Length> {
+    pub fn position(self) -> Option<Length> {
         self.position
-    }
-
-    /// Set the source of this error. Useful for e.g. propagating an additional error with
-    /// [`ErrorKind::Value`].
-    ///
-    /// Overwrites any previously set source.
-    #[cfg(feature = "std")]
-    pub fn set_source<E>(&mut self, source: E)
-    where
-        E: std::error::Error + Send + Sync + 'static,
-    {
-        self.source = Some(Box::new(source));
     }
 
     /// For errors occurring inside of a nested message, extend the position
@@ -87,11 +66,12 @@ impl Error {
         Self {
             kind: self.kind,
             position,
-            #[cfg(feature = "std")]
-            source: self.source,
         }
     }
 }
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -105,20 +85,11 @@ impl fmt::Display for Error {
     }
 }
 
-impl Eq for Error {}
-impl PartialEq for Error {
-    fn eq(&self, other: &Self) -> bool {
-        self.kind == other.kind && self.position == other.position
-    }
-}
-
 impl From<ErrorKind> for Error {
     fn from(kind: ErrorKind) -> Error {
         Error {
             kind,
             position: None,
-            #[cfg(feature = "std")]
-            source: None,
         }
     }
 }
@@ -130,12 +101,10 @@ impl From<Infallible> for Error {
 }
 
 impl From<TryFromIntError> for Error {
-    fn from(_err: TryFromIntError) -> Error {
+    fn from(_: TryFromIntError) -> Error {
         Error {
             kind: ErrorKind::Overflow,
             position: None,
-            #[cfg(feature = "std")]
-            source: Some(Box::new(_err)),
         }
     }
 }
@@ -145,8 +114,6 @@ impl From<Utf8Error> for Error {
         Error {
             kind: ErrorKind::Utf8(err),
             position: None,
-            #[cfg(feature = "std")]
-            source: Some(Box::new(err)),
         }
     }
 }
@@ -188,15 +155,6 @@ impl From<std::io::Error> for Error {
 impl From<time::error::ComponentRange> for Error {
     fn from(_: time::error::ComponentRange) -> Error {
         ErrorKind::DateTime.into()
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        self.source
-            .as_ref()
-            .map(|source| source.as_ref() as &(dyn std::error::Error + 'static))
     }
 }
 

--- a/pkcs1/src/error.rs
+++ b/pkcs1/src/error.rs
@@ -9,7 +9,7 @@ use der::pem;
 pub type Result<T> = core::result::Result<T, Error>;
 
 /// Error type
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum Error {
     /// ASN.1 DER-related errors.
@@ -92,13 +92,4 @@ impl From<pkcs8::spki::Error> for Error {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Error::Asn1(err) => Some(err),
-            #[cfg(feature = "pkcs8")]
-            Error::Pkcs8(err) => Some(err),
-            _ => None,
-        }
-    }
-}
+impl std::error::Error for Error {}

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -33,8 +33,6 @@ hex-literal = "0.4"
 
 [features]
 alloc = []
-std = ["alloc"]
-
 3des = ["dep:des", "pbes2"]
 des-insecure = ["dep:des", "pbes2"]
 getrandom = ["rand_core/getrandom"]

--- a/pkcs5/src/error.rs
+++ b/pkcs5/src/error.rs
@@ -54,6 +54,3 @@ impl fmt::Display for Error {
         }
     }
 }
-
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}

--- a/pkcs5/src/lib.rs
+++ b/pkcs5/src/lib.rs
@@ -29,9 +29,6 @@
 #[cfg(all(feature = "alloc", feature = "pbes2"))]
 extern crate alloc;
 
-#[cfg(feature = "std")]
-extern crate std;
-
 mod error;
 
 pub mod pbes1;

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -30,7 +30,7 @@ tempfile = "3"
 
 [features]
 alloc = ["der/alloc", "der/zeroize", "spki/alloc"]
-std = ["alloc", "der/std", "pkcs5?/std", "spki/std"]
+std = ["alloc", "der/std", "spki/std"]
 
 3des = ["encryption", "pkcs5/3des"]
 des-insecure = ["encryption", "pkcs5/des-insecure"]

--- a/pkcs8/src/error.rs
+++ b/pkcs8/src/error.rs
@@ -9,7 +9,7 @@ use der::pem;
 pub type Result<T> = core::result::Result<T, Error>;
 
 /// Error type
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum Error {
     /// ASN.1 DER-related errors.
@@ -48,17 +48,7 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Error::Asn1(err) => Some(err),
-            #[cfg(feature = "pkcs5")]
-            Error::EncryptedPrivateKey(err) => Some(err),
-            Error::PublicKey(err) => Some(err),
-            _ => None,
-        }
-    }
-}
+impl std::error::Error for Error {}
 
 impl From<der::Error> for Error {
     fn from(err: der::Error) -> Error {

--- a/pkcs8/tests/encrypted_private_key.rs
+++ b/pkcs8/tests/encrypted_private_key.rs
@@ -3,13 +3,10 @@
 #![cfg(feature = "pkcs5")]
 
 use hex_literal::hex;
-use pkcs8::{pkcs5::pbes2, EncryptedPrivateKeyInfo};
+use pkcs8::{pkcs5::pbes2, EncryptedPrivateKeyInfo, PrivateKeyInfo};
 
 #[cfg(feature = "alloc")]
 use der::Encode;
-
-#[cfg(feature = "encryption")]
-use pkcs8::PrivateKeyInfo;
 
 #[cfg(feature = "pem")]
 use der::EncodePem;

--- a/sec1/src/error.rs
+++ b/sec1/src/error.rs
@@ -9,7 +9,7 @@ use der::pem;
 pub type Result<T> = core::result::Result<T, Error>;
 
 /// Error type
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum Error {
     /// ASN.1 DER-related errors.

--- a/spki/src/error.rs
+++ b/spki/src/error.rs
@@ -10,7 +10,7 @@ pub type Result<T> = core::result::Result<T, Error>;
 use der::pem;
 
 /// Error type
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum Error {
     /// Algorithm parameters are missing.
@@ -65,11 +65,4 @@ impl From<pem::Error> for Error {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Error::Asn1(err) => Some(err),
-            _ => None,
-        }
-    }
-}
+impl std::error::Error for Error {}


### PR DESCRIPTION
This reverts commit 7784f2dfda3a870f191f88c27159960a8ffacbe7.

This ended up complicating downstream error types, particularly in `no_std` contexts.

It's also not really necessary now that #1055 has landed.

cc @baloo