### PR TITLE
x509-cert: remove unnecessary `builder` feature activations

### DIFF
--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -23,7 +23,7 @@ spki = { version = "0.8.0-rc.0", features = ["alloc"] }
 # optional dependencies
 arbitrary = { version = "1.4", features = ["derive"], optional = true }
 digest = { version = "0.11.0-pre.10", optional = true, default-features = false }
-sha1 = { version = "0.11.0-pre.5", optional = true }
+sha1 = { version = "0.11.0-pre.5", default-features = false, optional = true }
 signature = { version = "=2.3.0-pre.6", features = ["rand_core"], optional = true }
 tls_codec = { version = "0.4.0", default-features = false, features = ["derive"], optional = true }
 
@@ -44,7 +44,7 @@ default = ["pem", "std"]
 std = ["der/std", "spki/std", "tls_codec?/std"]
 
 arbitrary = ["dep:arbitrary", "std", "der/arbitrary", "spki/arbitrary"]
-builder = ["std", "sha1/default", "signature"]
+builder = ["dep:sha1", "signature"]
 digest = ["dep:digest", "spki/digest"]
 hazmat = []
 pem = ["der/pem", "spki/pem"]

--- a/x509-cert/src/builder.rs
+++ b/x509-cert/src/builder.rs
@@ -115,7 +115,8 @@ pub type Result<T> = core::result::Result<T, Error>;
 
 /// X509 Certificate builder
 ///
-/// ```
+#[cfg_attr(feature = "std", doc = "```")]
+#[cfg_attr(not(feature = "std"), doc = "```ignore")]
 /// use der::Decode;
 /// use x509_cert::spki::SubjectPublicKeyInfo;
 /// use x509_cert::builder::{CertificateBuilder, Builder, profile};

--- a/x509-cert/tests/builder.rs
+++ b/x509-cert/tests/builder.rs
@@ -1,4 +1,4 @@
-#![cfg(all(feature = "builder", feature = "pem"))]
+#![cfg(all(feature = "builder", feature = "pem", feature = "std"))]
 
 use der::{
     EncodePem,


### PR DESCRIPTION
- Removed sha1/default, since that includes std feature.
- Set der to the latest rc version.
- Used dep: syntax for feature based dependencies


Note: I was unable to run **all** tests due to not having the `zlint` installed.