### PR TITLE
der_derive: add DecodeValue, EncodeValue macros

### DIFF
--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -385,9 +385,7 @@ pub use crate::{
 pub use crate::{asn1::Any, document::Document};
 
 #[cfg(feature = "derive")]
-pub use der_derive::{
-    BitString, Choice, Enumerated, Sequence, SequenceDecode, SequenceEncode, ValueOrd,
-};
+pub use der_derive::{BitString, Choice, DecodeValue, EncodeValue, Enumerated, Sequence, ValueOrd};
 
 #[cfg(feature = "flagset")]
 pub use flagset;

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -385,7 +385,9 @@ pub use crate::{
 pub use crate::{asn1::Any, document::Document};
 
 #[cfg(feature = "derive")]
-pub use der_derive::{BitString, Choice, Enumerated, Sequence, ValueOrd};
+pub use der_derive::{
+    BitString, Choice, Enumerated, Sequence, SequenceDecode, SequenceEncode, ValueOrd,
+};
 
 #[cfg(feature = "flagset")]
 pub use flagset;

--- a/der/tests/derive.rs
+++ b/der/tests/derive.rs
@@ -627,6 +627,56 @@ mod sequence {
     }
 }
 
+/// Custom derive test cases for the `SequenceEncode` macro.
+mod sequence_encode {
+    use der::{Encode, FixedTag, SequenceEncode, Tag};
+    use hex_literal::hex;
+
+    #[derive(SequenceEncode, Default, Eq, PartialEq, Debug)]
+    #[asn1(tag_mode = "IMPLICIT")]
+    pub struct EncodeOnlyCheck<'a> {
+        #[asn1(type = "OCTET STRING", context_specific = "5")]
+        pub field: &'a [u8],
+    }
+    impl FixedTag for EncodeOnlyCheck<'_> {
+        const TAG: Tag = Tag::Sequence;
+    }
+
+    #[test]
+    fn sequence_encode_only_to_der() {
+        let obj = EncodeOnlyCheck {
+            field: &[0x33, 0x44],
+        };
+
+        let der_encoded = obj.to_der().unwrap();
+
+        assert_eq!(der_encoded, hex!("30 04 85 02 33 44"));
+    }
+}
+
+/// Custom derive test cases for the `SequenceDecode` macro.
+mod sequence_decode {
+    use der::{Decode, FixedTag, SequenceDecode, Tag};
+    use hex_literal::hex;
+
+    #[derive(SequenceDecode, Default, Eq, PartialEq, Debug)]
+    #[asn1(tag_mode = "IMPLICIT")]
+    pub struct DecodeOnlyCheck<'a> {
+        #[asn1(type = "OCTET STRING", context_specific = "5")]
+        pub field: &'a [u8],
+    }
+    impl FixedTag for DecodeOnlyCheck<'_> {
+        const TAG: Tag = Tag::Sequence;
+    }
+
+    #[test]
+    fn sequence_decode_only_from_der() {
+        let obj = DecodeOnlyCheck::from_der(&hex!("30 04 85 02 33 44")).unwrap();
+
+        assert_eq!(obj.field, &[0x33, 0x44]);
+    }
+}
+
 /// Custom derive test cases for the `BitString` macro.
 #[cfg(feature = "std")]
 mod bitstring {

--- a/der/tests/derive.rs
+++ b/der/tests/derive.rs
@@ -627,12 +627,12 @@ mod sequence {
     }
 }
 
