### PR TITLE
x509-cert: make `RdnSequence`'s inner field private

### DIFF
--- a/cms/tests/builder.rs
+++ b/cms/tests/builder.rs
@@ -56,9 +56,7 @@ fn signer_identifier(id: i32) -> SignerIdentifier {
         value: Any::from(Utf8StringRef::new(&format!("test client {id}")).unwrap()),
     }];
     let set_of_vector = SetOfVec::try_from(rdn.to_vec()).unwrap();
-    rdn_sequence
-        .0
-        .push(RelativeDistinguishedName::from(set_of_vector));
+    rdn_sequence.push(RelativeDistinguishedName::from(set_of_vector));
     SignerIdentifier::IssuerAndSerialNumber(IssuerAndSerialNumber {
         issuer: rdn_sequence,
         serial_number: SerialNumber::new(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06])
@@ -73,9 +71,7 @@ fn recipient_identifier(id: i32) -> RecipientIdentifier {
         value: Any::from(Utf8StringRef::new(&format!("test client {id}")).unwrap()),
     }];
     let set_of_vector = SetOfVec::try_from(rdn.to_vec()).unwrap();
-    rdn_sequence
-        .0
-        .push(RelativeDistinguishedName::from(set_of_vector));
+    rdn_sequence.push(RelativeDistinguishedName::from(set_of_vector));
     RecipientIdentifier::IssuerAndSerialNumber(IssuerAndSerialNumber {
         issuer: rdn_sequence,
         serial_number: SerialNumber::new(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06])

--- a/x509-cert/src/builder/profile/cabf.rs
+++ b/x509-cert/src/builder/profile/cabf.rs
@@ -43,7 +43,7 @@ pub fn check_names_encoding(name: &Name, multiple_allowed: bool) -> Result<()> {
 
     let mut seen = HashSet::new();
 
-    for rdn in name.0.iter() {
+    for rdn in name.iter() {
         if rdn.0.len() != 1 {
             return Err(Error::NonUniqueRdn);
         }
@@ -87,7 +87,7 @@ pub fn ca_certificate_naming(subject: &Name) -> Result<()> {
 
     check_names_encoding(subject, false)?;
 
-    for rdn in subject.0.iter() {
+    for rdn in subject.iter() {
         for atv in rdn.0.iter() {
             if !allowed.remove(&atv.oid) {
                 return Err(Error::InvalidAttribute { oid: atv.oid });

--- a/x509-cert/src/builder/profile/cabf/tls.rs
+++ b/x509-cert/src/builder/profile/cabf/tls.rs
@@ -145,7 +145,6 @@ impl CertificateType {
         // TODO(baloo): not very happy with all that, might as well throw that in a helper
         // or something.
         let rdns: vec::Vec<RelativeDistinguishedName> = subject
-            .0
             .iter()
             .filter_map(|rdn| {
                 let out = SetOfVec::<AttributeTypeAndValue>::from_iter(

--- a/x509-cert/src/name.rs
+++ b/x509-cert/src/name.rs
@@ -23,7 +23,7 @@ pub type Name = RdnSequence;
 /// [RFC 5280 Section 4.1.2.4]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.4
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct RdnSequence(pub Vec<RelativeDistinguishedName>);
+pub struct RdnSequence(Vec<RelativeDistinguishedName>);
 
 impl RdnSequence {
     /// Converts an `RDNSequence` string into an encoded `RDNSequence`.
@@ -35,6 +35,21 @@ impl RdnSequence {
     /// Is this [`RdnSequence`] empty?
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
+    }
+
+    /// Iterate over this [`RdnSequence`].
+    pub fn iter(&self) -> impl Iterator<Item = &RelativeDistinguishedName> {
+        self.0.iter()
+    }
+
+    /// Length of this [`RdnSequence`].
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Push a [`RelativeDistinguishedName`] onto this [`RdnSequence`].
+    pub fn push(&mut self, name: RelativeDistinguishedName) {
+        self.0.push(name)
     }
 }
 

--- a/x509-cert/tests/certificate.rs
+++ b/x509-cert/tests/certificate.rs
@@ -239,7 +239,7 @@ fn decode_cert() {
         .is_null());
 
     let mut counter = 0;
-    let i = cert.tbs_certificate().issuer().0.iter();
+    let i = cert.tbs_certificate().issuer().iter();
     for rdn in i {
         let i1 = rdn.0.iter();
         for atav in i1 {
@@ -294,7 +294,7 @@ fn decode_cert() {
     );
 
     counter = 0;
-    let i = cert.tbs_certificate().subject().0.iter();
+    let i = cert.tbs_certificate().subject().iter();
     for rdn in i {
         let i1 = rdn.0.iter();
         for atav in i1 {

--- a/x509-cert/tests/certreq.rs
+++ b/x509-cert/tests/certreq.rs
@@ -35,8 +35,8 @@ fn decode_rsa_2048_der() {
     assert_eq!(cr.info.version, Version::V1);
 
     // Check all the RDNs.
-    assert_eq!(cr.info.subject.0.len(), NAMES.len());
-    for (name, (oid, val)) in cr.info.subject.0.iter().zip(NAMES) {
+    assert_eq!(cr.info.subject.len(), NAMES.len());
+    for (name, (oid, val)) in cr.info.subject.iter().zip(NAMES) {
         let kind = name.0.get(0).unwrap();
         let value = match kind.value.tag() {
             Tag::Utf8String => Utf8StringRef::try_from(&kind.value).unwrap().as_str(),

--- a/x509-cert/tests/name.rs
+++ b/x509-cert/tests/name.rs
@@ -34,7 +34,7 @@ fn decode_name() {
     let rdn1a = rdn1.unwrap();
 
     let mut counter = 0;
-    let i = rdn1a.0.iter();
+    let i = rdn1a.iter();
     for rdn in i {
         let i1 = rdn.0.iter();
         for atav in i1 {
@@ -338,7 +338,7 @@ fn rdns_serde() {
         let mut brdns = RdnSequence::default();
         for rdn in rdns.iter() {
             let sofv = SetOfVec::try_from(rdn.to_vec()).unwrap();
-            brdns.0.push(RelativeDistinguishedName::from(sofv));
+            brdns.push(RelativeDistinguishedName::from(sofv));
         }
 
         // Check that serialization matches the expected output.
@@ -356,7 +356,7 @@ fn rdns_serde() {
 
             let rdns = RdnSequence::from_der(&der).unwrap();
 
-            for (l, r) in brdns.0.iter().zip(rdns.0.iter()) {
+            for (l, r) in brdns.iter().zip(rdns.iter()) {
                 for (ll, rr) in l.0.iter().zip(r.0.iter()) {
                     assert_eq!(ll, rr);
                 }

--- a/x509-cert/tests/pkix_extensions.rs
+++ b/x509-cert/tests/pkix_extensions.rs
@@ -581,7 +581,7 @@ fn decode_cert() {
     );
 
     let mut counter = 0;
-    let i = cert.tbs_certificate().issuer().0.iter();
+    let i = cert.tbs_certificate().issuer().iter();
     for rdn in i {
         let i1 = rdn.0.iter();
         for atav in i1 {
@@ -632,7 +632,7 @@ fn decode_cert() {
     );
 
     counter = 0;
-    let i = cert.tbs_certificate().subject().0.iter();
+    let i = cert.tbs_certificate().subject().iter();
     for rdn in i {
         let i1 = rdn.0.iter();
         for atav in i1 {
@@ -869,19 +869,19 @@ fn decode_idp() {
 
     let n =
         Name::from_der(&hex!("305A310B3009060355040613025553311F301D060355040A131654657374204365727469666963617465732032303137311C301A060355040B13136F6E6C79536F6D65526561736F6E7320434133310C300A0603550403130343524C")).unwrap();
-    assert_eq!(4, n.0.len());
+    assert_eq!(4, n.len());
 
     let gn =
         GeneralName::from_der(&hex!("A45C305A310B3009060355040613025553311F301D060355040A131654657374204365727469666963617465732032303137311C301A060355040B13136F6E6C79536F6D65526561736F6E7320434133310C300A0603550403130343524C")).unwrap();
     if let GeneralName::DirectoryName(gn) = gn {
-        assert_eq!(4, gn.0.len());
+        assert_eq!(4, gn.len());
     }
 
     let gns =
         GeneralNames::from_der(&hex!("305EA45C305A310B3009060355040613025553311F301D060355040A131654657374204365727469666963617465732032303137311C301A060355040B13136F6E6C79536F6D65526561736F6E7320434133310C300A0603550403130343524C")).unwrap();
     assert_eq!(1, gns.len());
     if let GeneralName::DirectoryName(gn) = gns.first().unwrap() {
-        assert_eq!(4, gn.0.len());
+        assert_eq!(4, gn.len());
     }
 
     //TODO - fix decode impl (expecting a SEQUENCE despite this being a CHOICE). Sort out FixedTag implementation.
@@ -906,7 +906,7 @@ fn decode_idp() {
     if let DistributionPointName::FullName(dpn) = dp.distribution_point.unwrap() {
         assert_eq!(1, dpn.len());
         if let GeneralName::DirectoryName(gn) = dpn.first().unwrap() {
-            assert_eq!(4, gn.0.len());
+            assert_eq!(4, gn.len());
         }
     }
 
@@ -1084,7 +1084,7 @@ fn decode_idp() {
             for gn in dp {
                 match gn {
                     GeneralName::DirectoryName(gn) => {
-                        assert_eq!(4, gn.0.len());
+                        assert_eq!(4, gn.len());
                     }
                     _ => {
                         panic!("Expected DirectoryName")
@@ -1113,7 +1113,7 @@ fn decode_idp() {
             for gn in dp {
                 match gn {
                     GeneralName::DirectoryName(gn) => {
-                        assert_eq!(4, gn.0.len());
+                        assert_eq!(4, gn.len());
                     }
                     _ => {
                         panic!("Expected DirectoryName")

--- a/x509-cert/tests/trust_anchor_format.rs
+++ b/x509-cert/tests/trust_anchor_format.rs
@@ -90,7 +90,7 @@ fn decode_ta1() {
             }
 
             counter = 0;
-            let i = cert_path.ta_name.0.iter();
+            let i = cert_path.ta_name.iter();
             for rdn in i {
                 let i1 = rdn.0.iter();
                 for atav in i1 {
@@ -167,7 +167,7 @@ fn decode_ta2() {
             let cert_path = tai.cert_path.as_ref().unwrap();
 
             let mut counter = 0;
-            let i = cert_path.ta_name.0.iter();
+            let i = cert_path.ta_name.iter();
             for rdn in i {
                 let i1 = rdn.0.iter();
                 for atav in i1 {
@@ -214,7 +214,7 @@ fn decode_ta2() {
             for gs in gsi {
                 match &gs.base {
                     GeneralName::DirectoryName(dn) => {
-                        let i = dn.0.iter();
+                        let i = dn.iter();
                         for rdn in i {
                             let i1 = rdn.0.iter();
                             for atav in i1 {
@@ -294,7 +294,7 @@ fn decode_ta3() {
             );
 
             let mut counter = 0;
-            let i = cert_path.ta_name.0.iter();
+            let i = cert_path.ta_name.iter();
             for rdn in i {
                 let i1 = rdn.0.iter();
                 for atav in i1 {
@@ -341,7 +341,7 @@ fn decode_ta3() {
             for gs in gsi {
                 match &gs.base {
                     GeneralName::DirectoryName(dn) => {
-                        let i = dn.0.iter();
+                        let i = dn.iter();
                         for rdn in i {
                             let i1 = rdn.0.iter();
                             for atav in i1 {
@@ -414,7 +414,7 @@ fn decode_ta4() {
             let cert_path = tai.cert_path.as_ref().unwrap();
 
             let mut counter = 0;
-            let i = cert_path.ta_name.0.iter();
+            let i = cert_path.ta_name.iter();
             for rdn in i {
                 let i1 = rdn.0.iter();
                 for atav in i1 {


### PR DESCRIPTION
Explicitly delegates the `iter`, `len`, and `push` methods.