### PR TITLE
der_derive: add BitString macro

### DIFF
--- a/der/src/asn1.rs
+++ b/der/src/asn1.rs
@@ -5,7 +5,7 @@
 mod internal_macros;
 
 mod any;
-mod bit_string;
+pub(crate) mod bit_string;
 #[cfg(feature = "alloc")]
 mod bmp_string;
 mod boolean;

--- a/der/src/asn1/bit_string.rs
+++ b/der/src/asn1/bit_string.rs
@@ -1,5 +1,7 @@
 //! ASN.1 `BIT STRING` support.
 
+pub mod fixed_len_bit_string;
+
 use crate::{
     BytesRef, DecodeValue, DerOrd, EncodeValue, Error, ErrorKind, FixedTag, Header, Length, Reader,
     Result, Tag, ValueOrd, Writer,
@@ -117,6 +119,17 @@ impl<'a> BitStringRef<'a> {
             bit_string: self,
             position: 0,
         }
+    }
+
+    /// Returns Some(bit) if index is valid
+    pub fn get(&self, position: usize) -> Option<bool> {
+        if position >= self.bit_len() {
+            return None;
+        }
+
+        let byte = self.raw_bytes().get(position / 8)?;
+        let bitmask = 1u8 << (7 - (position % 8));
+        Some(byte & bitmask != 0)
     }
 }
 
@@ -308,6 +321,11 @@ mod allocating {
         /// Iterator over the bits of this `BIT STRING`.
         pub fn bits(&self) -> BitStringIter<'_> {
             BitStringRef::from(self).bits()
+        }
+
+        /// Returns Some(bit) if index is valid
+        pub fn get(&self, position: usize) -> Option<bool> {
+            BitStringRef::from(self).get(position)
         }
     }
 

--- a/der/src/asn1/bit_string/fixed_len_bit_string.rs
+++ b/der/src/asn1/bit_string/fixed_len_bit_string.rs
@@ -1,0 +1,48 @@
+use core::ops::RangeInclusive;
+
+use crate::{Error, ErrorKind, Tag};
+
+/// Trait on automatically derived by BitString macro.
+/// Used for checking if binary data fits into defined struct.
+///
+/// ```
+/// /// Bit length of 2
+/// struct MyBitString {
+///     flag1: bool,
+///     flag2: bool,
+/// }
+/// ```
+///
+/// ```
+/// use der::BitString;
+///
+/// /// Bit length of 3..=4
+/// #[derive(BitString)]
+/// struct MyBitString {
+///     flag1: bool,
+///     flag2: bool,
+///     flag3: bool,
+///
+///     #[asn1(optional = "true")]
+///     flag4: bool,
+/// }
+/// ```
+pub trait FixedLenBitString {
+    /// Implementer must specify how many bits are allowed
+    const ALLOWED_LEN_RANGE: RangeInclusive<u16>;
+
+    /// Returns an error if the bitstring is not in expected length range
+    fn check_bit_len(bit_len: u16) -> Result<(), Error> {
+        let allowed_len_range = Self::ALLOWED_LEN_RANGE;
+
+        // forces allowed range to eg. 3..=4
+        if !allowed_len_range.contains(&bit_len) {
+            Err(ErrorKind::Length {
+                tag: Tag::BitString,
+            }
+            .into())
+        } else {
+            Ok(())
+        }
+    }
+}

--- a/der/src/asn1/bit_string/fixed_len_bit_string.rs
+++ b/der/src/asn1/bit_string/fixed_len_bit_string.rs
@@ -13,7 +13,7 @@ use crate::{Error, ErrorKind, Tag};
 /// }
 /// ```
 ///
