### PR TITLE
x509-cert: specify concrete types to help the compiler

### DIFF
--- a/x509-cert/src/ext.rs
+++ b/x509-cert/src/ext.rs
@@ -29,7 +29,7 @@ pub mod pkix;
 pub struct Extension {
     pub extn_id: ObjectIdentifier,
 
-    #[asn1(default = "Default::default")]
+    #[asn1(default = "bool::default")]
     pub critical: bool,
 
     pub extn_value: OctetString,

--- a/x509-cert/src/ext/pkix/constraints/basic.rs
+++ b/x509-cert/src/ext/pkix/constraints/basic.rs
@@ -14,7 +14,7 @@ use der::Sequence;
 #[derive(Clone, Debug, Eq, PartialEq, Sequence)]
 #[allow(missing_docs)]
 pub struct BasicConstraints {
-    #[asn1(default = "Default::default")]
+    #[asn1(default = "bool::default")]
     pub ca: bool,
     pub path_len_constraint: Option<u8>,
 }

--- a/x509-cert/src/ext/pkix/constraints/name.rs
+++ b/x509-cert/src/ext/pkix/constraints/name.rs
@@ -61,7 +61,7 @@ pub struct GeneralSubtree {
     #[asn1(
         context_specific = "0",
         tag_mode = "IMPLICIT",
-        default = "Default::default"
+        default = "u32::default"
     )]
     pub minimum: u32,
 

--- a/x509-cert/src/ext/pkix/crl/dp.rs
+++ b/x509-cert/src/ext/pkix/crl/dp.rs
@@ -31,14 +31,14 @@ pub struct IssuingDistributionPoint {
     #[asn1(
         context_specific = "1",
         tag_mode = "IMPLICIT",
-        default = "Default::default"
+        default = "bool::default"
     )]
     pub only_contains_user_certs: bool,
 
     #[asn1(
         context_specific = "2",
         tag_mode = "IMPLICIT",
-        default = "Default::default"
+        default = "bool::default"
     )]
     pub only_contains_ca_certs: bool,
 
@@ -48,14 +48,14 @@ pub struct IssuingDistributionPoint {
     #[asn1(
         context_specific = "4",
         tag_mode = "IMPLICIT",
-        default = "Default::default"
+        default = "bool::default"
     )]
     pub indirect_crl: bool,
 
     #[asn1(
         context_specific = "5",
         tag_mode = "IMPLICIT",
-        default = "Default::default"
+        default = "bool::default"
     )]
     pub only_contains_attribute_certs: bool,
 }


### PR DESCRIPTION
rustc fails to infer the appropriate types with `Default::default` when building a crate depending on
```
    femme = "2.2.1"
    getrandom = { version = "0.2.15", features = ["js"] }
    rand = "0.8.5
    x509-cert = { version = "0.2.5", features = ["hazmat", "builder"] }
```

This is the primary reason we at [Wire](https://github.com/wireapp) have a fork of `formats` so it'd be nice if we could go back to tracking upstream.