### PR TITLE
pem-rfc7468 v1.0.0-rc.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,7 +383,7 @@ dependencies = [
  "getrandom",
  "hex-literal",
  "p256",
- "pem-rfc7468",
+ "pem-rfc7468 1.0.0-rc.0",
  "pkcs5",
  "rand",
  "rsa",
@@ -515,7 +515,7 @@ dependencies = [
  "der_derive",
  "flagset",
  "hex-literal",
- "pem-rfc7468",
+ "pem-rfc7468 1.0.0-rc.0",
  "proptest",
  "time",
  "zeroize",
@@ -602,7 +602,7 @@ dependencies = [
  "ff",
  "group",
  "hybrid-array",
- "pem-rfc7468",
+ "pem-rfc7468 1.0.0-pre.0",
  "pkcs8",
  "rand_core",
  "sec1",
@@ -1057,6 +1057,15 @@ dependencies = [
 [[package]]
 name = "pem-rfc7468"
 version = "1.0.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a65e1c27d1680f8805b3f8c9949f08d6aa5d6cbd088c9896e64a53821dc27d"
+dependencies = [
+ "base64ct 1.6.0",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0-rc.0"
 dependencies = [
  "base64ct 1.6.0",
 ]

--- a/cms/Cargo.toml
+++ b/cms/Cargo.toml
@@ -34,7 +34,7 @@ zeroize = { version = "1.8.1", optional = true }
 [dev-dependencies]
 getrandom = "0.2"
 hex-literal = "0.4"
-pem-rfc7468 = "=1.0.0-pre.0"
+pem-rfc7468 = "=1.0.0-rc.0"
 pkcs5 = "=0.8.0-pre.0"
 rand = "0.8.5"
 rsa = { version = "=0.10.0-pre.1", features = ["sha2"] }

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -22,7 +22,7 @@ bytes = { version = "1", optional = true, default-features = false }
 const-oid = { version = "=0.10.0-pre.2", optional = true }
 der_derive = { version = "=0.8.0-pre.0", optional = true }
 flagset = { version = "0.4.6", optional = true }
-pem-rfc7468 = { version = "=1.0.0-pre.0", optional = true, features = ["alloc"] }
+pem-rfc7468 = { version = "1.0.0-rc.0", optional = true, features = ["alloc"] }
 time = { version = "0.3.4", optional = true, default-features = false }
 zeroize = { version = "1.8", optional = true, default-features = false }
 

--- a/pem-rfc7468/Cargo.toml
+++ b/pem-rfc7468/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pem-rfc7468"
-version = "1.0.0-pre.0"
+version = "1.0.0-rc.0"
 description = """
 PEM Encoding (RFC 7468) for PKIX, PKCS, and CMS Structures, implementing a
 strict subset of the original Privacy-Enhanced Mail encoding intended


### PR DESCRIPTION
Due to circular dependencies with https://github.com/rustcrypto/traits it seems I'm going to have to break the build to get this published