### PR TITLE
der: fix derive(Sequence) on field: Vec<u8>

### DIFF
--- a/der/src/asn1/bit_string.rs
+++ b/der/src/asn1/bit_string.rs
@@ -347,6 +347,36 @@ mod allocating {
         }
     }
 
+    // /// Hack for simplifying the custom derive use case.
+    // impl<'a> TryFrom<Vec<u8>> for BitStringRef<'a> {
+    //     type Error = Error;
+
+    //     fn try_from(bytes: Vec<u8>) -> Result<BitStringRef<'a>> {
+    //         BitStringRef::from_bytes(&bytes)
+    //     }
+    // }
+
+    /// Hack for simplifying the custom derive use case.
+    impl<'a> TryFrom<&'a Vec<u8>> for BitStringRef<'a> {
+        type Error = Error;
+
+        fn try_from(bytes: &'a Vec<u8>) -> Result<BitStringRef<'a>> {
+            BitStringRef::from_bytes(bytes)
+        }
+    }
+
+    /// Hack for simplifying the custom derive use case.
+    impl<'a> TryFrom<BitStringRef<'a>> for Vec<u8> {
+        type Error = Error;
+
+        fn try_from(bit_string: BitStringRef<'a>) -> Result<Vec<u8>> {
+            bit_string
+                .as_bytes()
+                .map(|bytes| bytes.to_vec())
+                .ok_or_else(|| Tag::BitString.value_error())
+        }
+    }
+
     impl ValueOrd for BitString {
         fn value_cmp(&self, other: &Self) -> Result<Ordering> {
             match self.unused_bits.cmp(&other.unused_bits) {

--- a/der/src/asn1/bit_string.rs
+++ b/der/src/asn1/bit_string.rs
@@ -347,15 +347,6 @@ mod allocating {
         }
     }
 
-    // /// Hack for simplifying the custom derive use case.
-    // impl<'a> TryFrom<Vec<u8>> for BitStringRef<'a> {
-    //     type Error = Error;
-
-    //     fn try_from(bytes: Vec<u8>) -> Result<BitStringRef<'a>> {
-    //         BitStringRef::from_bytes(&bytes)
-    //     }
-    // }
-
     /// Hack for simplifying the custom derive use case.
     impl<'a> TryFrom<&'a Vec<u8>> for BitStringRef<'a> {
         type Error = Error;

--- a/der/src/asn1/octet_string.rs
+++ b/der/src/asn1/octet_string.rs
@@ -227,6 +227,15 @@ mod allocating {
         }
     }
 
+    /// Hack for simplifying the custom derive use case.
+    impl<'a> TryFrom<&'a Vec<u8>> for OctetStringRef<'a> {
+        type Error = Error;
+
+        fn try_from(byte_vec: &'a Vec<u8>) -> Result<Self, Error> {
+            OctetStringRef::new(byte_vec)
+        }
+    }
+
     impl From<OctetString> for Vec<u8> {
         fn from(octet_string: OctetString) -> Vec<u8> {
             octet_string.into_bytes()

--- a/der/tests/derive.rs
+++ b/der/tests/derive.rs
@@ -531,8 +531,6 @@ mod sequence {
 
             owned_optional_explicit_bits: Some(vec![12, 13]),
             owned_optional_explicit_bytes: Some(vec![14, 15]),
-
-            ..Default::default()
         };
 
         let der_encoded = obj.to_der().unwrap();

--- a/der/tests/derive.rs
+++ b/der/tests/derive.rs
@@ -453,6 +453,79 @@ mod sequence {
         assert_eq!(obj, obj_decoded);
     }
 
+    #[derive(Sequence, Default, Eq, PartialEq, Debug)]
+    #[asn1(tag_mode = "IMPLICIT")]
+    pub struct TypeCheckOwnedSequenceFieldAttributeCombinations {
+        /// pure Vec<.> Needs additional deref in the derive macro
+        /// for the `OctetStringRef::try_from`
+        #[asn1(type = "OCTET STRING", context_specific = "0", deref = "true")]
+        pub owned_implicit_bytes: Vec<u8>,
+
+        /// deref
+        #[asn1(type = "BIT STRING", context_specific = "1", deref = "true")]
+        pub owned_implicit_bits: Vec<u8>,
+
+        /// deref
+        #[asn1(
+            type = "OCTET STRING",
+            context_specific = "2",
+            deref = "true",
+            tag_mode = "EXPLICIT"
+        )]
+        pub owned_explicit_bytes: Vec<u8>,
+
+        /// deref
+        #[asn1(
+            type = "BIT STRING",
+            context_specific = "3",
+            deref = "true",
+            tag_mode = "EXPLICIT"
+        )]
+        pub owned_explicit_bits: Vec<u8>,
+
+        /// Option<Vec<..>> does not need deref
+        #[asn1(type = "BIT STRING", context_specific = "4", optional = "true")]
+        pub owned_optional_implicit_bits: Option<Vec<u8>>,
+        #[asn1(type = "OCTET STRING", context_specific = "5", optional = "true")]
+        pub owned_optional_implicit_bytes: Option<Vec<u8>>,
+
+        #[asn1(
+            type = "OCTET STRING",
+            context_specific = "6",
+            optional = "true",
+            tag_mode = "EXPLICIT"
+        )]
+        pub owned_optional_explicit_bits: Option<Vec<u8>>,
+        #[asn1(
+            type = "OCTET STRING",
+            context_specific = "7",
+            optional = "true",
+            tag_mode = "EXPLICIT"
+        )]
+        pub owned_optional_explicit_bytes: Option<Vec<u8>>,
+    }
+
+    #[test]
+    fn type_combinations_alloc_instance() {
+        let obj = TypeCheckOwnedSequenceFieldAttributeCombinations {
+            owned_implicit_bytes: vec![0, 1],
+            owned_implicit_bits: vec![2, 3],
+            owned_explicit_bytes: vec![4, 5],
+            owned_explicit_bits: vec![6, 7],
+            owned_optional_implicit_bits: Some(vec![8, 9]),
+            owned_optional_implicit_bytes: Some(vec![10, 11]),
+            owned_optional_explicit_bits: Some(vec![12, 13]),
+            owned_optional_explicit_bytes: Some(vec![14, 15]),
+
+            ..Default::default()
+        };
+
+        let der_encoded = obj.to_der().unwrap();
+        let obj_decoded =
+            TypeCheckOwnedSequenceFieldAttributeCombinations::from_der(&der_encoded).unwrap();
+        assert_eq!(obj, obj_decoded);
+    }
+
     #[derive(Sequence)]
     #[asn1(error = CustomError)]
     pub struct TypeWithCustomError {

--- a/der/tests/derive.rs
+++ b/der/tests/derive.rs
@@ -456,6 +456,15 @@ mod sequence {
     #[derive(Sequence, Default, Eq, PartialEq, Debug)]
     #[asn1(tag_mode = "IMPLICIT")]
     pub struct TypeCheckOwnedSequenceFieldAttributeCombinations {
+        /// Without deref = "true" macro generates an error:
+        ///
+        /// the trait `From<Vec<u8>>` is not implemented for `BitStringRef<'_>`
+        #[asn1(type = "OCTET STRING", deref = "true")]
+        pub owned_bytes: Vec<u8>,
+
+        #[asn1(type = "BIT STRING", deref = "true")]
+        pub owned_bits: Vec<u8>,
+
         /// pure Vec<.> Needs additional deref in the derive macro
         /// for the `OctetStringRef::try_from`
         #[asn1(type = "OCTET STRING", context_specific = "0", deref = "true")]
@@ -508,12 +517,18 @@ mod sequence {
     #[test]
     fn type_combinations_alloc_instance() {
         let obj = TypeCheckOwnedSequenceFieldAttributeCombinations {
+            owned_bytes: vec![0xAA, 0xBB],
+            owned_bits: vec![0xCC, 0xDD],
+
             owned_implicit_bytes: vec![0, 1],
             owned_implicit_bits: vec![2, 3],
+
             owned_explicit_bytes: vec![4, 5],
             owned_explicit_bits: vec![6, 7],
+
             owned_optional_implicit_bits: Some(vec![8, 9]),
             owned_optional_implicit_bytes: Some(vec![10, 11]),
+
             owned_optional_explicit_bits: Some(vec![12, 13]),
             owned_optional_explicit_bytes: Some(vec![14, 15]),
 

--- a/der_derive/src/asn1_type.rs
+++ b/der_derive/src/asn1_type.rs
@@ -70,16 +70,7 @@ impl Asn1Type {
     /// Get a `der::Encoder` object for a particular ASN.1 type
     pub fn encoder(self, binding: &TokenStream) -> TokenStream {
         let type_path = self.type_path();
-
-        match self {
-            Asn1Type::Ia5String
-            | Asn1Type::OctetString
-            | Asn1Type::PrintableString
-            | Asn1Type::TeletexString
-            | Asn1Type::VideotexString
-            | Asn1Type::Utf8String => quote!(#type_path::try_from(#binding)?),
-            _ => quote!(#type_path::try_from(#binding)?),
-        }
+        quote!(#type_path::try_from(#binding)?)
     }
 
     /// Get the Rust type path for a particular ASN.1 type.


### PR DESCRIPTION
Fixes: 
- #1539

Adds attribute:
- `deref = "true"`

```rust
#[derive(Sequence)]
pub struct MySequence {
    /// Without deref = "true" macro generates an error:
    ///
    /// the trait `From<Vec<u8>>` is not implemented for `BitStringRef<'_>`
    #[asn1(type = "OCTET STRING", deref = "true")]
    pub owned_bytes: Vec<u8>,
}
```

Is there any better way to add `&` ?