### PR TITLE
Add feature flag to enable serde derive in re-export

### DIFF
--- a/serdect/Cargo.toml
+++ b/serdect/Cargo.toml
@@ -36,6 +36,7 @@ toml = "0.8"
 [features]
 default = ["alloc"]
 alloc = ["base16ct/alloc", "serde/alloc"]
+derive = ["serde/derive"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
I am working on adding support for the full set of JWK fields in the jwk implementation in the elliptic-curve repository. It would be really helpful to get access to serde/derive from the re-export to save having to import serde deirectly.