### PR TITLE
pkcs8: use `pbes2::Parameters::recommended`

### DIFF
--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -22,7 +22,7 @@ spki = { version = "=0.8.0-pre.0" }
 
 # optional dependencies
 rand_core = { version = "0.6", optional = true, default-features = false }
-pkcs5 = { version = "=0.8.0-pre.0", optional = true }
+pkcs5 = { version = "=0.8.0-pre.0", optional = true, features = ["rand_core"] }
 subtle = { version = "2", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/pkcs8/src/private_key_info.rs
+++ b/pkcs8/src/private_key_info.rs
@@ -13,10 +13,7 @@ use der::SecretDocument;
 
 #[cfg(feature = "encryption")]
 use {
-    crate::EncryptedPrivateKeyInfo,
-    der::zeroize::Zeroizing,
-    pkcs5::pbes2,
-    rand_core::{CryptoRng, RngCore},
+    crate::EncryptedPrivateKeyInfo, der::zeroize::Zeroizing, pkcs5::pbes2, rand_core::CryptoRngCore,
 };
 
 #[cfg(feature = "pem")]
@@ -137,7 +134,7 @@ impl<'a> PrivateKeyInfo<'a> {
     #[cfg(feature = "encryption")]
     pub fn encrypt(
         &self,
-        rng: impl CryptoRng + RngCore,
+        rng: &mut impl CryptoRngCore,
         password: impl AsRef<[u8]>,
     ) -> Result<SecretDocument> {
         let der = Zeroizing::new(self.to_der()?);

--- a/pkcs8/src/traits.rs
+++ b/pkcs8/src/traits.rs
@@ -6,10 +6,7 @@ use crate::{Error, PrivateKeyInfo, Result};
 use der::SecretDocument;
 
 #[cfg(feature = "encryption")]
-use {
-    crate::EncryptedPrivateKeyInfo,
-    rand_core::{CryptoRng, RngCore},
-};
+use {crate::EncryptedPrivateKeyInfo, rand_core::CryptoRngCore};
 
 #[cfg(feature = "pem")]
 use {
@@ -106,7 +103,7 @@ pub trait EncodePrivateKey {
     #[cfg(feature = "encryption")]
     fn to_pkcs8_encrypted_der(
         &self,
-        rng: impl CryptoRng + RngCore,
+        rng: &mut impl CryptoRngCore,
         password: impl AsRef<[u8]>,
     ) -> Result<SecretDocument> {
         EncryptedPrivateKeyInfo::encrypt(rng, password, self.to_pkcs8_der()?.as_bytes())
@@ -124,7 +121,7 @@ pub trait EncodePrivateKey {
     #[cfg(all(feature = "encryption", feature = "pem"))]
     fn to_pkcs8_encrypted_pem(
         &self,
-        rng: impl CryptoRng + RngCore,
+        rng: &mut impl CryptoRngCore,
         password: impl AsRef<[u8]>,
         line_ending: LineEnding,
     ) -> Result<Zeroizing<String>> {


### PR DESCRIPTION
When encrypting private keys, uses the recommended set of parameters from the `pbes2` crate.

This uses scrypt with parameters explicitly selected to be compatible with OpenSSL so it's capable of decrypting keys encrypted using the `pkcs8` crate.

Closes #429