### PR TITLE
der: introduce an `AnyLike` trait to mark parameters

### DIFF
--- a/der/src/asn1.rs
+++ b/der/src/asn1.rs
@@ -31,7 +31,7 @@ mod utf8_string;
 mod videotex_string;
 
 pub use self::{
-    any::AnyRef,
+    any::{AnyLike, AnyRef},
     bit_string::{BitStringIter, BitStringRef},
     choice::Choice,
     context_specific::{ContextSpecific, ContextSpecificRef},

--- a/pkcs5/src/pbes2/kdf.rs
+++ b/pkcs5/src/pbes2/kdf.rs
@@ -6,7 +6,7 @@ pub use self::salt::Salt;
 
 use crate::{AlgorithmIdentifierRef, Error, Result};
 use der::{
-    asn1::{AnyRef, ObjectIdentifier},
+    asn1::{AnyLike, AnyRef, ObjectIdentifier},
     Decode, DecodeValue, Encode, EncodeValue, ErrorKind, Length, Reader, Sequence, Tag, Tagged,
     Writer,
 };

--- a/pkcs8/tests/private_key.rs
+++ b/pkcs8/tests/private_key.rs
@@ -1,6 +1,6 @@
 //! PKCS#8 private key tests
 
-use der::asn1::ObjectIdentifier;
+use der::asn1::{AnyLike, ObjectIdentifier};
 use hex_literal::hex;
 use pkcs8::{PrivateKeyInfo, Version};
 

--- a/spki/src/algorithm.rs
+++ b/spki/src/algorithm.rs
@@ -175,7 +175,7 @@ impl<'a> AlgorithmIdentifierRef<'a> {
 #[cfg(feature = "alloc")]
 mod allocating {
     use super::*;
-    use der::referenced::*;
+    use der::{referenced::*, Tag};
 
     impl<'a> RefToOwned<'a> for AlgorithmIdentifierRef<'a> {
         type Owned = AlgorithmIdentifierOwned;
@@ -194,6 +194,14 @@ mod allocating {
                 oid: self.oid,
                 parameters: self.parameters.owned_to_ref(),
             }
+        }
+    }
+
+    impl From<&AlgorithmIdentifierRef<'_>> for Any {
+        fn from(alg: &AlgorithmIdentifierRef<'_>) -> Any {
+            let bytes = alg.to_der().expect("Algorithm invariant violated");
+
+            Any::new(Tag::Sequence, bytes).expect("Algorithm invariant violated")
         }
     }
 }

--- a/spki/src/algorithm.rs
+++ b/spki/src/algorithm.rs
@@ -3,7 +3,7 @@
 use crate::{Error, Result};
 use core::cmp::Ordering;
 use der::{
-    asn1::{AnyRef, Choice, ObjectIdentifier},
+    asn1::{AnyLike, AnyRef, Choice, ObjectIdentifier},
     Decode, DecodeValue, DerOrd, Encode, EncodeValue, Header, Length, Reader, Sequence, ValueOrd,
     Writer,
 };
@@ -22,7 +22,7 @@ use der::asn1::Any;
 /// [RFC 5280 Section 4.1.1.2]: https://tools.ietf.org/html/rfc5280#section-4.1.1.2
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
-pub struct AlgorithmIdentifier<Params> {
+pub struct AlgorithmIdentifier<Params: AnyLike> {
     /// Algorithm OID, i.e. the `algorithm` field in the `AlgorithmIdentifier`
     /// ASN.1 schema.
     pub oid: ObjectIdentifier,
@@ -31,7 +31,7 @@ pub struct AlgorithmIdentifier<Params> {
     pub parameters: Option<Params>,
 }
 
-impl<'a, Params> DecodeValue<'a> for AlgorithmIdentifier<Params>
+impl<'a, Params: AnyLike> DecodeValue<'a> for AlgorithmIdentifier<Params>
 where
     Params: Choice<'a, Error = der::Error>,
 {
@@ -47,7 +47,7 @@ where
     }
 }
 
-impl<Params> EncodeValue for AlgorithmIdentifier<Params>
+impl<Params: AnyLike> EncodeValue for AlgorithmIdentifier<Params>
 where
     Params: Encode,
 {
@@ -62,12 +62,12 @@ where
     }
 }
 
