### PR TITLE
x509-cert: time encoding, comply with rfc

### DIFF
--- a/x509-cert/src/time.rs
+++ b/x509-cert/src/time.rs
@@ -1,12 +1,13 @@
 //! X.501 time types as defined in RFC 5280
 
-use core::fmt;
-use core::time::Duration;
+use core::{fmt, marker::PhantomData, time::Duration};
 use der::asn1::{GeneralizedTime, UtcTime};
-use der::{Choice, DateTime, Sequence, ValueOrd};
+use der::{Choice, DateTime, DecodeValue, Encode, Header, Length, Reader, Sequence, ValueOrd};
 
 #[cfg(feature = "std")]
 use std::time::SystemTime;
+
+use crate::certificate::{Profile, Rfc5280};
 
 /// X.501 `Time` as defined in [RFC 5280 Section 4.1.2.5].
 ///
@@ -68,7 +69,6 @@ impl Time {
 
     /// Convert time to UTCTime representation
     /// As per RFC 5280: 4.1.2.5, date through 2049 should be expressed as UTC Time.
-    #[cfg(feature = "builder")]
     pub(crate) fn rfc5280_adjust_utc_time(&mut self) -> der::Result<()> {
         if let Time::GeneralTime(t) = self {
             let date = t.to_date_time();
@@ -132,16 +132,21 @@ impl TryFrom<SystemTime> for Time {
 /// ```
 /// [RFC 5280 Section 4.1.2.5]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.5
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Sequence, ValueOrd)]
-pub struct Validity {
+#[derive(Copy, Clone, Debug, Eq, PartialEq, ValueOrd)]
+pub struct Validity<P: Profile + 'static = Rfc5280> {
     /// notBefore value
     pub not_before: Time,
 
     /// notAfter value
     pub not_after: Time,
+
+    _profile: PhantomData<P>,
 }
 
-impl Validity {
+impl<P> Validity<P>
+where
+    P: Profile + 'static,
+{
     /// Creates a `Validity` which starts now and lasts for `duration`.
     #[cfg(feature = "std")]
     pub fn from_now(duration: Duration) -> der::Result<Self> {
@@ -151,6 +156,42 @@ impl Validity {
         Ok(Self {
             not_before: Time::try_from(now)?,
             not_after: Time::try_from(then)?,
+            _profile: PhantomData,
         })
     }
 }
+
+impl<'a, P: Profile + 'static> DecodeValue<'a> for Validity<P> {
+    type Error = ::der::Error;
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> der::Result<Self> {
+        reader.read_nested(header.length, |reader| {
+            let not_before = reader.decode()?;
+            let not_after = reader.decode()?;
+            let out = Self {
+                not_before,
+                not_after,
+                _profile: PhantomData,
+            };
+
+            Ok(out)
+        })
+    }
+}
+
+impl<P: Profile + 'static> ::der::EncodeValue for Validity<P> {
+    fn value_len(&self) -> ::der::Result<::der::Length> {
+        [
+            P::time_encoding(self.not_before)?.encoded_len()?,
+            P::time_encoding(self.not_after)?.encoded_len()?,
+        ]
+        .into_iter()
+        .try_fold(Length::ZERO, |acc, len| acc + len)
+    }
+    fn encode_value(&self, writer: &mut impl ::der::Writer) -> ::der::Result<()> {
+        P::time_encoding(self.not_before)?.encode(writer)?;
+        P::time_encoding(self.not_after)?.encode(writer)?;
+        Ok(())
+    }
+}
+
+impl<'a, P: Profile + 'static> Sequence<'a> for Validity<P> {}

--- a/x509-cert/tests/validity.rs
+++ b/x509-cert/tests/validity.rs
@@ -4,6 +4,8 @@ use der::{Decode, Encode};
 use hex_literal::hex;
 use x509_cert::time::Validity;
 
+use x509_cert::certificate::Rfc5280;
+
 #[test]
 fn decode_validity() {
     // Decode Validity from GoodCACert.crt in NIST's PKITS certificate collection
@@ -11,7 +13,7 @@ fn decode_validity() {
     // 104  13:       UTCTime 01/01/2010 08:30:00 GMT
     // 119  13:       UTCTime 31/12/2030 08:30:00 GMT
     //        :       }
-    let val1 = Validity::from_der(
+    let val1 = Validity::<Rfc5280>::from_der(
         &hex!("301E170D3130303130313038333030305A170D3330313233313038333030305A")[..],
     )
     .unwrap();
@@ -21,7 +23,7 @@ fn decode_validity() {
     //  99  13:       UTCTime 01/01/2010 08:30:00 GMT
     // 114  13:       UTCTime 01/01/2011 08:30:00 GMT
     //        :       }
-    let val2 = Validity::from_der(
+    let val2 = Validity::<Rfc5280>::from_der(
         &hex!("301E170D3130303130313038333030305A170D3131303130313038333030305A")[..],
     )
     .unwrap();
@@ -51,7 +53,7 @@ fn decode_validity() {
     //  99  13:       UTCTime 01/01/2010 08:30:00 GMT
     // 114  15:       GeneralizedTime 01/01/2050 12:01:00 GMT
     //        :       }
-    let val3 = Validity::from_der(
+    let val3 = Validity::<Rfc5280>::from_der(
         &hex!("3020170D3130303130313038333030305A180F32303530303130313132303130305A")[..],
     )
     .unwrap();
@@ -71,7 +73,7 @@ fn decode_validity() {
     //  99  15:       GeneralizedTime 01/01/2002 12:01:00 GMT
     // 116  13:       UTCTime 31/12/2030 08:30:00 GMT
     //        :       }
-    let val4 = Validity::from_der(
+    let val4 = Validity::<Rfc5280>::from_der(
         &hex!("3020180F32303032303130313132303130305A170D3330313233313038333030305A")[..],
     )
     .unwrap();
@@ -94,7 +96,7 @@ fn encode_validity() {
     // 104  13:       UTCTime 01/01/2010 08:30:00 GMT
     // 119  13:       UTCTime 31/12/2030 08:30:00 GMT
     //        :       }
-    let val1 = Validity::from_der(
+    let val1 = Validity::<Rfc5280>::from_der(
         &hex!("301E170D3130303130313038333030305A170D3330313233313038333030305A")[..],
     )
     .unwrap();
@@ -109,7 +111,7 @@ fn encode_validity() {
     //  99  13:       UTCTime 01/01/2010 08:30:00 GMT
     // 114  15:       GeneralizedTime 01/01/2050 12:01:00 GMT
     //        :       }
-    let val3 = Validity::from_der(
+    let val3 = Validity::<Rfc5280>::from_der(
         &hex!("3020170D3130303130313038333030305A180F32303530303130313132303130305A")[..],
     )
     .unwrap();
@@ -119,18 +121,38 @@ fn encode_validity() {
         &hex!("3020170D3130303130313038333030305A180F32303530303130313132303130305A")[..]
     );
 
+    #[cfg(feature = "hazmat")]
+    {
+        use x509_cert::certificate::Raw;
+
+        // Decode Validity from ValidGeneralizedTimenotBeforeDateTest4EE.crt in NIST's PKITS certificate collection
+        //  97  32:     SEQUENCE {
+        //  99  15:       GeneralizedTime 01/01/2002 12:01:00 GMT
+        // 116  13:       UTCTime 31/12/2030 08:30:00 GMT
+        //        :       }
+        let val4 = Validity::<Raw>::from_der(
+            &hex!("3020180F32303032303130313132303130305A170D3330313233313038333030305A")[..],
+        )
+        .unwrap();
+        let b4 = val4.to_der().unwrap();
+        assert_eq!(
+            b4,
+            &hex!("3020180F32303032303130313132303130305A170D3330313233313038333030305A")[..]
+        );
+    }
+
     // Decode Validity from ValidGeneralizedTimenotBeforeDateTest4EE.crt in NIST's PKITS certificate collection
     //  97  32:     SEQUENCE {
     //  99  15:       GeneralizedTime 01/01/2002 12:01:00 GMT
     // 116  13:       UTCTime 31/12/2030 08:30:00 GMT
     //        :       }
-    let val4 = Validity::from_der(
+    let val5 = Validity::<Rfc5280>::from_der(
         &hex!("3020180F32303032303130313132303130305A170D3330313233313038333030305A")[..],
     )
     .unwrap();
-    let b4 = val4.to_der().unwrap();
+    let b5 = val5.to_der().unwrap();
     assert_eq!(
-        b4,
-        &hex!("3020180F32303032303130313132303130305A170D3330313233313038333030305A")[..]
+        b5,
+        &hex!("301E170D3032303130313132303130305A170D3330313233313038333030305A")[..]
     );
 }


### PR DESCRIPTION
When serializing certificates, the validity should be encoded as UTCTime if the year is strictly below 2050, as per [RFC 5280 section 4.1.2.5]:
```
   CAs conforming to this profile MUST always encode certificate
   validity dates through the year 2049 as UTCTime; certificate validity
   dates in 2050 or later MUST be encoded as GeneralizedTime.
   Conforming applications MUST be able to process validity dates that
   are encoded in either UTCTime or GeneralizedTime.
```

Parsing is left untouched, no enforcement is made there.

Fixes #1496

[RFC 5280 section 4.1.2.5]: https://www.rfc-editor.org/rfc/rfc5280#section-4.1.2.5