### PR TITLE
const-oid: handle repeated dot characters in input

### DIFF
--- a/const-oid/src/error.rs
+++ b/const-oid/src/error.rs
@@ -37,6 +37,9 @@ pub enum Error {
     /// OID length is invalid (too short or too long).
     Length,
 
+    /// Repeated `..` characters in input data.
+    RepeatedDot,
+
     /// Trailing `.` character at end of input.
     TrailingDot,
 }
@@ -53,6 +56,7 @@ impl Error {
             Error::DigitExpected { .. } => panic!("OID expected to start with digit"),
             Error::Empty => panic!("OID value is empty"),
             Error::Length => panic!("OID length invalid"),
+            Error::RepeatedDot => panic!("repeated consecutive '..' characters in OID"),
             Error::TrailingDot => panic!("OID ends with invalid trailing '.'"),
         }
     }
@@ -69,6 +73,7 @@ impl fmt::Display for Error {
             }
             Error::Empty => f.write_str("OID value is empty"),
             Error::Length => f.write_str("OID length invalid"),
+            Error::RepeatedDot => f.write_str("repeated consecutive '..' characters in OID"),
             Error::TrailingDot => f.write_str("OID ends with invalid trailing '.'"),
         }
     }

--- a/const-oid/tests/oid.rs
+++ b/const-oid/tests/oid.rs
@@ -242,6 +242,11 @@ fn parse_invalid_second_arc() {
 }
 
 #[test]
+fn parse_invalid_repeat_dots() {
+    assert_eq!(ObjectIdentifier::new("1.2..3.4"), Err(Error::RepeatedDot))
+}
+
+#[test]
 fn parent() {
     let child = oid("1.2.3.4");
     let parent = child.parent().unwrap();


### PR DESCRIPTION
Adds an `Error::RepeatedDot` case and handles it within the parser