### PR TITLE
x509-ocsp: add support for parsing profiles

### DIFF
--- a/x509-cert/src/certificate.rs
+++ b/x509-cert/src/certificate.rs
@@ -17,7 +17,7 @@ use der::{
 /// [`Profile`] allows the consumer of this crate to customize the behavior when parsing
 /// certificates.
 /// By default, parsing will be made in a rfc5280-compliant manner.
-pub trait Profile: PartialEq + Debug + Eq + Clone {
+pub trait Profile: PartialEq + Debug + Eq + Clone + Default {
     /// Checks to run when parsing serial numbers
     fn check_serial_number(serial: &SerialNumber<Self>) -> der::Result<()> {
         // See the note in `SerialNumber::new`: we permit lengths of 21 bytes here,
@@ -32,7 +32,7 @@ pub trait Profile: PartialEq + Debug + Eq + Clone {
 }
 
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Default)]
 /// Parse certificates with rfc5280-compliant checks
 pub struct Rfc5280;
 
@@ -40,7 +40,7 @@ impl Profile for Rfc5280 {}
 
 #[cfg(feature = "hazmat")]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Default)]
 /// Parse raw x509 certificate and disable all the checks
 pub struct Raw;
 

--- a/x509-ocsp/src/builder/request.rs
+++ b/x509-ocsp/src/builder/request.rs
@@ -7,6 +7,7 @@ use rand_core::CryptoRngCore;
 use signature::{RandomizedSigner, Signer};
 use spki::{DynSignatureAlgorithmIdentifier, SignatureBitStringEncoding};
 use x509_cert::{
+    certificate::Rfc5280,
     ext::{pkix::name::GeneralName, AsExtension},
     name::Name,
     Certificate,
@@ -59,7 +60,7 @@ use x509_cert::{
 /// ```
 #[derive(Clone, Debug, Default)]
 pub struct OcspRequestBuilder {
-    tbs: TbsRequest,
+    tbs: TbsRequest<Rfc5280>,
 }
 
 impl OcspRequestBuilder {

--- a/x509-ocsp/src/cert_id.rs
+++ b/x509-ocsp/src/cert_id.rs
@@ -2,7 +2,10 @@
 
 use der::{asn1::OctetString, Sequence};
 use spki::AlgorithmIdentifierOwned;
-use x509_cert::serial_number::SerialNumber;
+use x509_cert::{
+    certificate::{Profile, Rfc5280},
+    serial_number::SerialNumber,
+};
 
 /// CertID structure as defined in [RFC 6960 Section 4.1.1].
 ///
@@ -17,11 +20,11 @@ use x509_cert::serial_number::SerialNumber;
 /// [RFC 6960 Section 4.1.1]: https://datatracker.ietf.org/doc/html/rfc6960#section-4.1.1
 #[derive(Clone, Debug, Eq, PartialEq, Sequence)]
 #[allow(missing_docs)]
-pub struct CertId {
+pub struct CertId<P: Profile + 'static = Rfc5280> {
     pub hash_algorithm: AlgorithmIdentifierOwned,
     pub issuer_name_hash: OctetString,
     pub issuer_key_hash: OctetString,
-    pub serial_number: SerialNumber,
+    pub serial_number: SerialNumber<P>,
 }
 
 impl From<&CertId> for CertId {

--- a/x509-ocsp/src/request.rs
+++ b/x509-ocsp/src/request.rs
@@ -7,7 +7,7 @@ use core::{default::Default, option::Option};
 use der::{asn1::BitString, Decode, Sequence};
 use spki::AlgorithmIdentifierOwned;
 use x509_cert::{
-    certificate::Certificate,
+    certificate::{CertificateInner, Profile, Rfc5280},
     ext::{pkix::name::GeneralName, Extensions},
 };
 
@@ -22,8 +22,8 @@ use x509_cert::{
 /// [RFC 6960 Section 4.1.1]: https://datatracker.ietf.org/doc/html/rfc6960#section-4.1.1
 #[derive(Clone, Debug, Eq, PartialEq, Sequence)]
 #[allow(missing_docs)]
-pub struct OcspRequest {
-    pub tbs_request: TbsRequest,
+pub struct OcspRequest<P: Profile + 'static = Rfc5280> {
+    pub tbs_request: TbsRequest<P>,
 
     #[asn1(context_specific = "0", optional = "true", tag_mode = "EXPLICIT")]
     pub optional_signature: Option<Signature>,
@@ -50,7 +50,7 @@ impl OcspRequest {
 /// [RFC 6960 Section 4.1.1]: https://datatracker.ietf.org/doc/html/rfc6960#section-4.1.1
 #[derive(Clone, Debug, Default, Eq, PartialEq, Sequence)]
 #[allow(missing_docs)]
-pub struct TbsRequest {
+pub struct TbsRequest<P: Profile + 'static = Rfc5280> {
     #[asn1(
         context_specific = "0",
         default = "Default::default",
@@ -61,7 +61,7 @@ pub struct TbsRequest {
     #[asn1(context_specific = "1", optional = "true", tag_mode = "EXPLICIT")]
     pub requestor_name: Option<GeneralName>,
 
-    pub request_list: Vec<Request>,
+    pub request_list: Vec<Request<P>>,
 
     #[asn1(context_specific = "2", optional = "true", tag_mode = "EXPLICIT")]
     pub request_extensions: Option<Extensions>,
@@ -96,12 +96,12 @@ impl TbsRequest {
 /// [RFC 6960 Section 4.1.1]: https://datatracker.ietf.org/doc/html/rfc6960#section-4.1.1
 #[derive(Clone, Debug, Eq, PartialEq, Sequence)]
 #[allow(missing_docs)]
-pub struct Signature {
+pub struct Signature<P: Profile + 'static = Rfc5280> {
     pub signature_algorithm: AlgorithmIdentifierOwned,
     pub signature: BitString,
 
     #[asn1(context_specific = "0", optional = "true", tag_mode = "EXPLICIT")]
-    pub certs: Option<Vec<Certificate>>,
+    pub certs: Option<Vec<CertificateInner<P>>>,
 }
 
 /// Request structure as defined in [RFC 6960 Section 4.1.1].
@@ -115,8 +115,8 @@ pub struct Signature {
 /// [RFC 6960 Section 4.1.1]: https://datatracker.ietf.org/doc/html/rfc6960#section-4.1.1
 #[derive(Clone, Debug, Eq, PartialEq, Sequence)]
 #[allow(missing_docs)]
-pub struct Request {
-    pub req_cert: CertId,
+pub struct Request<P: Profile + 'static = Rfc5280> {
+    pub req_cert: CertId<P>,
 
     #[asn1(context_specific = "0", optional = "true", tag_mode = "EXPLICIT")]
     pub single_request_extensions: Option<Extensions>,

--- a/x509-ocsp/tests/ocsp.rs
+++ b/x509-ocsp/tests/ocsp.rs
@@ -2,7 +2,7 @@ use const_oid::db::rfc6960::ID_PKIX_OCSP_BASIC;
 use der::asn1::{Null, ObjectIdentifier};
 use der::{Decode, Encode};
 use hex_literal::hex;
-use x509_cert::ext::pkix::CrlReason;
+use x509_cert::{certificate::Rfc5280, ext::pkix::CrlReason};
 use x509_ocsp::Version::V1;
 use x509_ocsp::*;
 
@@ -16,7 +16,7 @@ fn decode_ocsp_req_ca_signed() {
     pub const PKIXALG_SHA1: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.14.3.2.26");
 
     let ocsp_req =
-        OcspRequest::from_der(&hex!("3051304F304D304B3049300906052B0E03021A05000414A87E303106E4E88565CFE952598FA6DA7C00532F0414246E2B2DD06A925151256901AA9A47A689E7402002100E4239AB85E2E6A27C52C6DE9B9078D9")[..]).unwrap();
+        OcspRequest::<Rfc5280>::from_der(&hex!("3051304F304D304B3049300906052B0E03021A05000414A87E303106E4E88565CFE952598FA6DA7C00532F0414246E2B2DD06A925151256901AA9A47A689E7402002100E4239AB85E2E6A27C52C6DE9B9078D9")[..]).unwrap();
     assert_eq!(ocsp_req.tbs_request.version, V1);
     //assert!(ocsp_req.tbs_request.requestor_name.is_none());
     assert_eq!(ocsp_req.tbs_request.request_list.len(), 1);
@@ -172,7 +172,7 @@ fn decode_ocsp_req_delegated() {
     pub const PKIXALG_SHA1: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.14.3.2.26");
 
     let ocsp_req =
-        OcspRequest::from_der(&hex!("304530433041303F303D300906052B0E03021A050004140F0D5890F551D42ACF5431B7F42A321F7B74A4730414771441A65D9526D01DFF953B628CEAB7B55D3B92020401017467")[..]).unwrap();
+        OcspRequest::<Rfc5280>::from_der(&hex!("304530433041303F303D300906052B0E03021A050004140F0D5890F551D42ACF5431B7F42A321F7B74A4730414771441A65D9526D01DFF953B628CEAB7B55D3B92020401017467")[..]).unwrap();
     assert_eq!(ocsp_req.tbs_request.version, V1);
     //assert!(ocsp_req.tbs_request.requestor_name.is_none());
     assert_eq!(ocsp_req.tbs_request.request_list.len(), 1);


### PR DESCRIPTION
This allows an x509 validator to check for ocsp signature of RFC5280-invalid certificates.