### PR TITLE
Don't fail with InvalidLength when reading nothing at end of data

### DIFF
--- a/base64ct/src/decoder.rs
+++ b/base64ct/src/decoder.rs
@@ -103,8 +103,13 @@ impl<'i, E: Encoding> Decoder<'i, E> {
     ///
     /// # Returns
     /// - `Ok(bytes)` if the expected amount of data was read
-    /// - `Err(Error::InvalidLength)` if the exact amount of data couldn't be read
+    /// - `Err(Error::InvalidLength)` if the exact amount of data couldn't be read, or
+    ///   if the output buffer has a length of 0
     pub fn decode<'o>(&mut self, out: &'o mut [u8]) -> Result<&'o [u8], Error> {
+        if out.is_empty() {
+            return Err(InvalidLength);
+        }
+
         if self.is_finished() {
             return Err(InvalidLength);
         }
@@ -548,6 +553,8 @@ mod tests {
     use crate::{alphabet::Alphabet, test_vectors::*, Base64, Base64Unpadded, Decoder};
 
     #[cfg(feature = "std")]
+    use crate::Error::InvalidLength;
+    #[cfg(feature = "std")]
     use {alloc::vec::Vec, std::io::Read};
 
     #[test]
@@ -590,6 +597,16 @@ mod tests {
 
         assert_eq!(len, MULTILINE_PADDED_BIN.len());
         assert_eq!(buf.as_slice(), MULTILINE_PADDED_BIN);
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn reject_empty_read() {
+        let mut decoder = Decoder::<Base64>::new(b"AAAA").unwrap();
+
+        let mut buf: Vec<u8> = vec![];
+
+        assert_eq!(decoder.decode(&mut buf), Err(InvalidLength));
     }
 
     /// Core functionality of a decoding test


### PR DESCRIPTION
This is a curious corner case that can happen when, for example, you're reading the length-value encoded strings in OpenSSH. If the last string in the data is of zero-length, then decode() will be called with an empty buffer, so we don't need to read any bytes. However, since `is_finished()` was checked unconditionally, the zero-length read (which would be OK) was instead rejected because there was no data to (not) read.

The bug was particularly mischievous because `is_finished()` will return false if there's `=` padding, so 2/3 of empty read calls will work normally.