### PR TITLE
pkcs5: fix type annotation required error

### DIFF
--- a/pkcs5/src/pbes2/encryption.rs
+++ b/pkcs5/src/pbes2/encryption.rs
@@ -178,7 +178,7 @@ impl EncryptionKey {
     pub fn derive_from_password(password: &[u8], kdf: &Kdf, key_size: usize) -> Result<Self> {
         // if the kdf params defined a key length, ensure it matches the required key size
         if let Some(len) = kdf.key_length() {
-            if key_size != len.into() {
+            if key_size != len as usize {
                 return Err(kdf.to_alg_params_invalid());
             }
         }

--- a/pkcs5/src/pbes2/encryption.rs
+++ b/pkcs5/src/pbes2/encryption.rs
@@ -178,7 +178,7 @@ impl EncryptionKey {
     pub fn derive_from_password(password: &[u8], kdf: &Kdf, key_size: usize) -> Result<Self> {
         // if the kdf params defined a key length, ensure it matches the required key size
         if let Some(len) = kdf.key_length() {
-            if key_size != len as usize {
+            if key_size != usize::from(len) {
                 return Err(kdf.to_alg_params_invalid());
             }
         }


### PR DESCRIPTION
Fixes https://github.com/RustCrypto/formats/issues/1624

Without digging into why the error occurs, this seems to fix the error, and it seems safe to do the conversion in this instance. 