### PR TITLE
x509-cert: enable and fix clippy `core`/`alloc`/`std` lints

### DIFF
--- a/x509-cert/src/builder.rs
+++ b/x509-cert/src/builder.rs
@@ -66,8 +66,7 @@ pub enum Error {
     MissingAttributes,
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/x509-cert/src/ext/pkix/name/general.rs
+++ b/x509-cert/src/ext/pkix/name/general.rs
@@ -62,19 +62,18 @@ pub enum GeneralName {
     RegisteredId(ObjectIdentifier),
 }
 
-#[cfg(feature = "std")]
-impl From<std::net::IpAddr> for GeneralName {
-    fn from(ip: std::net::IpAddr) -> Self {
+impl From<core::net::IpAddr> for GeneralName {
+    fn from(ip: core::net::IpAddr) -> Self {
         // Safety: this is unfailable here, OctetString will issue an error if you go
         // over 256MiB, here the buffer is at most 16 bytes (ipv6). The two `expect`s
         // below are safe.
         let buf = match ip {
-            std::net::IpAddr::V4(v) => {
+            core::net::IpAddr::V4(v) => {
                 let value = v.octets();
                 OctetString::new(&value[..])
                     .expect("OctetString is not expected to fail with a 4 bytes long buffer")
             }
-            std::net::IpAddr::V6(v) => {
+            core::net::IpAddr::V6(v) => {
                 let value = v.octets();
                 OctetString::new(&value[..])
                     .expect("OctetString is not expected to fail with a 16 bytes long buffer")
@@ -85,7 +84,7 @@ impl From<std::net::IpAddr> for GeneralName {
     }
 }
 
-#[cfg(all(feature = "std", test))]
+#[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
@@ -93,7 +92,7 @@ mod tests {
 
     #[test]
     fn test_convert() {
-        use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+        use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
         let localhost_v4 = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
         let localhost_v6 = IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1));

--- a/x509-cert/src/lib.rs
+++ b/x509-cert/src/lib.rs
@@ -7,7 +7,10 @@
 )]
 #![forbid(unsafe_code)]
 #![warn(
+    clippy::alloc_instead_of_core,
     clippy::mod_module_files,
+    clippy::std_instead_of_alloc,
+    clippy::std_instead_of_core,
     clippy::unwrap_used,
     missing_docs,
     rust_2018_idioms,


### PR DESCRIPTION
Enables the following clippy lints:

- `clippy::alloc_instead_of_core`
- `clippy::std_instead_of_alloc`
- `clippy::std_instead_of_core`

These check that imports are coming from the correct package in the standard library, enabling more features to be used in `no_std` environments.