### PR TITLE
pkcs12: flatten API

### DIFF
--- a/pkcs12/src/lib.rs
+++ b/pkcs12/src/lib.rs
@@ -14,21 +14,35 @@
     unused_qualifications
 )]
 
-use const_oid::ObjectIdentifier;
 extern crate alloc;
 
-pub mod authenticated_safe;
-pub mod bag_type;
-pub mod cert_type;
-pub mod crl_type;
-pub mod digest_info;
-pub mod mac_data;
 pub mod pbe_params;
 pub mod pfx;
 pub mod safe_bag;
 
 #[cfg(feature = "kdf")]
 pub mod kdf;
+
+mod authenticated_safe;
+mod bag_type;
+mod cert_type;
+mod crl_type;
+mod digest_info;
+mod mac_data;
+
+pub use crate::{
+    authenticated_safe::AuthenticatedSafe,
+    bag_type::BagType,
+    cert_type::{CertBag, CertTypes},
+    crl_type::{CrlBag, CrlTypes},
+    digest_info::DigestInfo,
+    mac_data::MacData,
+    pfx::Pfx,
+    safe_bag::SafeBag,
+};
+pub use cms;
+
+use const_oid::ObjectIdentifier;
 
 // pbe oids
 /// `pbeWithSHAAnd128BitRC4` Object Identifier (OID).

--- a/pkcs12/src/safe_bag.rs
+++ b/pkcs12/src/safe_bag.rs
@@ -7,16 +7,16 @@ use der::{AnyRef, Decode, Enumerated, Sequence};
 use spki::AlgorithmIdentifierOwned;
 use x509_cert::attr::Attributes;
 
-/// The `SafeContents` type is defined in [RFC 7292 Section 4.1].
+/// The `SafeContents` type is defined in [RFC 7292 Section 4.2].
 ///
 /// ```text
 /// SafeContents ::= SEQUENCE OF SafeBag
 /// ```
 ///
-/// [RFC 7292 Section 4]: https://www.rfc-editor.org/rfc/rfc7292#section-4.2
+/// [RFC 7292 Section 4.2]: https://www.rfc-editor.org/rfc/rfc7292#section-4.2
 pub type SafeContents = Vec<SafeBag>;
 
-/// The `SafeBag` type is defined in [RFC 7292 Section 4.1].
+/// The `SafeBag` type is defined in [RFC 7292 Section 4.2].
 ///
 /// ```text
 /// SafeBag ::= SEQUENCE {
@@ -26,7 +26,7 @@ pub type SafeContents = Vec<SafeBag>;
 /// }
 /// ```
 ///
-/// [RFC 7292 Section 4]: https://www.rfc-editor.org/rfc/rfc7292#section-4.2
+/// [RFC 7292 Section 4.2]: https://www.rfc-editor.org/rfc/rfc7292#section-4.2
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[allow(missing_docs)]
 pub struct SafeBag {

--- a/pkcs12/tests/cert_tests.rs
+++ b/pkcs12/tests/cert_tests.rs
@@ -1,21 +1,29 @@
 use cms::encrypted_data::EncryptedData;
-use const_oid::db::rfc5911::{ID_DATA, ID_ENCRYPTED_DATA};
-use const_oid::db::rfc5912::ID_SHA_256;
-use der::asn1::OctetString;
-use der::{Decode, Encode};
+use const_oid::db::{
+    rfc5911::{ID_DATA, ID_ENCRYPTED_DATA},
+    rfc5912::ID_SHA_256,
+};
+use der::{
+    asn1::{ContextSpecific, OctetString},
+    Decode, Encode,
+};
 use hex_literal::hex;
-
-use der::asn1::ContextSpecific;
-use pkcs12::authenticated_safe::AuthenticatedSafe;
-use pkcs12::cert_type::CertBag;
-use pkcs12::pbe_params::Pbkdf2Params;
-use pkcs12::pfx::Pfx;
-use pkcs12::pfx::Version;
-use pkcs12::safe_bag::SafeContents;
-
-use pkcs8::pkcs5::pbes2::{AES_256_CBC_OID, HMAC_WITH_SHA256_OID, PBES2_OID, PBKDF2_OID};
-use pkcs8::{pkcs5, EncryptedPrivateKeyInfo};
+use pkcs8::{
+    pkcs5::{
+        self,
+        pbes2::{AES_256_CBC_OID, HMAC_WITH_SHA256_OID, PBES2_OID, PBKDF2_OID},
+    },
+    EncryptedPrivateKeyInfo,
+};
 use spki::AlgorithmIdentifierOwned;
+
+use pkcs12::{
+    pbe_params::Pbkdf2Params,
+    pfx::Pfx,
+    pfx::Version,
+    safe_bag::SafeContents,
+    {AuthenticatedSafe, CertBag},
+};
 
 //    0 1871: SEQUENCE {
 //    4    1:   INTEGER 3

--- a/x509-cert/src/request.rs
+++ b/x509-cert/src/request.rs
@@ -10,9 +10,8 @@ use alloc::vec::Vec;
 
 use const_oid::db::rfc5912::ID_EXTENSION_REQ;
 use const_oid::{AssociatedOid, ObjectIdentifier};
-use der::asn1::BitString;
 use der::{
-    asn1::{Any, SetOfVec},
+    asn1::{Any, BitString, SetOfVec},
     Decode, Enumerated, Sequence,
 };
 use spki::{AlgorithmIdentifierOwned, SubjectPublicKeyInfoOwned};
@@ -142,8 +141,7 @@ pub mod attributes {
     pub trait AsAttribute: AssociatedOid + Tagged + EncodeValue + Sized {
         /// Returns the Attribute with the content encoded.
         fn to_attribute(&self) -> Result<Attribute> {
-            let inner: Any = der::asn1::Any::encode_from(self)?;
-
+            let inner = Any::encode_from(self)?;
             let values = SetOfVec::try_from(vec![inner])?;
 
             Ok(Attribute {


### PR DESCRIPTION
Several modules contain a single type. This removes those modules from the public API and re-exports such types at the toplevel.