### PR TITLE
doc(der_derive): Add documentation for field-level tag_mode attribute.

### DIFF
--- a/der/derive/src/lib.rs
+++ b/der/derive/src/lib.rs
@@ -101,6 +101,13 @@
 //! Note: please open a GitHub Issue if you would like to request support
 //! for additional ASN.1 types.
 //!
+//! ### `#[asn1(tag_mode = "...")]` attribute: `EXPLICIT` vs `IMPLICIT`
+//!
+//! This attribute can be used to declare the tagging mode used for a field of a `struct`
+//! which derives [`Sequence`] or for a variant of an `enum` which derives [`Choice`].
+//! It allows to override the toplevel `tag_mode` attribute, for the fields and variants that
+//! specify it.
+//!
 //! [`der`]: https://docs.rs/der/
 //! [`Choice`]: derive@Choice
 //! [`Sequence`]: derive@Sequence


### PR DESCRIPTION
`der_derive` documentation doesn't mention `#[asn1(tag_mode = "...")]` attribute in _Field-level attributes_ section.