### PR TITLE
base64ct v1.7.1

### DIFF
--- a/base64ct/CHANGELOG.md
+++ b/base64ct/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.7.1 (2025-03-10)
+### Changed
+- MSRV 1.81 - edition downgraded to 2021 from yanked 1.7.0 release ([#1702])
+
+[#1702]: https://github.com/RustCrypto/formats/pull/1702
+
 ## 1.7.0 (2025-02-25) [YANKED]
 ### Added
 - derive additional traits on alphabets ([#1578])

--- a/base64ct/CHANGELOG.md
+++ b/base64ct/CHANGELOG.md
@@ -19,9 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - reject zero-length decode requests ([#1387])
 - use `core::error::Error` ([#1681])
 
-[#1670]: https://github.com/RustCrypto/formats/pull/1670
-[#1578]: https://github.com/RustCrypto/formats/pull/1578
 [#1387]: https://github.com/RustCrypto/formats/pull/1387
+[#1578]: https://github.com/RustCrypto/formats/pull/1578
+[#1670]: https://github.com/RustCrypto/formats/pull/1670
+[#1681]: https://github.com/RustCrypto/formats/pull/1681
 
 ## 1.6.0 (2023-02-26)
 ### Changed

--- a/base64ct/Cargo.lock
+++ b/base64ct/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "base64",
  "proptest",

--- a/base64ct/Cargo.toml
+++ b/base64ct/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base64ct"
-version = "1.7.0"
+version = "1.7.1"
 description = """
 Pure Rust implementation of Base64 (RFC 4648) which avoids any usages of
 data-dependent branches/LUTs and thereby provides portable "best effort"

--- a/base64ct/README.md
+++ b/base64ct/README.md
@@ -65,7 +65,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/base64ct
+[crate-image]: https://img.shields.io/crates/v/base64ct?logo=rust
 [crate-link]: https://crates.io/crates/base64ct
 [docs-image]: https://docs.rs/base64ct/badge.svg
 [docs-link]: https://docs.rs/base64ct/


### PR DESCRIPTION
- MSRV 1.81 - edition downgraded to 2021 from [yanked 1.7.0 release](https://github.com/RustCrypto/formats/blob/master/base64ct/CHANGELOG.md#170-2025-02-25-yanked) ([#1702])

[#1702]: https://github.com/RustCrypto/formats/pull/1702