### PR TITLE
x509-cert: make `Name` a new type over `RdnSequence`

### DIFF
--- a/cms/tests/builder.rs
+++ b/cms/tests/builder.rs
@@ -13,7 +13,7 @@ use cms::enveloped_data::RecipientInfo::Ktri;
 use cms::enveloped_data::{EnvelopedData, RecipientIdentifier, RecipientInfo};
 use cms::signed_data::{EncapsulatedContentInfo, SignedData, SignerIdentifier};
 use const_oid::ObjectIdentifier;
-use der::asn1::{OctetString, PrintableString, SetOfVec, Utf8StringRef};
+use der::asn1::{OctetString, PrintableString, SetOfVec};
 use der::{Any, AnyRef, Decode, DecodePem, Encode, Tag, Tagged};
 use p256::{pkcs8::DecodePrivateKey, NistP256};
 use pem_rfc7468::LineEnding;
@@ -24,8 +24,7 @@ use rsa::{Pkcs1v15Encrypt, RsaPrivateKey, RsaPublicKey};
 use sha2::Sha256;
 use signature::Verifier;
 use spki::AlgorithmIdentifierOwned;
-use x509_cert::attr::{Attribute, AttributeTypeAndValue, AttributeValue};
-use x509_cert::name::{RdnSequence, RelativeDistinguishedName};
+use x509_cert::attr::{Attribute, AttributeValue};
 use x509_cert::serial_number::SerialNumber;
 
 // TODO bk replace this by const_oid definitions as soon as released
@@ -50,30 +49,18 @@ fn ecdsa_signer() -> ecdsa::SigningKey<NistP256> {
 }
 
 fn signer_identifier(id: i32) -> SignerIdentifier {
-    let mut rdn_sequence = RdnSequence::default();
-    let rdn = &[AttributeTypeAndValue {
-        oid: const_oid::db::rfc4519::CN,
-        value: Any::from(Utf8StringRef::new(&format!("test client {id}")).unwrap()),
-    }];
-    let set_of_vector = SetOfVec::try_from(rdn.to_vec()).unwrap();
-    rdn_sequence.push(RelativeDistinguishedName::from(set_of_vector));
+    let issuer = format!("CN=test client {id}").parse().unwrap();
     SignerIdentifier::IssuerAndSerialNumber(IssuerAndSerialNumber {
-        issuer: rdn_sequence,
+        issuer,
         serial_number: SerialNumber::new(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06])
             .expect("failed to create a serial number"),
     })
 }
 
 fn recipient_identifier(id: i32) -> RecipientIdentifier {
-    let mut rdn_sequence = RdnSequence::default();
-    let rdn = &[AttributeTypeAndValue {
-        oid: const_oid::db::rfc4519::CN,
-        value: Any::from(Utf8StringRef::new(&format!("test client {id}")).unwrap()),
-    }];
-    let set_of_vector = SetOfVec::try_from(rdn.to_vec()).unwrap();
-    rdn_sequence.push(RelativeDistinguishedName::from(set_of_vector));
+    let issuer = format!("CN=test client {id}").parse().unwrap();
     RecipientIdentifier::IssuerAndSerialNumber(IssuerAndSerialNumber {
-        issuer: rdn_sequence,
+        issuer,
         serial_number: SerialNumber::new(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06])
             .expect("failed to create a serial number"),
     })

