### PR TITLE
Fix broken of encoded unpadded base32

### DIFF
--- a/base32ct/src/encoding.rs
+++ b/base32ct/src/encoding.rs
@@ -226,7 +226,7 @@ impl<T: Alphabet> Encoding for T {
         } else if Self::PADDED {
             ((bytes.len() - 1) / 5 + 1) * 8
         } else {
-            (bytes.len() * 8) / 5 + 1
+            (bytes.len() * 8 + 4) / 5
         }
     }
 }

--- a/base32ct/tests/vectors.rs
+++ b/base32ct/tests/vectors.rs
@@ -23,6 +23,18 @@ const LOWER_PADDED_VECTORS: &[TestVector] = &[
         decoded: &[32, 7],
         encoded: "eadq====",
     },
+    TestVector {
+        decoded: &[0x12, 0x34, 0x56],
+        encoded: "ci2fm===",
+    },
+    TestVector {
+        decoded: &[0x12, 0x34, 0x56, 0x78, 0x9a],
+        encoded: "ci2fm6e2",
+    },
+    TestVector {
+        decoded: &[0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc],
+        encoded: "ci2fm6e2xq======",
+    },
 ];
 
 const LOWER_UNPADDED_VECTORS: &[TestVector] = &[
@@ -37,6 +49,18 @@ const LOWER_UNPADDED_VECTORS: &[TestVector] = &[
     TestVector {
         decoded: &[32, 7],
         encoded: "eadq",
+    },
+    TestVector {
+        decoded: &[0x12, 0x34, 0x56],
+        encoded: "ci2fm",
+    },
+    TestVector {
+        decoded: &[0x12, 0x34, 0x56, 0x78, 0x9a],
+        encoded: "ci2fm6e2",
+    },
+    TestVector {
+        decoded: &[0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc],
+        encoded: "ci2fm6e2xq",
     },
 ];
 
@@ -53,6 +77,18 @@ const UPPER_PADDED_VECTORS: &[TestVector] = &[
         decoded: &[32, 7],
         encoded: "EADQ====",
     },
+    TestVector {
+        decoded: &[0x12, 0x34, 0x56],
+        encoded: "CI2FM===",
+    },
+    TestVector {
+        decoded: &[0x12, 0x34, 0x56, 0x78, 0x9a],
+        encoded: "CI2FM6E2",
+    },
+    TestVector {
+        decoded: &[0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc],
+        encoded: "CI2FM6E2XQ======",
+    },
 ];
 
 const UPPER_UNPADDED_VECTORS: &[TestVector] = &[
@@ -67,6 +103,18 @@ const UPPER_UNPADDED_VECTORS: &[TestVector] = &[
     TestVector {
         decoded: &[32, 7],
         encoded: "EADQ",
+    },
+    TestVector {
+        decoded: &[0x12, 0x34, 0x56],
+        encoded: "CI2FM",
+    },
+    TestVector {
+        decoded: &[0x12, 0x34, 0x56, 0x78, 0x9a],
+        encoded: "CI2FM6E2",
+    },
+    TestVector {
+        decoded: &[0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc],
+        encoded: "CI2FM6E2XQ",
     },
 ];
 


### PR DESCRIPTION
Keep in mind that this changes the output of the encoded forms and the encoded length from the utility function. Even if not technically a breaking change, users should be aware that the previous versions could lead to broken base32 strings.

Maybe it should be better to yank previous versions after a patch version is out. Eventually it could be also worth releasing a `0.1.1` with the fix. Choose what you consider the best option for the project.

Fixes #1420 