### PR TITLE
const-oid v0.10.0-rc.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,7 +362,7 @@ checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 name = "cmpv2"
 version = "0.3.0-pre"
 dependencies = [
- "const-oid",
+ "const-oid 0.10.0-pre.2",
  "crmf",
  "der",
  "hex-literal",
@@ -377,7 +377,7 @@ dependencies = [
  "aes",
  "cbc",
  "cipher",
- "const-oid",
+ "const-oid 0.10.0-pre.2",
  "der",
  "ecdsa",
  "getrandom",
@@ -405,6 +405,15 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 [[package]]
 name = "const-oid"
 version = "0.10.0-pre.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7e3352a27098ba6b09546e5f13b15165e6a88b5c2723afecb3ea9576b27e3ea"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.10.0-rc.0"
 dependencies = [
  "arbitrary",
  "hex-literal",
@@ -458,7 +467,7 @@ name = "crmf"
 version = "0.3.0-pre"
 dependencies = [
  "cms",
- "const-oid",
+ "const-oid 0.10.0-pre.2",
  "der",
  "spki",
  "x509-cert",
@@ -502,7 +511,7 @@ version = "0.8.0-pre.0"
 dependencies = [
  "arbitrary",
  "bytes",
- "const-oid",
+ "const-oid 0.10.0-pre.2",
  "der_derive",
  "flagset",
  "hex-literal",
@@ -557,7 +566,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "065d93ead7c220b85d5b4be4795d8398eac4ff68b5ee63895de0a3c1fb6edf25"
 dependencies = [
  "block-buffer",
- "const-oid",
+ "const-oid 0.10.0-pre.2",
  "crypto-common",
  "subtle",
 ]
@@ -1068,7 +1077,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 name = "pkcs1"
 version = "0.8.0-pre.0"
 dependencies = [
- "const-oid",
+ "const-oid 0.10.0-pre.2",
  "der",
  "hex-literal",
  "pkcs8",
@@ -1081,7 +1090,7 @@ name = "pkcs12"
 version = "0.2.0-pre"
 dependencies = [
  "cms",
- "const-oid",
+ "const-oid 0.10.0-pre.2",
  "der",
  "digest",
  "hex-literal",
@@ -1330,7 +1339,7 @@ version = "0.10.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43e0089f12e510517c97e1adc17d0f8374efbabdd021dfb7645d6619f85633e9"
 dependencies = [
- "const-oid",
+ "const-oid 0.10.0-pre.2",
  "digest",
  "num-bigint-dig",
  "num-integer",
@@ -1998,7 +2007,7 @@ version = "0.3.0-pre"
 dependencies = [
  "arbitrary",
  "async-signature",
- "const-oid",
+ "const-oid 0.10.0-pre.2",
  "der",
  "ecdsa",
  "hex-literal",
@@ -2029,7 +2038,7 @@ dependencies = [
 name = "x509-ocsp"
 version = "0.3.0-pre"
 dependencies = [
- "const-oid",
+ "const-oid 0.10.0-pre.2",
  "der",
  "digest",
  "hex-literal",

--- a/const-oid/Cargo.toml
+++ b/const-oid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "const-oid"
-version = "0.10.0-pre.2"
+version = "0.10.0-rc.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """

--- a/x509-cert/src/builder/profile/devid.rs
+++ b/x509-cert/src/builder/profile/devid.rs
@@ -27,9 +27,17 @@ use crate::{
     },
     name::Name,
 };
-use const_oid::db::tcgtpm;
 use der::{asn1::OctetString, ErrorKind};
 use spki::{ObjectIdentifier, SubjectPublicKeyInfoRef};
+
+// TODO(tarcieri): use this when `const-oid` has been bumped to v0.10.0-rc.0
+//use const_oid::db::tcgtpm;
+#[allow(missing_docs)]
+pub mod tcgtpm {
+    use const_oid::ObjectIdentifier;
+    pub const TCG_SV_TPM_12: ObjectIdentifier = ObjectIdentifier::new_unwrap("2.23.133.1.0");
+    pub const TCG_SV_TPM_20: ObjectIdentifier = ObjectIdentifier::new_unwrap("2.23.133.1.2");
+}
 
 /// DevID Certificate
 ///


### PR DESCRIPTION
This release is a soft API freeze, and we can start relaxing requirements not to use `=`

cc @baloo