### PR TITLE
der: refactor `Header::peek`

### DIFF
--- a/der/src/document.rs
+++ b/der/src/document.rs
@@ -1,6 +1,6 @@
 //! ASN.1 DER-encoded documents stored on the heap.
 
-use crate::{Decode, Encode, Error, FixedTag, Length, Reader, SliceReader, Tag, Writer};
+use crate::{Decode, Encode, Error, FixedTag, Header, Length, Reader, SliceReader, Tag, Writer};
 use alloc::vec::Vec;
 use core::fmt::{self, Debug};
 
@@ -148,7 +148,7 @@ impl<'a> Decode<'a> for Document {
     type Error = Error;
 
     fn decode<R: Reader<'a>>(reader: &mut R) -> Result<Document, Error> {
-        let header = reader.peek_header()?;
+        let header = Header::peek(reader)?;
         let length = (header.encoded_len()? + header.length)?;
         let bytes = reader.read_slice(length)?;
 
@@ -323,7 +323,7 @@ impl ZeroizeOnDrop for SecretDocument {}
 /// Attempt to decode a ASN.1 `SEQUENCE` from the given decoder, returning the
 /// entire sequence including the header.
 fn decode_sequence<'a>(decoder: &mut SliceReader<'a>) -> Result<&'a [u8], Error> {
-    let header = decoder.peek_header()?;
+    let header = Header::peek(decoder)?;
     header.tag.assert_eq(Tag::Sequence)?;
 
     let len = (header.encoded_len()? + header.length)?;

--- a/der/src/header.rs
+++ b/der/src/header.rs
@@ -24,6 +24,24 @@ impl Header {
         let length = length.try_into().map_err(|_| ErrorKind::Overflow)?;
         Ok(Self { tag, length })
     }
+
+    /// Peek forward in the reader, attempting to decode a [`Header`] at the current position.
+    ///
+    /// Does not modify the reader's state.
+    pub fn peek<'a>(reader: &impl Reader<'a>) -> Result<Self> {
+        let mut buf = [0u8; Self::MAX_SIZE];
+
+        for i in 2..Self::MAX_SIZE {
+            let slice = &mut buf[0..i];
+            if reader.peek_into(slice).is_ok() {
+                if let Ok(header) = Self::from_der(slice) {
+                    return Ok(header);
+                }
+            }
+        }
+
+        Self::from_der(&buf)
+    }
 }
 
 impl<'a> Decode<'a> for Header {
@@ -61,5 +79,27 @@ impl DerOrd for Header {
             Ordering::Equal => self.length.der_cmp(&other.length),
             ordering => Ok(ordering),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Header;
+    use crate::{Length, Reader, SliceReader, Tag};
+    use hex_literal::hex;
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn peek() {
+        // INTEGER: 42
+        const EXAMPLE_MSG: &[u8] = &hex!("02012A00");
+
+        let reader = SliceReader::new(EXAMPLE_MSG).unwrap();
+        assert_eq!(reader.position(), Length::ZERO);
+
+        let header = Header::peek(&reader).unwrap();
+        assert_eq!(header.tag, Tag::Integer);
+        assert_eq!(header.length, Length::ONE);
+        assert_eq!(reader.position(), Length::ZERO); // Position unchanged
     }
 }

--- a/der/src/reader/slice.rs
+++ b/der/src/reader/slice.rs
@@ -165,7 +165,7 @@ impl<'a> Reader<'a> for SliceReader<'a> {
 #[allow(clippy::unwrap_used, clippy::panic)]
 mod tests {
     use super::SliceReader;
-    use crate::{Decode, ErrorKind, Length, Reader, Tag};
+    use crate::{Decode, ErrorKind, Length, Reader};
     use hex_literal::hex;
 
     // INTEGER: 42
@@ -225,16 +225,5 @@ mod tests {
             },
             err.kind()
         );
-    }
-
-    #[test]
-    fn peek_header() {
-        let reader = SliceReader::new(EXAMPLE_MSG).unwrap();
-        assert_eq!(reader.position(), Length::ZERO);
-
-        let header = reader.peek_header().unwrap();
-        assert_eq!(header.tag, Tag::Integer);
-        assert_eq!(header.length, Length::ONE);
-        assert_eq!(reader.position(), Length::ZERO); // Position unchanged
     }
 }


### PR DESCRIPTION
Like #1479 did for `Tag::peek`, this refactors `Reader::peek_header` into `Header::peek`.