### PR TITLE
chrore: fixup rust 1.83 formatting

### DIFF
--- a/der/src/referenced.rs
+++ b/der/src/referenced.rs
@@ -38,7 +38,10 @@ impl<T> OwnedToRef for Option<T>
 where
     T: OwnedToRef,
 {
-    type Borrowed<'a> = Option<T::Borrowed<'a>> where T: 'a;
+    type Borrowed<'a>
+        = Option<T::Borrowed<'a>>
+    where
+        T: 'a;
 
     fn owned_to_ref(&self) -> Self::Borrowed<'_> {
         self.as_ref().map(|o| o.owned_to_ref())


### PR DESCRIPTION
Rust 1.83 has new suggestion on the formatting of code.

This fixes the CI.