### PR TITLE
chore(deps): bump rsa from 0.10.0-pre.2 to 0.10.0-pre.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1321,8 +1321,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.10.0-pre.2"
-source = "git+https://github.com/RustCrypto/RSA#aeedb5adf5297892fcb9e11f7c0f6c0157005c58"
+version = "0.10.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07058e83b684989ab0559f9e22322f4e3f7e49147834ed0bae40486b9e70473c"
 dependencies = [
  "const-oid",
  "digest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,3 @@ tls_codec_derive = { path = "./tls_codec/derive" }
 x509-tsp = { path = "./x509-tsp" }
 x509-cert = { path = "./x509-cert" }
 x509-ocsp = { path = "./x509-ocsp" }
-
-# Temp patches to external crates
-rsa = { git = "https://github.com/RustCrypto/RSA" }

--- a/cms/Cargo.toml
+++ b/cms/Cargo.toml
@@ -25,7 +25,7 @@ aes = { version = "=0.9.0-pre.2", optional = true }
 async-signature = { version = "=0.6.0-pre.4", features = ["digest", "rand_core"], optional = true }
 cbc = { version = "=0.2.0-pre.2", optional = true }
 cipher = { version = "=0.5.0-pre.7", features = ["alloc", "block-padding", "rand_core"], optional = true }
-rsa = { version = "=0.10.0-pre.2", optional = true }
+rsa = { version = "=0.10.0-pre.3", optional = true }
 sha1 = { version = "=0.11.0-pre.4", optional = true }
 sha2 = { version = "=0.11.0-pre.4", optional = true }
 sha3 = { version = "=0.11.0-pre.4", optional = true }
@@ -38,7 +38,7 @@ hex-literal = "0.4"
 pem-rfc7468 = "1.0.0-rc.1"
 pkcs5 = "0.8.0-rc.1"
 rand = "0.8.5"
-rsa = { version = "=0.10.0-pre.2", features = ["sha2"] }
+rsa = { version = "=0.10.0-pre.3", features = ["sha2"] }
 ecdsa = { version = "=0.17.0-pre.9", features = ["digest", "pem"] }
 p256 = "=0.14.0-pre.2"
 tokio = { version = "1.40.0", features = ["macros", "rt"] }

--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -30,7 +30,7 @@ tls_codec = { version = "0.4.0", default-features = false, features = ["derive"]
 [dev-dependencies]
 hex-literal = "0.4"
 rand = "0.8.5"
-rsa = { version = "=0.10.0-pre.2", features = ["sha2"] }
+rsa = { version = "=0.10.0-pre.3", features = ["sha2"] }
 ecdsa = { version = "=0.17.0-pre.9", features = ["digest", "pem"] }
 p256 = "=0.14.0-pre.2"
 rstest = "0.23"

--- a/x509-ocsp/Cargo.toml
+++ b/x509-ocsp/Cargo.toml
@@ -30,7 +30,7 @@ signature = { version = "=2.3.0-pre.4", optional = true, default-features = fals
 hex-literal = "0.4.1"
 lazy_static = "1.5.0"
 rand = "0.8.5"
-rsa = { version = "=0.10.0-pre.2", default-features = false, features = ["sha2"] }
+rsa = { version = "=0.10.0-pre.3", default-features = false, features = ["sha2"] }
 sha1 = { version = "=0.11.0-pre.4", default-features = false, features = ["oid"] }
 sha2 = { version = "=0.11.0-pre.4", default-features = false, features = ["oid"] }
 


### PR DESCRIPTION
This removes a git dependencies that was introduced when we broke `pkcs8` API.