### PR TITLE
der: fixup multiple-bounds-declaration warning

### DIFF
--- a/der/src/ord.rs
+++ b/der/src/ord.rs
@@ -53,10 +53,10 @@ where
 }
 
 /// Compare the order of two iterators using [`DerCmp`] on the values.
-pub(crate) fn iter_cmp<'a, I, T: 'a>(a: I, b: I) -> Result<Ordering>
+pub(crate) fn iter_cmp<'a, I, T>(a: I, b: I) -> Result<Ordering>
 where
     I: Iterator<Item = &'a T> + ExactSizeIterator,
-    T: DerOrd,
+    T: 'a + DerOrd,
 {
     let length_ord = a.len().cmp(&b.len());
 


### PR DESCRIPTION
```
warning: bound is defined in more than one place
  --> der/src/ord.rs:56:31
   |
56 | pub(crate) fn iter_cmp<'a, I, T: 'a>(a: I, b: I) -> Result<Ordering>
   |                               ^
...
59 |     T: DerOrd,
   |     ^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#multiple_bound_locations
   = note: `#[warn(clippy::multiple_bound_locations)]` on by default
```