### PR TITLE
der_derive: add workaround for `syn` v2.0.73

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,9 +1176,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.82"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -1637,9 +1637,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.61"
+version = "2.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c993ed8ccba56ae856363b1845da7266a7cb78e1d146c8a32d54b45a8b831fc9"
+checksum = "837a7e8026c6ce912ff01cefbe8cafc2f8010ac49682e2a3d9decc3bce1ecaaf"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/der_derive/src/choice.rs
+++ b/der_derive/src/choice.rs
@@ -54,17 +54,14 @@ impl DeriveChoice {
 
         // Use the first lifetime parameter as lifetime for Decode/Encode lifetime
         // if none found, add one.
-        let lifetime = generics
-            .lifetimes()
-            .next()
-            .map(|lt| lt.lifetime.clone())
-            .unwrap_or_else(|| {
-                let lt = default_lifetime();
-                generics
-                    .params
-                    .insert(0, GenericParam::Lifetime(LifetimeParam::new(lt.clone())));
-                lt
-            });
+        let maybe_lifetime = generics.lifetimes().next().map(|lt| lt.lifetime.clone());
+        let lifetime = maybe_lifetime.unwrap_or_else(|| {
+            let lt = default_lifetime();
+            generics
+                .params
+                .insert(0, GenericParam::Lifetime(LifetimeParam::new(lt.clone())));
+            lt
+        });
 
         // We may or may not have inserted a lifetime.
         let (_, ty_generics, where_clause) = self.generics.split_for_impl();

--- a/der_derive/src/sequence.rs
+++ b/der_derive/src/sequence.rs
@@ -54,17 +54,14 @@ impl DeriveSequence {
 
         // Use the first lifetime parameter as lifetime for Decode/Encode lifetime
         // if none found, add one.
-        let lifetime = generics
-            .lifetimes()
-            .next()
-            .map(|lt| lt.lifetime.clone())
-            .unwrap_or_else(|| {
-                let lt = default_lifetime();
-                generics
-                    .params
-                    .insert(0, GenericParam::Lifetime(LifetimeParam::new(lt.clone())));
-                lt
-            });
+        let maybe_lifetime = generics.lifetimes().next().map(|lt| lt.lifetime.clone());
+        let lifetime = maybe_lifetime.unwrap_or_else(|| {
+            let lt = default_lifetime();
+            generics
+                .params
+                .insert(0, GenericParam::Lifetime(LifetimeParam::new(lt.clone())));
+            lt
+        });
 
         // We may or may not have inserted a lifetime.
         let (_, ty_generics, where_clause) = self.generics.split_for_impl();


### PR DESCRIPTION
This workaround gets things compiling on `syn` v2.0.73.

See #1471, dtolnay/syn#1718