### PR TITLE
x509-tsp: re-export cmpv2

### DIFF
--- a/x509-tsp/src/lib.rs
+++ b/x509-tsp/src/lib.rs
@@ -20,6 +20,8 @@ use x509_cert::{
     spki::AlgorithmIdentifier,
 };
 
+pub use cmpv2;
+
 #[derive(Clone, Copy, Debug, Enumerated, Eq, PartialEq, PartialOrd, Ord)]
 #[asn1(type = "INTEGER")]
 #[repr(u8)]


### PR DESCRIPTION
`x509-tsp` makes use of structures defines in `cmpv2`:
  - `cmpv2::status::PkiStatusInfo` which itself refers: - `cmpv2::status::PkiStatus` and - `cmpv2::status::PkiFailureInfo`

Reexporting it makes it more convenient for a consumer.