### PR TITLE
base64ct: v1.7.3

### DIFF
--- a/base64ct/CHANGELOG.md
+++ b/base64ct/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.7.3 (2025-03-13)
+### Changed
+- Don't fail with `InvalidLength` when reading nothing at end of data ([#1716]).
+
+[#1716]: https://github.com/RustCrypto/formats/pull/1716
+
 ## 1.7.2 (2025-03-13)
 ### Changed
 - Revert [#1387]: reject zero-length decode requests as it's a breaking change ([#1714])

--- a/base64ct/Cargo.lock
+++ b/base64ct/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "base64",
  "proptest",

--- a/base64ct/Cargo.toml
+++ b/base64ct/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base64ct"
-version = "1.7.2"
+version = "1.7.3"
 description = """
 Pure Rust implementation of Base64 (RFC 4648) which avoids any usages of
 data-dependent branches/LUTs and thereby provides portable "best effort"


### PR DESCRIPTION
## 1.7.3 (2025-03-13)
### Changed
- Don't fail with `InvalidLength` when reading nothing at end of data ([#1716]).

[#1716]: https://github.com/RustCrypto/formats/pull/1716