### PR TITLE
rust 1.83 clippy fixup

### DIFF
--- a/base64ct/src/decoder.rs
+++ b/base64ct/src/decoder.rs
@@ -253,7 +253,7 @@ impl<'i, E: Encoding> Decoder<'i, E> {
 }
 
 #[cfg(feature = "std")]
-impl<'i, E: Encoding> io::Read for Decoder<'i, E> {
+impl<E: Encoding> io::Read for Decoder<'_, E> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         if self.is_finished() {
             return Ok(0);
@@ -344,7 +344,7 @@ pub struct Line<'i> {
     remaining: &'i [u8],
 }
 
-impl<'i> Default for Line<'i> {
+impl Default for Line<'_> {
     fn default() -> Self {
         Self::new(&[])
     }

--- a/base64ct/src/encoder.rs
+++ b/base64ct/src/encoder.rs
@@ -166,7 +166,7 @@ impl<'o, E: Encoding> Encoder<'o, E> {
 }
 
 #[cfg(feature = "std")]
-impl<'o, E: Encoding> io::Write for Encoder<'o, E> {
+impl<E: Encoding> io::Write for Encoder<'_, E> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.encode(buf)?;
         Ok(buf.len())

--- a/cms/src/builder.rs
+++ b/cms/src/builder.rs
@@ -179,7 +179,7 @@ impl<'s> SignerInfoBuilder<'s> {
     }
 }
 
-impl<'s> Builder for SignerInfoBuilder<'s> {
+impl Builder for SignerInfoBuilder<'_> {
     type Output = SignerInfo;
 
     /// Calculate the data to be signed

--- a/const-oid/src/arcs.rs
+++ b/const-oid/src/arcs.rs
@@ -111,7 +111,7 @@ impl<'a> Arcs<'a> {
     }
 }
 
-impl<'a> Iterator for Arcs<'a> {
+impl Iterator for Arcs<'_> {
     type Item = Arc;
 
     fn next(&mut self) -> Option<Arc> {

--- a/const-oid/src/encoder.rs
+++ b/const-oid/src/encoder.rs
@@ -132,7 +132,7 @@ const fn base128_byte(arc: Arc, pos: usize, total: usize) -> Result<u8> {
     debug_assert!(pos < total);
     let last_byte = checked_add!(pos, 1) == total;
     let mask = if last_byte { 0 } else { 0b10000000 };
-    let shift = checked_sub!(checked_sub!(total, pos), 1) * 7;
+    let shift = checked_mul!(checked_sub!(checked_sub!(total, pos), 1), 7);
     Ok(((arc >> shift) & 0b1111111) as u8 | mask)
 }
 

--- a/crmf/src/pop.rs
+++ b/crmf/src/pop.rs
@@ -248,7 +248,7 @@ impl<'a> ::der::Decode<'a> for EncKeyWithIdChoice<'a> {
         }
     }
 }
-impl<'a> ::der::EncodeValue for EncKeyWithIdChoice<'a> {
+impl ::der::EncodeValue for EncKeyWithIdChoice<'_> {
     fn encode_value(&self, encoder: &mut impl ::der::Writer) -> ::der::Result<()> {
         match self {
             Self::String(variant) => variant.encode_value(encoder),

--- a/der/src/arrayvec.rs
+++ b/der/src/arrayvec.rs
@@ -125,7 +125,7 @@ impl<'a, T> Iterator for Iter<'a, T> {
     }
 }
 
-impl<'a, T> ExactSizeIterator for Iter<'a, T> {}
+impl<T> ExactSizeIterator for Iter<'_, T> {}
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]

--- a/der/src/asn1/bit_string.rs
+++ b/der/src/asn1/bit_string.rs
@@ -190,7 +190,7 @@ impl<'a> TryFrom<BitStringRef<'a>> for &'a [u8] {
     }
 }
 
-impl<'a> FixedTag for BitStringRef<'a> {
+impl FixedTag for BitStringRef<'_> {
     const TAG: Tag = Tag::BitString;
 }
 
