### PR TITLE
der: forward std feature to pem

### DIFF
--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -32,7 +32,7 @@ proptest = "1"
 
 [features]
 alloc = ["zeroize?/alloc"]
-std = ["alloc"]
+std = ["alloc", "pem-rfc7468?/std"]
 
 arbitrary = ["dep:arbitrary", "const-oid?/arbitrary", "std"]
 bytes = ["dep:bytes", "alloc"]


### PR DESCRIPTION
This brings `std::error:Error` for `pem::error::Error`