### PR TITLE
x509-cert: simplify CI (fewer cargo-hack combos)

### DIFF
--- a/.github/workflows/x509-cert.yml
+++ b/.github/workflows/x509-cert.yml
@@ -45,8 +45,8 @@ jobs:
     if: false # TODO: temp disabled due to unpublished prerelease dependencies
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
     with:
-        working-directory: ${{ github.workflow }}
-        install-zlint: true
+      working-directory: ${{ github.workflow }}
+      install-zlint: true
 
   test:
     runs-on: ubuntu-latest
@@ -61,9 +61,15 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
       - uses: RustCrypto/actions/cargo-hack-install@master
-      - name: Install zlint
-        uses: RustCrypto/actions/zlint-install@master
-      - run: cargo hack test --feature-powerset --exclude-features base64
+      - uses: RustCrypto/actions/zlint-install@master
+      - run: cargo test --no-default-features
+      - run: cargo test
+      - run: cargo test --features arbitrary
+      - run: cargo test --features hazmat
+      - run: cargo test --features sct
+      - run: cargo hack test --feature-powerset --exclude-features arbitrary,base64,fingerprint,hazmat,sct
+      - run: cargo test --all-features
+      - run: cargo test --all-features --release
 
   fuzz:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Excludes several features from `cargo hack` to prevent a combinatorial explosion, namely features which just activate other features in dependencies:

- `arbitrary`
- `base64`
- `fingerprint`
- `hazmat`
- `sct`

The `arbitrary`, `hazmat`, and `sct` features are tested in isolation, and finally the crate is tested with `--all-features` in both debug and release modes.

This should significantly improve CI times.