-impl<'a, Params> Sequence<'a> for AlgorithmIdentifier<Params> where
+impl<'a, Params: AnyLike> Sequence<'a> for AlgorithmIdentifier<Params> where
     Params: Choice<'a, Error = der::Error> + Encode
 {
 }
 
-impl<'a, Params> TryFrom<&'a [u8]> for AlgorithmIdentifier<Params>
+impl<'a, Params: AnyLike> TryFrom<&'a [u8]> for AlgorithmIdentifier<Params>
 where
     Params: Choice<'a, Error = der::Error> + Encode,
 {
@@ -78,7 +78,7 @@ where
     }
 }
 
-impl<Params> ValueOrd for AlgorithmIdentifier<Params>
+impl<Params: AnyLike> ValueOrd for AlgorithmIdentifier<Params>
 where
     Params: DerOrd,
 {
@@ -100,7 +100,7 @@ pub type AlgorithmIdentifierWithOid = AlgorithmIdentifier<ObjectIdentifier>;
 #[cfg(feature = "alloc")]
 pub type AlgorithmIdentifierOwned = AlgorithmIdentifier<Any>;
 
-impl<Params> AlgorithmIdentifier<Params> {
+impl<Params: AnyLike> AlgorithmIdentifier<Params> {
     /// Assert the `algorithm` OID is an expected value.
     pub fn assert_algorithm_oid(&self, expected_oid: ObjectIdentifier) -> Result<ObjectIdentifier> {
         if self.oid == expected_oid {

--- a/spki/src/lib.rs
+++ b/spki/src/lib.rs
@@ -21,6 +21,7 @@
 //! Borrow the [`ObjectIdentifier`] first then use [`der::AnyRef::from`] or `.into()`:
 //!
 //! ```
+//! use der::asn1::AnyRef;
 //! use spki::{AlgorithmIdentifier, ObjectIdentifier};
 //!
 //! let alg_oid = "1.2.840.10045.2.1".parse::<ObjectIdentifier>().unwrap();
@@ -28,7 +29,7 @@
 //!
 //! let alg_id = AlgorithmIdentifier {
 //!     oid: alg_oid,
-//!     parameters: Some(params_oid)
+//!     parameters: Some(AnyRef::from(&params_oid))
 //! };
 //! ```
 

--- a/spki/src/traits.rs
+++ b/spki/src/traits.rs
@@ -1,7 +1,7 @@
 //! Traits for encoding/decoding SPKI public keys.
 
 use crate::{AlgorithmIdentifier, Error, Result, SubjectPublicKeyInfoRef};
-use der::{EncodeValue, Tagged};
+use der::{asn1::AnyLike, EncodeValue, Tagged};
 
 #[cfg(feature = "alloc")]
 use {
@@ -103,7 +103,7 @@ pub trait EncodePublicKey {
 /// This is useful for e.g. keys for digital signature algorithms.
 pub trait AssociatedAlgorithmIdentifier {
     /// Algorithm parameters.
-    type Params: Tagged + EncodeValue;
+    type Params: Tagged + EncodeValue + AnyLike;
 
     /// `AlgorithmIdentifier` for this structure.
     const ALGORITHM_IDENTIFIER: AlgorithmIdentifier<Self::Params>;
@@ -141,7 +141,7 @@ where
 /// private keys.
 pub trait SignatureAlgorithmIdentifier {
     /// Algorithm parameters.
-    type Params: Tagged + EncodeValue;
+    type Params: Tagged + EncodeValue + AnyLike;
 
     /// `AlgorithmIdentifier` for the corresponding singature system.
     const SIGNATURE_ALGORITHM_IDENTIFIER: AlgorithmIdentifier<Self::Params>;

--- a/spki/tests/spki.rs
+++ b/spki/tests/spki.rs
@@ -1,6 +1,6 @@
 //! `SubjectPublicKeyInfo` tests.
 
-use der::asn1::ObjectIdentifier;
+use der::asn1::{AnyLike, ObjectIdentifier};
 use hex_literal::hex;
 use spki::SubjectPublicKeyInfoRef;
 


### PR DESCRIPTION
This newly defined `AnyLike` trait would help to make sure the parameters of `spki::AlgorithmIdentifier` are serialized as Any.