### PR TITLE
der: have `Reader::peek*` methods take `&mut self`

### DIFF
--- a/der/src/reader.rs
+++ b/der/src/reader.rs
@@ -23,16 +23,16 @@ pub trait Reader<'r>: Sized {
     /// Get the length of the input.
     fn input_len(&self) -> Length;
 
-    /// Peek at the next byte of input without modifying the cursor.
-    fn peek_byte(&self) -> Option<u8>;
+    /// Peek at the next byte of input without modifying the position within the reader.
+    fn peek_byte(&mut self) -> Option<u8>;
 
     /// Peek forward in the input data, attempting to decode a [`Header`] from
     /// the data at the current position in the decoder.
     ///
-    /// Does not modify the decoder's state.
-    fn peek_header(&self) -> Result<Header, Error>;
+    /// Does not modify the position within the reader.
+    fn peek_header(&mut self) -> Result<Header, Error>;
 
-    /// Get the position within the buffer.
+    /// Get the position within the reader in bytes.
     fn position(&self) -> Length;
 
     /// Attempt to read data borrowed directly from the input as a slice,
@@ -103,8 +103,8 @@ pub trait Reader<'r>: Sized {
     /// Peek at the next byte in the decoder and attempt to decode it as a
     /// [`Tag`] value.
     ///
-    /// Does not modify the decoder's state.
-    fn peek_tag(&self) -> Result<Tag, Error> {
+    /// Does not modify the position within the reader.
+    fn peek_tag(&mut self) -> Result<Tag, Error> {
         match self.peek_byte() {
             Some(byte) => byte.try_into(),
             None => Err(Error::incomplete(self.input_len())),

--- a/der/src/reader/nested.rs
+++ b/der/src/reader/nested.rs
@@ -59,7 +59,7 @@ impl<'i, 'r, R: Reader<'r>> Reader<'r> for NestedReader<'i, R> {
         self.input_len
     }
 
-    fn peek_byte(&self) -> Option<u8> {
+    fn peek_byte(&mut self) -> Option<u8> {
         if self.is_finished() {
             None
         } else {
@@ -67,7 +67,7 @@ impl<'i, 'r, R: Reader<'r>> Reader<'r> for NestedReader<'i, R> {
         }
     }
 
-    fn peek_header(&self) -> Result<Header> {
+    fn peek_header(&mut self) -> Result<Header> {
         if self.is_finished() {
             Err(Error::incomplete(self.offset()))
         } else {

--- a/der/src/reader/slice.rs
+++ b/der/src/reader/slice.rs
@@ -77,13 +77,13 @@ impl<'a> Reader<'a> for SliceReader<'a> {
         self.bytes.len()
     }
 
-    fn peek_byte(&self) -> Option<u8> {
+    fn peek_byte(&mut self) -> Option<u8> {
         self.remaining()
             .ok()
             .and_then(|bytes| bytes.first().cloned())
     }
 
-    fn peek_header(&self) -> Result<Header, Error> {
+    fn peek_header(&mut self) -> Result<Header, Error> {
         Header::decode(&mut self.clone())
     }
 
@@ -212,7 +212,7 @@ mod tests {
 
     #[test]
     fn peek_tag() {
-        let reader = SliceReader::new(EXAMPLE_MSG).unwrap();
+        let mut reader = SliceReader::new(EXAMPLE_MSG).unwrap();
         assert_eq!(reader.position(), Length::ZERO);
         assert_eq!(reader.peek_tag().unwrap(), Tag::Integer);
         assert_eq!(reader.position(), Length::ZERO); // Position unchanged
@@ -220,7 +220,7 @@ mod tests {
 
     #[test]
     fn peek_header() {
-        let reader = SliceReader::new(EXAMPLE_MSG).unwrap();
+        let mut reader = SliceReader::new(EXAMPLE_MSG).unwrap();
         assert_eq!(reader.position(), Length::ZERO);
 
         let header = reader.peek_header().unwrap();


### PR DESCRIPTION
Right now `PemReader` uses interior mutability via `RefCell`, because peeking might involve filling an internal peek buffer (i.e. decoding the Base64 in a PEM document).

Rather than trying to hide the fact we're potentially modifying internal buffers (but not the cursor/position) when peeking, this changes the methods to explicitly accept `&mut self`, and with that change eliminates all usages of `RefCell`.

This change appears to have no practical drawbacks, since peeking always occurs during the decoding process where we need mutable access to the reader anyway.