### PR TITLE
Rust 1.80 fixes

### DIFF
--- a/const-oid/src/arcs.rs
+++ b/const-oid/src/arcs.rs
@@ -1,7 +1,7 @@
 //! Arcs are integer values which exist within an OID's hierarchy.
 
 use crate::{Error, Result};
-use core::mem;
+use core::mem::size_of;
 
 #[cfg(doc)]
 use crate::ObjectIdentifier;
@@ -25,7 +25,7 @@ pub(crate) const ARC_MAX_FIRST: Arc = 2;
 pub(crate) const ARC_MAX_SECOND: Arc = 39;
 
 /// Maximum number of bytes supported in an arc.
-const ARC_MAX_BYTES: usize = mem::size_of::<Arc>();
+const ARC_MAX_BYTES: usize = size_of::<Arc>();
 
 /// Maximum value of the last byte in an arc.
 const ARC_MAX_LAST_OCTET: u8 = 0b11110000; // Max bytes of leading 1-bits

--- a/der/src/asn1/bit_string.rs
+++ b/der/src/asn1/bit_string.rs
@@ -6,6 +6,9 @@ use crate::{
 };
 use core::{cmp::Ordering, iter::FusedIterator};
 
+#[cfg(feature = "flagset")]
+use core::mem::size_of_val;
+
 /// ASN.1 `BIT STRING` type.
 ///
 /// This type contains a sequence of any number of bits, modeled internally as
@@ -454,7 +457,7 @@ where
 
         let mut flags = T::none().bits();
 
-        if bits.bit_len() > core::mem::size_of_val(&flags) * 8 {
+        if bits.bit_len() > size_of_val(&flags) * 8 {
             return Err(Error::new(ErrorKind::Overlength, position));
         }
 

--- a/der/src/asn1/integer.rs
+++ b/der/src/asn1/integer.rs
@@ -3,7 +3,7 @@
 pub(super) mod int;
 pub(super) mod uint;
 
-use core::{cmp::Ordering, mem};
+use core::{cmp::Ordering, mem::size_of};
 
 use crate::{EncodeValue, Result, SliceWriter};
 
@@ -22,7 +22,7 @@ where
     T: Copy + EncodeValue + Sized,
 {
     const MAX_INT_SIZE: usize = 16;
-    debug_assert!(mem::size_of::<T>() <= MAX_INT_SIZE);
+    debug_assert!(size_of::<T>() <= MAX_INT_SIZE);
 
     let mut buf1 = [0u8; MAX_INT_SIZE];
     let mut encoder1 = SliceWriter::new(&mut buf1);

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -375,9 +375,6 @@ pub use crate::{
 #[cfg(feature = "alloc")]
 pub use crate::{asn1::Any, document::Document};
 
-#[cfg(feature = "bigint")]
-pub use crypto_bigint as bigint;
-
 #[cfg(feature = "derive")]
 pub use der_derive::{Choice, Enumerated, Sequence, ValueOrd};
 

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -35,6 +35,8 @@ hex-literal = "0.4"
 
 [features]
 alloc = []
+std = []
+
 3des = ["dep:des", "pbes2"]
 des-insecure = ["dep:des", "pbes2"]
 getrandom = ["rand_core/getrandom"]

--- a/pkcs5/src/lib.rs
+++ b/pkcs5/src/lib.rs
@@ -29,6 +29,9 @@
 #[cfg(all(feature = "alloc", feature = "pbes2"))]
 extern crate alloc;
 
+#[cfg(feature = "std")]
+extern crate std;
+
 mod error;
 
 pub mod pbes1;

--- a/pkcs5/src/pbes2/kdf.rs
+++ b/pkcs5/src/pbes2/kdf.rs
@@ -11,6 +11,9 @@ use der::{
     Writer,
 };
 
+#[cfg(feature = "pbes2")]
+use core::mem::size_of;
+
 /// Password-Based Key Derivation Function (PBKDF2) OID.
 pub const PBKDF2_OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549.1.5.12");
 
@@ -483,7 +486,7 @@ impl TryFrom<&ScryptParams> for scrypt::Params {
         let n = params.cost_parameter;
 
         // Compute log2 and verify its correctness
-        let log_n = ((8 * core::mem::size_of::<ScryptCost>() as u32) - n.leading_zeros() - 1) as u8;
+        let log_n = ((8 * size_of::<ScryptCost>() as u32) - n.leading_zeros() - 1) as u8;
 
         if 1 << log_n != n {
             return Err(ScryptParams::INVALID_ERR);

--- a/tls_codec/Cargo.toml
+++ b/tls_codec/Cargo.toml
@@ -53,3 +53,7 @@ harness = false
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ['cfg(fuzzing)']


### PR DESCRIPTION
- `size_of` and `size_of_val` have been moved to the prelude, so import them directly as `core::mem::{size_of, size_of_val}` rather than importing `core::mem`.
- Removes dead code gated on removed features
- `pkcs5`: add missing `std` feature
- `tls_codec`: allow `cfg(fuzzing)`