### PR TITLE
tai64: v4.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1626,7 +1626,7 @@ dependencies = [
 
 [[package]]
 name = "tai64"
-version = "5.0.0-pre"
+version = "4.1.0"
 dependencies = [
  "serde",
  "zeroize",

--- a/tai64/CHANGELOG.md
+++ b/tai64/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 4.1.0 (2024-10-29)
+
+### Changed
+- MSRV bump from 1.56 to 1.60 ([#802])
+
+### Fixed
+- fix TAI offset and verify with GH Action ([#1583])
+
+[#802]: https://github.com/RustCrypto/formats/pull/802
+[#1583]: https://github.com/RustCrypto/formats/pull/1583
+
 ## 4.0.0 (2021-11-04)
 ### Changed
 - Upgrade to Rust 2021 edition; MSRV 1.56+

--- a/tai64/Cargo.toml
+++ b/tai64/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tai64"
 description = "TAI64 and TAI64N (i.e. Temps Atomique International) timestamp support for Rust"
-version = "5.0.0-pre"
+version = "4.1.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 homepage = "https://github.com/RustCrypto/formats/tree/master/tai64"


### PR DESCRIPTION
Fixed:
- fix TAI offset and verify with GH Action (#1583)

Changed:
- MSRV bump from 1.56 to 1.60 (#802)