### PR TITLE
x509-cert: use `BuilderProfile` for consistency

### DIFF
--- a/x509-cert/src/builder.rs
+++ b/x509-cert/src/builder.rs
@@ -21,13 +21,13 @@ use crate::{
 
 pub mod profile;
 
-use self::profile::BuildProfile;
+use self::profile::BuilderProfile;
 
 #[deprecated(
     since = "0.3.0",
-    note = "please use `x509_cert::builder::profile::BuildProfile` instead"
+    note = "please use `x509_cert::builder::profile::BuilderProfile` instead"
 )]
-pub use self::profile::BuildProfile as Profile;
+pub use self::profile::BuilderProfile as Profile;
 
 const NULL_OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("0.0.0");
 
@@ -152,7 +152,7 @@ pub struct CertificateBuilder<P> {
 
 impl<P> CertificateBuilder<P>
 where
-    P: BuildProfile,
+    P: BuilderProfile,
 {
     /// Creates a new certificate builder
     pub fn new(
@@ -352,7 +352,7 @@ pub trait Builder: Sized {
 
 impl<P> Builder for CertificateBuilder<P>
 where
-    P: BuildProfile,
+    P: BuilderProfile,
 {
     type Output = Certificate;
 

--- a/x509-cert/src/builder/profile.rs
+++ b/x509-cert/src/builder/profile.rs
@@ -1,6 +1,6 @@
 //! Certificate profiles
 //!
-//! Profiles need implement by the [`BuildProfile`] trait.
+//! Profiles need implement by the [`BuilderProfile`] trait.
 //! They may then be consumed by a [`builder::CertificateBuilder`].
 //!
 //!
@@ -29,7 +29,7 @@ pub mod devid;
 /// generate a [`cabf::Root`], or a TLS [`cabf::tls::Subscriber`] certificate.
 ///
 /// See [implementors](#implementors) for a full list of existing profiles.
-pub trait BuildProfile {
+pub trait BuilderProfile {
     /// Issuer to be used for issued certificates
     fn get_issuer(&self, subject: &Name) -> Name;
 

--- a/x509-cert/src/builder/profile/cabf.rs
+++ b/x509-cert/src/builder/profile/cabf.rs
@@ -5,7 +5,7 @@ use alloc::vec;
 use std::collections::HashSet;
 
 use crate::{
-    builder::{BuildProfile, Error, Result},
+    builder::{BuilderProfile, Error, Result},
     certificate::TbsCertificate,
     ext::{
         pkix::{
@@ -123,7 +123,7 @@ impl Root {
     }
 }
 
-impl BuildProfile for Root {
+impl BuilderProfile for Root {
     fn get_issuer(&self, subject: &Name) -> Name {
         subject.clone()
     }

--- a/x509-cert/src/builder/profile/cabf/tls.rs
+++ b/x509-cert/src/builder/profile/cabf/tls.rs
@@ -13,7 +13,7 @@ use const_oid::db::rfc5912;
 
 use crate::{
     attr::AttributeTypeAndValue,
-    builder::{BuildProfile, Result},
+    builder::{BuilderProfile, Result},
     certificate::TbsCertificate,
     ext::{
         pkix::{
@@ -50,7 +50,7 @@ pub struct Subordinate {
     pub client_auth: bool,
 }
 
-impl BuildProfile for Subordinate {
+impl BuilderProfile for Subordinate {
     fn get_issuer(&self, _subject: &Name) -> Name {
         self.issuer.clone()
     }
@@ -231,7 +231,7 @@ pub struct Tls12Options {
     pub enable_key_agreement: bool,
 }
 
-impl BuildProfile for Subscriber {
+impl BuilderProfile for Subscriber {
     fn get_issuer(&self, _subject: &Name) -> Name {
         self.issuer.clone()
     }

--- a/x509-cert/src/builder/profile/devid.rs
+++ b/x509-cert/src/builder/profile/devid.rs
@@ -16,7 +16,7 @@
 use alloc::vec;
 
 use crate::{
-    builder::{BuildProfile, Result},
+    builder::{BuilderProfile, Result},
     certificate::TbsCertificate,
     ext::{
         pkix::{
@@ -112,7 +112,7 @@ impl DevId {
     }
 }
 
-impl BuildProfile for DevId {
+impl BuilderProfile for DevId {
     fn get_issuer(&self, _subject: &Name) -> Name {
         self.issuer.clone()
     }


### PR DESCRIPTION
followup on #1514.

Use `BuilderProfile` instead of `BuildProfile` for consistency with the builder.