### PR TITLE
x509-cert: re-export `spki` types without `*Owned` suffixes

### DIFF
--- a/x509-cert/src/anchor.rs
+++ b/x509-cert/src/anchor.rs
@@ -4,11 +4,13 @@ use crate::certificate::{CertificateInner, Profile, Rfc5280, TbsCertificateInner
 use crate::ext::pkix::{certpolicy::CertificatePolicies, NameConstraints};
 use crate::{ext::Extensions, name::Name};
 
+use crate::SubjectPublicKeyInfo;
 use alloc::string::String;
-use der::asn1::OctetString;
-use der::flagset::{flags, FlagSet};
-use der::{Choice, Enumerated, Sequence};
-use spki::SubjectPublicKeyInfoOwned;
+use der::{
+    asn1::OctetString,
+    flagset::{flags, FlagSet},
+    Choice, Enumerated, Sequence,
+};
 
 /// Version identifier for TrustAnchorInfo
 #[derive(Clone, Debug, Default, Copy, PartialEq, Eq, Enumerated)]
@@ -41,7 +43,7 @@ pub struct TrustAnchorInfo<P: Profile = Rfc5280> {
     #[asn1(default = "Default::default")]
     pub version: Version,
 
-    pub pub_key: SubjectPublicKeyInfoOwned,
+    pub pub_key: SubjectPublicKeyInfo,
 
     pub key_id: OctetString,
 

--- a/x509-cert/src/builder.rs
+++ b/x509-cert/src/builder.rs
@@ -6,8 +6,7 @@ use core::fmt;
 use der::{asn1::BitString, referenced::OwnedToRef, Encode};
 use signature::{rand_core::CryptoRngCore, Keypair, RandomizedSigner, Signer};
 use spki::{
-    AlgorithmIdentifier, DynSignatureAlgorithmIdentifier, EncodePublicKey, ObjectIdentifier,
-    SignatureBitStringEncoding, SubjectPublicKeyInfoOwned,
+    DynSignatureAlgorithmIdentifier, EncodePublicKey, ObjectIdentifier, SignatureBitStringEncoding,
 };
 
 use crate::{
@@ -17,6 +16,7 @@ use crate::{
     request::{attributes::AsAttribute, CertReq, CertReqInfo, ExtensionReq},
     serial_number::SerialNumber,
     time::Validity,
+    AlgorithmIdentifier, SubjectPublicKeyInfo,
 };
 
 pub mod profile;
@@ -107,7 +107,7 @@ pub type Result<T> = core::result::Result<T, Error>;
 ///
 /// ```
 /// use der::Decode;
-/// use x509_cert::spki::SubjectPublicKeyInfoOwned;
+/// use x509_cert::spki::SubjectPublicKeyInfo;
 /// use x509_cert::builder::{CertificateBuilder, Builder, profile};
 /// use x509_cert::name::Name;
 /// use x509_cert::serial_number::SerialNumber;
@@ -131,7 +131,7 @@ pub type Result<T> = core::result::Result<T, Error>;
 /// let subject = Name::from_str("CN=World domination corporation,O=World domination Inc,C=US").unwrap();
 /// let profile = profile::cabf::Root::new(false,subject).expect("Create root profile");
 ///
-/// let pub_key = SubjectPublicKeyInfoOwned::try_from(RSA_2048_DER).expect("get rsa pub key");
+/// let pub_key = SubjectPublicKeyInfo::try_from(RSA_2048_DER).expect("get rsa pub key");
 ///
 /// let mut signer = rsa_signer();
 /// let mut builder = CertificateBuilder::new(
@@ -159,7 +159,7 @@ where
         profile: P,
         serial_number: SerialNumber,
         mut validity: Validity,
-        subject_public_key_info: SubjectPublicKeyInfoOwned,
+        subject_public_key_info: SubjectPublicKeyInfo,
     ) -> Result<Self> {
         let signature_alg = AlgorithmIdentifier {
             oid: NULL_OID,
@@ -255,7 +255,7 @@ impl RequestBuilder {
             oid: NULL_OID,
             parameters: None,
         };
-        let public_key = SubjectPublicKeyInfoOwned {
+        let public_key = SubjectPublicKeyInfo {
             algorithm,
             subject_public_key: BitString::from_bytes(&[]).expect("unable to parse empty object"),
         };
@@ -362,7 +362,7 @@ where
         S::VerifyingKey: EncodePublicKey,
     {
         let verifying_key = cert_signer.verifying_key();
-        let signer_pub = SubjectPublicKeyInfoOwned::from_key(&verifying_key)?;
+        let signer_pub = SubjectPublicKeyInfo::from_key(&verifying_key)?;
 
         self.tbs.signature = cert_signer.signature_algorithm_identifier()?;
 
@@ -413,7 +413,7 @@ impl Builder for RequestBuilder {
         S::VerifyingKey: EncodePublicKey,
     {
         let verifying_key = signer.verifying_key();
-        let public_key = SubjectPublicKeyInfoOwned::from_key(&verifying_key)?;
+        let public_key = SubjectPublicKeyInfo::from_key(&verifying_key)?;
         self.info.public_key = public_key;
 
         self.info

--- a/x509-cert/src/certificate.rs
+++ b/x509-cert/src/certificate.rs
@@ -1,12 +1,11 @@
 //! Certificate types
 
 use crate::{ext, name::Name, serial_number::SerialNumber, time::Validity};
+use crate::{AlgorithmIdentifier, SubjectPublicKeyInfo};
 use alloc::vec::Vec;
 use const_oid::AssociatedOid;
 use core::{cmp::Ordering, fmt::Debug};
-use der::asn1::BitString;
-use der::{Decode, Enumerated, ErrorKind, Sequence, Tag, ValueOrd};
-use spki::{AlgorithmIdentifierOwned, SubjectPublicKeyInfoOwned};
+use der::{asn1::BitString, Decode, Enumerated, ErrorKind, Sequence, Tag, ValueOrd};
 
 #[cfg(feature = "pem")]
 use der::{
@@ -146,11 +145,11 @@ pub struct TbsCertificateInner<P: Profile = Rfc5280> {
     pub(crate) version: Version,
 
     pub(crate) serial_number: SerialNumber<P>,
-    pub(crate) signature: AlgorithmIdentifierOwned,
+    pub(crate) signature: AlgorithmIdentifier,
     pub(crate) issuer: Name,
     pub(crate) validity: Validity<P>,
     pub(crate) subject: Name,
-    pub(crate) subject_public_key_info: SubjectPublicKeyInfoOwned,
+    pub(crate) subject_public_key_info: SubjectPublicKeyInfo,
 
     #[asn1(context_specific = "1", tag_mode = "IMPLICIT", optional = "true")]
     pub(crate) issuer_unique_id: Option<BitString>,
@@ -179,7 +178,7 @@ impl<P: Profile> TbsCertificateInner<P> {
     /// Identifies the signature algorithm that this `TBSCertificate` should be signed with.
     ///
     /// In a signed certificate, matches [`CertificateInner::signature_algorithm`].
-    pub fn signature(&self) -> &AlgorithmIdentifierOwned {
+    pub fn signature(&self) -> &AlgorithmIdentifier {
         &self.signature
     }
 
@@ -203,7 +202,7 @@ impl<P: Profile> TbsCertificateInner<P> {
 
     /// Subject Public Key Info (SPKI): public key information about this certificate including
     /// algorithm identifier and key data.
-    pub fn subject_public_key_info(&self) -> &SubjectPublicKeyInfoOwned {
+    pub fn subject_public_key_info(&self) -> &SubjectPublicKeyInfo {
         &self.subject_public_key_info
     }
 
@@ -330,7 +329,7 @@ pub type Certificate = CertificateInner<Rfc5280>;
 #[allow(missing_docs)]
 pub struct CertificateInner<P: Profile = Rfc5280> {
     pub(crate) tbs_certificate: TbsCertificateInner<P>,
-    pub(crate) signature_algorithm: AlgorithmIdentifierOwned,
+    pub(crate) signature_algorithm: AlgorithmIdentifier,
     pub(crate) signature: BitString,
 }
 
@@ -341,7 +340,7 @@ impl<P: Profile> CertificateInner<P> {
     }
 
     /// Signature algorithm used to sign the serialization of [`CertificateInner::tbs_certificate`].
-    pub fn signature_algorithm(&self) -> &AlgorithmIdentifierOwned {
+    pub fn signature_algorithm(&self) -> &AlgorithmIdentifier {
         &self.signature_algorithm
     }
 

--- a/x509-cert/src/crl.rs
+++ b/x509-cert/src/crl.rs
@@ -1,17 +1,18 @@
 //! Certificate Revocation List types
 
-use crate::certificate::{Profile, Rfc5280};
-use crate::ext::Extensions;
-use crate::name::Name;
-use crate::serial_number::SerialNumber;
-use crate::time::Time;
-use crate::Version;
+use crate::{
+    certificate::{Profile, Rfc5280},
+    ext::Extensions,
+    name::Name,
+    serial_number::SerialNumber,
+    time::Time,
+    AlgorithmIdentifier, Version,
+};
 
 use alloc::vec::Vec;
 
 use der::asn1::BitString;
 use der::{Sequence, ValueOrd};
-use spki::AlgorithmIdentifierOwned;
 
 /// `CertificateList` as defined in [RFC 5280 Section 5.1].
 ///
@@ -28,7 +29,7 @@ use spki::AlgorithmIdentifierOwned;
 #[allow(missing_docs)]
 pub struct CertificateList<P: Profile = Rfc5280> {
     pub tbs_cert_list: TbsCertList<P>,
-    pub signature_algorithm: AlgorithmIdentifierOwned,
+    pub signature_algorithm: AlgorithmIdentifier,
     pub signature: BitString,
 }
 
@@ -77,7 +78,7 @@ pub struct RevokedCert<P: Profile = Rfc5280> {
 #[allow(missing_docs)]
 pub struct TbsCertList<P: Profile = Rfc5280> {
     pub version: Version,
-    pub signature: AlgorithmIdentifierOwned,
+    pub signature: AlgorithmIdentifier,
     pub issuer: Name,
     pub this_update: Time,
     pub next_update: Option<Time>,

--- a/x509-cert/src/lib.rs
+++ b/x509-cert/src/lib.rs
@@ -39,3 +39,7 @@ pub mod builder;
 pub use certificate::{Certificate, PkiPath, TbsCertificate, Version};
 pub use der;
 pub use spki;
+pub use spki::{
+    AlgorithmIdentifierOwned as AlgorithmIdentifier,
+    SubjectPublicKeyInfoOwned as SubjectPublicKeyInfo,
+};

--- a/x509-cert/src/request.rs
+++ b/x509-cert/src/request.rs
@@ -4,6 +4,7 @@ use crate::{
     attr::{Attribute, AttributeValue, Attributes},
     ext::Extension,
     name::Name,
+    AlgorithmIdentifier, SubjectPublicKeyInfo,
 };
 
 use alloc::vec::Vec;
@@ -14,7 +15,6 @@ use der::{
     asn1::{Any, BitString, SetOfVec},
     Decode, Enumerated, Sequence,
 };
-use spki::{AlgorithmIdentifierOwned, SubjectPublicKeyInfoOwned};
 
 #[cfg(feature = "pem")]
 use der::pem::PemLabel;
@@ -52,7 +52,7 @@ pub struct CertReqInfo {
     pub subject: Name,
 
     /// Subject public key info.
-    pub public_key: SubjectPublicKeyInfoOwned,
+    pub public_key: SubjectPublicKeyInfo,
 
     /// Request attributes.
     #[asn1(context_specific = "0", tag_mode = "IMPLICIT")]
@@ -76,7 +76,7 @@ pub struct CertReq {
     pub info: CertReqInfo,
 
     /// Signature algorithm identifier.
-    pub algorithm: AlgorithmIdentifierOwned,
+    pub algorithm: AlgorithmIdentifier,
 
     /// Signature.
     pub signature: BitString,

--- a/x509-cert/tests/builder.rs
+++ b/x509-cert/tests/builder.rs
@@ -10,7 +10,7 @@ use rand::rngs::OsRng;
 use rsa::pkcs1::DecodeRsaPrivateKey;
 use rsa::pkcs1v15::SigningKey;
 use sha2::Sha256;
-use spki::SubjectPublicKeyInfoOwned;
+use spki::SubjectPublicKeyInfo;
 use std::{str::FromStr, time::Duration};
 use x509_cert::{
     builder::{profile, AsyncBuilder, Builder, CertificateBuilder, RequestBuilder},
@@ -39,8 +39,7 @@ fn root_ca_certificate() {
         Name::from_str("CN=World domination corporation,O=World domination Inc,C=US").unwrap();
     let profile = profile::cabf::Root::new(false, subject).expect("create root profile");
 
-    let pub_key =
-        SubjectPublicKeyInfoOwned::try_from(RSA_2048_DER_EXAMPLE).expect("get rsa pub key");
+    let pub_key = SubjectPublicKeyInfo::try_from(RSA_2048_DER_EXAMPLE).expect("get rsa pub key");
 
     let signer = rsa_signer();
     let builder = CertificateBuilder::new(profile, serial_number, validity, pub_key)
@@ -63,8 +62,7 @@ fn root_ca_certificate_ecdsa() {
     let subject =
         Name::from_str("CN=World domination corporation,O=World domination Inc,C=US").unwrap();
     let profile = profile::cabf::Root::new(false, subject).expect("create root profile");
-    let pub_key =
-        SubjectPublicKeyInfoOwned::try_from(PKCS8_PUBLIC_KEY_DER).expect("get ecdsa pub key");
+    let pub_key = SubjectPublicKeyInfo::try_from(PKCS8_PUBLIC_KEY_DER).expect("get ecdsa pub key");
 
     let signer = ecdsa_signer();
     let builder = CertificateBuilder::new(profile, serial_number, validity, pub_key)
@@ -96,8 +94,7 @@ fn sub_ca_certificate() {
         emits_ocsp_response: true,
     };
 
-    let pub_key =
-        SubjectPublicKeyInfoOwned::try_from(RSA_2048_DER_EXAMPLE).expect("get rsa pub key");
+    let pub_key = SubjectPublicKeyInfo::try_from(RSA_2048_DER_EXAMPLE).expect("get rsa pub key");
 
     let signer = ecdsa_signer();
     let builder = CertificateBuilder::new(profile, serial_number, validity, pub_key)
@@ -144,8 +141,7 @@ fn leaf_certificate() {
         enable_data_encipherment: false,
     };
 
-    let pub_key =
-        SubjectPublicKeyInfoOwned::try_from(RSA_2048_DER_EXAMPLE).expect("get rsa pub key");
+    let pub_key = SubjectPublicKeyInfo::try_from(RSA_2048_DER_EXAMPLE).expect("get rsa pub key");
 
     let signer = ecdsa_signer();
     let builder =
@@ -208,8 +204,7 @@ fn pss_certificate() {
         enable_data_encipherment: false,
     };
 
-    let pub_key =
-        SubjectPublicKeyInfoOwned::try_from(RSA_2048_DER_EXAMPLE).expect("get rsa pub key");
+    let pub_key = SubjectPublicKeyInfo::try_from(RSA_2048_DER_EXAMPLE).expect("get rsa pub key");
 
     let signer = rsa_pss_signer();
     let builder = CertificateBuilder::new(profile, serial_number, validity, pub_key)
@@ -343,8 +338,7 @@ async fn async_builder() {
         Name::from_str("CN=World domination corporation,O=World domination Inc,C=US").unwrap();
     let profile = profile::cabf::Root::new(false, subject).expect("create root profile");
 
-    let pub_key =
-        SubjectPublicKeyInfoOwned::try_from(PKCS8_PUBLIC_KEY_DER).expect("get ecdsa pub key");
+    let pub_key = SubjectPublicKeyInfo::try_from(PKCS8_PUBLIC_KEY_DER).expect("get ecdsa pub key");
 
     let signer = ecdsa_signer();
     let builder = CertificateBuilder::new(profile, serial_number, validity, pub_key)


### PR DESCRIPTION
Re-exports the following with shorter names:
- `spki::AlgorithmIdentifierOwned` => `x509_cert::AlgorithmIdentifier`
- `spki::SubjectPublicKeyInfoOwned` => `x509_cert::SubjectPublicKeyInfo`

These names are already quite long to begin with even without the `*Owned` suffix.

The `x509-cert` crate has a hard dependency on `alloc` and always uses the `*Owned` types, so this allows for more convenient names in this scenario.