### PR TITLE
cms: remove `alloc` feature

### DIFF
--- a/cms/Cargo.toml
+++ b/cms/Cargo.toml
@@ -45,7 +45,6 @@ tokio = { version = "1.40.0", features = ["macros", "rt"] }
 x509-cert = { version = "=0.3.0-pre.0", features = ["pem"] }
 
 [features]
-alloc = ["der/alloc"]
 std = ["der/std", "spki/std"]
 builder = ["aes", "async-signature", "cbc", "cipher", "rsa", "sha1", "sha2", "sha3", "signature", "std", "spki/alloc", "x509-cert/builder", "zeroize"]
 

--- a/x509-tsp/Cargo.toml
+++ b/x509-tsp/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.81"
 
 [dependencies]
 der = { version = "0.8.0-rc.0", features = ["alloc", "derive", "oid", "pem"] }
-cms = { version = "=0.3.0-pre.0", features = ["alloc"] }
+cms = { version = "=0.3.0-pre.0" }
 cmpv2 = { version = "=0.3.0-pre.0", features = ["alloc"] }
 x509-cert = { version = "=0.3.0-pre.0", default-features = false }
 


### PR DESCRIPTION
The crate has a hard dependency on liballoc, so it shouldn't be feature-gated