### PR TITLE
x509-cert: document `add_extension` link to examples

### DIFF
--- a/x509-cert/src/builder.rs
+++ b/x509-cert/src/builder.rs
@@ -194,6 +194,10 @@ where
     }
 
     /// Add an extension to this certificate
+    ///
+    /// Extensions need to implement [`AsExtension`], examples may be found in
+    /// in [`AsExtension` documentation](../ext/trait.AsExtension.html#examples) or
+    /// [the implementors](../ext/trait.AsExtension.html#implementors).
     pub fn add_extension<E: AsExtension>(&mut self, extension: &E) -> Result<()> {
         let ext = extension.to_extension(&self.tbs.subject, &self.extensions)?;
         self.extensions.push(ext);
@@ -265,6 +269,10 @@ impl RequestBuilder {
     }
 
     /// Add an extension to this certificate request
+    ///
+    /// Extensions need to implement [`AsExtension`], examples may be found in
+    /// in [`AsExtension` documentation](../ext/trait.AsExtension.html#examples) or
+    /// [the implementors](../ext/trait.AsExtension.html#implementors).
     pub fn add_extension<E: AsExtension>(&mut self, extension: &E) -> Result<()> {
         let ext = extension.to_extension(&self.info.subject, &self.extension_req.0)?;
 


### PR DESCRIPTION
This makes `add_extension` link back to the example provided in `AsExtension`.

Fixes #1490