### PR TITLE
Cut `pkcs*` crate prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,18 @@ name = "aead"
 version = "0.6.0-pre.0"
 source = "git+https://github.com/RustCrypto/traits.git#0a3687b58e59d5d2e196f59ca883a2d46eb76abb"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.2.0-pre.5",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher 0.4.4",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -32,7 +43,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25512cae539ab9089dcbd69c4f704e787fdc8c1cea8d9daa68a9d89b02b0501f"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.5.0-pre.4",
  "cpufeatures",
 ]
 
@@ -42,8 +53,8 @@ version = "0.11.0-pre"
 source = "git+https://github.com/RustCrypto/AEADs.git#ad109f38b03124e7498bfe5e9830d1328f811d27"
 dependencies = [
  "aead",
- "aes",
- "cipher",
+ "aes 0.9.0-pre",
+ "cipher 0.5.0-pre.4",
  "ctr",
  "ghash",
  "subtle",
@@ -237,11 +248,29 @@ checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.11.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ded684142010808eb980d9974ef794da2bcf97d13396143b1515e9f0fb4a10e"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.2.0-pre.5",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -273,10 +302,19 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "cbc"
 version = "0.2.0-pre"
 source = "git+https://github.com/RustCrypto/block-modes.git#957d4c989a6afd171b218c57e451c44269fac8a4"
 dependencies = [
- "cipher",
+ "cipher 0.5.0-pre.4",
 ]
 
 [[package]]
@@ -323,12 +361,22 @@ dependencies = [
 
 [[package]]
 name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.6",
+ "inout 0.1.3",
+]
+
+[[package]]
+name = "cipher"
 version = "0.5.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84fba98785cecd0e308818a87c817576a40f99d8bab6405bf422bacd3efb6c1f"
 dependencies = [
- "crypto-common",
- "inout",
+ "crypto-common 0.2.0-pre.5",
+ "inout 0.2.0-pre.4",
 ]
 
 [[package]]
@@ -366,7 +414,7 @@ dependencies = [
  "crmf",
  "der 0.8.0-pre.0",
  "hex-literal",
- "spki",
+ "spki 0.8.0-pre.0",
  "x509-cert",
 ]
 
@@ -374,9 +422,9 @@ dependencies = [
 name = "cms"
 version = "0.3.0-pre"
 dependencies = [
- "aes",
- "cbc",
- "cipher",
+ "aes 0.9.0-pre",
+ "cbc 0.2.0-pre",
+ "cipher 0.5.0-pre.4",
  "const-oid 0.10.0-pre.2",
  "der 0.8.0-pre.0",
  "ecdsa",
@@ -384,14 +432,14 @@ dependencies = [
  "hex-literal",
  "p256",
  "pem-rfc7468 1.0.0-rc.0",
- "pkcs5",
+ "pkcs5 0.8.0-pre.0",
  "rand",
  "rsa",
  "sha1",
- "sha2",
+ "sha2 0.11.0-pre.3",
  "sha3",
  "signature",
- "spki",
+ "spki 0.8.0-pre.0",
  "x509-cert",
  "zeroize",
 ]
@@ -469,7 +517,7 @@ dependencies = [
  "cms",
  "const-oid 0.10.0-pre.2",
  "der 0.8.0-pre.0",
- "spki",
+ "spki 0.8.0-pre.0",
  "x509-cert",
 ]
 
@@ -488,6 +536,16 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "crypto-common"
 version = "0.2.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7aa2ec04f5120b830272a481e8d9d8ba4dda140d2cda59b0f1110d5eb93c38e"
@@ -502,7 +560,7 @@ name = "ctr"
 version = "0.10.0-pre"
 source = "git+https://github.com/RustCrypto/block-modes.git#a0051b2892626f4bd4f96c8ec7ca942a1047bb3c"
 dependencies = [
- "cipher",
+ "cipher 0.5.0-pre.4",
 ]
 
 [[package]]
@@ -577,11 +635,31 @@ dependencies = [
 
 [[package]]
 name = "des"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
+dependencies = [
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "des"
 version = "0.9.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f106bfb220e7015669775195f68a439f4255a0baf95a437de2846f751b25997"
 dependencies = [
- "cipher",
+ "cipher 0.5.0-pre.4",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.6",
+ "subtle",
 ]
 
 [[package]]
@@ -590,9 +668,9 @@ version = "0.11.0-pre.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "065d93ead7c220b85d5b4be4795d8398eac4ff68b5ee63895de0a3c1fb6edf25"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.11.0-pre.5",
  "const-oid 0.10.0-pre.2",
- "crypto-common",
+ "crypto-common 0.2.0-pre.5",
  "subtle",
 ]
 
@@ -602,11 +680,11 @@ version = "0.17.0-pre.5"
 source = "git+https://github.com/RustCrypto/signatures#c2f3ee6497d8ab8069c149c5c922a342eedd3334"
 dependencies = [
  "der 0.8.0-pre.0",
- "digest",
+ "digest 0.11.0-pre.8",
  "elliptic-curve",
  "rfc6979",
  "signature",
- "spki",
+ "spki 0.8.0-pre.0",
 ]
 
 [[package]]
@@ -623,14 +701,14 @@ checksum = "4a1775af172997a40c14854c3a9fde9e03e5772084b334b6a0bb18bf7f93ac16"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.11.0-pre.8",
  "ff",
  "group",
  "hybrid-array",
  "pem-rfc7468 1.0.0-pre.0",
- "pkcs8",
+ "pkcs8 0.11.0-pre.0",
  "rand_core",
- "sec1",
+ "sec1 0.8.0-pre.1",
  "subtle",
  "zeroize",
 ]
@@ -775,6 +853,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -824,7 +912,7 @@ version = "0.2.0-pre"
 dependencies = [
  "der 0.8.0-pre.0",
  "hex-literal",
- "spki",
+ "spki 0.8.0-pre.0",
  "x509-cert",
 ]
 
@@ -854,11 +942,20 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
 version = "0.13.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffd790a0795ee332ed3e8959e5b177beb70d7112eb7d345428ec17427897d5ce"
 dependencies = [
- "digest",
+ "digest 0.11.0-pre.8",
 ]
 
 [[package]]
@@ -883,11 +980,21 @@ dependencies = [
 
 [[package]]
 name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "block-padding 0.3.3",
+ "generic-array",
+]
+
+[[package]]
+name = "inout"
 version = "0.2.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a2cc35b920cc3b344af824e64e508ffc2c819fc2368ed4d253244446194d2fe"
 dependencies = [
- "block-padding",
+ "block-padding 0.4.0-pre.4",
  "hybrid-array",
 ]
 
@@ -1051,7 +1158,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.11.0-pre.3",
 ]
 
 [[package]]
@@ -1062,12 +1169,22 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest 0.10.7",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "pbkdf2"
 version = "0.13.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4cf4eb113be91873131bc3c309666600c9b7b68919dd90ccaa20a1b37b84d26"
 dependencies = [
- "digest",
- "hmac",
+ "digest 0.11.0-pre.8",
+ "hmac 0.13.0-pre.3",
 ]
 
 [[package]]
@@ -1075,8 +1192,8 @@ name = "pbkdf2"
 version = "0.13.0-pre.0"
 source = "git+https://github.com/RustCrypto/password-hashes.git#f453d34b407a7494b4eb4603f523bef25edbf162"
 dependencies = [
- "digest",
- "hmac",
+ "digest 0.11.0-pre.8",
+ "hmac 0.13.0-pre.3",
 ]
 
 [[package]]
@@ -1110,12 +1227,23 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "pkcs1"
 version = "0.8.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f6af6e88ac39402f67488e22faa9eb15cf065f520cf4a09419393691a6d0133"
 dependencies = [
- "const-oid 0.10.0-pre.2",
  "der 0.8.0-pre.0",
+ "pkcs8 0.11.0-pre.0",
+ "spki 0.8.0-pre.0",
+]
+
+[[package]]
+name = "pkcs1"
+version = "0.8.0-rc.0"
+dependencies = [
+ "const-oid 0.10.0-rc.0",
+ "der 0.8.0-rc.0",
  "hex-literal",
- "pkcs8",
- "spki",
+ "pkcs8 0.11.0-rc.0",
+ "spki 0.8.0-rc.0",
  "tempfile",
 ]
 
@@ -1126,12 +1254,12 @@ dependencies = [
  "cms",
  "const-oid 0.10.0-pre.2",
  "der 0.8.0-pre.0",
- "digest",
+ "digest 0.11.0-pre.8",
  "hex-literal",
- "pkcs5",
- "pkcs8",
- "sha2",
- "spki",
+ "pkcs5 0.8.0-pre.0",
+ "pkcs8 0.11.0-pre.0",
+ "sha2 0.11.0-pre.3",
+ "spki 0.8.0-pre.0",
  "whirlpool",
  "x509-cert",
  "zeroize",
@@ -1140,30 +1268,58 @@ dependencies = [
 [[package]]
 name = "pkcs5"
 version = "0.8.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6aebdab8ec0fe71f347de8d37212be79ccdedeb0f46133b0cf2bc5f6d2c65a"
 dependencies = [
- "aes",
- "aes-gcm",
- "cbc",
+ "aes 0.8.4",
+ "cbc 0.1.2",
  "der 0.8.0-pre.0",
- "des",
+ "des 0.8.1",
+ "pbkdf2 0.12.2",
+ "scrypt 0.11.0",
+ "sha2 0.10.8",
+ "spki 0.8.0-pre.0",
+]
+
+[[package]]
+name = "pkcs5"
+version = "0.8.0-rc.0"
+dependencies = [
+ "aes 0.9.0-pre",
+ "aes-gcm",
+ "cbc 0.2.0-pre",
+ "der 0.8.0-rc.0",
+ "des 0.9.0-pre.0",
  "hex-literal",
  "pbkdf2 0.13.0-pre.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core",
- "scrypt",
+ "scrypt 0.12.0-pre.0",
  "sha1",
- "sha2",
- "spki",
+ "sha2 0.11.0-pre.3",
+ "spki 0.8.0-rc.0",
 ]
 
 [[package]]
 name = "pkcs8"
 version = "0.11.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "935c09e0aecb0cb8f8907b57438b19a068cb74a25189b06724f061170b2465ff"
 dependencies = [
  "der 0.8.0-pre.0",
- "hex-literal",
- "pkcs5",
+ "pkcs5 0.8.0-pre.0",
  "rand_core",
- "spki",
+ "spki 0.8.0-pre.0",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0-rc.0"
+dependencies = [
+ "der 0.8.0-rc.0",
+ "hex-literal",
+ "pkcs5 0.8.0-rc.0",
+ "rand_core",
+ "spki 0.8.0-rc.0",
  "subtle",
  "tempfile",
 ]
@@ -1341,7 +1497,7 @@ name = "rfc6979"
 version = "0.5.0-pre.3"
 source = "git+https://github.com/RustCrypto/signatures#c2f3ee6497d8ab8069c149c5c922a342eedd3334"
 dependencies = [
- "hmac",
+ "hmac 0.13.0-pre.3",
  "subtle",
 ]
 
@@ -1374,16 +1530,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43e0089f12e510517c97e1adc17d0f8374efbabdd021dfb7645d6619f85633e9"
 dependencies = [
  "const-oid 0.10.0-pre.2",
- "digest",
+ "digest 0.11.0-pre.8",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
- "pkcs1",
- "pkcs8",
+ "pkcs1 0.8.0-pre.0",
+ "pkcs8 0.11.0-pre.0",
  "rand_core",
- "sha2",
+ "sha2 0.11.0-pre.3",
  "signature",
- "spki",
+ "spki 0.8.0-pre.0",
  "subtle",
  "zeroize",
 ]
@@ -1466,10 +1622,19 @@ checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "salsa20"
 version = "0.11.0-pre"
 source = "git+https://github.com/RustCrypto/stream-ciphers.git#fea3dd013ee9c35fba56903ad44b411957de8cb2"
 dependencies = [
- "cipher",
+ "cipher 0.5.0-pre.4",
 ]
 
 [[package]]
@@ -1483,23 +1648,48 @@ dependencies = [
 
 [[package]]
 name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "pbkdf2 0.12.2",
+ "salsa20 0.10.2",
+ "sha2 0.10.8",
+]
+
+[[package]]
+name = "scrypt"
 version = "0.12.0-pre.0"
 source = "git+https://github.com/RustCrypto/password-hashes.git#f453d34b407a7494b4eb4603f523bef25edbf162"
 dependencies = [
  "pbkdf2 0.13.0-pre.0 (git+https://github.com/RustCrypto/password-hashes.git)",
- "salsa20",
- "sha2",
+ "salsa20 0.11.0-pre",
+ "sha2 0.11.0-pre.3",
 ]
 
 [[package]]
 name = "sec1"
 version = "0.8.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02dc081ed777a3bab68583b52ffb8221677b6e90d483b320963a247e2c07f328"
 dependencies = [
  "base16ct",
  "der 0.8.0-pre.0",
+ "hybrid-array",
+ "pkcs8 0.11.0-pre.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.8.0-rc.0"
+dependencies = [
+ "base16ct",
+ "der 0.8.0-rc.0",
  "hex-literal",
  "hybrid-array",
- "pkcs8",
+ "pkcs8 0.11.0-rc.0",
  "serdect",
  "subtle",
  "tempfile",
@@ -1587,7 +1777,18 @@ checksum = "3885de8cb916f223718c1ccd47a840b91f806333e76002dc5cb3862154b4fed3"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.11.0-pre.8",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1598,7 +1799,7 @@ checksum = "8f33549bf3064b62478926aa89cbfc7c109aab66ae8f0d5d2ef839e482cc30d6"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.11.0-pre.8",
 ]
 
 [[package]]
@@ -1607,7 +1808,7 @@ version = "0.11.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f32c02b9987a647a3d6af14c3e88df86594e4283050d9d8ee3a035df247785b9"
 dependencies = [
- "digest",
+ "digest 0.11.0-pre.8",
  "keccak",
 ]
 
@@ -1617,7 +1818,7 @@ version = "2.3.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1700c22ba9ce32c7b0a1495068a906c3552e7db386af7cf865162e0dea498523"
 dependencies = [
- "digest",
+ "digest 0.11.0-pre.8",
  "rand_core",
 ]
 
@@ -1645,12 +1846,24 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 [[package]]
 name = "spki"
 version = "0.8.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb2b56670f5ef52934c97efad30bf42585de0c33ec3e2a886e38b80d2db67243"
 dependencies = [
  "arbitrary",
  "base64ct 1.6.0",
  "der 0.8.0-pre.0",
+ "sha2 0.10.8",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0-rc.0"
+dependencies = [
+ "arbitrary",
+ "base64ct 1.6.0",
+ "der 0.8.0-rc.0",
  "hex-literal",
- "sha2",
+ "sha2 0.11.0-pre.3",
  "tempfile",
 ]
 
@@ -1877,7 +2090,7 @@ version = "0.6.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a05336f34009f6bb1c24794e2c04df87f4a0ced7a091692e395119f34fd3f4c5"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.2.0-pre.5",
  "subtle",
 ]
 
@@ -1886,6 +2099,12 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"
@@ -1917,7 +2136,7 @@ name = "whirlpool"
 version = "0.11.0-pre.2"
 source = "git+https://github.com/RustCrypto/hashes.git#e4dcf120629bd6461eff9ca1b281736336de423c"
 dependencies = [
- "digest",
+ "digest 0.11.0-pre.8",
 ]
 
 [[package]]
@@ -2050,9 +2269,9 @@ dependencies = [
  "rsa",
  "rstest",
  "sha1",
- "sha2",
+ "sha2 0.11.0-pre.3",
  "signature",
- "spki",
+ "spki 0.8.0-pre.0",
  "tempfile",
  "tls_codec 0.4.1",
  "tokio",
@@ -2074,16 +2293,16 @@ version = "0.3.0-pre"
 dependencies = [
  "const-oid 0.10.0-pre.2",
  "der 0.8.0-pre.0",
- "digest",
+ "digest 0.11.0-pre.8",
  "hex-literal",
  "lazy_static",
  "rand",
  "rand_core",
  "rsa",
  "sha1",
- "sha2",
+ "sha2 0.11.0-pre.3",
  "signature",
- "spki",
+ "spki 0.8.0-pre.0",
  "x509-cert",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,11 +410,11 @@ checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 name = "cmpv2"
 version = "0.3.0-pre"
 dependencies = [
- "const-oid 0.10.0-pre.2",
+ "const-oid 0.10.0-rc.0",
  "crmf",
- "der 0.8.0-pre.0",
+ "der 0.8.0-rc.0",
  "hex-literal",
- "spki 0.8.0-pre.0",
+ "spki 0.8.0-rc.0",
  "x509-cert",
 ]
 
@@ -425,8 +425,8 @@ dependencies = [
  "aes 0.9.0-pre",
  "cbc 0.2.0-pre",
  "cipher 0.5.0-pre.4",
- "const-oid 0.10.0-pre.2",
- "der 0.8.0-pre.0",
+ "const-oid 0.10.0-rc.0",
+ "der 0.8.0-rc.0",
  "ecdsa",
  "getrandom",
  "hex-literal",
@@ -439,7 +439,7 @@ dependencies = [
  "sha2 0.11.0-pre.3",
  "sha3",
  "signature",
- "spki 0.8.0-pre.0",
+ "spki 0.8.0-rc.0",
  "x509-cert",
  "zeroize",
 ]
@@ -455,9 +455,6 @@ name = "const-oid"
 version = "0.10.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7e3352a27098ba6b09546e5f13b15165e6a88b5c2723afecb3ea9576b27e3ea"
-dependencies = [
- "arbitrary",
-]
 
 [[package]]
 name = "const-oid"
@@ -515,9 +512,9 @@ name = "crmf"
 version = "0.3.0-pre"
 dependencies = [
  "cms",
- "const-oid 0.10.0-pre.2",
- "der 0.8.0-pre.0",
- "spki 0.8.0-pre.0",
+ "const-oid 0.10.0-rc.0",
+ "der 0.8.0-rc.0",
+ "spki 0.8.0-rc.0",
  "x509-cert",
 ]
 
@@ -569,10 +566,7 @@ version = "0.8.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b489fd2221710c1dd46637d66b984161fb66134f81437a8489800306bcc2ecea"
 dependencies = [
- "arbitrary",
  "const-oid 0.10.0-pre.2",
- "der_derive 0.8.0-pre.0",
- "flagset",
  "pem-rfc7468 1.0.0-pre.0",
  "zeroize",
 ]
@@ -584,24 +578,13 @@ dependencies = [
  "arbitrary",
  "bytes",
  "const-oid 0.10.0-rc.0",
- "der_derive 0.8.0-rc.0",
+ "der_derive",
  "flagset",
  "hex-literal",
  "pem-rfc7468 1.0.0-rc.0",
  "proptest",
  "time",
  "zeroize",
-]
-
-[[package]]
-name = "der_derive"
-version = "0.8.0-pre.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd1ee9778ac378876dc78f546d2821fae40a1b69ec8d82f3745392d69ff89ce6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -910,9 +893,9 @@ dependencies = [
 name = "gss-api"
 version = "0.2.0-pre"
 dependencies = [
- "der 0.8.0-pre.0",
+ "der 0.8.0-rc.0",
  "hex-literal",
- "spki 0.8.0-pre.0",
+ "spki 0.8.0-rc.0",
  "x509-cert",
 ]
 
@@ -1252,14 +1235,14 @@ name = "pkcs12"
 version = "0.2.0-pre"
 dependencies = [
  "cms",
- "const-oid 0.10.0-pre.2",
- "der 0.8.0-pre.0",
+ "const-oid 0.10.0-rc.0",
+ "der 0.8.0-rc.0",
  "digest 0.11.0-pre.8",
  "hex-literal",
  "pkcs5 0.8.0-pre.0",
  "pkcs8 0.11.0-pre.0",
  "sha2 0.11.0-pre.3",
- "spki 0.8.0-pre.0",
+ "spki 0.8.0-rc.0",
  "whirlpool",
  "x509-cert",
  "zeroize",
@@ -1849,10 +1832,8 @@ version = "0.8.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb2b56670f5ef52934c97efad30bf42585de0c33ec3e2a886e38b80d2db67243"
 dependencies = [
- "arbitrary",
  "base64ct 1.6.0",
  "der 0.8.0-pre.0",
- "sha2 0.10.8",
 ]
 
 [[package]]
@@ -2260,8 +2241,8 @@ version = "0.3.0-pre"
 dependencies = [
  "arbitrary",
  "async-signature",
- "const-oid 0.10.0-pre.2",
- "der 0.8.0-pre.0",
+ "const-oid 0.10.0-rc.0",
+ "der 0.8.0-rc.0",
  "ecdsa",
  "hex-literal",
  "p256",
@@ -2271,7 +2252,7 @@ dependencies = [
  "sha1",
  "sha2 0.11.0-pre.3",
  "signature",
- "spki 0.8.0-pre.0",
+ "spki 0.8.0-rc.0",
  "tempfile",
  "tls_codec 0.4.1",
  "tokio",
@@ -2291,8 +2272,8 @@ dependencies = [
 name = "x509-ocsp"
 version = "0.3.0-pre"
 dependencies = [
- "const-oid 0.10.0-pre.2",
- "der 0.8.0-pre.0",
+ "const-oid 0.10.0-rc.0",
+ "der 0.8.0-rc.0",
  "digest 0.11.0-pre.8",
  "hex-literal",
  "lazy_static",
@@ -2302,7 +2283,7 @@ dependencies = [
  "sha1",
  "sha2 0.11.0-pre.3",
  "signature",
- "spki 0.8.0-pre.0",
+ "spki 0.8.0-rc.0",
  "x509-cert",
 ]
 
@@ -2312,7 +2293,7 @@ version = "0.2.0-pre"
 dependencies = [
  "cmpv2",
  "cms",
- "der 0.8.0-pre.0",
+ "der 0.8.0-rc.0",
  "hex-literal",
  "x509-cert",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,8 +49,9 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.11.0-pre"
-source = "git+https://github.com/RustCrypto/AEADs.git#ad109f38b03124e7498bfe5e9830d1328f811d27"
+version = "0.11.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecfb53f89da26583b83c16dd289dbabc9ecdcf144e4df2e639ee858fca0d519c"
 dependencies = [
  "aead",
  "aes 0.9.0-pre",
@@ -311,8 +312,9 @@ dependencies = [
 
 [[package]]
 name = "cbc"
-version = "0.2.0-pre"
-source = "git+https://github.com/RustCrypto/block-modes.git#957d4c989a6afd171b218c57e451c44269fac8a4"
+version = "0.2.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0ef1d4741d47264eb090d82f44ecbb37955934078467b0b48ef657bfa4e3c8a"
 dependencies = [
  "cipher 0.5.0-pre.4",
 ]
@@ -423,7 +425,7 @@ name = "cms"
 version = "0.3.0-pre"
 dependencies = [
  "aes 0.9.0-pre",
- "cbc 0.2.0-pre",
+ "cbc 0.2.0-pre.0",
  "cipher 0.5.0-pre.4",
  "const-oid 0.10.0-rc.0",
  "der 0.8.0-rc.0",
@@ -554,8 +556,9 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.10.0-pre"
-source = "git+https://github.com/RustCrypto/block-modes.git#a0051b2892626f4bd4f96c8ec7ca942a1047bb3c"
+version = "0.10.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36d153f259d848d742d829e332f32466d415e2b9dc247c0ea471e68da953f5e1"
 dependencies = [
  "cipher 0.5.0-pre.4",
 ]
@@ -1270,7 +1273,7 @@ version = "0.8.0-rc.0"
 dependencies = [
  "aes 0.9.0-pre",
  "aes-gcm",
- "cbc 0.2.0-pre",
+ "cbc 0.2.0-pre.0",
  "der 0.8.0-rc.0",
  "des 0.9.0-pre.0",
  "hex-literal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,14 +64,9 @@ x509-ocsp = { path = "./x509-ocsp" }
 p256 = { git = "https://github.com/RustCrypto/elliptic-curves.git" }
 # Pending a release of 0.11.0-pre.2
 whirlpool = { git = "https://github.com/RustCrypto/hashes.git" }
-# Pending a release of 0.2.0-pre
-cbc = { git = "https://github.com/RustCrypto/block-modes.git" }
 # Pending a release of 0.11.0-pre
 salsa20 = { git = "https://github.com/RustCrypto/stream-ciphers.git" }
-# Pending a release of 0.11.0-pre
-aes-gcm = { git = "https://github.com/RustCrypto/AEADs.git" }
 aead = { git = "https://github.com/RustCrypto/traits.git" }
-ctr = { git = "https://github.com/RustCrypto/block-modes.git" }
 
 # https://github.com/RustCrypto/formats/pull/1055
 # https://github.com/RustCrypto/signatures/pull/809

--- a/cmpv2/Cargo.toml
+++ b/cmpv2/Cargo.toml
@@ -17,12 +17,12 @@ rust-version = "1.75"
 
 [dependencies]
 crmf = "=0.3.0-pre"
-der = { version = "=0.8.0-pre.0", features = ["alloc", "derive", "flagset", "oid"] }
-spki = { version = "=0.8.0-pre.0" }
+der = { version = "0.8.0-rc.0", features = ["alloc", "derive", "flagset", "oid"] }
+spki = { version = "0.8.0-rc.0" }
 x509-cert = { version = "=0.3.0-pre", default-features = false }
 
 [dev-dependencies]
-const-oid = { version = "=0.10.0-pre.2", features = ["db"] }
+const-oid = { version = "0.10.0-rc.0", features = ["db"] }
 hex-literal = "0.4"
 
 [features]

--- a/cms/Cargo.toml
+++ b/cms/Cargo.toml
@@ -15,10 +15,10 @@ edition = "2021"
 rust-version = "1.75"
 
 [dependencies]
-der = { version = "=0.8.0-pre.0", features = ["alloc", "derive", "oid", "pem"] }
-spki = { version = "=0.8.0-pre.0" }
+der = { version = "0.8.0-rc.0", features = ["alloc", "derive", "oid", "pem"] }
+spki = { version = "0.8.0-rc.0" }
 x509-cert = { version = "=0.3.0-pre", default-features = false, features = ["pem"] }
-const-oid = { version = "=0.10.0-pre.2", features = ["db"] }
+const-oid = { version = "0.10.0-rc.0", features = ["db"] }
 
 # optional dependencies
 aes = { version = "=0.9.0-pre", optional = true }

--- a/cms/Cargo.toml
+++ b/cms/Cargo.toml
@@ -22,7 +22,7 @@ const-oid = { version = "0.10.0-rc.0", features = ["db"] }
 
 # optional dependencies
 aes = { version = "=0.9.0-pre", optional = true }
-cbc = { version = "=0.2.0-pre", optional = true }
+cbc = { version = "=0.2.0-pre.0", optional = true }
 cipher = { version = "=0.5.0-pre.4", features = ["alloc", "block-padding", "rand_core"], optional = true }
 rsa = { version = "=0.10.0-pre.1", optional = true }
 sha1 = { version = "=0.11.0-pre.3", optional = true }

--- a/crmf/Cargo.toml
+++ b/crmf/Cargo.toml
@@ -17,12 +17,12 @@ rust-version = "1.75"
 
 [dependencies]
 cms = "=0.3.0-pre"
-der = { version = "=0.8.0-pre.0", features = ["alloc", "derive"] }
-spki = "=0.8.0-pre.0"
+der = { version = "0.8.0-rc.0", features = ["alloc", "derive"] }
+spki = "0.8.0-rc.0"
 x509-cert = { version = "=0.3.0-pre", default-features = false }
 
 [dev-dependencies]
-const-oid = "=0.10.0-pre.2"
+const-oid = "0.10.0-rc.0"
 
 [features]
 alloc = ["der/alloc"]

--- a/gss-api/Cargo.toml
+++ b/gss-api/Cargo.toml
@@ -16,12 +16,12 @@ edition = "2021"
 rust-version = "1.75"
 
 [dependencies]
-der = { version = "=0.8.0-pre.0", features = ["oid", "alloc"] }
-spki = { version = "=0.8.0-pre.0" }
+der = { version = "0.8.0-rc.0", features = ["oid", "alloc"] }
+spki = { version = "0.8.0-rc.0" }
 x509-cert = { version = "=0.3.0-pre", default-features = false }
 
 [dev-dependencies]
-der = { version = "=0.8.0-pre.0", features = ["oid", "pem", "alloc"] }
+der = { version = "0.8.0-rc.0", features = ["oid", "pem", "alloc"] }
 hex-literal = "0.4"
 x509-cert = { version = "=0.3.0-pre", default-features = false, features = ["pem"] }
 

--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs1"
-version = "0.8.0-pre.0"
+version = "0.8.0-rc.0"
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #1:
 RSA Cryptography Specifications Version 2.2 (RFC 8017)
@@ -16,14 +16,14 @@ edition = "2021"
 rust-version = "1.72"
 
 [dependencies]
-der = { version = "=0.8.0-pre.0", features = ["oid"] }
-spki = { version = "=0.8.0-pre.0" }
+der = { version = "0.8.0-rc.0", features = ["oid"] }
+spki = { version = "0.8.0-rc.0" }
 
 # optional dependencies
-pkcs8 = { version = "=0.11.0-pre.0", optional = true, default-features = false }
+pkcs8 = { version = "0.11.0-rc.0", optional = true, default-features = false }
 
 [dev-dependencies]
-const-oid = { version = "=0.10.0-pre.2", features = ["db"] }
+const-oid = { version = "0.10.0-rc.0", features = ["db"] }
 hex-literal = "0.4"
 tempfile = "3"
 

--- a/pkcs12/Cargo.toml
+++ b/pkcs12/Cargo.toml
@@ -16,10 +16,10 @@ edition = "2021"
 rust-version = "1.75"
 
 [dependencies]
-der = { version = "=0.8.0-pre.0", features = ["alloc", "derive", "oid", "pem"] }
-spki = { version = "=0.8.0-pre.0" }
+der = { version = "0.8.0-rc.0", features = ["alloc", "derive", "oid", "pem"] }
+spki = { version = "0.8.0-rc.0" }
 x509-cert = { version = "=0.3.0-pre", default-features = false, features = ["pem"] }
-const-oid = { version = "=0.10.0-pre.2", features = ["db"] }
+const-oid = { version = "0.10.0-rc.0", features = ["db"] }
 cms = "=0.3.0-pre"
 digest = { version = "0.11.0-pre.8", features=["alloc"], optional = true }
 zeroize = "1.8.1"

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs5"
-version = "0.8.0-pre.0"
+version = "0.8.0-rc.0"
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #5:
 Password-Based Cryptography Specification Version 2.1 (RFC 8018)
@@ -16,8 +16,8 @@ edition = "2021"
 rust-version = "1.72"
 
 [dependencies]
-der = { version = "=0.8.0-pre.0", features = ["oid"] }
-spki = { version = "=0.8.0-pre.0" }
+der = { version = "0.8.0-rc.0", features = ["oid"] }
+spki = { version = "0.8.0-rc.0" }
 
 # optional dependencies
 cbc = { version = "=0.2.0-pre", optional = true }

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -20,9 +20,9 @@ der = { version = "0.8.0-rc.0", features = ["oid"] }
 spki = { version = "0.8.0-rc.0" }
 
 # optional dependencies
-cbc = { version = "=0.2.0-pre", optional = true }
+cbc = { version = "=0.2.0-pre.0", optional = true }
 aes = { version = "=0.9.0-pre", optional = true, default-features = false }
-aes-gcm = { version = "=0.11.0-pre", optional = true, default-features = false, features = ["aes"] }
+aes-gcm = { version = "=0.11.0-pre.0", optional = true, default-features = false, features = ["aes"] }
 des = { version = "=0.9.0-pre.0", optional = true, default-features = false }
 pbkdf2 = { version = "=0.13.0-pre.0", optional = true, default-features = false, features = ["hmac"] }
 rand_core = { version = "0.6.4", optional = true, default-features = false }

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs8"
-version = "0.11.0-pre.0"
+version = "0.11.0-rc.0"
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #8:
 Private-Key Information Syntax Specification (RFC 5208), with additional
@@ -17,12 +17,12 @@ edition = "2021"
 rust-version = "1.72"
 
 [dependencies]
-der = { version = "=0.8.0-pre.0", features = ["oid"] }
-spki = { version = "=0.8.0-pre.0" }
+der = { version = "0.8.0-rc.0", features = ["oid"] }
+spki = { version = "0.8.0-rc.0" }
 
 # optional dependencies
 rand_core = { version = "0.6", optional = true, default-features = false }
-pkcs5 = { version = "=0.8.0-pre.0", optional = true, features = ["rand_core"] }
+pkcs5 = { version = "0.8.0-rc.0", optional = true, features = ["rand_core"] }
 subtle = { version = "2", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sec1"
-version = "0.8.0-pre.1"
+version = "0.8.0-rc.0"
 description = """
 Pure Rust implementation of SEC1: Elliptic Curve Cryptography encoding formats
 including ASN.1 DER-serialized private keys as well as the
@@ -18,9 +18,9 @@ rust-version = "1.72"
 
 [dependencies]
 base16ct = { version = "0.2", optional = true, default-features = false }
-der = { version = "=0.8.0-pre.0", optional = true, features = ["oid"] }
+der = { version = "0.8.0-rc.0", optional = true, features = ["oid"] }
 hybrid-array = { version = "0.2.0-rc.9", optional = true, default-features = false }
-pkcs8 = { version = "=0.11.0-pre.0", optional = true, default-features = false }
+pkcs8 = { version = "0.11.0-rc.0", optional = true, default-features = false }
 serdect = { version = "=0.3.0-pre.0", optional = true, default-features = false, features = ["alloc"] }
 subtle = { version = "2", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }

--- a/spki/Cargo.toml
+++ b/spki/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spki"
-version = "0.8.0-pre.0"
+version = "0.8.0-rc.0"
 description = """
 X.509 Subject Public Key Info (RFC5280) describing public keys as well as their
 associated AlgorithmIdentifiers (i.e. OIDs)
@@ -16,7 +16,7 @@ edition = "2021"
 rust-version = "1.72"
 
 [dependencies]
-der = { version = "=0.8.0-pre.0", features = ["oid"] }
+der = { version = "0.8.0-rc.0", features = ["oid"] }
 
 # Optional dependencies
 arbitrary = { version = "1.2", features = ["derive"], optional = true }

--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -16,9 +16,9 @@ edition = "2021"
 rust-version = "1.75"
 
 [dependencies]
-const-oid = { version = "=0.10.0-pre.2", features = ["db"] }
-der = { version = "=0.8.0-pre.0", features = ["alloc", "derive", "flagset", "oid"] }
-spki = { version = "=0.8.0-pre.0", features = ["alloc"] }
+const-oid = { version = "0.10.0-rc.0", features = ["db"] }
+der = { version = "0.8.0-rc.0", features = ["alloc", "derive", "flagset", "oid"] }
+spki = { version = "0.8.0-rc.0", features = ["alloc"] }
 
 # optional dependencies
 arbitrary = { version = "1.3", features = ["derive"], optional = true }

--- a/x509-ocsp/Cargo.toml
+++ b/x509-ocsp/Cargo.toml
@@ -16,9 +16,9 @@ edition = "2021"
 rust-version = "1.75"
 
 [dependencies]
-const-oid = { version = "=0.10.0-pre.2", default-features = false, features = ["db"] }
-der = { version = "=0.8.0-pre.0", features = ["alloc", "derive", "oid"] }
-spki = { version = "=0.8.0-pre.0", features = ["alloc"] }
+const-oid = { version = "0.10.0-rc.0", default-features = false, features = ["db"] }
+der = { version = "0.8.0-rc.0", features = ["alloc", "derive", "oid"] }
+spki = { version = "0.8.0-rc.0", features = ["alloc"] }
 x509-cert = { version = "=0.3.0-pre", default-features = false }
 
 # Optional

--- a/x509-tsp/Cargo.toml
+++ b/x509-tsp/Cargo.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 rust-version = "1.75"
 
 [dependencies]
-der = { version = "=0.8.0-pre.0", features = ["alloc", "derive", "oid", "pem"] }
+der = { version = "0.8.0-rc.0", features = ["alloc", "derive", "oid", "pem"] }
 cms = { version = "=0.3.0-pre", features = ["alloc"] }
 cmpv2 = { version = "=0.3.0-pre", features = ["alloc"] }
 x509-cert = { version = "=0.3.0-pre", default-features = false }


### PR DESCRIPTION
As well as `sec1` and `spki`:

- `pkcs1` v0.8.0-rc.0
- `pkcs5` v0.8.0-rc.0
- `pkcs8` v0.11.0-rc.0
- `sec1` v0.8.0-rc.0
- `spki` v0.8.0-rc.0