--- a/x509-cert/src/builder/profile/cabf.rs
+++ b/x509-cert/src/builder/profile/cabf.rs
@@ -43,7 +43,7 @@ pub fn check_names_encoding(name: &Name, multiple_allowed: bool) -> Result<()> {
 
     let mut seen = HashSet::new();
 
-    for rdn in name.iter() {
+    for rdn in name.iter_rdn() {
         if rdn.len() != 1 {
             return Err(Error::NonUniqueRdn);
         }
@@ -87,13 +87,11 @@ pub fn ca_certificate_naming(subject: &Name) -> Result<()> {
 
     check_names_encoding(subject, false)?;
 
-    for rdn in subject.iter() {
-        for atv in rdn.iter() {
-            if !allowed.remove(&atv.oid) {
-                return Err(Error::InvalidAttribute { oid: atv.oid });
-            }
-            required.remove(&atv.oid);
+    for atv in subject.iter() {
+        if !allowed.remove(&atv.oid) {
+            return Err(Error::InvalidAttribute { oid: atv.oid });
         }
+        required.remove(&atv.oid);
     }
 
     if !required.is_empty() {

--- a/x509-cert/src/builder/profile/cabf/tls.rs
+++ b/x509-cert/src/builder/profile/cabf/tls.rs
@@ -22,7 +22,7 @@ use crate::{
         },
         AsExtension, Extension,
     },
-    name::{Name, RdnSequence, RelativeDistinguishedName},
+    name::{Name, RelativeDistinguishedName},
 };
 use spki::SubjectPublicKeyInfoRef;
 
@@ -159,8 +159,7 @@ impl CertificateType {
             .filter(|rdn| !rdn.is_empty())
             .collect();
 
-        let subject: RdnSequence = rdns.into();
-        let subject: Name = subject.into();
+        let subject: Name = Name(rdns.into());
 
         Ok(Self::DomainValidated(DomainValidated { subject, names }))
     }

--- a/x509-cert/src/builder/profile/cabf/tls.rs
+++ b/x509-cert/src/builder/profile/cabf/tls.rs
@@ -22,7 +22,7 @@ use crate::{
         },
         AsExtension, Extension,
     },
-    name::{Name, RelativeDistinguishedName},
+    name::{Name, RdnSequence, RelativeDistinguishedName},
 };
 use spki::SubjectPublicKeyInfoRef;
 
@@ -145,7 +145,7 @@ impl CertificateType {
         // TODO(baloo): not very happy with all that, might as well throw that in a helper
         // or something.
         let rdns: vec::Vec<RelativeDistinguishedName> = subject
-            .iter()
+            .iter_rdn()
             .filter_map(|rdn| {
                 let out = SetOfVec::<AttributeTypeAndValue>::from_iter(
                     rdn.iter()
@@ -159,7 +159,8 @@ impl CertificateType {
             .filter(|rdn| !rdn.is_empty())
             .collect();
 
-        let subject: Name = rdns.into();
+        let subject: RdnSequence = rdns.into();
+        let subject: Name = subject.into();
 
         Ok(Self::DomainValidated(DomainValidated { subject, names }))
     }

--- a/x509-cert/tests/certificate.rs
+++ b/x509-cert/tests/certificate.rs
@@ -238,41 +238,35 @@ fn decode_cert() {
         .unwrap()
         .is_null());
 
-    let mut counter = 0;
-    let i = cert.tbs_certificate().issuer().iter();
-    for rdn in i {
-        let i1 = rdn.iter();
-        for atav in i1 {
-            if 0 == counter {
-                assert_eq!(atav.oid.to_string(), "2.5.4.6");
-                assert_eq!(
-                    PrintableStringRef::try_from(&atav.value)
-                        .unwrap()
-                        .to_string(),
-                    "US"
-                );
-            } else if 1 == counter {
-                assert_eq!(atav.oid.to_string(), "2.5.4.10");
-                assert_eq!(
-                    PrintableStringRef::try_from(&atav.value)
-                        .unwrap()
-                        .to_string(),
-                    "Mock"
-                );
-            } else if 2 == counter {
-                assert_eq!(atav.oid.to_string(), "2.5.4.10");
-                assert_eq!(
-                    Utf8StringRef::try_from(&atav.value).unwrap().to_string(),
-                    "IdenTrust Services LLC"
-                );
-            } else if 3 == counter {
-                assert_eq!(atav.oid.to_string(), "2.5.4.3");
-                assert_eq!(
-                    Utf8StringRef::try_from(&atav.value).unwrap().to_string(),
-                    "PTE IdenTrust Global Common Root CA 1"
-                );
-            }
-            counter += 1;
+    for (counter, atav) in cert.tbs_certificate().issuer().iter().enumerate() {
+        if 0 == counter {
+            assert_eq!(atav.oid.to_string(), "2.5.4.6");
+            assert_eq!(
+                PrintableStringRef::try_from(&atav.value)
+                    .unwrap()
+                    .to_string(),
+                "US"
+            );
+        } else if 1 == counter {
+            assert_eq!(atav.oid.to_string(), "2.5.4.10");
+            assert_eq!(
+                PrintableStringRef::try_from(&atav.value)
+                    .unwrap()
+                    .to_string(),
+                "Mock"
+            );
+        } else if 2 == counter {
+            assert_eq!(atav.oid.to_string(), "2.5.4.10");
+            assert_eq!(
+                Utf8StringRef::try_from(&atav.value).unwrap().to_string(),
+                "IdenTrust Services LLC"
+            );
+        } else if 3 == counter {
+            assert_eq!(atav.oid.to_string(), "2.5.4.3");
+            assert_eq!(
+                Utf8StringRef::try_from(&atav.value).unwrap().to_string(),
+                "PTE IdenTrust Global Common Root CA 1"
+            );
         }
     }
 
@@ -293,46 +287,40 @@ fn decode_cert() {
         1516628593
     );
 
-    counter = 0;
-    let i = cert.tbs_certificate().subject().iter();
-    for rdn in i {
-        let i1 = rdn.iter();
-        for atav in i1 {
-            // Yes, this cert features RDNs encoded in reverse order
-            if 0 == counter {
-                assert_eq!(atav.oid.to_string(), "2.5.4.3");
-                assert_eq!(
-                    PrintableStringRef::try_from(&atav.value)
-                        .unwrap()
-                        .to_string(),
-                    "Test Federal Bridge CA"
-                );
-            } else if 1 == counter {
-                assert_eq!(atav.oid.to_string(), "2.5.4.11");
-                assert_eq!(
-                    PrintableStringRef::try_from(&atav.value)
-                        .unwrap()
-                        .to_string(),
-                    "TestFPKI"
-                );
-            } else if 2 == counter {
-                assert_eq!(atav.oid.to_string(), "2.5.4.10");
-                assert_eq!(
-                    PrintableStringRef::try_from(&atav.value)
-                        .unwrap()
-                        .to_string(),
-                    "U.S. Government"
-                );
-            } else if 3 == counter {
-                assert_eq!(atav.oid.to_string(), "2.5.4.6");
-                assert_eq!(
-                    PrintableStringRef::try_from(&atav.value)
-                        .unwrap()
-                        .to_string(),
-                    "US"
-                );
-            }
-            counter += 1;
+    for (counter, atav) in cert.tbs_certificate().subject().iter().enumerate() {
+        // Yes, this cert features RDNs encoded in reverse order
+        if 0 == counter {
+            assert_eq!(atav.oid.to_string(), "2.5.4.3");
+            assert_eq!(
+                PrintableStringRef::try_from(&atav.value)
+                    .unwrap()
+                    .to_string(),
+                "Test Federal Bridge CA"
+            );
+        } else if 1 == counter {
+            assert_eq!(atav.oid.to_string(), "2.5.4.11");
+            assert_eq!(
+                PrintableStringRef::try_from(&atav.value)
+                    .unwrap()
+                    .to_string(),
+                "TestFPKI"
+            );
+        } else if 2 == counter {
+            assert_eq!(atav.oid.to_string(), "2.5.4.10");
+            assert_eq!(
+                PrintableStringRef::try_from(&atav.value)
+                    .unwrap()
+                    .to_string(),
+                "U.S. Government"
+            );
+        } else if 3 == counter {
+            assert_eq!(atav.oid.to_string(), "2.5.4.6");
+            assert_eq!(
+                PrintableStringRef::try_from(&atav.value)
+                    .unwrap()
+                    .to_string(),
+                "US"
+            );
         }
     }
 

--- a/x509-cert/tests/certreq.rs
+++ b/x509-cert/tests/certreq.rs
@@ -36,7 +36,7 @@ fn decode_rsa_2048_der() {
 
     // Check all the RDNs.
     assert_eq!(cr.info.subject.len(), NAMES.len());
-    for (name, (oid, val)) in cr.info.subject.iter().zip(NAMES) {
+    for (name, (oid, val)) in cr.info.subject.iter_rdn().zip(NAMES) {
         let kind = name.iter().next().unwrap();
         let value = match kind.value.tag() {
             Tag::Utf8String => Utf8StringRef::try_from(&kind.value).unwrap().as_str(),

--- a/x509-cert/tests/name.rs
+++ b/x509-cert/tests/name.rs
@@ -33,37 +33,31 @@ fn decode_name() {
         Name::from_der(&hex!("3040310B3009060355040613025553311F301D060355040A1316546573742043657274696669636174657320323031313110300E06035504031307476F6F64204341")[..]);
     let rdn1a = rdn1.unwrap();
 
-    let mut counter = 0;
-    let i = rdn1a.iter();
-    for rdn in i {
-        let i1 = rdn.iter();
-        for atav in i1 {
-            if 0 == counter {
-                assert_eq!(atav.oid.to_string(), "2.5.4.6");
-                assert_eq!(
-                    PrintableStringRef::try_from(&atav.value)
-                        .unwrap()
-                        .to_string(),
-                    "US"
-                );
-            } else if 1 == counter {
-                assert_eq!(atav.oid.to_string(), "2.5.4.10");
-                assert_eq!(
-                    PrintableStringRef::try_from(&atav.value)
-                        .unwrap()
-                        .to_string(),
-                    "Test Certificates 2011"
-                );
-            } else if 2 == counter {
-                assert_eq!(atav.oid.to_string(), "2.5.4.3");
-                assert_eq!(
-                    PrintableStringRef::try_from(&atav.value)
-                        .unwrap()
-                        .to_string(),
-                    "Good CA"
-                );
-            }
-            counter += 1;
+    for (counter, atav) in rdn1a.iter().enumerate() {
+        if 0 == counter {
+            assert_eq!(atav.oid.to_string(), "2.5.4.6");
+            assert_eq!(
+                PrintableStringRef::try_from(&atav.value)
+                    .unwrap()
+                    .to_string(),
+                "US"
+            );
+        } else if 1 == counter {
+            assert_eq!(atav.oid.to_string(), "2.5.4.10");
+            assert_eq!(
+                PrintableStringRef::try_from(&atav.value)
+                    .unwrap()
+                    .to_string(),
+                "Test Certificates 2011"
+            );
+        } else if 2 == counter {
+            assert_eq!(atav.oid.to_string(), "2.5.4.3");
+            assert_eq!(
+                PrintableStringRef::try_from(&atav.value)
+                    .unwrap()
+                    .to_string(),
+                "Good CA"
+            );
         }
     }
 
@@ -365,4 +359,54 @@ fn rdns_serde() {
             assert_eq!(brdns, rdns);
         }
     }
+}
+
+#[cfg(feature = "std")]
+#[test]
+fn access_attributes() {
+    use std::str::FromStr;
+
+    let name = Name::from_str("emailAddress=foo@example.com,UID=identity:ds.group.3891111,OU=management:ds.group.3891111,CN=OQFAvDNDWs.google.com,O=Google LLC,L=Mountain View,ST=California,C=US").unwrap();
+
+    assert_eq!(
+        <_ as AsRef<str>>::as_ref(&name.common_name().unwrap().unwrap()),
+        "OQFAvDNDWs.google.com"
+    );
+
+    assert_eq!(
+        <_ as AsRef<str>>::as_ref(&name.country().unwrap().unwrap()),
+        "US"
+    );
+
+    assert_eq!(
+        <_ as AsRef<str>>::as_ref(&name.state_or_province().unwrap().unwrap()),
+        "California"
+    );
+
+    assert_eq!(
+        <_ as AsRef<str>>::as_ref(&name.locality().unwrap().unwrap()),
+        "Mountain View"
+    );
+
+    assert_eq!(
+        <_ as AsRef<str>>::as_ref(&name.organization().unwrap().unwrap()),
+        "Google LLC"
+    );
+
+    assert_eq!(
+        <_ as AsRef<str>>::as_ref(&name.organization_unit().unwrap().unwrap()),
+        "management:ds.group.3891111"
+    );
+
+    assert_eq!(
+        <_ as AsRef<str>>::as_ref(&name.email_address().unwrap().unwrap()),
+        "foo@example.com"
+    );
+
+    let name = Name::from_str("C=DE,C=US").unwrap();
+
+    assert_eq!(
+        <_ as AsRef<str>>::as_ref(&name.country().unwrap().unwrap()),
+        "US"
+    );
 }

--- a/x509-cert/tests/pkix_extensions.rs
+++ b/x509-cert/tests/pkix_extensions.rs
@@ -580,37 +580,31 @@ fn decode_cert() {
         true
     );
 
-    let mut counter = 0;
-    let i = cert.tbs_certificate().issuer().iter();
-    for rdn in i {
-        let i1 = rdn.iter();
-        for atav in i1 {
-            if 0 == counter {
-                assert_eq!(atav.oid.to_string(), "2.5.4.6");
-                assert_eq!(
-                    PrintableStringRef::try_from(&atav.value)
-                        .unwrap()
-                        .to_string(),
-                    "US"
-                );
-            } else if 1 == counter {
-                assert_eq!(atav.oid.to_string(), "2.5.4.10");
-                assert_eq!(
-                    PrintableStringRef::try_from(&atav.value)
-                        .unwrap()
-                        .to_string(),
-                    "Test Certificates 2011"
-                );
-            } else if 2 == counter {
-                assert_eq!(atav.oid.to_string(), "2.5.4.3");
-                assert_eq!(
-                    PrintableStringRef::try_from(&atav.value)
-                        .unwrap()
-                        .to_string(),
-                    "Trust Anchor"
-                );
-            }
-            counter += 1;
+    for (counter, atav) in cert.tbs_certificate().issuer().iter().enumerate() {
+        if 0 == counter {
+            assert_eq!(atav.oid.to_string(), "2.5.4.6");
+            assert_eq!(
+                PrintableStringRef::try_from(&atav.value)
+                    .unwrap()
+                    .to_string(),
+                "US"
+            );
+        } else if 1 == counter {
+            assert_eq!(atav.oid.to_string(), "2.5.4.10");
+            assert_eq!(
+                PrintableStringRef::try_from(&atav.value)
+                    .unwrap()
+                    .to_string(),
+                "Test Certificates 2011"
+            );
+        } else if 2 == counter {
+            assert_eq!(atav.oid.to_string(), "2.5.4.3");
+            assert_eq!(
+                PrintableStringRef::try_from(&atav.value)
+                    .unwrap()
+                    .to_string(),
+                "Trust Anchor"
+            );
         }
     }
 
@@ -631,37 +625,31 @@ fn decode_cert() {
         1924936200
     );
 
-    counter = 0;
-    let i = cert.tbs_certificate().subject().iter();
-    for rdn in i {
-        let i1 = rdn.iter();
-        for atav in i1 {
-            if 0 == counter {
-                assert_eq!(atav.oid.to_string(), "2.5.4.6");
-                assert_eq!(
-                    PrintableStringRef::try_from(&atav.value)
-                        .unwrap()
-                        .to_string(),
-                    "US"
-                );
-            } else if 1 == counter {
-                assert_eq!(atav.oid.to_string(), "2.5.4.10");
-                assert_eq!(
-                    PrintableStringRef::try_from(&atav.value)
-                        .unwrap()
-                        .to_string(),
-                    "Test Certificates 2011"
-                );
-            } else if 2 == counter {
-                assert_eq!(atav.oid.to_string(), "2.5.4.3");
-                assert_eq!(
-                    PrintableStringRef::try_from(&atav.value)
-                        .unwrap()
-                        .to_string(),
-                    "Good CA"
-                );
-            }
-            counter += 1;
+    for (counter, atav) in cert.tbs_certificate().subject().iter().enumerate() {
+        if 0 == counter {
+            assert_eq!(atav.oid.to_string(), "2.5.4.6");
+            assert_eq!(
+                PrintableStringRef::try_from(&atav.value)
+                    .unwrap()
+                    .to_string(),
+                "US"
+            );
+        } else if 1 == counter {
+            assert_eq!(atav.oid.to_string(), "2.5.4.10");
+            assert_eq!(
+                PrintableStringRef::try_from(&atav.value)
+                    .unwrap()
+                    .to_string(),
+                "Test Certificates 2011"
+            );
+        } else if 2 == counter {
+            assert_eq!(atav.oid.to_string(), "2.5.4.3");
+            assert_eq!(
+                PrintableStringRef::try_from(&atav.value)
+                    .unwrap()
+                    .to_string(),
+                "Good CA"
+            );
         }
     }
 
@@ -696,10 +684,8 @@ fn decode_cert() {
 
     // TODO - parse and compare public key
 
-    counter = 0;
     let exts = cert.tbs_certificate().extensions().unwrap();
-    let i = exts.iter();
-    for ext in i {
+    for (counter, ext) in exts.iter().enumerate() {
         if 0 == counter {
             assert_eq!(
                 ext.extn_id.to_string(),
@@ -746,8 +732,6 @@ fn decode_cert() {
             assert_eq!(bc.ca, true);
             assert_eq!(bc.path_len_constraint, Option::None);
         }
-
-        counter += 1;
     }
     assert_eq!(
         cert.signature_algorithm().oid.to_string(),

--- a/x509-cert/tests/trust_anchor_format.rs
+++ b/x509-cert/tests/trust_anchor_format.rs
@@ -81,53 +81,44 @@ fn decode_ta1() {
             ];
 
             let cert_path = tai.cert_path.as_ref().unwrap();
-            let mut counter = 0;
             let exts = cert_path.policy_set.as_ref().unwrap();
-            let i = exts.0.iter();
-            for ext in i {
+            for (counter, ext) in exts.0.iter().enumerate() {
                 assert_eq!(policy_ids[counter], ext.policy_identifier.to_string());
-                counter += 1;
             }
 
-            counter = 0;
-            let i = cert_path.ta_name.iter();
-            for rdn in i {
-                let i1 = rdn.iter();
-                for atav in i1 {
-                    if 0 == counter {
-                        assert_eq!(atav.oid.to_string(), "2.5.4.6");
-                        assert_eq!(
-                            PrintableStringRef::try_from(&atav.value)
-                                .unwrap()
-                                .to_string(),
-                            "US"
-                        );
-                    } else if 1 == counter {
-                        assert_eq!(atav.oid.to_string(), "2.5.4.10");
-                        assert_eq!(
-                            PrintableStringRef::try_from(&atav.value)
-                                .unwrap()
-                                .to_string(),
-                            "U.S. Government"
-                        );
-                    } else if 2 == counter {
-                        assert_eq!(atav.oid.to_string(), "2.5.4.11");
-                        assert_eq!(
-                            PrintableStringRef::try_from(&atav.value)
-                                .unwrap()
-                                .to_string(),
-                            "ECA"
-                        );
-                    } else if 3 == counter {
-                        assert_eq!(atav.oid.to_string(), "2.5.4.3");
-                        assert_eq!(
-                            PrintableStringRef::try_from(&atav.value)
-                                .unwrap()
-                                .to_string(),
-                            "ECA Root CA 4"
-                        );
-                    }
-                    counter += 1;
+            for (counter, atav) in cert_path.ta_name.iter().enumerate() {
+                if 0 == counter {
+                    assert_eq!(atav.oid.to_string(), "2.5.4.6");
+                    assert_eq!(
+                        PrintableStringRef::try_from(&atav.value)
+                            .unwrap()
+                            .to_string(),
+                        "US"
+                    );
+                } else if 1 == counter {
+                    assert_eq!(atav.oid.to_string(), "2.5.4.10");
+                    assert_eq!(
+                        PrintableStringRef::try_from(&atav.value)
+                            .unwrap()
+                            .to_string(),
+                        "U.S. Government"
+                    );
+                } else if 2 == counter {
+                    assert_eq!(atav.oid.to_string(), "2.5.4.11");
+                    assert_eq!(
+                        PrintableStringRef::try_from(&atav.value)
+                            .unwrap()
+                            .to_string(),
+                        "ECA"
+                    );
+                } else if 3 == counter {
+                    assert_eq!(atav.oid.to_string(), "2.5.4.3");
+                    assert_eq!(
+                        PrintableStringRef::try_from(&atav.value)
+                            .unwrap()
+                            .to_string(),
+                        "ECA Root CA 4"
+                    );
                 }
             }
 
@@ -166,84 +157,72 @@ fn decode_ta2() {
 
             let cert_path = tai.cert_path.as_ref().unwrap();
 
-            let mut counter = 0;
-            let i = cert_path.ta_name.iter();
-            for rdn in i {
-                let i1 = rdn.iter();
-                for atav in i1 {
-                    if 0 == counter {
-                        assert_eq!(atav.oid.to_string(), "2.5.4.6");
-                        assert_eq!(
-                            PrintableStringRef::try_from(&atav.value)
-                                .unwrap()
-                                .to_string(),
-                            "US"
-                        );
-                    } else if 1 == counter {
-                        assert_eq!(atav.oid.to_string(), "2.5.4.10");
-                        assert_eq!(
-                            PrintableStringRef::try_from(&atav.value)
-                                .unwrap()
-                                .to_string(),
-                            "Entrust"
-                        );
-                    } else if 2 == counter {
-                        assert_eq!(atav.oid.to_string(), "2.5.4.11");
-                        assert_eq!(
-                            PrintableStringRef::try_from(&atav.value)
-                                .unwrap()
-                                .to_string(),
-                            "Certification Authorities"
-                        );
-                    } else if 3 == counter {
-                        assert_eq!(atav.oid.to_string(), "2.5.4.11");
-                        assert_eq!(
-                            PrintableStringRef::try_from(&atav.value)
-                                .unwrap()
-                                .to_string(),
-                            "Entrust Managed Services NFI Root CA"
-                        );
-                    }
-                    counter += 1;
+            for (counter, atav) in cert_path.ta_name.iter().enumerate() {
+                if 0 == counter {
+                    assert_eq!(atav.oid.to_string(), "2.5.4.6");
+                    assert_eq!(
+                        PrintableStringRef::try_from(&atav.value)
+                            .unwrap()
+                            .to_string(),
+                        "US"
+                    );
+                } else if 1 == counter {
+                    assert_eq!(atav.oid.to_string(), "2.5.4.10");
+                    assert_eq!(
+                        PrintableStringRef::try_from(&atav.value)
+                            .unwrap()
+                            .to_string(),
+                        "Entrust"
+                    );
+                } else if 2 == counter {
+                    assert_eq!(atav.oid.to_string(), "2.5.4.11");
+                    assert_eq!(
+                        PrintableStringRef::try_from(&atav.value)
+                            .unwrap()
+                            .to_string(),
+                        "Certification Authorities"
+                    );
+                } else if 3 == counter {
+                    assert_eq!(atav.oid.to_string(), "2.5.4.11");
+                    assert_eq!(
+                        PrintableStringRef::try_from(&atav.value)
+                            .unwrap()
+                            .to_string(),
+                        "Entrust Managed Services NFI Root CA"
+                    );
                 }
             }
 
             let nc = cert_path.name_constr.as_ref().unwrap();
-            counter = 0;
             let gsi = nc.excluded_subtrees.as_ref().unwrap().iter();
             for gs in gsi {
                 match &gs.base {
                     GeneralName::DirectoryName(dn) => {
-                        let i = dn.iter();
-                        for rdn in i {
-                            let i1 = rdn.iter();
-                            for atav in i1 {
-                                if 0 == counter {
-                                    assert_eq!(atav.oid.to_string(), "2.5.4.6");
-                                    assert_eq!(
-                                        PrintableStringRef::try_from(&atav.value)
-                                            .unwrap()
-                                            .to_string(),
-                                        "US"
-                                    );
-                                } else if 1 == counter {
-                                    assert_eq!(atav.oid.to_string(), "2.5.4.10");
-                                    assert_eq!(
-                                        PrintableStringRef::try_from(&atav.value)
-                                            .unwrap()
-                                            .to_string(),
-                                        "U.S. Government"
-                                    );
-                                } else if 2 == counter {
-                                    assert_eq!(atav.oid.to_string(), "2.5.4.11");
-                                    assert_eq!(
-                                        PrintableStringRef::try_from(&atav.value)
-                                            .unwrap()
-                                            .to_string(),
-                                        "DoD"
-                                    );
-                                }
-                                counter += 1;
+                        for (counter, atav) in dn.iter().enumerate() {
+                            if 0 == counter {
+                                assert_eq!(atav.oid.to_string(), "2.5.4.6");
+                                assert_eq!(
+                                    PrintableStringRef::try_from(&atav.value)
+                                        .unwrap()
+                                        .to_string(),
+                                    "US"
+                                );
+                            } else if 1 == counter {
+                                assert_eq!(atav.oid.to_string(), "2.5.4.10");
+                                assert_eq!(
+                                    PrintableStringRef::try_from(&atav.value)
+                                        .unwrap()
+                                        .to_string(),
+                                    "U.S. Government"
+                                );
+                            } else if 2 == counter {
+                                assert_eq!(atav.oid.to_string(), "2.5.4.11");
+                                assert_eq!(
+                                    PrintableStringRef::try_from(&atav.value)
+                                        .unwrap()
+                                        .to_string(),
+                                    "DoD"
+                                );
                             }
                         }
                     }
@@ -293,84 +272,72 @@ fn decode_ta3() {
                 cert_path.policy_flags.unwrap()
             );
 
-            let mut counter = 0;
-            let i = cert_path.ta_name.iter();
-            for rdn in i {
-                let i1 = rdn.iter();
-                for atav in i1 {
-                    if 0 == counter {
-                        assert_eq!(atav.oid.to_string(), "2.5.4.6");
-                        assert_eq!(
-                            PrintableStringRef::try_from(&atav.value)
-                                .unwrap()
-                                .to_string(),
-                            "US"
-                        );
-                    } else if 1 == counter {
-                        assert_eq!(atav.oid.to_string(), "2.5.4.10");
-                        assert_eq!(
-                            PrintableStringRef::try_from(&atav.value)
-                                .unwrap()
-                                .to_string(),
-                            "Exostar LLC"
-                        );
-                    } else if 2 == counter {
-                        assert_eq!(atav.oid.to_string(), "2.5.4.11");
-                        assert_eq!(
-                            PrintableStringRef::try_from(&atav.value)
-                                .unwrap()
-                                .to_string(),
-                            "Certification Authorities"
-                        );
-                    } else if 3 == counter {
-                        assert_eq!(atav.oid.to_string(), "2.5.4.3");
-                        assert_eq!(
-                            PrintableStringRef::try_from(&atav.value)
-                                .unwrap()
-                                .to_string(),
-                            "Exostar Federated Identity Service Root CA 1"
-                        );
-                    }
-                    counter += 1;
+            for (counter, atav) in cert_path.ta_name.iter().enumerate() {
+                if 0 == counter {
+                    assert_eq!(atav.oid.to_string(), "2.5.4.6");
+                    assert_eq!(
+                        PrintableStringRef::try_from(&atav.value)
+                            .unwrap()
+                            .to_string(),
+                        "US"
+                    );
+                } else if 1 == counter {
+                    assert_eq!(atav.oid.to_string(), "2.5.4.10");
+                    assert_eq!(
+                        PrintableStringRef::try_from(&atav.value)
+                            .unwrap()
+                            .to_string(),
+                        "Exostar LLC"
+                    );
+                } else if 2 == counter {
+                    assert_eq!(atav.oid.to_string(), "2.5.4.11");
+                    assert_eq!(
+                        PrintableStringRef::try_from(&atav.value)
+                            .unwrap()
+                            .to_string(),
+                        "Certification Authorities"
+                    );
+                } else if 3 == counter {
+                    assert_eq!(atav.oid.to_string(), "2.5.4.3");
+                    assert_eq!(
+                        PrintableStringRef::try_from(&atav.value)
+                            .unwrap()
+                            .to_string(),
+                        "Exostar Federated Identity Service Root CA 1"
+                    );
                 }
             }
 
             let nc = cert_path.name_constr.as_ref().unwrap();
-            counter = 0;
             let gsi = nc.excluded_subtrees.as_ref().unwrap().iter();
             for gs in gsi {
                 match &gs.base {
                     GeneralName::DirectoryName(dn) => {
-                        let i = dn.iter();
-                        for rdn in i {
-                            let i1 = rdn.iter();
-                            for atav in i1 {
-                                if 0 == counter {
-                                    assert_eq!(atav.oid.to_string(), "2.5.4.6");
-                                    assert_eq!(
-                                        PrintableStringRef::try_from(&atav.value)
-                                            .unwrap()
-                                            .to_string(),
-                                        "US"
-                                    );
-                                } else if 1 == counter {
-                                    assert_eq!(atav.oid.to_string(), "2.5.4.10");
-                                    assert_eq!(
-                                        PrintableStringRef::try_from(&atav.value)
-                                            .unwrap()
-                                            .to_string(),
-                                        "U.S. Government"
-                                    );
-                                } else if 2 == counter {
-                                    assert_eq!(atav.oid.to_string(), "2.5.4.11");
-                                    assert_eq!(
-                                        PrintableStringRef::try_from(&atav.value)
-                                            .unwrap()
-                                            .to_string(),
-                                        "DoD"
-                                    );
-                                }
-                                counter += 1;
+                        for (counter, atav) in dn.iter().enumerate() {
+                            if 0 == counter {
+                                assert_eq!(atav.oid.to_string(), "2.5.4.6");
+                                assert_eq!(
+                                    PrintableStringRef::try_from(&atav.value)
+                                        .unwrap()
+                                        .to_string(),
+                                    "US"
+                                );
+                            } else if 1 == counter {
+                                assert_eq!(atav.oid.to_string(), "2.5.4.10");
+                                assert_eq!(
+                                    PrintableStringRef::try_from(&atav.value)
+                                        .unwrap()
+                                        .to_string(),
+                                    "U.S. Government"
+                                );
+                            } else if 2 == counter {
+                                assert_eq!(atav.oid.to_string(), "2.5.4.11");
+                                assert_eq!(
+                                    PrintableStringRef::try_from(&atav.value)
+                                        .unwrap()
+                                        .to_string(),
+                                    "DoD"
+                                );
                             }
                         }
                     }
@@ -413,41 +380,35 @@ fn decode_ta4() {
 
             let cert_path = tai.cert_path.as_ref().unwrap();
 
-            let mut counter = 0;
-            let i = cert_path.ta_name.iter();
-            for rdn in i {
-                let i1 = rdn.iter();
-                for atav in i1 {
-                    if 0 == counter {
-                        assert_eq!(atav.oid.to_string(), "0.9.2342.19200300.100.1.25");
-                        assert_eq!(
-                            Ia5StringRef::try_from(&atav.value).unwrap().to_string(),
-                            "com"
-                        );
-                    } else if 1 == counter {
-                        assert_eq!(atav.oid.to_string(), "0.9.2342.19200300.100.1.25");
-                        assert_eq!(
-                            Ia5StringRef::try_from(&atav.value).unwrap().to_string(),
-                            "raytheon"
-                        );
-                    } else if 2 == counter {
-                        assert_eq!(atav.oid.to_string(), "2.5.4.10");
-                        assert_eq!(
-                            PrintableStringRef::try_from(&atav.value)
-                                .unwrap()
-                                .to_string(),
-                            "CAs"
-                        );
-                    } else if 3 == counter {
-                        assert_eq!(atav.oid.to_string(), "2.5.4.11");
-                        assert_eq!(
-                            PrintableStringRef::try_from(&atav.value)
-                                .unwrap()
-                                .to_string(),
-                            "RaytheonRoot"
-                        );
-                    }
-                    counter += 1;
+            for (counter, atav) in cert_path.ta_name.iter().enumerate() {
+                if 0 == counter {
+                    assert_eq!(atav.oid.to_string(), "0.9.2342.19200300.100.1.25");
+                    assert_eq!(
+                        Ia5StringRef::try_from(&atav.value).unwrap().to_string(),
+                        "com"
+                    );
+                } else if 1 == counter {
+                    assert_eq!(atav.oid.to_string(), "0.9.2342.19200300.100.1.25");
+                    assert_eq!(
+                        Ia5StringRef::try_from(&atav.value).unwrap().to_string(),
+                        "raytheon"
+                    );
+                } else if 2 == counter {
+                    assert_eq!(atav.oid.to_string(), "2.5.4.10");
+                    assert_eq!(
+                        PrintableStringRef::try_from(&atav.value)
+                            .unwrap()
+                            .to_string(),
+                        "CAs"
+                    );
+                } else if 3 == counter {
+                    assert_eq!(atav.oid.to_string(), "2.5.4.11");
+                    assert_eq!(
+                        PrintableStringRef::try_from(&atav.value)
+                            .unwrap()
+                            .to_string(),
+                        "RaytheonRoot"
+                    );
                 }
             }
 


### PR DESCRIPTION
This make `FromStr` documented way to build a name. This also exposes a set of getter methods to get elements from the name (CN, Org, ...).

see:
 - #1489 
 - fixes #1493