### PR TITLE
base32ct v0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,7 +123,7 @@ checksum = "022dfe9eb35f19ebbcb51e0b40a5ab759f46ad60cadf7297e0bd085afb50e076"
 
 [[package]]
 name = "base32ct"
-version = "0.3.0-pre"
+version = "0.2.2"
 dependencies = [
  "base32",
  "proptest",

--- a/base32ct/CHANGELOG.md
+++ b/base32ct/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.2 (2025-02-23)
+### Added
+- `const fn` for `encoded_len` ([#1424])
+
+[#1424]: https://github.com/RustCrypto/formats/pull/1424
+
 ## 0.2.1 (2024-05-28)
 ### Added
 - Support for Base32 upper unpadded alphabet ([#1406])

--- a/base32ct/Cargo.toml
+++ b/base32ct/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base32ct"
-version = "0.3.0-pre"
+version = "0.2.2"
 description = """
 Pure Rust implementation of Base32 (RFC 4648) which avoids any usages of
 data-dependent branches/LUTs and thereby provides portable "best effort"
@@ -15,7 +15,7 @@ categories = ["cryptography", "encoding", "no-std", "parser-implementations"]
 keywords = ["crypto"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.60"
 
 [dev-dependencies]
 base32 = "0.5"


### PR DESCRIPTION
### Added
- `const fn` for `encoded_len` ([#1424])

[#1424]: https://github.com/RustCrypto/formats/pull/1424