### PR TITLE
der: conversions between `BitStringRef`/`OctetStringRef` and `[u8; N]`

### DIFF
--- a/der/src/asn1/bit_string.rs
+++ b/der/src/asn1/bit_string.rs
@@ -207,7 +207,7 @@ impl<'a, const N: usize> TryFrom<BitStringRef<'a>> for [u8; N] {
     type Error = Error;
 
     fn try_from(bit_string: BitStringRef<'a>) -> Result<Self> {
-        let expected_len = Length::new_usize(N)?;
+        let expected_len = Length::try_from(N)?;
         let bytes = bit_string
             .as_bytes()
             .ok_or_else(|| Tag::BitString.value_error())?;

--- a/der/src/asn1/bit_string.rs
+++ b/der/src/asn1/bit_string.rs
@@ -193,6 +193,34 @@ impl<'a> TryFrom<&&'a [u8]> for BitStringRef<'a> {
     }
 }
 
+/// Hack for simplifying the custom derive use case.
+impl<'a, const N: usize> TryFrom<&'a [u8; N]> for BitStringRef<'a> {
+    type Error = Error;
+
+    fn try_from(bytes: &'a [u8; N]) -> Result<BitStringRef<'a>> {
+        BitStringRef::from_bytes(bytes)
+    }
+}
+
+/// Hack for simplifying the custom derive use case.
+impl<'a, const N: usize> TryFrom<BitStringRef<'a>> for [u8; N] {
+    type Error = Error;
+
+    fn try_from(bit_string: BitStringRef<'a>) -> Result<Self> {
+        let expected_len = Length::new_usize(N)?;
+        let bytes = bit_string
+            .as_bytes()
+            .ok_or_else(|| Tag::BitString.value_error())?;
+
+        bytes.try_into().map_err(|_| {
+            Error::from_kind(ErrorKind::Incomplete {
+                expected_len,
+                actual_len: bit_string.byte_len(),
+            })
+        })
+    }
+}
+
 impl<'a> TryFrom<BitStringRef<'a>> for &'a [u8] {
     type Error = Error;
 

--- a/der/src/asn1/bit_string.rs
+++ b/der/src/asn1/bit_string.rs
@@ -205,17 +205,9 @@ impl<'a, const N: usize> TryFrom<BitStringRef<'a>> for [u8; N] {
     type Error = Error;
 
     fn try_from(bit_string: BitStringRef<'a>) -> Result<Self> {
-        let expected_len = Length::try_from(N)?;
-        let bytes = bit_string
-            .as_bytes()
-            .ok_or_else(|| Tag::BitString.value_error())?;
+        let bytes: &[u8] = TryFrom::try_from(bit_string)?;
 
-        bytes.try_into().map_err(|_| {
-            Error::from_kind(ErrorKind::Incomplete {
-                expected_len,
-                actual_len: bit_string.byte_len(),
-            })
-        })
+        bytes.try_into().map_err(|_| Tag::BitString.length_error())
     }
 }
 

--- a/der/src/asn1/bit_string.rs
+++ b/der/src/asn1/bit_string.rs
@@ -193,7 +193,6 @@ impl<'a> TryFrom<&&'a [u8]> for BitStringRef<'a> {
     }
 }
 
-/// Hack for simplifying the custom derive use case.
 impl<'a, const N: usize> TryFrom<&'a [u8; N]> for BitStringRef<'a> {
     type Error = Error;
 
@@ -202,7 +201,6 @@ impl<'a, const N: usize> TryFrom<&'a [u8; N]> for BitStringRef<'a> {
     }
 }
 
