### PR TITLE
der v0.7.9

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,4 +1,5 @@
 [advisories]
 ignore = [
     "RUSTSEC-2021-0127", # serde_cbor is unmaintained
+    "RUSTSEC-2023-0071", # rsa: Marvin Attack: potential key recovery
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "arbitrary",
  "bytes",

--- a/der/CHANGELOG.md
+++ b/der/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.9 (2024-04-01)
+### Changed
+- ignore RUSTSEC-2023-0071 (backport [#1276])
+- make sure der is comptatible with potential language breaking changed (backport [#1374])
+
+[#1276]: https://github.com/RustCrypto/formats/pull/1276
+[#1374]: https://github.com/RustCrypto/formats/pull/1374
+
 ## 0.7.8 (2023-08-07)
 ### Added
 - `bytes` feature ([#1156])

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der"
-version = "0.7.8"
+version = "0.7.9"
 description = """
 Pure Rust embedded-friendly implementation of the Distinguished Encoding Rules
 (DER) for Abstract Syntax Notation One (ASN.1) as described in ITU X.690 with


### PR DESCRIPTION
Changed
- ignore RUSTSEC-2023-0071 (backport #1276)
- make sure der is comptatible with potential language breaking changed (backport of #1374)