### PR TITLE
CI: fix security audit

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,5 +1,4 @@
 [advisories]
 ignore = [
-    "RUSTSEC-2021-0127", # serde_cbor is unmaintained
-    "RUSTSEC-2023-0071", # rsa: Marvin Attack: potential key recovery
-]
+    "RUSTSEC-2024-0436", #paste
+] # advisory IDs to ignore e.g. ["RUSTSEC-2019-0001", ...]

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -21,11 +21,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-      # TODO(tarcieri): investigate why cached binaries aren't working
-      #- uses: actions/cache@v4
-      #  with:
-      #    path: ~/.cargo/bin
-      #    key: ${{ runner.os }}-cargo-audit-v0.20
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin
+          key: ${{ runner.os }}-cargo-audit-v0.21.2
       - uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Ignores RUSTSEC-2024-0436: `paste` is unmaintained