### PR TITLE
x509-cert: loosen the lifetime requirement for AsyncBuilder

### DIFF
--- a/x509-cert/src/builder.rs
+++ b/x509-cert/src/builder.rs
@@ -466,7 +466,7 @@ pub trait AsyncBuilder: Sized {
         S: AsyncSigner<Signature>,
         S: Keypair + DynSignatureAlgorithmIdentifier,
         S::VerifyingKey: EncodePublicKey,
-        Signature: SignatureBitStringEncoding + 'static,
+        Signature: SignatureBitStringEncoding,
     {
         let blob = self.finalize(signer)?;
 
@@ -485,7 +485,7 @@ pub trait AsyncBuilder: Sized {
         S: AsyncRandomizedSigner<Signature>,
         S: Keypair + DynSignatureAlgorithmIdentifier,
         S::VerifyingKey: EncodePublicKey,
-        Signature: SignatureBitStringEncoding + 'static,
+        Signature: SignatureBitStringEncoding,
     {
         let blob = self.finalize(signer)?;
 


### PR DESCRIPTION
I'm not entirely sure why I introduced that lifetime in the original PR (#1280).