### PR TITLE
rust 1.78 fixups

### DIFF
--- a/base16ct/src/error.rs
+++ b/base16ct/src/error.rs
@@ -25,8 +25,8 @@ impl fmt::Display for Error {
 #[cfg(feature = "std")]
 impl std::error::Error for Error {}
 
-impl From<Error> for core::fmt::Error {
-    fn from(_: Error) -> core::fmt::Error {
-        core::fmt::Error
+impl From<Error> for fmt::Error {
+    fn from(_: Error) -> fmt::Error {
+        fmt::Error
     }
 }

--- a/base16ct/src/upper.rs
+++ b/base16ct/src/upper.rs
@@ -46,7 +46,7 @@ pub fn encode_string(input: &[u8]) -> String {
     let res = encode(input, &mut dst).expect("dst length is correct");
 
     debug_assert_eq!(elen, res.len());
-    unsafe { crate::String::from_utf8_unchecked(dst) }
+    unsafe { String::from_utf8_unchecked(dst) }
 }
 
 /// Decode a single nibble of upper hex

--- a/cms/src/builder.rs
+++ b/cms/src/builder.rs
@@ -205,7 +205,7 @@ impl<'s> Builder for SignerInfoBuilder<'s> {
                 Some(content) => {
                     let mut hasher = get_hasher(&self.digest_algorithm).ok_or_else(|| {
                         // Unsupported hash algorithm: {}, &self.digest_algorithm.oid.to_string()
-                        x509_cert::builder::Error::from(der::Error::from(ErrorKind::Failed))
+                        builder::Error::from(der::Error::from(ErrorKind::Failed))
                     })?;
                     // Only the octets comprising the value of the eContent
                     // OCTET STRING are input to the message digest algorithm, not the tag
@@ -284,7 +284,7 @@ impl<'s> Builder for SignerInfoBuilder<'s> {
             });
 
         let signature_value =
-            SignatureValue::new(signature.raw_bytes()).map_err(x509_cert::builder::Error::from)?;
+            SignatureValue::new(signature.raw_bytes()).map_err(builder::Error::from)?;
 
         let signature_algorithm = signer.signature_algorithm_identifier()?;
 

--- a/pkcs1/src/error.rs
+++ b/pkcs1/src/error.rs
@@ -75,18 +75,18 @@ impl From<pkcs8::Error> for Error {
 }
 
 #[cfg(feature = "pkcs8")]
-impl From<Error> for pkcs8::spki::Error {
-    fn from(err: Error) -> pkcs8::spki::Error {
+impl From<Error> for spki::Error {
+    fn from(err: Error) -> spki::Error {
         match err {
-            Error::Asn1(e) => pkcs8::spki::Error::Asn1(e),
-            _ => pkcs8::spki::Error::KeyMalformed,
+            Error::Asn1(e) => spki::Error::Asn1(e),
+            _ => spki::Error::KeyMalformed,
         }
     }
 }
 
 #[cfg(feature = "pkcs8")]
-impl From<pkcs8::spki::Error> for Error {
-    fn from(err: pkcs8::spki::Error) -> Error {
+impl From<spki::Error> for Error {
+    fn from(err: spki::Error) -> Error {
         Error::Pkcs8(pkcs8::Error::PublicKey(err))
     }
 }

--- a/pkcs1/src/traits.rs
+++ b/pkcs1/src/traits.rs
@@ -171,7 +171,7 @@ where
 #[cfg(feature = "pkcs8")]
 impl<T> DecodeRsaPublicKey for T
 where
-    T: for<'a> TryFrom<pkcs8::SubjectPublicKeyInfoRef<'a>, Error = pkcs8::spki::Error>,
+    T: for<'a> TryFrom<pkcs8::SubjectPublicKeyInfoRef<'a>, Error = spki::Error>,
 {
     fn from_pkcs1_der(public_key: &[u8]) -> Result<Self> {
         Ok(Self::try_from(pkcs8::SubjectPublicKeyInfoRef {

--- a/pkcs5/src/pbes1.rs
+++ b/pkcs5/src/pbes1.rs
@@ -93,8 +93,8 @@ impl<'a> TryFrom<AlgorithmIdentifierRef<'a>> for Algorithm {
 
     fn try_from(alg: AlgorithmIdentifierRef<'a>) -> der::Result<Self> {
         // Ensure that we have a supported PBES1 algorithm identifier
-        let encryption = EncryptionScheme::try_from(alg.oid)
-            .map_err(|_| der::Tag::ObjectIdentifier.value_error())?;
+        let encryption =
+            EncryptionScheme::try_from(alg.oid).map_err(|_| Tag::ObjectIdentifier.value_error())?;
 
         let parameters = alg
             .parameters
@@ -157,7 +157,7 @@ impl TryFrom<AnyRef<'_>> for Parameters {
                 salt: OctetStringRef::decode(reader)?
                     .as_bytes()
                     .try_into()
-                    .map_err(|_| der::Tag::OctetString.value_error())?,
+                    .map_err(|_| Tag::OctetString.value_error())?,
                 iteration_count: reader.decode()?,
             })
         })

--- a/pkcs5/src/pbes2.rs
+++ b/pkcs5/src/pbes2.rs
@@ -391,31 +391,25 @@ impl TryFrom<AlgorithmIdentifierRef<'_>> for EncryptionScheme {
 
         match alg.oid {
             AES_128_CBC_OID => Ok(Self::Aes128Cbc {
-                iv: iv
-                    .try_into()
-                    .map_err(|_| der::Tag::OctetString.value_error())?,
+                iv: iv.try_into().map_err(|_| Tag::OctetString.value_error())?,
             }),
             AES_192_CBC_OID => Ok(Self::Aes192Cbc {
-                iv: iv
-                    .try_into()
-                    .map_err(|_| der::Tag::OctetString.value_error())?,
+                iv: iv.try_into().map_err(|_| Tag::OctetString.value_error())?,
             }),
             AES_256_CBC_OID => Ok(Self::Aes256Cbc {
-                iv: iv
-                    .try_into()
-                    .map_err(|_| der::Tag::OctetString.value_error())?,
+                iv: iv.try_into().map_err(|_| Tag::OctetString.value_error())?,
             }),
             #[cfg(feature = "des-insecure")]
             DES_CBC_OID => Ok(Self::DesCbc {
                 iv: iv[0..DES_BLOCK_SIZE]
                     .try_into()
-                    .map_err(|_| der::Tag::OctetString.value_error())?,
+                    .map_err(|_| Tag::OctetString.value_error())?,
             }),
             #[cfg(feature = "3des")]
             DES_EDE3_CBC_OID => Ok(Self::DesEde3Cbc {
                 iv: iv[0..DES_BLOCK_SIZE]
                     .try_into()
-                    .map_err(|_| der::Tag::OctetString.value_error())?,
+                    .map_err(|_| Tag::OctetString.value_error())?,
             }),
             oid => Err(ErrorKind::OidUnknown { oid }.into()),
         }

--- a/sec1/src/private_key.rs
+++ b/sec1/src/private_key.rs
@@ -100,7 +100,7 @@ impl<'a> DecodeValue<'a> for EcPrivateKey<'a> {
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> der::Result<Self> {
         reader.read_nested(header.length, |reader| {
             if u8::decode(reader)? != VERSION {
-                return Err(der::Tag::Integer.value_error());
+                return Err(Tag::Integer.value_error());
             }
 
             let private_key = OctetStringRef::decode(reader)?.as_bytes();


### PR DESCRIPTION
rustc 1.78 just released and it brings new warnings.

This fixes all `unnecessary qualification` warnings