### PR TITLE
der: add `Reader::peek_into`

### DIFF
--- a/der/src/header.rs
+++ b/der/src/header.rs
@@ -14,6 +14,9 @@ pub struct Header {
 }
 
 impl Header {
+    /// Maximum number of DER octets a header can be in this crate.
+    pub(crate) const MAX_SIZE: usize = 1 + Length::MAX_SIZE;
+
     /// Create a new [`Header`] from a [`Tag`] and a specified length.
     ///
     /// Returns an error if the length exceeds the limits of [`Length`].

--- a/der/src/length.rs
+++ b/der/src/length.rs
@@ -7,10 +7,6 @@ use core::{
     ops::{Add, Sub},
 };
 
-/// Maximum number of octets in a DER encoding of a [`Length`] using the
-/// rules implemented by this crate.
-const MAX_DER_OCTETS: usize = 5;
-
 /// Maximum length as a `u32` (256 MiB).
 const MAX_U32: u32 = 0xfff_ffff;
 
@@ -36,6 +32,10 @@ impl Length {
 
     /// Maximum length currently supported: 256 MiB
     pub const MAX: Self = Self(MAX_U32);
+
+    /// Maximum number of octets in a DER encoding of a [`Length`] using the
+    /// rules implemented by this crate.
+    pub(crate) const MAX_SIZE: usize = 5;
 
     /// Create a new [`Length`] for any value which fits inside of a [`u16`].
     ///
@@ -277,8 +277,8 @@ impl Encode for Length {
 
 impl DerOrd for Length {
     fn der_cmp(&self, other: &Self) -> Result<Ordering> {
-        let mut buf1 = [0u8; MAX_DER_OCTETS];
-        let mut buf2 = [0u8; MAX_DER_OCTETS];
+        let mut buf1 = [0u8; Self::MAX_SIZE];
+        let mut buf2 = [0u8; Self::MAX_SIZE];
 
         let mut encoder1 = SliceWriter::new(&mut buf1);
         encoder1.encode(self)?;

--- a/der/src/reader/pem.rs
+++ b/der/src/reader/pem.rs
@@ -1,7 +1,7 @@
 //! Streaming PEM reader.
 
 use super::Reader;
-use crate::{Decode, EncodingRules, Error, ErrorKind, Header, Length};
+use crate::{EncodingRules, Error, ErrorKind, Length};
 use pem_rfc7468::Decoder;
 
 /// `Reader` type which decodes PEM on-the-fly.
@@ -45,15 +45,6 @@ impl<'i> PemReader<'i> {
     pub fn type_label(&self) -> &'i str {
         self.decoder.type_label()
     }
-
-    /// Peek at the decoded PEM without updating the internal state, writing into the provided
-    /// output buffer.
-    ///
-    /// Attempts to fill the entire buffer, returning an error if there is not enough data.
-    pub fn peek_into(&self, buf: &mut [u8]) -> crate::Result<()> {
-        self.clone().read_into(buf)?;
-        Ok(())
-    }
 }
 
 #[cfg(feature = "pem")]
@@ -67,13 +58,9 @@ impl<'i> Reader<'i> for PemReader<'i> {
         self.input_len
     }
 
-    fn peek_byte(&self) -> Option<u8> {
-        let mut byte = [0];
-        self.peek_into(&mut byte).ok().map(|_| byte[0])
-    }
-
-    fn peek_header(&self) -> crate::Result<Header> {
-        Header::decode(&mut self.clone())
+    fn peek_into(&self, buf: &mut [u8]) -> crate::Result<()> {
+        self.clone().read_into(buf)?;
+        Ok(())
     }
 
     fn position(&self) -> Length {

--- a/der/src/reader/slice.rs
+++ b/der/src/reader/slice.rs
@@ -1,6 +1,6 @@
 //! Slice reader.
 
-use crate::{BytesRef, Decode, EncodingRules, Error, ErrorKind, Header, Length, Reader, Tag};
+use crate::{BytesRef, Decode, EncodingRules, Error, ErrorKind, Length, Reader, Tag};
 
 /// [`Reader`] which consumes an input byte slice.
 #[derive(Clone, Debug)]
@@ -77,14 +77,9 @@ impl<'a> Reader<'a> for SliceReader<'a> {
         self.bytes.len()
     }
 
-    fn peek_byte(&self) -> Option<u8> {
-        self.remaining()
-            .ok()
-            .and_then(|bytes| bytes.first().cloned())
-    }
-
-    fn peek_header(&self) -> Result<Header, Error> {
-        Header::decode(&mut self.clone())
+    fn peek_into(&self, buf: &mut [u8]) -> crate::Result<()> {
+        self.clone().read_into(buf)?;
+        Ok(())
     }
 
     fn position(&self) -> Length {


### PR DESCRIPTION
Adds a method for peeking from a reader into a provided buffer.

This method is used to provide implementations of `Reader::peek_byte` and `Reader::peek_header`.

Closes #1279 