### PR TITLE
der_derive: use `TryFrom` conversions for `asn1(type = ...)`

### DIFF
--- a/der/src/asn1/ia5_string.rs
+++ b/der/src/asn1/ia5_string.rs
@@ -137,15 +137,21 @@ mod allocation {
     }
 
     impl<'a> From<Ia5StringRef<'a>> for Ia5String {
-        fn from(international_string: Ia5StringRef<'a>) -> Ia5String {
-            let inner = international_string.inner.into();
+        fn from(ia5_string: Ia5StringRef<'a>) -> Ia5String {
+            let inner = ia5_string.inner.into();
             Self { inner }
         }
     }
 
     impl<'a> From<&'a Ia5String> for AnyRef<'a> {
-        fn from(international_string: &'a Ia5String) -> AnyRef<'a> {
-            AnyRef::from_tag_and_value(Tag::Ia5String, (&international_string.inner).into())
+        fn from(ia5_string: &'a Ia5String) -> AnyRef<'a> {
+            AnyRef::from_tag_and_value(Tag::Ia5String, (&ia5_string.inner).into())
+        }
+    }
+
+    impl<'a> From<&'a Ia5String> for Ia5StringRef<'a> {
+        fn from(ia5_string: &'a Ia5String) -> Ia5StringRef<'a> {
+            ia5_string.owned_to_ref()
         }
     }
 

--- a/der/src/asn1/octet_string.rs
+++ b/der/src/asn1/octet_string.rs
@@ -96,6 +96,14 @@ impl<'a> From<OctetStringRef<'a>> for &'a [u8] {
     }
 }
 
+impl<'a> TryFrom<&'a [u8]> for OctetStringRef<'a> {
+    type Error = Error;
+
+    fn try_from(byte_slice: &'a [u8]) -> Result<Self, Error> {
+        OctetStringRef::new(byte_slice)
+    }
+}
+
 #[cfg(feature = "alloc")]
 pub use self::allocating::OctetString;
 

--- a/der/src/asn1/printable_string.rs
+++ b/der/src/asn1/printable_string.rs
@@ -204,6 +204,12 @@ mod allocation {
         }
     }
 
+    impl<'a> From<&'a PrintableString> for PrintableStringRef<'a> {
+        fn from(printable_string: &'a PrintableString) -> PrintableStringRef<'a> {
+            printable_string.owned_to_ref()
+        }
+    }
+
     impl<'a> RefToOwned<'a> for PrintableStringRef<'a> {
         type Owned = PrintableString;
         fn ref_to_owned(&self) -> Self::Owned {

--- a/der/src/asn1/teletex_string.rs
+++ b/der/src/asn1/teletex_string.rs
@@ -166,6 +166,12 @@ mod allocation {
         }
     }
 
+    impl<'a> From<&'a TeletexString> for TeletexStringRef<'a> {
+        fn from(teletex_string: &'a TeletexString) -> TeletexStringRef<'a> {
+            teletex_string.owned_to_ref()
+        }
+    }
+
     impl<'a> RefToOwned<'a> for TeletexStringRef<'a> {
         type Owned = TeletexString;
         fn ref_to_owned(&self) -> Self::Owned {

--- a/der/src/asn1/utf8_string.rs
+++ b/der/src/asn1/utf8_string.rs
@@ -68,6 +68,14 @@ impl<'a> From<Utf8StringRef<'a>> for AnyRef<'a> {
     }
 }
 
+impl<'a> TryFrom<&'a str> for Utf8StringRef<'a> {
+    type Error = Error;
+
+    fn try_from(s: &'a str) -> Result<Self> {
+        Self::new(s)
+    }
+}
+
 impl<'a> fmt::Debug for Utf8StringRef<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Utf8String({:?})", self.as_str())
@@ -111,6 +119,15 @@ impl<'a> TryFrom<AnyRef<'a>> for String {
 
     fn try_from(any: AnyRef<'a>) -> Result<String> {
         Utf8StringRef::try_from(any).map(|s| s.as_str().to_owned())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a> TryFrom<&'a String> for Utf8StringRef<'a> {
+    type Error = Error;
+
+    fn try_from(s: &'a String) -> Result<Self> {
+        Self::new(s.as_str())
     }
 }
 

--- a/der_derive/src/asn1_type.rs
+++ b/der_derive/src/asn1_type.rs
@@ -77,7 +77,7 @@ impl Asn1Type {
             | Asn1Type::PrintableString
             | Asn1Type::TeletexString
             | Asn1Type::VideotexString
-            | Asn1Type::Utf8String => quote!(#type_path::new(#binding)?),
+            | Asn1Type::Utf8String => quote!(#type_path::try_from(#binding)?),
             _ => quote!(#type_path::try_from(#binding)?),
         }
     }

--- a/der_derive/src/choice/variant.rs
+++ b/der_derive/src/choice/variant.rs
@@ -225,7 +225,7 @@ mod tests {
         assert_eq!(
             variant.to_encode_value_tokens().to_string(),
             quote! {
-                Self::ExampleVariant(variant) => ::der::asn1::Utf8StringRef::new(variant)?.encode_value(encoder),
+                Self::ExampleVariant(variant) => ::der::asn1::Utf8StringRef::try_from(variant)?.encode_value(encoder),
             }
             .to_string()
         );


### PR DESCRIPTION
Previously it was using `<asn1_type>::new`.

Using `TryFrom` is more flexible in terms of the possible conversions that it permits.

Also fills out the missing `From`/`TryFrom` conversions needed for the existing crates in this repo (most notably `x509-cert` to compile with the changes).