### PR TITLE
base32ct+base64ct: unpin `proptest`; MSRV 1.65

### DIFF
--- a/.github/workflows/base64ct.yml
+++ b/.github/workflows/base64ct.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -40,14 +40,14 @@ jobs:
   minimal-versions:
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
     with:
-        working-directory: ${{ github.workflow }}
+      working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,7 @@ checksum = "d1ce0365f4d5fb6646220bb52fe547afd51796d90f914d4063cb0b032ebee088"
 
 [[package]]
 name = "base32ct"
-version = "0.2.1"
+version = "0.3.0-pre"
 dependencies = [
  "base32",
  "proptest",
@@ -158,6 +158,12 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 [[package]]
 name = "base64ct"
 version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "base64ct"
+version = "1.7.0-pre"
 dependencies = [
  "base64",
  "proptest",
@@ -998,7 +1004,7 @@ dependencies = [
 name = "pem-rfc7468"
 version = "1.0.0-pre.0"
 dependencies = [
- "base64ct",
+ "base64ct 1.6.0",
 ]
 
 [[package]]
@@ -1536,7 +1542,7 @@ name = "spki"
 version = "0.8.0-pre.0"
 dependencies = [
  "arbitrary",
- "base64ct",
+ "base64ct 1.6.0",
  "der",
  "hex-literal",
  "sha2",

--- a/base32ct/Cargo.toml
+++ b/base32ct/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base32ct"
-version = "0.2.1"
+version = "0.3.0-pre"
 description = """
 Pure Rust implementation of Base32 (RFC 4648) which avoids any usages of
 data-dependent branches/LUTs and thereby provides portable "best effort"
@@ -15,12 +15,11 @@ categories = ["cryptography", "encoding", "no-std", "parser-implementations"]
 keywords = ["crypto"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.65"
 
 [dev-dependencies]
 base32 = "0.5"
-# pinned to preserve MSRV
-proptest = { version = "=1.2.0", default-features = false, features = ["std"] }
+proptest = { version = "1.2", default-features = false, features = ["std"] }
 
 [features]
 alloc = []

--- a/base32ct/README.md
+++ b/base32ct/README.md
@@ -20,7 +20,7 @@ Supports `no_std` environments and avoids heap allocations in the core API
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.60** at a minimum.
+This crate requires **Rust 1.65** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -49,7 +49,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/formats/actions/workflows/base32ct.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/formats/actions/workflows/base32ct.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.60+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 

--- a/base64ct/Cargo.toml
+++ b/base64ct/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base64ct"
-version = "1.6.0"
+version = "1.7.0-pre"
 description = """
 Pure Rust implementation of Base64 (RFC 4648) which avoids any usages of
 data-dependent branches/LUTs and thereby provides portable "best effort"
@@ -15,12 +15,11 @@ categories = ["cryptography", "encoding", "no-std", "parser-implementations"]
 keywords = ["crypto", "base64", "pem", "phc"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.65"
 
 [dev-dependencies]
 base64 = "0.22"
-# pinned to preserve MSRV
-proptest = { version = "=1.2.0", default-features = false, features = ["std"] }
+proptest = { version = "1.2", default-features = false, features = ["std"] }
 
 [features]
 alloc = []

--- a/base64ct/README.md
+++ b/base64ct/README.md
@@ -43,7 +43,7 @@ fixed-width line wrapping.
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.60** at a minimum.
+This crate requires **Rust 1.65** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -72,7 +72,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/formats/actions/workflows/base64ct.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/formats/actions/workflows/base64ct.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.60+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 


### PR DESCRIPTION
This seems like the lowest maintenance way to do this.

An alternative would be to check MSRV only on build, which would allow us to run tests with a higher rustc version, but that wouldn't actually verify tests pass under MSRV.