### PR TITLE
tls_codec: remove measuring allocs in benchmarks

### DIFF
--- a/tls_codec/benches/quic_vec.rs
+++ b/tls_codec/benches/quic_vec.rs
@@ -1,26 +1,27 @@
 use criterion::{criterion_group, criterion_main};
 use criterion::{BatchSize, Criterion};
 
+use tls_codec::*;
+
+/// Length of the test bytes vector.
+const N: usize = 0xFFFF;
+
 fn vector(c: &mut Criterion) {
-    use tls_codec::*;
     c.bench_function("TLS Serialize VL Vector", |b| {
-        b.iter_batched(
-            || vec![77u8; 65535],
-            |long_vector| {
-                let _serialized_long_vec = long_vector.tls_serialize_detached().unwrap();
-            },
+        b.iter_batched_ref(
+            || (vec![77u8; N], Vec::with_capacity(8 + N)),
+            |(long_vec, buf)| Serialize::tls_serialize(long_vec, buf).unwrap(),
             BatchSize::SmallInput,
         )
     });
     c.bench_function("TLS Deserialize VL Vector", |b| {
-        b.iter_batched(
+        b.iter_batched_ref(
             || {
-                let long_vector = vec![77u8; 65535];
-                long_vector.tls_serialize_detached().unwrap()
+                let long_vec = vec![77u8; N];
+                long_vec.tls_serialize_detached().unwrap()
             },
             |serialized_long_vec| {
-                let _deserialized_long_vec =
-                    Vec::<u8>::tls_deserialize(&mut serialized_long_vec.as_slice()).unwrap();
+                Vec::<u8>::tls_deserialize(&mut serialized_long_vec.as_slice()).unwrap()
             },
             BatchSize::SmallInput,
         )
@@ -28,25 +29,21 @@ fn vector(c: &mut Criterion) {
 }
 
 fn byte_vector(c: &mut Criterion) {
-    use tls_codec::*;
     c.bench_function("TLS Serialize VL Byte Vector", |b| {
-        b.iter_batched(
-            || VLBytes::new(vec![77u8; 65535]),
-            |long_vector| {
-                let _serialized_long_vec = long_vector.tls_serialize_detached().unwrap();
-            },
+        b.iter_batched_ref(
+            || (VLBytes::new(vec![77u8; N]), Vec::with_capacity(8 + N)),
+            |(long_vec, buf)| Serialize::tls_serialize(long_vec, buf).unwrap(),
             BatchSize::SmallInput,
         )
     });
     c.bench_function("TLS Deserialize VL Byte Vector", |b| {
-        b.iter_batched(
+        b.iter_batched_ref(
             || {
-                let long_vector = vec![77u8; 65535];
-                VLByteSlice(&long_vector).tls_serialize_detached().unwrap()
+                let long_vec = vec![77u8; N];
+                VLByteSlice(&long_vec).tls_serialize_detached().unwrap()
             },
             |serialized_long_vec| {
-                let _deserialized_long_vec =
-                    VLBytes::tls_deserialize(&mut serialized_long_vec.as_slice()).unwrap();
+                VLBytes::tls_deserialize(&mut serialized_long_vec.as_slice()).unwrap()
             },
             BatchSize::SmallInput,
         )
@@ -54,27 +51,20 @@ fn byte_vector(c: &mut Criterion) {
 }
 
 fn byte_slice(c: &mut Criterion) {
-    use tls_codec::*;
     c.bench_function("TLS Serialize VL Byte Slice", |b| {
-        b.iter_batched(
-            || vec![77u8; 65535],
-            |long_vector| {
-                let _serialized_long_vec =
-                    VLByteSlice(&long_vector).tls_serialize_detached().unwrap();
-            },
+        b.iter_batched_ref(
+            || (vec![77u8; N], Vec::with_capacity(8 + N)),
+            |(long_vec, buf)| VLByteSlice(long_vec).tls_serialize(buf).unwrap(),
             BatchSize::SmallInput,
         )
     });
 }
 
 fn slice(c: &mut Criterion) {
-    use tls_codec::*;
     c.bench_function("TLS Serialize VL Slice", |b| {
-        b.iter_batched(
-            || vec![77u8; 65535],
-            |long_vector| {
-                let _serialized_long_vec = long_vector.tls_serialize_detached().unwrap();
-            },
+        b.iter_batched_ref(
+            || (vec![77u8; N], Vec::with_capacity(8 + N)),
+            |(long_vec, buf)| Serialize::tls_serialize(&long_vec.as_slice(), buf).unwrap(),
             BatchSize::SmallInput,
         )
     });

--- a/tls_codec/benches/tls_vec.rs
+++ b/tls_codec/benches/tls_vec.rs
@@ -1,26 +1,26 @@
 use criterion::{criterion_group, criterion_main};
 use criterion::{BatchSize, Criterion};
 
+/// Length of the test bytes vector.
+const N: usize = 0xFFFF;
+
 fn vector(c: &mut Criterion) {
     use tls_codec::*;
     c.bench_function("TLS Serialize Vector", |b| {
-        b.iter_batched(
-            || TlsVecU32::from(vec![77u8; 65535]),
-            |long_vector| {
-                let _serialized_long_vec = long_vector.tls_serialize_detached().unwrap();
-            },
+        b.iter_batched_ref(
+            || (TlsVecU32::from(vec![77u8; N]), Vec::with_capacity(8 + N)),
+            |(long_vec, buf)| long_vec.tls_serialize(buf).unwrap(),
             BatchSize::SmallInput,
         )
     });
     c.bench_function("TLS Deserialize Vector", |b| {
-        b.iter_batched(
+        b.iter_batched_ref(
             || {
-                let long_vector = vec![77u8; 65535];
-                TlsSliceU32(&long_vector).tls_serialize_detached().unwrap()
+                let long_vec = vec![77u8; N];
+                TlsSliceU32(&long_vec).tls_serialize_detached().unwrap()
             },
             |serialized_long_vec| {
-                let _deserialized_long_vec =
-                    TlsVecU32::<u8>::tls_deserialize(&mut serialized_long_vec.as_slice()).unwrap();
+                TlsVecU32::<u8>::tls_deserialize(&mut serialized_long_vec.as_slice()).unwrap()
             },
             BatchSize::SmallInput,
         )
@@ -30,25 +30,25 @@ fn vector(c: &mut Criterion) {
 fn byte_vector(c: &mut Criterion) {
     use tls_codec::*;
     c.bench_function("TLS Serialize Byte Vector", |b| {
-        b.iter_batched(
-            || TlsByteVecU32::from(vec![77u8; 65535]),
-            |long_vector| {
-                let _serialized_long_vec = long_vector.tls_serialize_detached().unwrap();
+        b.iter_batched_ref(
+            || {
+                (
+                    TlsByteVecU32::from(vec![77u8; N]),
+                    Vec::with_capacity(8 + N),
+                )
             },
+            |(long_vec, buf)| Serialize::tls_serialize(long_vec, buf).unwrap(),
             BatchSize::SmallInput,
         )
     });
     c.bench_function("TLS Deserialize Byte Vector", |b| {
-        b.iter_batched(
+        b.iter_batched_ref(
             || {
-                let long_vector = vec![77u8; 65535];
-                TlsByteSliceU32(&long_vector)
-                    .tls_serialize_detached()
-                    .unwrap()
+                let long_vec = vec![77u8; N];
+                TlsByteSliceU32(&long_vec).tls_serialize_detached().unwrap()
             },
             |serialized_long_vec| {
-                let _deserialized_long_vec =
-                    TlsVecU32::<u8>::tls_deserialize(&mut serialized_long_vec.as_slice()).unwrap();
+                TlsVecU32::<u8>::tls_deserialize(&mut serialized_long_vec.as_slice()).unwrap()
             },
             BatchSize::SmallInput,
         )
@@ -58,13 +58,9 @@ fn byte_vector(c: &mut Criterion) {
 fn byte_slice(c: &mut Criterion) {
     use tls_codec::*;
     c.bench_function("TLS Serialize Byte Slice", |b| {
-        b.iter_batched(
-            || vec![77u8; 65535],
-            |long_vector| {
-                let _serialized_long_vec = TlsByteSliceU32(&long_vector)
-                    .tls_serialize_detached()
-                    .unwrap();
-            },
+        b.iter_batched_ref(
+            || (vec![77u8; N], Vec::with_capacity(8 + N)),
+            |(long_vec, buf)| TlsByteSliceU32(long_vec).tls_serialize(buf).unwrap(),
             BatchSize::SmallInput,
         )
     });
@@ -73,12 +69,9 @@ fn byte_slice(c: &mut Criterion) {
 fn slice(c: &mut Criterion) {
     use tls_codec::*;
     c.bench_function("TLS Serialize Slice", |b| {
-        b.iter_batched(
-            || vec![77u8; 65535],
-            |long_vector| {
-                let _serialized_long_vec =
-                    TlsSliceU32(&long_vector).tls_serialize_detached().unwrap();
-            },
+        b.iter_batched_ref(
+            || (vec![77u8; N], Vec::with_capacity(8 + N)),
+            |(long_vec, buf)| TlsSliceU32(long_vec).tls_serialize(buf).unwrap(),
             BatchSize::SmallInput,
         )
     });


### PR DESCRIPTION
Benches now use [`iter_batched_ref`] with provided buffers when serializing and returned buffers when deserializing. This avoids measuring allocations.

[`iter_batched_ref`]: https://docs.rs/criterion/0.5.1/criterion/struct.Bencher.html#method.iter_batched_ref