### PR TITLE
der: refactor `Tag::peek`

### DIFF
--- a/crmf/src/pop.rs
+++ b/crmf/src/pop.rs
@@ -234,7 +234,7 @@ impl<'a> ::der::Decode<'a> for EncKeyWithIdChoice<'a> {
     type Error = ::der::Error;
 
     fn decode<R: ::der::Reader<'a>>(reader: &mut R) -> ::der::Result<Self> {
-        let t = reader.peek_tag()?;
+        let t = der::Tag::peek(reader)?;
         if t == <Utf8StringRef<'a> as ::der::FixedTag>::TAG {
             Ok(Self::String(reader.decode()?))
         } else if t.is_context_specific() {

--- a/der/src/reader.rs
+++ b/der/src/reader.rs
@@ -125,17 +125,6 @@ pub trait Reader<'r>: Sized {
         Header::from_der(&buf)
     }
 
-    /// Peek at the next byte in the decoder and attempt to decode it as a
-    /// [`Tag`] value.
-    ///
-    /// Does not modify the decoder's state.
-    fn peek_tag(&self) -> Result<Tag, Error> {
-        match self.peek_byte() {
-            Some(byte) => byte.try_into(),
-            None => Err(Error::incomplete(self.input_len())),
-        }
-    }
-
     /// Read a single byte.
     fn read_byte(&mut self) -> Result<u8, Error> {
         let mut buf = [0];

--- a/der/src/reader/slice.rs
+++ b/der/src/reader/slice.rs
@@ -228,14 +228,6 @@ mod tests {
     }
 
     #[test]
-    fn peek_tag() {
-        let reader = SliceReader::new(EXAMPLE_MSG).unwrap();
-        assert_eq!(reader.position(), Length::ZERO);
-        assert_eq!(reader.peek_tag().unwrap(), Tag::Integer);
-        assert_eq!(reader.position(), Length::ZERO); // Position unchanged
-    }
-
-    #[test]
     fn peek_header() {
         let reader = SliceReader::new(EXAMPLE_MSG).unwrap();
         assert_eq!(reader.position(), Length::ZERO);

--- a/der_derive/src/choice.rs
+++ b/der_derive/src/choice.rs
@@ -96,7 +96,7 @@ impl DeriveChoice {
 
                 fn decode<R: ::der::Reader<#lifetime>>(reader: &mut R) -> ::der::Result<Self> {
                     use der::Reader as _;
-                    match reader.peek_tag()? {
+                    match ::der::Tag::peek(reader)? {
                         #(#decode_body)*
                         actual => Err(der::ErrorKind::TagUnexpected {
                             expected: None,


### PR DESCRIPTION
Removes the provided `Reader::peek_tag` method, factoring it onto the `Tag` type itself.