-/// ```
+/// ```rust,ignore
 /// use der::BitString;
 ///
 /// /// Bit length of 3..=4

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -365,6 +365,7 @@ mod document;
 mod str_owned;
 
 pub use crate::{
+    asn1::bit_string::fixed_len_bit_string::FixedLenBitString,
     asn1::{AnyRef, Choice, Sequence},
     datetime::DateTime,
     decode::{Decode, DecodeOwned, DecodeValue},
@@ -384,7 +385,7 @@ pub use crate::{
 pub use crate::{asn1::Any, document::Document};
 
 #[cfg(feature = "derive")]
-pub use der_derive::{Choice, Enumerated, Sequence, ValueOrd};
+pub use der_derive::{BitString, Choice, Enumerated, Sequence, ValueOrd};
 
 #[cfg(feature = "flagset")]
 pub use flagset;

--- a/der_derive/src/bitstring.rs
+++ b/der_derive/src/bitstring.rs
@@ -1,0 +1,183 @@
+//! Support for deriving the `BitString` trait on bool structs for the purposes of
+//! decoding/encoding ASN.1 `BITSTRING` types as mapped to struct fields.
+
+use crate::{TypeAttrs, default_lifetime};
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{DeriveInput, GenericParam, Generics, Ident, LifetimeParam};
+
+use self::field::BitStringField;
+
+mod field;
+
+/// Derive the `BitString` trait for a struct
+pub(crate) struct DeriveBitString {
+    /// Name of the bitsting struct.
+    ident: Ident,
+
+    /// Generics of the struct.
+    generics: Generics,
+
+    /// Fields of the struct.
+    fields: Vec<BitStringField>,
+}
+
+impl DeriveBitString {
+    /// Parse [`DeriveInput`].
+    pub fn new(input: DeriveInput) -> syn::Result<Self> {
+        let data = match input.data {
+            syn::Data::Struct(data) => data,
+            _ => abort!(
+                input.ident,
+                "can't derive `BitString` on this type: only `struct` types are allowed",
+            ),
+        };
+
+        let type_attrs = TypeAttrs::parse(&input.attrs)?;
+
+        let fields = data
+            .fields
+            .iter()
+            .map(|field| BitStringField::new(field, &type_attrs))
+            .collect::<syn::Result<_>>()?;
+
+        Ok(Self {
+            ident: input.ident,
+            generics: input.generics.clone(),
+            fields,
+        })
+    }
+
+    /// Lower the derived output into a [`TokenStream`].
+    pub fn to_tokens(&self) -> TokenStream {
+        let ident = &self.ident;
+        let mut generics = self.generics.clone();
+
+        // Use the first lifetime parameter as lifetime for Decode/Encode lifetime
+        // if none found, add one.
+        let lifetime = generics
+            .lifetimes()
+            .next()
+            .map(|lt| lt.lifetime.clone())
+            .unwrap_or_else(|| {
+                let lt = default_lifetime();
+                generics
+                    .params
+                    .insert(0, GenericParam::Lifetime(LifetimeParam::new(lt.clone())));
+                lt
+            });
+
+        // We may or may not have inserted a lifetime.
+        let (_, ty_generics, where_clause) = self.generics.split_for_impl();
+        let (impl_generics, _, _) = generics.split_for_impl();
+
+        let mut decode_body = Vec::new();
+
+        let mut min_expected_fields: u16 = 0;
+        let mut max_expected_fields: u16 = 0;
+        for field in &self.fields {
+            max_expected_fields += 1;
+
+            if !field.attrs.optional {
+                min_expected_fields += 1;
+            }
+        }
+        let min_expected_bytes = (min_expected_fields + 7) / 8;
+
+        for (i, field) in self.fields.iter().enumerate().rev() {
+            let field_name = &field.ident;
+
+            decode_body.push(quote!(
+                #field_name: bs.get(#i).unwrap_or(false)
+            ));
+        }
+
+        let mut encode_bytes = Vec::new();
+
+        for chunk in self.fields.chunks(8) {
+            let mut encode_bits = Vec::with_capacity(8);
+
+            for (i, field) in chunk.iter().enumerate() {
+                let bitn = 7 - i;
+                let field_name = &field.ident;
+                encode_bits.push(quote!(
+                        bits |= (self.#field_name as u8) << #bitn;
+                ));
+            }
+            encode_bytes.push(quote!({
+                let mut bits: u8 = 0;
+                #(#encode_bits)*
+                bits
+            }));
+        }
+
+        quote! {
+            impl ::der::FixedTag for #ident #ty_generics #where_clause {
+                const TAG: der::Tag = ::der::Tag::BitString;
+            }
+            impl ::der::FixedLenBitString for #ident #ty_generics #where_clause {
+                const ALLOWED_LEN_RANGE: ::core::ops::RangeInclusive<u16> = #min_expected_fields..=#max_expected_fields;
+            }
+
+            impl #impl_generics ::der::DecodeValue<#lifetime> for #ident #ty_generics #where_clause {
+                type Error = ::der::Error;
+
+                fn decode_value<R: ::der::Reader<#lifetime>>(
+                    reader: &mut R,
+                    header: ::der::Header,
+                ) -> ::core::result::Result<Self, ::der::Error> {
+                    use ::der::{Decode as _, DecodeValue as _, Reader as _};
+                    use ::der::FixedLenBitString as _;
+
+
+                    let bs = ::der::asn1::BitStringRef::decode_value(reader, header)?;
+
+                    Self::check_bit_len(bs.bit_len() as u16)?;
+
+                    let b = bs.raw_bytes();
+                    let flags = Self {
+                        #(#decode_body),*
+
+                    };
+                    Ok(flags)
+
+                }
+
+            }
+
+            impl #impl_generics ::der::EncodeValue for #ident #ty_generics #where_clause {
+                fn value_len(&self) -> der::Result<der::Length> {
+                    Ok(der::Length::new(#min_expected_bytes + 1))
+                }
+
+                fn encode_value(&self, writer: &mut impl ::der::Writer) -> ::der::Result<()> {
+                    use ::der::Encode as _;
+                    use der::FixedLenBitString as _;
+
+                    let arr = [#(#encode_bytes),*];
+
+                    let min_bits = {
+                        let max_bits = *Self::ALLOWED_LEN_RANGE.end();
+                        let last_byte_bits = (max_bits % 8) as u8;
+                        let bs = ::der::asn1::BitStringRef::new(8 - last_byte_bits, &arr)?;
+
+                        let mut min_bits = *Self::ALLOWED_LEN_RANGE.start();
+
+                        // find last lit bit
+                        for bit_index in Self::ALLOWED_LEN_RANGE.rev() {
+                            if bs.get(bit_index as usize).unwrap_or_default() {
+                                min_bits = bit_index + 1;
+                                break;
+                            }
+                        }
+                        min_bits
+                    };
+
+                    let last_byte_bits = (min_bits % 8) as u8;
+                    let bs = ::der::asn1::BitStringRef::new(8 - last_byte_bits, &arr)?;
+                    bs.encode_value(writer)
+                }
+            }
+        }
+    }
+}

--- a/der_derive/src/bitstring/field.rs
+++ b/der_derive/src/bitstring/field.rs
@@ -5,7 +5,6 @@ use crate::{FieldAttrs, TypeAttrs};
 use syn::{Field, Ident};
 
 /// "IR" for a field of a derived `BitString`.
-
 pub(super) struct BitStringField {
     /// Variant name.
     pub(super) ident: Ident,
@@ -16,7 +15,6 @@ pub(super) struct BitStringField {
 
 impl BitStringField {
     /// Create a new [`BitStringField`] from the input [`Field`].
-
     pub(super) fn new(field: &Field, type_attrs: &TypeAttrs) -> syn::Result<Self> {
         let ident = field.ident.as_ref().cloned().ok_or_else(|| {
             syn::Error::new_spanned(

--- a/der_derive/src/bitstring/field.rs
+++ b/der_derive/src/bitstring/field.rs
@@ -1,0 +1,46 @@
+//! Sequence field IR and lowerings
+
+use crate::{FieldAttrs, TypeAttrs};
+
+use syn::{Field, Ident};
+
+/// "IR" for a field of a derived `BitString`.
+
+pub(super) struct BitStringField {
+    /// Variant name.
+    pub(super) ident: Ident,
+
+    /// Field-level attributes.
+    pub(super) attrs: FieldAttrs,
+}
+
+impl BitStringField {
+    /// Create a new [`BitStringField`] from the input [`Field`].
+
+    pub(super) fn new(field: &Field, type_attrs: &TypeAttrs) -> syn::Result<Self> {
+        let ident = field.ident.as_ref().cloned().ok_or_else(|| {
+            syn::Error::new_spanned(
+                field,
+                "no name on struct field i.e. tuple structs unsupported",
+            )
+        })?;
+
+        let attrs = FieldAttrs::parse(&field.attrs, type_attrs)?;
+
+        if attrs.asn1_type.is_some() && attrs.default.is_some() {
+            return Err(syn::Error::new_spanned(
+                ident,
+                "ASN.1 `type` and `default` options cannot be combined",
+            ));
+        }
+
+        if attrs.default.is_some() && attrs.optional {
+            return Err(syn::Error::new_spanned(
+                ident,
+                "`optional` and `default` field qualifiers are mutually exclusive",
+            ));
+        }
+
+        Ok(Self { ident, attrs })
+    }
+}

--- a/der_derive/src/lib.rs
+++ b/der_derive/src/lib.rs
@@ -151,6 +151,7 @@ macro_rules! abort {
 
 mod asn1_type;
 mod attributes;
+mod bitstring;
 mod choice;
 mod enumerated;
 mod sequence;
@@ -160,6 +161,7 @@ mod value_ord;
 use crate::{
     asn1_type::Asn1Type,
     attributes::{ATTR_NAME, ErrorType, FieldAttrs, TypeAttrs},
+    bitstring::DeriveBitString,
     choice::DeriveChoice,
     enumerated::DeriveEnumerated,
     sequence::DeriveSequence,
@@ -312,6 +314,18 @@ pub fn derive_value_ord(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     match DeriveValueOrd::new(input) {
         Ok(t) => t.to_tokens().into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+/// Derive the [`BitString`] on a bool `struct`.
+#[proc_macro_derive(BitString, attributes(asn1))]
+pub fn derive_bitstring(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    match DeriveBitString::new(input) {
+        Ok(t) => t.to_tokens().into(),
+
         Err(e) => e.to_compile_error().into(),
     }
 }

--- a/der_derive/src/lib.rs
+++ b/der_derive/src/lib.rs
@@ -318,7 +318,18 @@ pub fn derive_value_ord(input: TokenStream) -> TokenStream {
     }
 }
 
-/// Derive the [`BitString`] on a bool `struct`.
+/// Derive the [`BitString`] on a `struct` with bool fields.
+///
+/// ```ignore
+/// use der::BitString;
+///
+/// #[derive(BitString)]
+/// pub struct MyFlags {
+///     pub flag_0: bool,
+///     pub flag_1: bool,
+///     pub flag_2: bool,
+/// }
+/// ```
 #[proc_macro_derive(BitString, attributes(asn1))]
 pub fn derive_bitstring(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);


### PR DESCRIPTION
Adds macro:

```rust
#[derive(BitString)]
pub struct MyBitString {
    pub flag_0: bool,
    pub flag_1: bool,
    pub flag_2: bool,
}
```

Which produces example ASN.1: https://lapo.it/asn1js/#AwIF4A
```
BIT STRING (3 bit) 111

03 02 05 E0
```
