### PR TITLE
base32ct v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,7 @@ checksum = "d1ce0365f4d5fb6646220bb52fe547afd51796d90f914d4063cb0b032ebee088"
 
 [[package]]
 name = "base32ct"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base32",
  "proptest",

--- a/base32ct/CHANGELOG.md
+++ b/base32ct/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.1 (2024-05-28)
+### Added
+- Support for Base32 upper unpadded alphabet ([#1406])
+
+### Fixed
+- Broken encoding of unpadded base32 ([#1421])
+
+[#1406]: https://github.com/RustCrypto/formats/pull/1406
+[#1421]: https://github.com/RustCrypto/formats/pull/1421
+
 ## 0.2.0 (2023-02-26)
 ### Changed
 - MSRV 1.60 ([#802])

--- a/base32ct/Cargo.toml
+++ b/base32ct/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base32ct"
-version = "0.2.0"
+version = "0.2.1"
 description = """
 Pure Rust implementation of Base32 (RFC 4648) which avoids any usages of
 data-dependent branches/LUTs and thereby provides portable "best effort"


### PR DESCRIPTION
### Added
- Support for Base32 upper unpadded alphabet ([#1406])

### Fixed
- Broken encoding of unpadded base32 ([#1421])

[#1406]: https://github.com/RustCrypto/formats/pull/1406
[#1421]: https://github.com/RustCrypto/formats/pull/1421