### PR TITLE
CI: bump `clippy` to v1.84

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.81.0
+          toolchain: 1.84.0
           components: clippy
       - run: cargo clippy --all --all-features --tests
 
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable

--- a/base64ct/src/encoder.rs
+++ b/base64ct/src/encoder.rs
@@ -153,7 +153,7 @@ impl<'o, E: Encoding> Encoder<'o, E> {
 
     /// Perform Base64 encoding operation.
     fn perform_encode(&mut self, input: &[u8]) -> Result<usize, Error> {
-        let mut len = E::encode(input, self.remaining())?.as_bytes().len();
+        let mut len = E::encode(input, self.remaining())?.len();
 
         // Insert newline characters into the output as needed
         if let Some(line_wrapper) = &mut self.line_wrapper {

--- a/cms/tests/builder.rs
+++ b/cms/tests/builder.rs
@@ -700,7 +700,7 @@ fn test_create_password_recipient_info() {
             }
         }
     }
-    impl<'a> PwriEncryptor for Aes128CbcPwriEncryptor<'a> {
+    impl PwriEncryptor for Aes128CbcPwriEncryptor<'_> {
         const BLOCK_LENGTH_BITS: usize = 128; // AES block length
         fn encrypt_rfc3211(
             &mut self,

--- a/der/src/str_owned.rs
+++ b/der/src/str_owned.rs
@@ -22,7 +22,7 @@ impl StrOwned {
     /// Create a new [`StrOwned`], ensuring that the byte representation of
     /// the provided `str` value is shorter than `Length::max()`.
     pub fn new(s: String) -> Result<Self> {
-        let length = Length::try_from(s.as_bytes().len())?;
+        let length = Length::try_from(s.len())?;
 
         Ok(Self { inner: s, length })
     }

--- a/der/src/str_ref.rs
+++ b/der/src/str_ref.rs
@@ -20,7 +20,7 @@ impl<'a> StrRef<'a> {
     pub fn new(s: &'a str) -> Result<Self> {
         Ok(Self {
             inner: s,
-            length: Length::try_from(s.as_bytes().len())?,
+            length: Length::try_from(s.len())?,
         })
     }
 

--- a/pem-rfc7468/src/encoder.rs
+++ b/pem-rfc7468/src/encoder.rs
@@ -135,13 +135,13 @@ fn encapsulated_len_inner(
 ) -> Result<usize> {
     [
         PRE_ENCAPSULATION_BOUNDARY.len(),
-        label.as_bytes().len(),
+        label.len(),
         ENCAPSULATION_BOUNDARY_DELIMITER.len(),
         line_ending.len(),
         base64_len,
         line_ending.len(),
         POST_ENCAPSULATION_BOUNDARY.len(),
-        label.as_bytes().len(),
+        label.len(),
         ENCAPSULATION_BOUNDARY_DELIMITER.len(),
         line_ending.len(),
     ]

--- a/pkcs1/src/private_key.rs
+++ b/pkcs1/src/private_key.rs
@@ -250,7 +250,7 @@ impl EncodeValue for OtherPrimeInfos<'_> {
 }
 
 #[cfg(not(feature = "alloc"))]
-impl<'a> der::FixedTag for OtherPrimeInfos<'a> {
+impl der::FixedTag for OtherPrimeInfos<'_> {
     const TAG: Tag = Tag::Sequence;
 }
 


### PR DESCRIPTION
Also runs `cargo clippy --fix` to correct warnings