### PR TITLE
cut pkcs1 pkcs8 and sec1 pre-releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1061,7 +1061,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs1"
-version = "0.8.0-rc.0"
+version = "0.8.0-rc.1"
 dependencies = [
  "const-oid",
  "der",
@@ -1109,7 +1109,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.1"
 dependencies = [
  "der",
  "hex-literal",
@@ -1442,7 +1442,7 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.8.0-rc.0"
+version = "0.8.0-rc.1"
 dependencies = [
  "base16ct",
  "der",
@@ -1872,7 +1872,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs1"
-version = "0.8.0-rc.0"
+version = "0.8.0-rc.1"
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #1:
 RSA Cryptography Specifications Version 2.2 (RFC 8017)
@@ -20,7 +20,7 @@ der = { version = "0.8.0-rc.0", features = ["oid"] }
 spki = { version = "0.8.0-rc.0" }
 
 # optional dependencies
-pkcs8 = { version = "0.11.0-rc.0", optional = true, default-features = false }
+pkcs8 = { version = "0.11.0-rc.1", optional = true, default-features = false }
 
 [dev-dependencies]
 const-oid = { version = "0.10.0-rc.0", features = ["db"] }

--- a/pkcs12/Cargo.toml
+++ b/pkcs12/Cargo.toml
@@ -26,7 +26,7 @@ zeroize = "1.8.1"
 
 [dev-dependencies]
 hex-literal = "0.4"
-pkcs8 = { version = "0.11.0-rc.0", features = ["pkcs5", "getrandom"] }
+pkcs8 = { version = "0.11.0-rc.1", features = ["pkcs5", "getrandom"] }
 pkcs5 = { version = "0.8.0-rc.0", features = ["pbes2", "3des"] }
 sha2 = "=0.11.0-pre.4"
 whirlpool = "=0.11.0-pre.4"

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs8"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.1"
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #8:
 Private-Key Information Syntax Specification (RFC 5208), with additional

--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sec1"
-version = "0.8.0-rc.0"
+version = "0.8.0-rc.1"
 description = """
 Pure Rust implementation of SEC1: Elliptic Curve Cryptography encoding formats
 including ASN.1 DER-serialized private keys as well as the
@@ -20,7 +20,7 @@ rust-version = "1.72"
 base16ct = { version = "0.2", optional = true, default-features = false }
 der = { version = "0.8.0-rc.0", optional = true, features = ["oid"] }
 hybrid-array = { version = "0.2.0-rc.9", optional = true, default-features = false }
-pkcs8 = { version = "0.11.0-rc.0", optional = true, default-features = false }
+pkcs8 = { version = "0.11.0-rc.1", optional = true, default-features = false }
 serdect = { version = "=0.3.0-pre.0", optional = true, default-features = false, features = ["alloc"] }
 subtle = { version = "2", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }


### PR DESCRIPTION
 - pkcs1 `0.8.0-rc.1`
 - pkcs8 `0.11.0-rc.1`
 - sec1 `0.8.0-rc.1`

This comes after the merge of API breaks on pkcs8 ([#1483])

[#1483]: https://github.com/RustCrypto/formats/pull/1483