@@ -401,7 +401,7 @@ pub struct BitStringIter<'a> {
     position: usize,
 }
 
-impl<'a> Iterator for BitStringIter<'a> {
+impl Iterator for BitStringIter<'_> {
     type Item = bool;
 
     #[allow(clippy::arithmetic_side_effects)]
@@ -417,13 +417,13 @@ impl<'a> Iterator for BitStringIter<'a> {
     }
 }
 
-impl<'a> ExactSizeIterator for BitStringIter<'a> {
+impl ExactSizeIterator for BitStringIter<'_> {
     fn len(&self) -> usize {
         self.bit_string.bit_len()
     }
 }
 
-impl<'a> FusedIterator for BitStringIter<'a> {}
+impl FusedIterator for BitStringIter<'_> {}
 
 #[cfg(feature = "flagset")]
 impl<T: flagset::Flags> FixedTag for flagset::FlagSet<T> {

--- a/der/src/asn1/context_specific.rs
+++ b/der/src/asn1/context_specific.rs
@@ -234,7 +234,7 @@ impl<'a, T> ContextSpecificRef<'a, T> {
     }
 }
 
-impl<'a, T> EncodeValue for ContextSpecificRef<'a, T>
+impl<T> EncodeValue for ContextSpecificRef<'_, T>
 where
     T: EncodeValue + Tagged,
 {
@@ -247,7 +247,7 @@ where
     }
 }
 
-impl<'a, T> Tagged for ContextSpecificRef<'a, T>
+impl<T> Tagged for ContextSpecificRef<'_, T>
 where
     T: Tagged,
 {

--- a/der/src/asn1/integer/int.rs
+++ b/der/src/asn1/integer/int.rs
@@ -151,7 +151,7 @@ impl<'a> DecodeValue<'a> for IntRef<'a> {
     }
 }
 
-impl<'a> EncodeValue for IntRef<'a> {
+impl EncodeValue for IntRef<'_> {
     fn value_len(&self) -> Result<Length> {
         // Signed integers always hold their full encoded form.
         Ok(self.inner.len())
@@ -168,11 +168,11 @@ impl<'a> From<&IntRef<'a>> for IntRef<'a> {
     }
 }
 
-impl<'a> FixedTag for IntRef<'a> {
+impl FixedTag for IntRef<'_> {
     const TAG: Tag = Tag::Integer;
 }
 
-impl<'a> OrdIsValueOrd for IntRef<'a> {}
+impl OrdIsValueOrd for IntRef<'_> {}
 
 #[cfg(feature = "alloc")]
 mod allocating {

--- a/der/src/asn1/integer/uint.rs
+++ b/der/src/asn1/integer/uint.rs
@@ -134,7 +134,7 @@ impl<'a> DecodeValue<'a> for UintRef<'a> {
     }
 }
 
-impl<'a> EncodeValue for UintRef<'a> {
+impl EncodeValue for UintRef<'_> {
     fn value_len(&self) -> Result<Length> {
         encoded_len(self.inner.as_slice())
     }
@@ -155,11 +155,11 @@ impl<'a> From<&UintRef<'a>> for UintRef<'a> {
     }
 }
 
-impl<'a> FixedTag for UintRef<'a> {
+impl FixedTag for UintRef<'_> {
     const TAG: Tag = Tag::Integer;
 }
 
-impl<'a> OrdIsValueOrd for UintRef<'a> {}
+impl OrdIsValueOrd for UintRef<'_> {}
 
 #[cfg(feature = "alloc")]
 mod allocating {

--- a/der/src/asn1/sequence_of.rs
+++ b/der/src/asn1/sequence_of.rs
@@ -127,7 +127,7 @@ impl<'a, T> Iterator for SequenceOfIter<'a, T> {
     }
 }
 
-impl<'a, T> ExactSizeIterator for SequenceOfIter<'a, T> {}
+impl<T> ExactSizeIterator for SequenceOfIter<'_, T> {}
 
 impl<'a, T, const N: usize> DecodeValue<'a> for [T; N]
 where

