### PR TITLE
fix: derive(Sequence) on field: Option<&'a [u8]>

### DIFF
--- a/der/src/asn1/octet_string.rs
+++ b/der/src/asn1/octet_string.rs
@@ -96,21 +96,11 @@ impl<'a> From<OctetStringRef<'a>> for &'a [u8] {
     }
 }
 
-impl<'a> From<&'a [u8]> for OctetStringRef<'a> {
-    fn from(byte_slice: &'a [u8]) -> Self {
-        OctetStringRef::new(byte_slice).expect("byte_slice to be sane length")
-    }
-}
+impl<'a> TryFrom<&'a [u8]> for OctetStringRef<'a> {
+    type Error = Error;
 
-impl<'a> From<&&'a [u8]> for OctetStringRef<'a> {
-    fn from(byte_slice: &&'a [u8]) -> Self {
-        From::<&'a [u8]>::from(byte_slice)
-    }
-}
-
-impl<'a> From<&&&'a [u8]> for OctetStringRef<'a> {
-    fn from(byte_slice: &&&'a [u8]) -> Self {
-        From::<&'a [u8]>::from(byte_slice)
+    fn try_from(byte_slice: &'a [u8]) -> Result<Self, Error> {
+        OctetStringRef::new(byte_slice)
     }
 }
 

--- a/der/src/asn1/octet_string.rs
+++ b/der/src/asn1/octet_string.rs
@@ -96,11 +96,21 @@ impl<'a> From<OctetStringRef<'a>> for &'a [u8] {
     }
 }
 
-impl<'a> TryFrom<&'a [u8]> for OctetStringRef<'a> {
-    type Error = Error;
+impl<'a> From<&'a [u8]> for OctetStringRef<'a> {
+    fn from(byte_slice: &'a [u8]) -> Self {
+        OctetStringRef::new(byte_slice).expect("byte_slice to be sane length")
+    }
+}
 
-    fn try_from(byte_slice: &'a [u8]) -> Result<Self, Error> {
-        OctetStringRef::new(byte_slice)
+impl<'a> From<&&'a [u8]> for OctetStringRef<'a> {
+    fn from(byte_slice: &&'a [u8]) -> Self {
+        From::<&'a [u8]>::from(byte_slice)
+    }
+}
+
+impl<'a> From<&&&'a [u8]> for OctetStringRef<'a> {
+    fn from(byte_slice: &&&'a [u8]) -> Self {
+        From::<&'a [u8]>::from(byte_slice)
     }
 }
 

--- a/der/src/asn1/octet_string.rs
+++ b/der/src/asn1/octet_string.rs
@@ -112,13 +112,6 @@ impl<'a> TryFrom<&&'a [u8]> for OctetStringRef<'a> {
     }
 }
 
-impl<'a> TryFrom<&&&'a [u8]> for OctetStringRef<'a> {
-    type Error = Error;
-
-    fn try_from(byte_slice: &&&'a [u8]) -> Result<Self, Error> {
-        TryFrom::<&'a [u8]>::try_from(byte_slice)
-    }
-}
 
 #[cfg(feature = "alloc")]
 pub use self::allocating::OctetString;

--- a/der/src/asn1/octet_string.rs
+++ b/der/src/asn1/octet_string.rs
@@ -104,6 +104,22 @@ impl<'a> TryFrom<&'a [u8]> for OctetStringRef<'a> {
     }
 }
 
+impl<'a> TryFrom<&&'a [u8]> for OctetStringRef<'a> {
+    type Error = Error;
+
+    fn try_from(byte_slice: &&'a [u8]) -> Result<Self, Error> {
+        TryFrom::<&'a [u8]>::try_from(byte_slice)
+    }
+}
+
+impl<'a> TryFrom<&&&'a [u8]> for OctetStringRef<'a> {
+    type Error = Error;
+
+    fn try_from(byte_slice: &&&'a [u8]) -> Result<Self, Error> {
+        TryFrom::<&'a [u8]>::try_from(byte_slice)
+    }
+}
+
 #[cfg(feature = "alloc")]
 pub use self::allocating::OctetString;
 

