### PR TITLE
Add new action to update leap seconds automatically

### DIFF
--- a/.github/workflows/tai64_update_leap_seconds.yml
+++ b/.github/workflows/tai64_update_leap_seconds.yml
@@ -1,0 +1,27 @@
+name: Update Leap Seconds
+on:
+  schedule:
+    - cron: 0 0 * * 1
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Update leap seconds in code
+        run: |
+          curl -o leap_seconds_list -L https://data.iana.org/time-zones/data/leap-seconds.list
+          number=$(grep -v '^#' leap_seconds_list | tail -n1 | awk '{print $2}')
+          sed -i "s/\(1970-01-01 00:00:\)[0-9]\+ TAI/\1${number} TAI/" tai64/src/lib.rs
+          sed -i -E 's/(Self\()[0-9]+ \+ \(1 << 62\)\)/\1'"${number}"' + (1 << 62))/' tai64/src/lib.rs
+          rm leap_seconds_list
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: update leap seconds in tai64
+          title: Update leap seconds in tai64
+          body: 'Following this source: https://data.iana.org/time-zones/data/leap-seconds.list, the leap seconds counter has been updated.'
+          branch: update-leap-seconds
+          base: master

--- a/.github/workflows/tai64_update_leap_seconds.yml
+++ b/.github/workflows/tai64_update_leap_seconds.yml
@@ -25,3 +25,4 @@ jobs:
           body: 'Following this source: https://data.iana.org/time-zones/data/leap-seconds.list, the leap seconds counter has been updated.'
           branch: update-leap-seconds
           base: master
+          delete-branch: true

--- a/tai64/src/lib.rs
+++ b/tai64/src/lib.rs
@@ -36,8 +36,8 @@ const NANOS_PER_SECOND: u32 = 1_000_000_000;
 pub struct Tai64(pub u64);
 
 impl Tai64 {
-    /// Unix epoch in `TAI64`: 1970-01-01 00:00:10 TAI.
-    pub const UNIX_EPOCH: Self = Self(10 + (1 << 62));
+    /// Unix epoch in `TAI64`: 1970-01-01 00:00:37 TAI.
+    pub const UNIX_EPOCH: Self = Self(37 + (1 << 62));
 
     /// Length of serialized `TAI64` timestamp in bytes.
     pub const BYTE_SIZE: usize = 8;
@@ -151,7 +151,7 @@ impl Zeroize for Tai64N {
 }
 
 impl Tai64N {
-    /// Unix epoch in `TAI64N`: 1970-01-01 00:00:10 TAI.
+    /// Unix epoch in `TAI64N`: 1970-01-01 00:00:37 TAI.
     pub const UNIX_EPOCH: Self = Self(Tai64::UNIX_EPOCH, 0);
 
     /// Length of serialized `TAI64N` timestamp.


### PR DESCRIPTION
Resolves : https://github.com/RustCrypto/formats/issues/675

This PR adds a github actions that runs each week, to check for the leap seconds change in a reputable source and creates a PR to update if necessary.

The PR doesn't contains the process to release automatically as the process could change and maybe we don't want to directly change the version and make the release.

This current PR also include the changes to start with the current value 37 seconds.
Here is some tests I did on a fork : https://github.com/AurelienFT/formats/actions/runs/11470018305/job/31918401654 / https://github.com/AurelienFT/formats/pull/5/files

It could be nice to release a new major this time to have the correct time available for everyone.