--- a/der/src/asn1/set_of.rs
+++ b/der/src/asn1/set_of.rs
@@ -193,7 +193,7 @@ impl<'a, T> Iterator for SetOfIter<'a, T> {
     }
 }
 
-impl<'a, T> ExactSizeIterator for SetOfIter<'a, T> {}
+impl<T> ExactSizeIterator for SetOfIter<'_, T> {}
 
 /// ASN.1 `SET OF` backed by a [`Vec`].
 ///

--- a/der/src/asn1/utf8_string.rs
+++ b/der/src/asn1/utf8_string.rs
@@ -76,7 +76,7 @@ impl<'a> TryFrom<&'a str> for Utf8StringRef<'a> {
     }
 }
 
-impl<'a> fmt::Debug for Utf8StringRef<'a> {
+impl fmt::Debug for Utf8StringRef<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Utf8String({:?})", self.as_str())
     }

--- a/der/src/asn1/videotex_string.rs
+++ b/der/src/asn1/videotex_string.rs
@@ -75,7 +75,7 @@ impl<'a> From<VideotexStringRef<'a>> for &'a [u8] {
     }
 }
 
-impl<'a> fmt::Debug for VideotexStringRef<'a> {
+impl fmt::Debug for VideotexStringRef<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "VideotexString({:?})", self.as_str())
     }

--- a/der/src/encode_ref.rs
+++ b/der/src/encode_ref.rs
@@ -8,13 +8,13 @@ use core::cmp::Ordering;
 /// type which impls the same.
 pub struct EncodeRef<'a, T>(pub &'a T);
 
-impl<'a, T> AsRef<T> for EncodeRef<'a, T> {
+impl<T> AsRef<T> for EncodeRef<'_, T> {
     fn as_ref(&self) -> &T {
         self.0
     }
 }
 
-impl<'a, T> Encode for EncodeRef<'a, T>
+impl<T> Encode for EncodeRef<'_, T>
 where
     T: Encode,
 {
@@ -33,13 +33,13 @@ where
 /// By virtue of the blanket impl, this type also impls `Encode`.
 pub struct EncodeValueRef<'a, T>(pub &'a T);
 
-impl<'a, T> AsRef<T> for EncodeValueRef<'a, T> {
+impl<T> AsRef<T> for EncodeValueRef<'_, T> {
     fn as_ref(&self) -> &T {
         self.0
     }
 }
 
-impl<'a, T> EncodeValue for EncodeValueRef<'a, T>
+impl<T> EncodeValue for EncodeValueRef<'_, T>
 where
     T: EncodeValue,
 {
@@ -52,7 +52,7 @@ where
     }
 }
 
-impl<'a, T> Tagged for EncodeValueRef<'a, T>
+impl<T> Tagged for EncodeValueRef<'_, T>
 where
     T: Tagged,
 {
@@ -61,7 +61,7 @@ where
     }
 }
 
-impl<'a, T> ValueOrd for EncodeValueRef<'a, T>
+impl<T> ValueOrd for EncodeValueRef<'_, T>
 where
     T: ValueOrd,
 {

--- a/der/src/str_ref.rs
+++ b/der/src/str_ref.rs
@@ -70,7 +70,7 @@ impl<'a> DecodeValue<'a> for StrRef<'a> {
     }
 }
 
-impl<'a> EncodeValue for StrRef<'a> {
+impl EncodeValue for StrRef<'_> {
     fn value_len(&self) -> Result<Length> {
         Ok(self.length)
     }

--- a/der/src/writer/slice.rs
+++ b/der/src/writer/slice.rs
@@ -126,7 +126,7 @@ impl<'a> SliceWriter<'a> {
     }
 }
 
