### PR TITLE
der: use `core::error::Error`

### DIFF
--- a/der/src/error.rs
+++ b/der/src/error.rs
@@ -70,8 +70,7 @@ impl Error {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
Allows the `Error` trait to be used on `no_std` platforms