-/// Custom derive test cases for the `SequenceEncode` macro.
-mod sequence_encode {
-    use der::{Encode, FixedTag, SequenceEncode, Tag};
+/// Custom derive test cases for the `EncodeValue` macro.
+mod encode_value {
+    use der::{Encode, EncodeValue, FixedTag, Tag};
     use hex_literal::hex;
 
-    #[derive(SequenceEncode, Default, Eq, PartialEq, Debug)]
+    #[derive(EncodeValue, Default, Eq, PartialEq, Debug)]
     #[asn1(tag_mode = "IMPLICIT")]
     pub struct EncodeOnlyCheck<'a> {
         #[asn1(type = "OCTET STRING", context_specific = "5")]
@@ -654,12 +654,12 @@ mod sequence_encode {
     }
 }
 
-/// Custom derive test cases for the `SequenceDecode` macro.
-mod sequence_decode {
-    use der::{Decode, FixedTag, SequenceDecode, Tag};
+/// Custom derive test cases for the `DecodeValue` macro.
+mod decode_value {
+    use der::{Decode, DecodeValue, FixedTag, Tag};
     use hex_literal::hex;
 
-    #[derive(SequenceDecode, Default, Eq, PartialEq, Debug)]
+    #[derive(DecodeValue, Default, Eq, PartialEq, Debug)]
     #[asn1(tag_mode = "IMPLICIT")]
     pub struct DecodeOnlyCheck<'a> {
         #[asn1(type = "OCTET STRING", context_specific = "5")]

--- a/der_derive/src/lib.rs
+++ b/der_derive/src/lib.rs
@@ -308,7 +308,7 @@ pub fn derive_sequence(input: TokenStream) -> TokenStream {
 /// Derive the [`EncodeValue`][1] trait on a `struct`.
 ///
 /// [1]: https://docs.rs/der/latest/der/trait.EncodeValue.html
-#[proc_macro_derive(SequenceEncode, attributes(asn1))]
+#[proc_macro_derive(EncodeValue, attributes(asn1))]
 pub fn derive_sequence_encode(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     match DeriveSequence::new(input) {
@@ -320,7 +320,7 @@ pub fn derive_sequence_encode(input: TokenStream) -> TokenStream {
 /// Derive the [`DecodeValue`][1] trait on a `struct`.
 ///
 /// [1]: https://docs.rs/der/latest/der/trait.DecodeValue.html
-#[proc_macro_derive(SequenceDecode, attributes(asn1))]
+#[proc_macro_derive(DecodeValue, attributes(asn1))]
 pub fn derive_sequence_decode(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     match DeriveSequence::new(input) {

--- a/der_derive/src/lib.rs
+++ b/der_derive/src/lib.rs
@@ -261,7 +261,7 @@ pub fn derive_enumerated(input: TokenStream) -> TokenStream {
     }
 }
 
-/// Derive the [`Sequence`][1] trait on a `struct`.
+/// Derive the [`DecodeValue`][1], [`EncodeValue`][2], [`Sequence`][3] traits on a `struct`.
 ///
 /// This custom derive macro can be used to automatically impl the
 /// `Sequence` trait for any struct which can be decoded/encoded as an
@@ -289,16 +289,42 @@ pub fn derive_enumerated(input: TokenStream) -> TokenStream {
 ///
 /// # `#[asn1(type = "...")]` attribute
 ///
-/// See [toplevel documentation for the `der_derive` crate][2] for more
+/// See [toplevel documentation for the `der_derive` crate][4] for more
 /// information about the `#[asn1]` attribute.
 ///
-/// [1]: https://docs.rs/der/latest/der/trait.Sequence.html
-/// [2]: https://docs.rs/der_derive/
+/// [1]: https://docs.rs/der/latest/der/trait.DecodeValue.html
+/// [2]: https://docs.rs/der/latest/der/trait.EncodeValue.html
+/// [3]: https://docs.rs/der/latest/der/trait.Sequence.html
+/// [4]: https://docs.rs/der_derive/
 #[proc_macro_derive(Sequence, attributes(asn1))]
 pub fn derive_sequence(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     match DeriveSequence::new(input) {
-        Ok(t) => t.to_tokens().into(),
+        Ok(t) => t.to_tokens_all().into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+/// Derive the [`EncodeValue`][1] trait on a `struct`.
+///
+/// [1]: https://docs.rs/der/latest/der/trait.EncodeValue.html
+#[proc_macro_derive(SequenceEncode, attributes(asn1))]
+pub fn derive_sequence_encode(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    match DeriveSequence::new(input) {
+        Ok(t) => t.to_tokens_encode().into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+/// Derive the [`DecodeValue`][1] trait on a `struct`.
+///
+/// [1]: https://docs.rs/der/latest/der/trait.DecodeValue.html
+#[proc_macro_derive(SequenceDecode, attributes(asn1))]
+pub fn derive_sequence_decode(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    match DeriveSequence::new(input) {
+        Ok(t) => t.to_tokens_decode().into(),
         Err(e) => e.to_compile_error().into(),
     }
 }


### PR DESCRIPTION
Fixes
- #1705

Adds DecodeValue macro:
```rust
#[derive(DecodeValue)]
struct MyDecodeOnly {
    field: u8,
}
impl FixedTag for MyDecodeOnly {
    const TAG: Tag = Tag::Sequence;
}
```

and EncodeValue:
```rust
#[derive(EncodeValue)]
struct MyEncodeOnly {
    field: u8,
}
impl FixedTag for MyEncodeOnly {
    const TAG: Tag = Tag::Sequence;
}

```