### PR TITLE
const-oid: remove `std` feature; MSRV 1.81

### DIFF
--- a/.github/workflows/const-oid.yml
+++ b/.github/workflows/const-oid.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.71.0 # MSRV
+          - 1.81.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -40,14 +40,14 @@ jobs:
   minimal-versions:
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
     with:
-        working-directory: ${{ github.workflow }}
+      working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         rust:
-          - 1.71.0 # MSRV
+          - 1.81.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/der.yml
+++ b/.github/workflows/der.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.71.0 # MSRV
+          - 1.81.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -52,7 +52,7 @@ jobs:
           # 32-bit Linux
           - targets: i686-unknown-linux-gnu
             platform: ubuntu-latest
-            rust: 1.71.0 # MSRV
+            rust: 1.81.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - targets: i686-unknown-linux-gnu
             platform: ubuntu-latest
@@ -62,7 +62,7 @@ jobs:
           # 64-bit Linux
           - targets: x86_64-unknown-linux-gnu
             platform: ubuntu-latest
-            rust: 1.71.0 # MSRV
+            rust: 1.81.0 # MSRV
           - targets: x86_64-unknown-linux-gnu
             platform: ubuntu-latest
             rust: stable
@@ -71,7 +71,7 @@ jobs:
           # 64-bit Windows
           #- targets: x86_64-pc-windows-msvc
           #  platform: windows-latest
-          #  rust: 1.71.0 # MSRV
+          #  rust: 1.81.0 # MSRV
           #- targets: x86_64-pc-windows-msvc
           #  platform: windows-latest
           #  rust: stable
@@ -91,7 +91,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.71.0 # MSRV
+          - 1.81.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/const-oid/Cargo.toml
+++ b/const-oid/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["cryptography", "data-structures", "encoding", "no-std", "parser-i
 keywords = ["iso", "iec", "itu", "oid"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.71"
+rust-version = "1.81"
 
 [dependencies]
 arbitrary = { version = "1.2", optional = true, features = ["derive"] }
@@ -25,7 +25,6 @@ hex-literal = "0.4"
 
 [features]
 db = []
-std = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/const-oid/README.md
+++ b/const-oid/README.md
@@ -57,7 +57,7 @@ well as a runtime OID library.
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.71** at a minimum.
+This crate requires **Rust 1.81** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -84,7 +84,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/const-oid/badge.svg
 [docs-link]: https://docs.rs/const-oid/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.71+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.81+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 [build-image]: https://github.com/RustCrypto/formats/workflows/const-oid/badge.svg?branch=master&event=push

--- a/const-oid/src/error.rs
+++ b/const-oid/src/error.rs
@@ -74,5 +74,4 @@ impl fmt::Display for Error {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}

--- a/const-oid/src/lib.rs
+++ b/const-oid/src/lib.rs
@@ -19,9 +19,6 @@
     unused_qualifications
 )]
 
-#[cfg(feature = "std")]
-extern crate std;
-
 #[macro_use]
 mod checked;
 

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["cryptography", "data-structures", "encoding", "no-std", "parser-i
 keywords = ["asn1", "crypto", "itu", "pkcs"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.71"
+rust-version = "1.81"
 
 [dependencies]
 arbitrary = { version = "1.3", features = ["derive"], optional = true }

--- a/der/README.md
+++ b/der/README.md
@@ -49,7 +49,7 @@ encountered. There is currently no way to disable these checks.
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.71** at a minimum.
+This crate requires **Rust 1.81** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -78,7 +78,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/formats/actions/workflows/der.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/formats/actions/workflows/der.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.71+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.81+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 

--- a/der/src/reader/slice.rs
+++ b/der/src/reader/slice.rs
@@ -130,9 +130,8 @@ impl<'a> Reader<'a> for SliceReader<'a> {
             return Err(self.error(ErrorKind::Failed).into());
         }
 
-        T::decode(self).map_err(|e| {
+        T::decode(self).inspect_err(|_| {
             self.failed = true;
-            e
         })
     }
 

--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -41,7 +41,7 @@ x509-cert-test-support = { path = "./test-support" }
 
 [features]
 default = ["pem", "std"]
-std = ["const-oid/std", "der/std", "spki/std", "tls_codec?/std"]
+std = ["der/std", "spki/std", "tls_codec?/std"]
 
 arbitrary = ["dep:arbitrary", "std", "der/arbitrary", "spki/arbitrary"]
 builder = ["async-signature", "std", "sha1/default", "signature"]


### PR DESCRIPTION
Leverages stable support for `core::error::Error` in lieu of `std::error::Error`.

Since this was the only usage of `std`, also removes the `std` feature.