### PR TITLE
serdect v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,7 +605,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1394,7 +1394,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "serdect"
-version = "0.3.0-rc.0"
+version = "0.3.0"
 dependencies = [
  "base16ct",
  "bincode",
@@ -1656,7 +1656,7 @@ dependencies = [
  "fastrand",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1878,7 +1878,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/serdect/CHANGELOG.md
+++ b/serdect/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2025-01-06)
+
+NOTE: this release includes major breaking changes to the wire format, namely
+all bytestrings now include a length prefix, even when serializing fixed-size
+arrays. This is intended to work around deficiencies in the `serde` API
+(see serde-rs/serde#2120) as well as serde-based format implementations which
+have variable-time behavior when using `serialize_tuple`.
+
+Any binary data serialized with previous versions of `serdect` now needs a
+length prefix prepended to the data, which will vary depending on the
+particular data format.
+
+### Changed
+- Switch to length-prefixed encoding using the `serialize_bytes` method ([#1112], [#1515])
+- MSRV 1.70 ([#1244])
+
+[#1112]: https://github.com/RustCrypto/formats/pull/1112
+[#1515]: https://github.com/RustCrypto/formats/pull/1515
+[#1244]: https://github.com/RustCrypto/formats/pull/1244
+
 ## 0.2.0 (2023-02-26)
 ### Changed
 - MSRV 1.60 ([#802])

--- a/serdect/Cargo.toml
+++ b/serdect/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Constant-time serde serializer/deserializer helpers for data that potentially
 contains secrets (e.g. cryptographic keys)
 """
-version = "0.3.0-rc.0"
+version = "0.3.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 homepage = "https://github.com/RustCrypto/formats/tree/master/serdect"
@@ -19,7 +19,7 @@ rust-version = "1.70"
 base16ct = { version = "0.2", default-features = false }
 serde = { version = "1.0.184", default-features = false }
 
-# optional features
+# optional featuresw
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/serdect/src/common.rs
+++ b/serdect/src/common.rs
@@ -7,7 +7,7 @@ use serde::{
 };
 
 #[cfg(feature = "alloc")]
-use ::{alloc::vec::Vec, serde::Serialize};
+use {alloc::vec::Vec, serde::Serialize};
 
 #[cfg(not(feature = "alloc"))]
 use serde::ser::Error as SerError;


### PR DESCRIPTION
NOTE: this release includes major breaking changes to the wire format, namely all bytestrings now include a length prefix, even when serializing fixed-size arrays. This is intended to work around deficiencies in the `serde` API (see serde-rs/serde#2120) as well as serde-based format implementations which have variable-time behavior when using `serialize_tuple`.

Any binary data serialized with previous versions of `serdect` now needs a length prefix prepended to the data, which will vary depending on the particular data format.

### Changed
- Switch to length-prefixed encoding using the `serialize_bytes` method ([#1112], [#1515])
- MSRV 1.70 ([#1244])

[#1112]: https://github.com/RustCrypto/formats/pull/1112
[#1515]: https://github.com/RustCrypto/formats/pull/1515
[#1244]: https://github.com/RustCrypto/formats/pull/1244