### PR TITLE
base32ct: add const encoded_len fn

### DIFF
--- a/base32ct/src/encoding.rs
+++ b/base32ct/src/encoding.rs
@@ -220,14 +220,9 @@ impl<T: Alphabet> Encoding for T {
         }
     }
 
+    #[inline]
     fn encoded_len(bytes: &[u8]) -> usize {
-        if bytes.is_empty() {
-            0
-        } else if Self::PADDED {
-            ((bytes.len() - 1) / 5 + 1) * 8
-        } else {
-            (bytes.len() * 8 + 4) / 5
-        }
+        encoded_len::<Self>(bytes.len())
     }
 }
 
@@ -257,6 +252,17 @@ fn remove_padding(mut input: &[u8]) -> Result<&[u8]> {
     }
 
     Ok(input)
+}
+
+/// Get the length of Base32 produced by encoding the given amount of bytes.
+pub const fn encoded_len<T: Encoding>(length: usize) -> usize {
+    if length == 0 {
+        0
+    } else if T::PADDED {
+        ((length - 1) / 5 + 1) * 8
+    } else {
+        (length * 8 + 4) / 5
+    }
 }
 
 #[cfg(all(test, feature = "alloc"))]

--- a/base32ct/src/lib.rs
+++ b/base32ct/src/lib.rs
@@ -59,6 +59,6 @@ mod error;
 
 pub use crate::{
     alphabet::rfc4648::{Base32, Base32Unpadded, Base32Upper, Base32UpperUnpadded},
-    encoding::Encoding,
+    encoding::{encoded_len, Encoding},
     error::{Error, Result},
 };


### PR DESCRIPTION
This can be handy to avoid an heap allocation, because it is possible to use the result of the const fn to allocate an array of the right size.

EDIT: I changed a bit the initial proposal in order to make it actually easier to use in const context. Previously `encoded_len` took a slice (like in the trait), now it takes an `usize` representing the number of bytes to encode.