### PR TITLE
base64ct: derive additional traits on alphabets

### DIFF
--- a/base64ct/src/alphabet/bcrypt.rs
+++ b/base64ct/src/alphabet/bcrypt.rs
@@ -8,7 +8,7 @@ use super::{Alphabet, DecodeStep, EncodeStep};
 /// ./         [A-Z]      [a-z]     [0-9]
 /// 0x2e-0x2f, 0x41-0x5a, 0x61-0x7a, 0x30-0x39
 /// ```
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Base64Bcrypt;
 
 impl Alphabet for Base64Bcrypt {

--- a/base64ct/src/alphabet/crypt.rs
+++ b/base64ct/src/alphabet/crypt.rs
@@ -8,7 +8,7 @@ use super::{Alphabet, DecodeStep, EncodeStep};
 /// [.-9]      [A-Z]      [a-z]
 /// 0x2e-0x39, 0x41-0x5a, 0x61-0x7a
 /// ```
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Base64Crypt;
 
 impl Alphabet for Base64Crypt {

--- a/base64ct/src/alphabet/shacrypt.rs
+++ b/base64ct/src/alphabet/shacrypt.rs
@@ -12,7 +12,7 @@ use super::{Alphabet, DecodeStep, EncodeStep};
 /// [.-9]      [A-Z]      [a-z]
 /// 0x2e-0x39, 0x41-0x5a, 0x61-0x7a
 /// ```
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Base64ShaCrypt;
 
 impl Alphabet for Base64ShaCrypt {

--- a/base64ct/src/alphabet/standard.rs
+++ b/base64ct/src/alphabet/standard.rs
@@ -8,7 +8,7 @@ use super::{Alphabet, DecodeStep, EncodeStep};
 /// [A-Z]      [a-z]      [0-9]      +     /
 /// 0x41-0x5a, 0x61-0x7a, 0x30-0x39, 0x2b, 0x2f
 /// ```
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Base64;
 
 impl Alphabet for Base64 {
@@ -25,7 +25,7 @@ impl Alphabet for Base64 {
 /// [A-Z]      [a-z]      [0-9]      +     /
 /// 0x41-0x5a, 0x61-0x7a, 0x30-0x39, 0x2b, 0x2f
 /// ```
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Base64Unpadded;
 
 impl Alphabet for Base64Unpadded {

--- a/base64ct/src/alphabet/url.rs
+++ b/base64ct/src/alphabet/url.rs
@@ -8,7 +8,7 @@ use super::{Alphabet, DecodeStep, EncodeStep};
 /// [A-Z]      [a-z]      [0-9]      -     _
 /// 0x41-0x5a, 0x61-0x7a, 0x30-0x39, 0x2d, 0x5f
 /// ```
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Base64Url;
 
 impl Alphabet for Base64Url {
@@ -25,7 +25,7 @@ impl Alphabet for Base64Url {
 /// [A-Z]      [a-z]      [0-9]      -     _
 /// 0x41-0x5a, 0x61-0x7a, 0x30-0x39, 0x2d, 0x5f
 /// ```
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Base64UrlUnpadded;
 
 impl Alphabet for Base64UrlUnpadded {


### PR DESCRIPTION
This PR will implement all derivable std-traits mentioned in [C-COMMON-TRAITS](https://rust-lang.github.io/api-guidelines/interoperability.html) for base64-alphabets. This allows using these types e.g. as `PhantomData<E> where E: Encoding` and derive `PartialOrd` for the container-type. These alphabet-types are unit-structs, so there is not really a reason not to derive everything possible to make them more usable.