### PR TITLE
x509-cert: rename `builder::BuildProfile` to avoid confusion

### DIFF
--- a/x509-cert/src/builder.rs
+++ b/x509-cert/src/builder.rs
@@ -21,7 +21,13 @@ use crate::{
 
 pub mod profile;
 
-use self::profile::Profile;
+use self::profile::BuildProfile;
+
+#[deprecated(
+    since = "0.3.0",
+    note = "please use `x509_cert::builder::profile::BuildProfile` instead"
+)]
+pub use self::profile::BuildProfile as Profile;
 
 const NULL_OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("0.0.0");
 
@@ -146,7 +152,7 @@ pub struct CertificateBuilder<P> {
 
 impl<P> CertificateBuilder<P>
 where
-    P: Profile,
+    P: BuildProfile,
 {
     /// Creates a new certificate builder
     pub fn new(
@@ -338,7 +344,7 @@ pub trait Builder: Sized {
 
 impl<P> Builder for CertificateBuilder<P>
 where
-    P: Profile,
+    P: BuildProfile,
 {
     type Output = Certificate;
 

--- a/x509-cert/src/builder/profile.rs
+++ b/x509-cert/src/builder/profile.rs
@@ -1,6 +1,6 @@
 //! Certificate profiles
 //!
-//! Profiles need implement by the [`Profile`] trait.
+//! Profiles need implement by the [`BuildProfile`] trait.
 //! They may then be consumed by a [`builder::CertificateBuilder`].
 //!
 //!
@@ -24,7 +24,12 @@ pub mod cabf;
 pub mod devid;
 
 /// Profile for certificates
-pub trait Profile {
+///
+/// The profile will define the various extensions to add to a certificate, this may be used to
+/// generate a [`cabf::Root`], or a TLS [`cabf::tls::Subscriber`] certificate.
+///
+/// See [implementors](#implementors) for a full list of existing profiles.
+pub trait BuildProfile {
     /// Issuer to be used for issued certificates
     fn get_issuer(&self, subject: &Name) -> Name;
 

--- a/x509-cert/src/builder/profile/cabf.rs
+++ b/x509-cert/src/builder/profile/cabf.rs
@@ -5,7 +5,7 @@ use alloc::vec;
 use std::collections::HashSet;
 
 use crate::{
-    builder::{Error, Profile, Result},
+    builder::{BuildProfile, Error, Result},
     certificate::TbsCertificate,
     ext::{
         pkix::{
@@ -123,7 +123,7 @@ impl Root {
     }
 }
 
-impl Profile for Root {
+impl BuildProfile for Root {
     fn get_issuer(&self, subject: &Name) -> Name {
         subject.clone()
     }

--- a/x509-cert/src/builder/profile/cabf/tls.rs
+++ b/x509-cert/src/builder/profile/cabf/tls.rs
@@ -13,7 +13,7 @@ use const_oid::db::rfc5912;
 
 use crate::{
     attr::AttributeTypeAndValue,
-    builder::{Profile, Result},
+    builder::{BuildProfile, Result},
     certificate::TbsCertificate,
     ext::{
         pkix::{
@@ -50,7 +50,7 @@ pub struct Subordinate {
     pub client_auth: bool,
 }
 
-impl Profile for Subordinate {
+impl BuildProfile for Subordinate {
     fn get_issuer(&self, _subject: &Name) -> Name {
         self.issuer.clone()
     }
@@ -231,7 +231,7 @@ pub struct Tls12Options {
     pub enable_key_agreement: bool,
 }
 
-impl Profile for Subscriber {
+impl BuildProfile for Subscriber {
     fn get_issuer(&self, _subject: &Name) -> Name {
         self.issuer.clone()
     }

--- a/x509-cert/src/builder/profile/devid.rs
+++ b/x509-cert/src/builder/profile/devid.rs
@@ -16,7 +16,7 @@
 use alloc::vec;
 
 use crate::{
-    builder::{Profile, Result},
+    builder::{BuildProfile, Result},
     certificate::TbsCertificate,
     ext::{
         pkix::{
@@ -112,7 +112,7 @@ impl DevId {
     }
 }
 
-impl Profile for DevId {
+impl BuildProfile for DevId {
     fn get_issuer(&self, _subject: &Name) -> Name {
         self.issuer.clone()
     }


### PR DESCRIPTION
Fixes #1487