### PR TITLE
CI: disable `security-audit` cache

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -21,10 +21,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-      - uses: actions/cache@v4
-        with:
-          path: ~/.cargo/bin
-          key: ${{ runner.os }}-cargo-audit-v0.20
+      # TODO(tarcieri): investigate why cached binaries aren't working
+      #- uses: actions/cache@v4
+      #  with:
+      #    path: ~/.cargo/bin
+      #    key: ${{ runner.os }}-cargo-audit-v0.20
       - uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We're encountering errors like:

      /home/runner/.cargo/bin/cargo-audit: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by /home/runner/.cargo/bin/cargo-audit)

These are occurring even with freshly-built binaries.

To avoid blocking PRs, temporarily disable the build cache until we have time to properly investigate.