### PR TITLE
const-oid: replace panics with `checked_*!` macros

### DIFF
--- a/const-oid/src/checked.rs
+++ b/const-oid/src/checked.rs
@@ -10,10 +10,20 @@ macro_rules! checked_add {
     };
 }
 
-/// `const fn`-friendly checked addition helper.
+/// `const fn`-friendly checked subtraction helper.
 macro_rules! checked_sub {
     ($a:expr, $b:expr) => {
         match $a.checked_sub($b) {
+            Some(n) => n,
+            None => return Err(Error::Overflow),
+        }
+    };
+}
+
+/// `const fn`-friendly checked multiplication helper.
+macro_rules! checked_mul {
+    ($a:expr, $b:expr) => {
+        match $a.checked_mul($b) {
             Some(n) => n,
             None => return Err(Error::Overflow),
         }

--- a/const-oid/src/error.rs
+++ b/const-oid/src/error.rs
@@ -38,6 +38,8 @@ pub enum Error {
     Length,
 
     /// Arithmetic overflow (or underflow) errors.
+    ///
+    /// These generally indicate a bug in the `const-oid` crate.
     Overflow,
 
     /// Repeated `..` characters in input data.


### PR DESCRIPTION
Returns `Error::Overflow` if any operations overflow