--- a/der/src/asn1/octet_string.rs
+++ b/der/src/asn1/octet_string.rs
@@ -113,7 +113,6 @@ impl<'a> TryFrom<&&'a [u8]> for OctetStringRef<'a> {
     }
 }
 
-
 #[cfg(feature = "alloc")]
 pub use self::allocating::OctetString;
 

--- a/der/src/asn1/octet_string.rs
+++ b/der/src/asn1/octet_string.rs
@@ -109,7 +109,7 @@ impl<'a> TryFrom<&&'a [u8]> for OctetStringRef<'a> {
     type Error = Error;
 
     fn try_from(byte_slice: &&'a [u8]) -> Result<Self, Error> {
-        TryFrom::<&'a [u8]>::try_from(byte_slice)
+        OctetStringRef::new(byte_slice)
     }
 }
 

--- a/der/src/asn1/octet_string.rs
+++ b/der/src/asn1/octet_string.rs
@@ -104,6 +104,7 @@ impl<'a> TryFrom<&'a [u8]> for OctetStringRef<'a> {
     }
 }
 
+/// Hack for simplifying the custom derive use case.
 impl<'a> TryFrom<&&'a [u8]> for OctetStringRef<'a> {
     type Error = Error;
 

--- a/der/tests/derive.rs
+++ b/der/tests/derive.rs
@@ -404,7 +404,7 @@ mod sequence {
     const ALGORITHM_IDENTIFIER_DER: &[u8] =
         &hex!("30 13 06 07 2a 86 48 ce 3d 02 01 06 08 2a 86 48 ce 3d 03 01 07");
 
-    #[derive(Sequence)]
+    #[derive(Sequence, Default, Eq, PartialEq, Debug)]
     #[asn1(tag_mode = "IMPLICIT")]
     pub struct TypeCheckExpandedSequenceFieldAttributeCombinations<'a> {
         pub simple: bool,
@@ -423,7 +423,34 @@ mod sequence {
         #[asn1(context_specific = "3", default = "default_false_example")]
         pub context_specific_default: bool,
         #[asn1(type = "BIT STRING", context_specific = "4", optional = "true")]
-        pub typed_context_specific_optional: Option<&'a [u8]>,
+        pub typed_context_specific_optional_bits: Option<&'a [u8]>,
+        #[asn1(type = "OCTET STRING", context_specific = "5", optional = "true")]
+        pub typed_context_specific_optional_implicit: Option<&'a [u8]>,
+        #[asn1(
+            type = "OCTET STRING",
+            context_specific = "6",
+            optional = "true",
+            tag_mode = "EXPLICIT"
+        )]
+        pub typed_context_specific_optional_explicit: Option<&'a [u8]>,
+    }
+
+    #[test]
+    fn type_combinations_instance() {
+        let obj = TypeCheckExpandedSequenceFieldAttributeCombinations {
+            context_specific_optional: Some(true),
+            typed_context_specific: &[0, 1],
+            typed_context_specific_optional_bits: Some(&[2, 3]),
+            typed_context_specific_optional_implicit: Some(&[4, 5, 6]),
+            typed_context_specific_optional_explicit: Some(&[7, 8]),
+
+            ..Default::default()
+        };
+
+        let der_encoded = obj.to_der().unwrap();
+        let obj_decoded =
+            TypeCheckExpandedSequenceFieldAttributeCombinations::from_der(&der_encoded).unwrap();
+        assert_eq!(obj, obj_decoded);
     }
 
     #[derive(Sequence)]


### PR DESCRIPTION
Fixes simple case:

```rust
#[derive(Sequence)]
pub struct MySequence<'a> {
    #[asn1(type = "OCTET STRING", context_specific = "0", optional = "true")]
    pub my_byte_slice: Option<&'a [u8]>,
}
```

Helpful:
`cargo test -p der -F derive,alloc,oid --test derive -- sequence::type_combinations_instance`
`cargo expand --test derive -p der -F derive,alloc,oid > expanded.rs`