### PR TITLE
Add support for 64-bit moduli

### DIFF
--- a/sec1/src/point.rs
+++ b/sec1/src/point.rs
@@ -15,7 +15,7 @@ use core::{
     str,
 };
 use hybrid_array::{
-    typenum::{U1, U24, U28, U32, U48, U66},
+    typenum::{U1, U24, U28, U32, U48, U66, U8},
     Array, ArraySize,
 };
 
@@ -68,8 +68,8 @@ macro_rules! impl_modulus_size {
     }
 }
 
-// Support for 192-bit, 224-bit, 256-bit, 384-bit, and 521-bit modulus sizes
-impl_modulus_size!(U24, U28, U32, U48, U66);
+// Support for 64-bit, 192-bit, 224-bit, 256-bit, 384-bit, and 528-bit modulus sizes
+impl_modulus_size!(U8, U24, U28, U32, U48, U66);
 
 /// SEC1 encoded curve point.
 ///


### PR DESCRIPTION
The `tiny-curve` crate uses 64-bit [`FieldBytesSize`](https://github.com/fjarri/tiny-curve/blob/master/src/curve64.rs#L50), and when used in combination with the [`FromEncodedPoint`](https://docs.rs/elliptic-curve/0.13.8/elliptic_curve/sec1/trait.FromEncodedPoint.html) trait, there's a problem with a missing impl of the `ModulusSize` trait. 

Adding `U8` to the list of impl'd types should fix this.
