### PR TITLE
Make sure `der` crate is compatible with potential language breaking changes

### DIFF
--- a/der/src/writer/slice.rs
+++ b/der/src/writer/slice.rs
@@ -31,7 +31,7 @@ impl<'a> SliceWriter<'a> {
     /// Encode a value which impls the [`Encode`] trait.
     pub fn encode<T: Encode>(&mut self, encodable: &T) -> Result<()> {
         if self.is_failed() {
-            self.error(ErrorKind::Failed)?;
+            self.error(ErrorKind::Failed)?
         }
 
         encodable.encode(self).map_err(|e| {


### PR DESCRIPTION
`?` currently influences inference s.t. for `error()?` rustc infers `T = ()`. However, it is quite confusing -- `?` is not supposed to influence inference, it's just a conicidence because of the curent implementation. There is an idea to change this behavior in future Rust versions, such that this code won't compile without this change.

See https://github.com/rust-lang/rust/pull/122412 for more information about the change.
(`der` is used by cargo, so this partially blocks the PR, please ping me once you release a new `der` version so I can update it inside cargo)