### PR TITLE
base64ct: v1.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,13 +98,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
-
-[[package]]
-name = "base64ct"
-version = "1.7.0-pre"
+version = "1.7.0"
 dependencies = [
  "base64",
  "proptest",
@@ -643,7 +637,7 @@ dependencies = [
 name = "pem-rfc7468"
 version = "1.0.0-rc.2"
 dependencies = [
- "base64ct 1.6.0",
+ "base64ct",
 ]
 
 [[package]]
@@ -1031,7 +1025,7 @@ name = "spki"
 version = "0.8.0-rc.1"
 dependencies = [
  "arbitrary",
- "base64ct 1.6.0",
+ "base64ct",
  "der",
  "hex-literal",
  "sha2",

--- a/base64ct/CHANGELOG.md
+++ b/base64ct/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.7.0 (2025-02-25)
+### Added
+- derive additional traits on alphabets ([#1578])
+
+### Changed
+- MSRV 1.85 // Edition 2024 ([#1670])
+- reject zero-length decode requests ([#1387])
+- use `core::error::Error` ([#1681])
+
+[#1670]: https://github.com/RustCrypto/formats/pull/1670
+[#1578]: https://github.com/RustCrypto/formats/pull/1578
+[#1387]: https://github.com/RustCrypto/formats/pull/1387
+
 ## 1.6.0 (2023-02-26)
 ### Changed
 - MSRV 1.60 ([#802])

--- a/base64ct/Cargo.toml
+++ b/base64ct/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base64ct"
-version = "1.7.0-pre"
+version = "1.7.0"
 description = """
 Pure Rust implementation of Base64 (RFC 4648) which avoids any usages of
 data-dependent branches/LUTs and thereby provides portable "best effort"


### PR DESCRIPTION
Added
- derive additional traits on alphabets (#1578)

Changed
- MSRV 1.85 // Edition 2024 (#1670)
- reject zero-length decode requests (#1387)
- use `core::error::Error` (#1681)