### PR TITLE
const-oid: elimiate arithmetic side effects in arc encoder

### DIFF
--- a/const-oid/src/parser.rs
+++ b/const-oid/src/parser.rs
@@ -59,6 +59,7 @@ impl Parser {
                     None => 0,
                 };
 
+                // TODO(tarcieri): use `and_then` when const traits are stable
                 self.current_arc = match arc.checked_mul(10) {
                     Some(arc) => match arc.checked_add(digit as Arc) {
                         None => return Err(Error::ArcTooBig),


### PR DESCRIPTION
Ensures overflow will always cause a panic instead