### PR TITLE
x509-cert: move `'static` bounds to `Profile` trait

### DIFF
--- a/x509-cert/src/anchor.rs
+++ b/x509-cert/src/anchor.rs
@@ -37,7 +37,7 @@ pub enum Version {
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq, Sequence)]
 #[allow(missing_docs)]
-pub struct TrustAnchorInfo<P: Profile + 'static = Rfc5280> {
+pub struct TrustAnchorInfo<P: Profile = Rfc5280> {
     #[asn1(default = "Default::default")]
     pub version: Version,
 
@@ -70,7 +70,7 @@ pub struct TrustAnchorInfo<P: Profile + 'static = Rfc5280> {
 /// ```
 #[derive(Clone, Debug, Eq, PartialEq, Sequence)]
 #[allow(missing_docs)]
-pub struct CertPathControls<P: Profile + 'static = Rfc5280> {
+pub struct CertPathControls<P: Profile = Rfc5280> {
     pub ta_name: Name,
 
     #[asn1(context_specific = "0", tag_mode = "IMPLICIT", optional = "true")]
@@ -129,7 +129,7 @@ pub type CertPolicyFlags = FlagSet<CertPolicies>;
 #[derive(Clone, Debug, PartialEq, Eq, Choice)]
 #[allow(clippy::large_enum_variant)]
 #[allow(missing_docs)]
-pub enum TrustAnchorChoice<P: Profile + 'static = Rfc5280> {
+pub enum TrustAnchorChoice<P: Profile = Rfc5280> {
     Certificate(CertificateInner<P>),
 
     #[asn1(context_specific = "1", tag_mode = "EXPLICIT", constructed = "true")]

--- a/x509-cert/src/certificate.rs
+++ b/x509-cert/src/certificate.rs
@@ -19,7 +19,7 @@ use crate::time::Time;
 /// [`Profile`] allows the consumer of this crate to customize the behavior when parsing
 /// certificates.
 /// By default, parsing will be made in a rfc5280-compliant manner.
-pub trait Profile: PartialEq + Debug + Eq + Clone + Default {
+pub trait Profile: PartialEq + Debug + Eq + Clone + Default + 'static {
     /// Checks to run when parsing serial numbers
     fn check_serial_number(serial: &SerialNumber<Self>) -> der::Result<()> {
         // See the note in `SerialNumber::new`: we permit lengths of 21 bytes here,
@@ -135,7 +135,7 @@ pub type TbsCertificate = TbsCertificateInner<Rfc5280>;
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, Eq, PartialEq, Sequence, ValueOrd)]
 #[allow(missing_docs)]
-pub struct TbsCertificateInner<P: Profile + 'static = Rfc5280> {
+pub struct TbsCertificateInner<P: Profile = Rfc5280> {
     /// The certificate version
     ///
     /// Note that this value defaults to Version 1 per the RFC. However,
@@ -215,7 +215,7 @@ pub type Certificate = CertificateInner<Rfc5280>;
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, Eq, PartialEq, Sequence, ValueOrd)]
 #[allow(missing_docs)]
-pub struct CertificateInner<P: Profile + 'static = Rfc5280> {
+pub struct CertificateInner<P: Profile = Rfc5280> {
     pub tbs_certificate: TbsCertificateInner<P>,
     pub signature_algorithm: AlgorithmIdentifierOwned,
     pub signature: BitString,

--- a/x509-cert/src/crl.rs
+++ b/x509-cert/src/crl.rs
@@ -26,7 +26,7 @@ use spki::AlgorithmIdentifierOwned;
 /// [RFC 5280 Section 5.1]: https://datatracker.ietf.org/doc/html/rfc5280#section-5.1
 #[derive(Clone, Debug, Eq, PartialEq, Sequence, ValueOrd)]
 #[allow(missing_docs)]
-pub struct CertificateList<P: Profile + 'static = Rfc5280> {
+pub struct CertificateList<P: Profile = Rfc5280> {
     pub tbs_cert_list: TbsCertList<P>,
     pub signature_algorithm: AlgorithmIdentifierOwned,
     pub signature: BitString,
@@ -48,7 +48,7 @@ pub struct CertificateList<P: Profile + 'static = Rfc5280> {
 /// [RFC 5280 Section 5.1]: https://datatracker.ietf.org/doc/html/rfc5280#section-5.1
 #[derive(Clone, Debug, Eq, PartialEq, Sequence, ValueOrd)]
 #[allow(missing_docs)]
-pub struct RevokedCert<P: Profile + 'static = Rfc5280> {
+pub struct RevokedCert<P: Profile = Rfc5280> {
     pub serial_number: SerialNumber<P>,
     pub revocation_date: Time,
     pub crl_entry_extensions: Option<Extensions>,
@@ -75,7 +75,7 @@ pub struct RevokedCert<P: Profile + 'static = Rfc5280> {
 /// [RFC 5280 Section 5.1]: https://datatracker.ietf.org/doc/html/rfc5280#section-5.1
 #[derive(Clone, Debug, Eq, PartialEq, Sequence, ValueOrd)]
 #[allow(missing_docs)]
-pub struct TbsCertList<P: Profile + 'static = Rfc5280> {
+pub struct TbsCertList<P: Profile = Rfc5280> {
     pub version: Version,
     pub signature: AlgorithmIdentifierOwned,
     pub issuer: Name,

--- a/x509-cert/src/time.rs
+++ b/x509-cert/src/time.rs
@@ -133,7 +133,7 @@ impl TryFrom<SystemTime> for Time {
 /// [RFC 5280 Section 4.1.2.5]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.5
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, ValueOrd)]
-pub struct Validity<P: Profile + 'static = Rfc5280> {
+pub struct Validity<P: Profile = Rfc5280> {
     /// notBefore value
     pub not_before: Time,
 
@@ -145,7 +145,7 @@ pub struct Validity<P: Profile + 'static = Rfc5280> {
 
 impl<P> Validity<P>
 where
-    P: Profile + 'static,
+    P: Profile,
 {
     /// Creates a `Validity` which starts now and lasts for `duration`.
     #[cfg(feature = "std")]
@@ -161,7 +161,7 @@ where
     }
 }
 
-impl<'a, P: Profile + 'static> DecodeValue<'a> for Validity<P> {
+impl<'a, P: Profile> DecodeValue<'a> for Validity<P> {
     type Error = ::der::Error;
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> der::Result<Self> {
         reader.read_nested(header.length, |reader| {
@@ -178,7 +178,7 @@ impl<'a, P: Profile + 'static> DecodeValue<'a> for Validity<P> {
     }
 }
 
-impl<P: Profile + 'static> ::der::EncodeValue for Validity<P> {
+impl<P: Profile> ::der::EncodeValue for Validity<P> {
     fn value_len(&self) -> ::der::Result<::der::Length> {
         [
             P::time_encoding(self.not_before)?.encoded_len()?,
@@ -194,4 +194,4 @@ impl<P: Profile + 'static> ::der::EncodeValue for Validity<P> {
     }
 }
 
-impl<'a, P: Profile + 'static> Sequence<'a> for Validity<P> {}
+impl<'a, P: Profile> Sequence<'a> for Validity<P> {}


### PR DESCRIPTION
Avoids repeating the `Profile + 'static` bound by moving the requirement to the bounds of the `Profile` trait itself.