### PR TITLE
serdect: return the deserialized buffer during deserialization

### DIFF
--- a/serdect/src/array.rs
+++ b/serdect/src/array.rs
@@ -57,7 +57,7 @@ impl LengthCheck for ExactLength {
 /// Deserialize from hex when using human-readable formats or binary if the
 /// format is binary. Fails if the `buffer` isn't the exact same size as the
 /// resulting array.
-pub fn deserialize_hex_or_bin<'de, D>(buffer: &mut [u8], deserializer: D) -> Result<(), D::Error>
+pub fn deserialize_hex_or_bin<'de, D>(buffer: &mut [u8], deserializer: D) -> Result<&[u8], D::Error>
 where
     D: Deserializer<'de>,
 {

--- a/serdect/src/slice.rs
+++ b/serdect/src/slice.rs
@@ -61,7 +61,7 @@ impl LengthCheck for UpperBound {
 /// Deserialize from hex when using human-readable formats or binary if the
 /// format is binary. Fails if the `buffer` is smaller then the resulting
 /// slice.
-pub fn deserialize_hex_or_bin<'de, D>(buffer: &mut [u8], deserializer: D) -> Result<(), D::Error>
+pub fn deserialize_hex_or_bin<'de, D>(buffer: &mut [u8], deserializer: D) -> Result<&[u8], D::Error>
 where
     D: Deserializer<'de>,
 {


### PR DESCRIPTION
Fixes #1322

Also fixed a TODO in `StrIntoBufVisitor::visit_str` by mapping `base16ct` errors to `serde` errors.