### PR TITLE
der: pem reader rejects zero lengths reads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,18 +91,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
 name = "base64ct"
-version = "1.7.0"
-dependencies = [
- "base64",
- "proptest",
-]
+version = "1.7.1"
 
 [[package]]
 name = "bincode"

--- a/der/src/reader/pem.rs
+++ b/der/src/reader/pem.rs
@@ -87,6 +87,10 @@ impl<'i> Reader<'i> for PemReader<'i> {
     }
 
     fn read_into<'o>(&mut self, buf: &'o mut [u8]) -> crate::Result<&'o [u8]> {
+        if buf.is_empty() {
+            return Ok(buf);
+        }
+
         let new_position = (self.position + buf.len())?;
         if new_position > self.input_len {
             return Err(ErrorKind::Incomplete {

--- a/der/tests/pem.rs
+++ b/der/tests/pem.rs
@@ -3,7 +3,7 @@
 #![cfg(all(feature = "derive", feature = "oid", feature = "pem"))]
 
 use der::{
-    Decode, DecodePem, EncodePem, Sequence,
+    Any, Decode, DecodePem, EncodePem, Sequence,
     asn1::{BitString, ObjectIdentifier},
     pem::{LineEnding, PemLabel},
 };
@@ -15,14 +15,14 @@ const SPKI_DER: &[u8] = include_bytes!("examples/spki.der");
 const SPKI_PEM: &str = include_str!("examples/spki.pem");
 
 /// X.509 `AlgorithmIdentifier`
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Sequence)]
+#[derive(Clone, Debug, Eq, PartialEq, Sequence)]
 pub struct AlgorithmIdentifier {
     pub algorithm: ObjectIdentifier,
-    // pub parameters: ... (not used in spki.pem)
+    pub parameters: Option<Any>,
 }
 
 /// X.509 `SubjectPublicKeyInfo` (SPKI) in borrowed form
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Sequence)]
+#[derive(Clone, Debug, Eq, PartialEq, Sequence)]
 pub struct SpkiBorrowed<'a> {
     pub algorithm: AlgorithmIdentifier,
     #[asn1(type = "BIT STRING")]
@@ -64,4 +64,18 @@ fn to_pem() {
     let spki = SpkiBorrowed::from_der(SPKI_DER).unwrap();
     let pem = spki.to_pem(LineEnding::LF).unwrap();
     assert_eq!(&pem, SPKI_PEM);
+}
+
+#[test]
+fn read_zero_slices_from_pem() {
+    let spki = SpkiOwned {
+        algorithm: AlgorithmIdentifier {
+            algorithm: ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.11"),
+            parameters: Some(Any::null()),
+        },
+        subject_public_key: BitString::new(0, []).unwrap(),
+    };
+
+    let pem = spki.to_pem(LineEnding::LF).unwrap();
+    SpkiOwned::from_pem(pem).unwrap();
 }


### PR DESCRIPTION
Since base64ct 1.7.0 (#1387), we now rejects zero lengths reads. This happens to trigger with an sha256WithRSAEncryption AlgorithmIdentifier where the parameters are null.