### PR TITLE
pkcs8: add hint on `private_key` field about its format (#1749)

### DIFF
--- a/pkcs8/src/private_key_info.rs
+++ b/pkcs8/src/private_key_info.rs
@@ -95,7 +95,7 @@ pub struct PrivateKeyInfo<Params, Key, PubKey> {
     /// X.509 `AlgorithmIdentifier` for the private key type.
     pub algorithm: AlgorithmIdentifier<Params>,
 
-    /// Private key data.
+    /// Private key data. Exact content format is different between algorithms.
     pub private_key: Key,
 
     /// Public key data, optionally available if version is V2.


### PR DESCRIPTION
Adds a hint that might have prevented #1749.

The different formats of the private key per algorithm is already mentioned in the struct documentation and the referenced RFC also documents this fact.

Here we add a breadcrumb inline on the specific field to that fact. This should tell people "Hey, this isn't the actual private key. It's still encoded."

The new generic struct already gives a neat hint towards that fact. Previously it was just a byte slice.