### PR TITLE
x509-cert: adds a `Validity::new` method

### DIFF
--- a/x509-cert/src/time.rs
+++ b/x509-cert/src/time.rs
@@ -147,6 +147,15 @@ impl<P> Validity<P>
 where
     P: Profile,
 {
+    /// Creates a `Validity` with the provided bounds
+    pub const fn new(not_before: Time, not_after: Time) -> Self {
+        Self {
+            not_before,
+            not_after,
+            _profile: PhantomData,
+        }
+    }
+
     /// Creates a `Validity` which starts now and lasts for `duration`.
     #[cfg(feature = "std")]
     pub fn from_now(duration: Duration) -> der::Result<Self> {


### PR DESCRIPTION
Having the profile be private makes it impossible to create a `Validity`. This adds a `Validity::new` to do that.