### PR TITLE
Add support for Base32 upper unpadded alphabet

### DIFF
--- a/base32ct/src/alphabet/rfc4648.rs
+++ b/base32ct/src/alphabet/rfc4648.rs
@@ -56,3 +56,20 @@ impl Alphabet for Base32Upper {
     const ENCODER: &'static [EncodeStep] = &[EncodeStep(25, 41)];
     const PADDED: bool = true;
 }
+
+/// RFC4648 upper case Base32 encoding *without* padding.
+///
+/// ```text
+/// [A-Z]      [2-7]
+/// 0x41-0x5a, 0x32-0x37
+/// ```
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct Base32UpperUnpadded;
+
+impl Alphabet for Base32UpperUnpadded {
+    const BASE: u8 = b'A';
+    const DECODER: &'static [DecodeStep] =
+        &[DecodeStep(b'A'..=b'Z', -64), DecodeStep(b'2'..=b'7', -23)];
+    const ENCODER: &'static [EncodeStep] = &[EncodeStep(25, 41)];
+    const PADDED: bool = false;
+}

--- a/base32ct/src/lib.rs
+++ b/base32ct/src/lib.rs
@@ -58,7 +58,7 @@ mod encoding;
 mod error;
 
 pub use crate::{
-    alphabet::rfc4648::{Base32, Base32Unpadded, Base32Upper},
+    alphabet::rfc4648::{Base32, Base32Unpadded, Base32Upper, Base32UpperUnpadded},
     encoding::Encoding,
     error::{Error, Result},
 };

--- a/base32ct/tests/vectors.rs
+++ b/base32ct/tests/vectors.rs
@@ -2,7 +2,7 @@
 
 #![cfg(feature = "alloc")]
 
-use base32ct::{Base32, Base32Unpadded, Base32Upper, Encoding, Error};
+use base32ct::{Base32, Base32Unpadded, Base32Upper, Base32UpperUnpadded, Encoding, Error};
 
 #[derive(Debug)]
 struct TestVector {
@@ -55,6 +55,21 @@ const UPPER_PADDED_VECTORS: &[TestVector] = &[
     },
 ];
 
+const UPPER_UNPADDED_VECTORS: &[TestVector] = &[
+    TestVector {
+        decoded: &[0],
+        encoded: "AA",
+    },
+    TestVector {
+        decoded: &[1, 2, 3, 5, 9, 17, 33, 65, 129],
+        encoded: "AEBAGBIJCEQUDAI",
+    },
+    TestVector {
+        decoded: &[32, 7],
+        encoded: "EADQ",
+    },
+];
+
 #[test]
 fn decode_valid_base32() {
     for vector in LOWER_PADDED_VECTORS {
@@ -71,6 +86,13 @@ fn decode_valid_base32() {
     for vector in UPPER_PADDED_VECTORS {
         assert_eq!(
             &Base32Upper::decode_vec(vector.encoded).unwrap(),
+            vector.decoded
+        );
+    }
+
+    for vector in UPPER_UNPADDED_VECTORS {
+        assert_eq!(
+            &Base32UpperUnpadded::decode_vec(vector.encoded).unwrap(),
             vector.decoded
         );
     }
@@ -106,5 +128,12 @@ fn encode_base32() {
 
     for vector in UPPER_PADDED_VECTORS {
         assert_eq!(&Base32Upper::encode_string(vector.decoded), vector.encoded);
+    }
+
+    for vector in UPPER_UNPADDED_VECTORS {
+        assert_eq!(
+            &Base32UpperUnpadded::encode_string(vector.decoded),
+            vector.encoded
+        );
     }
 }


### PR DESCRIPTION
This is a pretty straightforward addition, without any breaking change.

I added a couple of tests, almost copy-pasting the code already available.

Closes #1405