-impl<'a> Writer for SliceWriter<'a> {
+impl Writer for SliceWriter<'_> {
     fn write(&mut self, slice: &[u8]) -> Result<()> {
         self.reserve(slice.len())?.copy_from_slice(slice);
         Ok(())

--- a/gss-api/src/lib.rs
+++ b/gss-api/src/lib.rs
@@ -54,7 +54,7 @@ pub struct InitialContextToken<'a> {
     pub inner_context_token: AnyRef<'a>,
 }
 
-impl<'a> FixedTag for InitialContextToken<'a> {
+impl FixedTag for InitialContextToken<'_> {
     const TAG: Tag = Tag::Application {
         constructed: true,
         number: TagNumber::new(0),
@@ -72,7 +72,7 @@ impl<'a> DecodeValue<'a> for InitialContextToken<'a> {
     }
 }
 
-impl<'a> EncodeValue for InitialContextToken<'a> {
+impl EncodeValue for InitialContextToken<'_> {
     fn value_len(&self) -> der::Result<Length> {
         self.this_mech.encoded_len()? + self.inner_context_token.encoded_len()?
     }

--- a/gss-api/src/negotiation.rs
+++ b/gss-api/src/negotiation.rs
@@ -145,7 +145,7 @@ pub struct NegTokenTarg<'a> {
     ///  processed by the target (accept_incomplete) and a mechToken
     ///  sent by the initiator and processed by the target
     ///  (accept_completed).
-    ///
+    //
     //  For those targets that support piggybacking the initial mechToken,
     //  an optimistic negotiation response is possible and includes in that
     //  case a responseToken which may continue the authentication exchange
@@ -154,7 +154,7 @@ pub struct NegTokenTarg<'a> {
     //  the responseToken is used to carry the tokens specific to the
     //  mechanism selected. For subsequent tokens (if any) returned by the
     //  target, negResult, and supportedMech are not present.
-
+    //
     //  For the last token returned by the target, the mechListMIC, when
     //  present, is a MIC computed over the MechTypes using the selected
     //  mechanism.

--- a/pem-rfc7468/src/decoder.rs
+++ b/pem-rfc7468/src/decoder.rs
@@ -145,7 +145,7 @@ impl<'i> From<Decoder<'i>> for Base64Decoder<'i> {
 }
 
 #[cfg(feature = "std")]
-impl<'i> io::Read for Decoder<'i> {
+impl io::Read for Decoder<'_> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.base64.read(buf)
     }

--- a/pem-rfc7468/src/encoder.rs
+++ b/pem-rfc7468/src/encoder.rs
@@ -286,7 +286,7 @@ impl<'l, 'o> Encoder<'l, 'o> {
 }
 
 #[cfg(feature = "std")]
-impl<'l, 'o> io::Write for Encoder<'l, 'o> {
+impl io::Write for Encoder<'_, '_> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.encode(buf)?;
         Ok(buf.len())

--- a/pkcs1/src/params.rs
+++ b/pkcs1/src/params.rs
@@ -168,7 +168,7 @@ impl<'a> RsaPssParams<'a> {
     }
 }
 
-impl<'a> Default for RsaPssParams<'a> {
+impl Default for RsaPssParams<'_> {
     fn default() -> Self {
         Self {
             hash: SHA_1_AI,
@@ -335,7 +335,7 @@ impl<'a> RsaOaepParams<'a> {
     }
 }
 
-impl<'a> Default for RsaOaepParams<'a> {
+impl Default for RsaOaepParams<'_> {
     fn default() -> Self {
         Self {
             hash: SHA_1_AI,

--- a/pkcs12/src/kdf.rs
+++ b/pkcs12/src/kdf.rs
@@ -105,8 +105,8 @@ where
         Pkcs12KeyType::Mac => vec![3u8; block_size],
     };
 
-    let slen = block_size * ((salt.len() + block_size - 1) / block_size);
-    let plen = block_size * ((pass.len() + block_size - 1) / block_size);
+    let slen = block_size * salt.len().div_ceil(block_size);
+    let plen = block_size * pass.len().div_ceil(block_size);
     let ilen = slen + plen;
     let mut init_key = vec![0u8; ilen];
     // 2. Concatenate copies of the salt together to create a string S of

--- a/pkcs12/src/safe_bag.rs
+++ b/pkcs12/src/safe_bag.rs
@@ -89,7 +89,7 @@ impl ::der::EncodeValue for SafeBag {
         Ok(())
     }
 }
-impl<'a> ::der::Sequence<'a> for SafeBag {}
+impl ::der::Sequence<'_> for SafeBag {}
 
 /// Version for the PrivateKeyInfo structure as defined in [RFC 5208 Section 5].
 ///

--- a/pkcs8/src/private_key_info.rs
+++ b/pkcs8/src/private_key_info.rs
@@ -378,7 +378,7 @@ pub trait BitStringLike {
     fn as_bit_string(&self) -> BitStringRef<'_>;
 }
 
-impl<'a> BitStringLike for BitStringRef<'a> {
+impl BitStringLike for BitStringRef<'_> {
     fn as_bit_string(&self) -> BitStringRef<'_> {
         BitStringRef::from(self)
     }

--- a/sec1/src/point.rs
+++ b/sec1/src/point.rs
@@ -458,7 +458,7 @@ pub enum Coordinates<'a, Size: ModulusSize> {
     },
 }
 
-impl<'a, Size: ModulusSize> Coordinates<'a, Size> {
+impl<Size: ModulusSize> Coordinates<'_, Size> {
     /// Get the tag octet needed to encode this set of [`Coordinates`]
     pub fn tag(&self) -> Tag {
         match self {

--- a/sec1/src/private_key.rs
+++ b/sec1/src/private_key.rs
@@ -146,7 +146,7 @@ impl<'a> TryFrom<&'a [u8]> for EcPrivateKey<'a> {
     }
 }
 
-impl<'a> fmt::Debug for EcPrivateKey<'a> {
+impl fmt::Debug for EcPrivateKey<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("EcPrivateKey")
             .field("parameters", &self.parameters)

--- a/serdect/src/common.rs
+++ b/serdect/src/common.rs
@@ -22,17 +22,17 @@ where
 {
     #[cfg(feature = "alloc")]
     if UPPERCASE {
-        return base16ct::upper::encode_string(value.as_ref()).serialize(serializer);
+        base16ct::upper::encode_string(value.as_ref()).serialize(serializer)
     } else {
-        return base16ct::lower::encode_string(value.as_ref()).serialize(serializer);
+        base16ct::lower::encode_string(value.as_ref()).serialize(serializer)
     }
     #[cfg(not(feature = "alloc"))]
     {
         let _ = value;
         let _ = serializer;
-        return Err(S::Error::custom(
+        Err(S::Error::custom(
             "serializer is human readable, which requires the `alloc` crate feature",
-        ));
+        ))
     }
 }
 
@@ -73,7 +73,7 @@ pub(crate) trait LengthCheck {
 
 pub(crate) struct StrIntoBufVisitor<'b, T: LengthCheck>(pub &'b mut [u8], pub PhantomData<T>);
 
-impl<'de, 'b, T: LengthCheck> Visitor<'de> for StrIntoBufVisitor<'b, T> {
+impl<'b, T: LengthCheck> Visitor<'_> for StrIntoBufVisitor<'b, T> {
     type Value = &'b [u8];
 
     fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -100,7 +100,7 @@ impl<'de, 'b, T: LengthCheck> Visitor<'de> for StrIntoBufVisitor<'b, T> {
 pub(crate) struct StrIntoVecVisitor;
 
 #[cfg(feature = "alloc")]
-impl<'de> Visitor<'de> for StrIntoVecVisitor {
+impl Visitor<'_> for StrIntoVecVisitor {
     type Value = Vec<u8>;
 
     fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -117,7 +117,7 @@ impl<'de> Visitor<'de> for StrIntoVecVisitor {
 
 pub(crate) struct SliceVisitor<'b, T: LengthCheck>(pub &'b mut [u8], pub PhantomData<T>);
 
-impl<'de, 'b, T: LengthCheck> Visitor<'de> for SliceVisitor<'b, T> {
+impl<'b, T: LengthCheck> Visitor<'_> for SliceVisitor<'b, T> {
     type Value = &'b [u8];
 
     fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -160,7 +160,7 @@ impl<'de, 'b, T: LengthCheck> Visitor<'de> for SliceVisitor<'b, T> {
 pub(crate) struct VecVisitor;
 
 #[cfg(feature = "alloc")]
-impl<'de> Visitor<'de> for VecVisitor {
+impl Visitor<'_> for VecVisitor {
     type Value = Vec<u8>;
 
     fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/spki/src/spki.rs
+++ b/spki/src/spki.rs
@@ -86,7 +86,7 @@ where
     }
 }
 
-impl<'a: 'k, 'k, Params, Key: 'k> DecodeValue<'a> for SubjectPublicKeyInfo<Params, Key>
+impl<'a, Params, Key> DecodeValue<'a> for SubjectPublicKeyInfo<Params, Key>
 where
     Params: Choice<'a, Error = der::Error> + Encode,
     Key: Decode<'a, Error = der::Error>,

--- a/tls_codec/src/quic_vec.rs
+++ b/tls_codec/src/quic_vec.rs
@@ -387,7 +387,7 @@ impl Size for &VLBytes {
 
 pub struct VLByteSlice<'a>(pub &'a [u8]);
 
-impl<'a> fmt::Debug for VLByteSlice<'a> {
+impl fmt::Debug for VLByteSlice<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "VLByteSlice {{ ")?;
         write_hex(f, self.0)?;
@@ -395,7 +395,7 @@ impl<'a> fmt::Debug for VLByteSlice<'a> {
     }
 }
 
-impl<'a> VLByteSlice<'a> {
+impl VLByteSlice<'_> {
     /// Get the raw slice.
     #[inline(always)]
     pub fn as_slice(&self) -> &[u8] {
@@ -403,14 +403,14 @@ impl<'a> VLByteSlice<'a> {
     }
 }
 
-impl<'a> Size for &VLByteSlice<'a> {
+impl Size for &VLByteSlice<'_> {
     #[inline]
     fn tls_serialized_len(&self) -> usize {
         tls_serialize_bytes_len(self.0)
     }
 }
 
-impl<'a> Size for VLByteSlice<'a> {
+impl Size for VLByteSlice<'_> {
     #[inline]
     fn tls_serialized_len(&self) -> usize {
         tls_serialize_bytes_len(self.0)
@@ -598,13 +598,13 @@ mod rw_bytes {
         }
     }
 
-    impl<'a> Serialize for &VLByteSlice<'a> {
+    impl Serialize for &VLByteSlice<'_> {
         fn tls_serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, Error> {
             tls_serialize_bytes(writer, self.0)
         }
     }
 
-    impl<'a> Serialize for VLByteSlice<'a> {
+    impl Serialize for VLByteSlice<'_> {
         fn tls_serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, Error> {
             tls_serialize_bytes(writer, self.0)
         }

--- a/x509-cert/src/builder/profile/cabf/tls.rs
+++ b/x509-cert/src/builder/profile/cabf/tls.rs
@@ -328,7 +328,7 @@ trait KeyType {
 }
 
 #[cfg(feature = "hazmat")]
-impl<'a> KeyType for SubjectPublicKeyInfoRef<'a> {
+impl KeyType for SubjectPublicKeyInfoRef<'_> {
     fn is_rsa(&self) -> bool {
         self.algorithm.oid == rfc5912::RSA_ENCRYPTION
     }

--- a/x509-cert/src/time.rs
+++ b/x509-cert/src/time.rs
@@ -215,4 +215,4 @@ impl<P: Profile> ::der::EncodeValue for Validity<P> {
     }
 }
 
-impl<'a, P: Profile> Sequence<'a> for Validity<P> {}
+impl<P: Profile> Sequence<'_> for Validity<P> {}


### PR DESCRIPTION
A collection of small fixes clippy is going to raise with rust 1.83. Those did not come up in CI yet because we're pinned at 1.81 but they are annoying when running clippy manually.