-/// Hack for simplifying the custom derive use case.
 impl<'a, const N: usize> TryFrom<BitStringRef<'a>> for [u8; N] {
     type Error = Error;
 

--- a/der/src/asn1/octet_string.rs
+++ b/der/src/asn1/octet_string.rs
@@ -125,13 +125,10 @@ impl<'a, const N: usize> TryFrom<OctetStringRef<'a>> for [u8; N] {
     type Error = Error;
 
     fn try_from(octet_string: OctetStringRef<'a>) -> Result<Self, Self::Error> {
-        let expected_len = Length::try_from(N)?;
-        octet_string.as_bytes().try_into().map_err(|_| {
-            Error::from_kind(ErrorKind::Incomplete {
-                expected_len,
-                actual_len: octet_string.len(),
-            })
-        })
+        octet_string
+            .as_bytes()
+            .try_into()
+            .map_err(|_| Tag::OctetString.length_error())
     }
 }
 

--- a/der/src/asn1/octet_string.rs
+++ b/der/src/asn1/octet_string.rs
@@ -127,7 +127,7 @@ impl<'a, const N: usize> TryFrom<OctetStringRef<'a>> for [u8; N] {
     type Error = Error;
 
     fn try_from(octet_string: OctetStringRef<'a>) -> Result<Self, Self::Error> {
-        let expected_len = Length::new_usize(N)?;
+        let expected_len = Length::try_from(N)?;
         octet_string.as_bytes().try_into().map_err(|_| {
             Error::from_kind(ErrorKind::Incomplete {
                 expected_len,

--- a/der/src/asn1/octet_string.rs
+++ b/der/src/asn1/octet_string.rs
@@ -113,7 +113,6 @@ impl<'a> TryFrom<&&'a [u8]> for OctetStringRef<'a> {
     }
 }
 
-/// Hack for simplifying the custom derive use case.
 impl<'a, const N: usize> TryFrom<&'a [u8; N]> for OctetStringRef<'a> {
     type Error = Error;
 
@@ -122,7 +121,6 @@ impl<'a, const N: usize> TryFrom<&'a [u8; N]> for OctetStringRef<'a> {
     }
 }
 
-/// Hack for simplifying the custom derive use case.
 impl<'a, const N: usize> TryFrom<OctetStringRef<'a>> for [u8; N] {
     type Error = Error;
 

--- a/der/tests/derive.rs
+++ b/der/tests/derive.rs
@@ -528,7 +528,7 @@ mod sequence {
         pub owned_optional_implicit_bytes: Option<Vec<u8>>,
 
         #[asn1(
-            type = "OCTET STRING",
+            type = "BIT STRING",
             context_specific = "6",
             optional = "true",
             tag_mode = "EXPLICIT"
@@ -565,6 +565,85 @@ mod sequence {
         let der_encoded = obj.to_der().unwrap();
         let obj_decoded =
             TypeCheckOwnedSequenceFieldAttributeCombinations::from_der(&der_encoded).unwrap();
+        assert_eq!(obj, obj_decoded);
+    }
+
+    #[derive(Sequence, Default, Eq, PartialEq, Debug)]
+    #[asn1(tag_mode = "IMPLICIT")]
+    pub struct TypeCheckArraysSequenceFieldAttributeCombinations {
+        #[asn1(type = "OCTET STRING", deref = "true")]
+        pub array_bytes: [u8; 2],
+
+        #[asn1(type = "BIT STRING", deref = "true")]
+        pub array_bits: [u8; 2],
+
+        #[asn1(type = "OCTET STRING", context_specific = "0", deref = "true")]
+        pub array_implicit_bytes: [u8; 2],
+
+        #[asn1(type = "BIT STRING", context_specific = "1", deref = "true")]
+        pub array_implicit_bits: [u8; 2],
+
+        #[asn1(
+            type = "OCTET STRING",
+            context_specific = "2",
+            tag_mode = "EXPLICIT",
+            deref = "true"
+        )]
+        pub array_explicit_bytes: [u8; 2],
+
+        #[asn1(
+            type = "BIT STRING",
+            context_specific = "3",
+            tag_mode = "EXPLICIT",
+            deref = "true"
+        )]
+        pub array_explicit_bits: [u8; 2],
+
+        #[asn1(type = "BIT STRING", context_specific = "4", optional = "true")]
+        pub array_optional_implicit_bits: Option<[u8; 2]>,
+
+        #[asn1(type = "OCTET STRING", context_specific = "5", optional = "true")]
+        pub array_optional_implicit_bytes: Option<[u8; 2]>,
+
+        #[asn1(
+            type = "BIT STRING",
+            context_specific = "6",
+            optional = "true",
+            tag_mode = "EXPLICIT"
+        )]
+        pub array_optional_explicit_bits: Option<[u8; 2]>,
+
+        #[asn1(
+            type = "OCTET STRING",
+            context_specific = "7",
+            optional = "true",
+            tag_mode = "EXPLICIT"
+        )]
+        pub array_optional_explicit_bytes: Option<[u8; 2]>,
+    }
+
+    #[test]
+    fn type_combinations_arrays_instance() {
+        let obj = TypeCheckArraysSequenceFieldAttributeCombinations {
+            array_bytes: [0xAA, 0xBB],
+            array_bits: [0xCC, 0xDD],
+
+            array_implicit_bytes: [0, 1],
+            array_implicit_bits: [2, 3],
+
+            array_explicit_bytes: [4, 5],
+            array_explicit_bits: [6, 7],
+
+            array_optional_implicit_bits: Some([8, 9]),
+            array_optional_implicit_bytes: Some([10, 11]),
+
+            array_optional_explicit_bits: Some([12, 13]),
+            array_optional_explicit_bytes: Some([14, 15]),
+        };
+
+        let der_encoded = obj.to_der().unwrap();
+        let obj_decoded =
+            TypeCheckArraysSequenceFieldAttributeCombinations::from_der(&der_encoded).unwrap();
         assert_eq!(obj, obj_decoded);
     }
 


### PR DESCRIPTION
Fixes: 
- #1730

```rust
#[derive(Sequence)]
pub struct MyStackAllocSequence {
    #[asn1(type = "OCTET STRING", deref = "true")]
    pub array_bytes: [u8; 2],
}
```