### PR TITLE
implement `std::error::Error` for `cms` and `pkcs5` crates

### DIFF
--- a/cms/src/builder.rs
+++ b/cms/src/builder.rs
@@ -66,6 +66,9 @@ pub enum Error {
     Builder(String),
 }
 
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
+
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/pkcs5/src/error.rs
+++ b/pkcs5/src/error.rs
@@ -36,6 +36,9 @@ pub enum Error {
     },
 }
 
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
+
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {


### PR DESCRIPTION
I am using the `cms` crate to calculate a PKCS#7 signature. There, I have noticed that many RustCrypto crates support the conversion of errors into `anyhow::Error` but the `cms` crate does not provide it.

I looked through all crates in this repository and found `pkcs5`, too.

Here is my small demo program which I have used to test the PR:
```rust
use anyhow::Context;
use cms::builder::SignedDataBuilder;
use cms::signed_data::EncapsulatedContentInfo;
use der::asn1::PrintableStringRef;
use spki::AlgorithmIdentifierOwned;

fn main() -> anyhow::Result<()> {
    // runtime error: '@' is not allowed in ASN.1 PrintableString
    let content = "abc@example.com".to_owned();
    let content = PrintableStringRef::new(&content).context("cannot create PrintableStringRef")?;
    let content = EncapsulatedContentInfo {
        econtent_type: const_oid::db::rfc5911::ID_DATA,
        econtent: Some(content.into()),
    };

    let digest_algorithm = AlgorithmIdentifierOwned {
        oid: const_oid::db::rfc5912::ID_SHA_256,
        parameters: None,
    };

    let mut builder = SignedDataBuilder::new(&content);
    builder
        .add_digest_algorithm(digest_algorithm)
        .context("cannot add digest algorithm")?;
    Ok(())
}
```

Output of the above demo program (irrelevant for PR but for completeness):
```
Error: cannot create PrintableStringRef

Caused by:
    malformed ASN.1 DER value for PrintableString
```

Without the changes, the cargo build would throw the following error:
```console
error[E0599]: the method `context` exists for enum `Result<&mut SignedDataBuilder<'_>, Error>`, but its trait bounds were not satisfied
  --> src/main.rs:24:10
   |
22 | /     builder
23 | |         .add_digest_algorithm(digest_algorithm)
24 | |         .context("cannot add digest algorithm")?;
   | |         -^^^^^^^ method cannot be called on `Result<&mut SignedDataBuilder<'_>, Error>` due to unsatisfied trait bounds
   | |_________|
   | 
   |
  ::: /home/develangel/workspace2/rust/cms-test/rustcrypto-formats/cms/src/builder.rs:48:1
   |
48 |   pub enum Error {
   |   -------------- doesn't satisfy `_: StdError`
   |
   = note: the following trait bounds were not satisfied:
           `cms::builder::Error: anyhow::context::ext::StdError`
           which is required by `Result<&mut SignedDataBuilder<'_>, cms::builder::Error>: anyhow::Context<&mut SignedDataBuilder<'_>, cms::builder::Error>`

For more information about this error, try `rustc --explain E0599`.
```