### PR TITLE
x509-cert: add a CRL builder

### DIFF
--- a/x509-cert/src/builder.rs
+++ b/x509-cert/src/builder.rs
@@ -13,9 +13,13 @@ use spki::{
 use crate::{
     AlgorithmIdentifier, SubjectPublicKeyInfo,
     certificate::{Certificate, TbsCertificate, Version},
-    ext::{AsExtension, Extensions},
+    crl::{CertificateList, RevokedCert, TbsCertList},
+    ext::{
+        AsExtension, Extensions,
+        pkix::{AuthorityKeyIdentifier, CrlNumber, SubjectKeyIdentifier},
+    },
     serial_number::SerialNumber,
-    time::Validity,
+    time::{Time, Validity},
 };
 
 pub mod profile;
@@ -409,5 +413,121 @@ where
         S::VerifyingKey: EncodePublicKey,
     {
         <T as Builder>::finalize(self, signer)
+    }
+}
+
+/// X.509 CRL builder
+pub struct CrlBuilder {
+    tbs: TbsCertList,
+}
+
+impl CrlBuilder {
+    /// Create a `CrlBuilder` with the given issuer and the given monotonic [`CrlNumber`]
+    #[cfg(feature = "std")]
+    pub fn new(issuer: &Certificate, crl_number: CrlNumber) -> der::Result<Self> {
+        let this_update = Time::now()?;
+        Self::new_with_this_update(issuer, crl_number, this_update)
+    }
+
+    /// Create a `CrlBuilder` with the given issuer, a given monotonic [`CrlNumber`], and valid
+    /// from the given `this_update` start validity date.
+    pub fn new_with_this_update(
+        issuer: &Certificate,
+        crl_number: CrlNumber,
+        this_update: Time,
+    ) -> der::Result<Self> {
+        // Replaced later when the finalize is called
+        let signature_alg = AlgorithmIdentifier {
+            oid: NULL_OID,
+            parameters: None,
+        };
+
+        let issuer_name = issuer.tbs_certificate.subject().clone();
+
+        let mut crl_extensions = Extensions::new();
+        crl_extensions.push(crl_number.to_extension(&issuer_name, &crl_extensions)?);
+        let aki = match issuer
+            .tbs_certificate
+            .get_extension::<AuthorityKeyIdentifier>()?
+        {
+            Some((_, aki)) => aki,
+            None => {
+                let ski = SubjectKeyIdentifier::try_from(
+                    issuer
+                        .tbs_certificate
+                        .subject_public_key_info()
+                        .owned_to_ref(),
+                )?;
+                AuthorityKeyIdentifier {
+                    // KeyIdentifier must be the same as subjectKeyIdentifier
+                    key_identifier: Some(ski.0.clone()),
+                    // other fields must not be present.
+                    ..Default::default()
+                }
+            }
+        };
+        crl_extensions.push(aki.to_extension(&issuer_name, &crl_extensions)?);
+
+        let tbs = TbsCertList {
+            version: Version::V2,
+            signature: signature_alg,
+            issuer: issuer_name,
+            this_update,
+            next_update: None,
+            revoked_certificates: None,
+            crl_extensions: Some(crl_extensions),
+        };
+
+        Ok(Self { tbs })
+    }
+
+    /// Make the CRL valid until the given `next_update`
+    pub fn with_next_update(mut self, next_update: Option<Time>) -> Self {
+        self.tbs.next_update = next_update;
+        self
+    }
+
+    /// Add certificates to the revocation list
+    pub fn with_certificates<I>(mut self, revoked: I) -> Self
+    where
+        I: Iterator<Item = RevokedCert>,
+    {
+        let certificates = self
+            .tbs
+            .revoked_certificates
+            .get_or_insert_with(vec::Vec::new);
+
+        let mut revoked: vec::Vec<RevokedCert> = revoked.collect();
+        certificates.append(&mut revoked);
+
+        self
+    }
+}
+
+impl Builder for CrlBuilder {
+    type Output = CertificateList;
+
+    fn finalize<S>(&mut self, cert_signer: &S) -> Result<vec::Vec<u8>>
+    where
+        S: Keypair + DynSignatureAlgorithmIdentifier,
+        S::VerifyingKey: EncodePublicKey,
+    {
+        self.tbs.signature = cert_signer.signature_algorithm_identifier()?;
+
+        self.tbs.to_der().map_err(Error::from)
+    }
+
+    fn assemble<S>(self, signature: BitString, _signer: &S) -> Result<Self::Output>
+    where
+        S: Keypair + DynSignatureAlgorithmIdentifier,
+        S::VerifyingKey: EncodePublicKey,
+    {
+        let signature_algorithm = self.tbs.signature.clone();
+
+        Ok(CertificateList {
+            tbs_cert_list: self.tbs,
+            signature_algorithm,
+            signature,
+        })
     }
 }

--- a/x509-cert/src/crl.rs
+++ b/x509-cert/src/crl.rs
@@ -14,6 +14,9 @@ use alloc::vec::Vec;
 use der::asn1::BitString;
 use der::{Sequence, ValueOrd};
 
+#[cfg(feature = "pem")]
+use der::pem::PemLabel;
+
 /// `CertificateList` as defined in [RFC 5280 Section 5.1].
 ///
 /// ```text
@@ -31,6 +34,11 @@ pub struct CertificateList<P: Profile = Rfc5280> {
     pub tbs_cert_list: TbsCertList<P>,
     pub signature_algorithm: AlgorithmIdentifier,
     pub signature: BitString,
+}
+
+#[cfg(feature = "pem")]
+impl<P: Profile> PemLabel for CertificateList<P> {
+    const PEM_LABEL: &'static str = "X509 CRL";
 }
 
 /// Implicit intermediate structure from the ASN.1 definition of `TBSCertList`.

--- a/x509-cert/src/ext/pkix/crl.rs
+++ b/x509-cert/src/ext/pkix/crl.rs
@@ -30,6 +30,22 @@ impl AssociatedOid for CrlNumber {
 impl_newtype!(CrlNumber, Uint);
 impl_extension!(CrlNumber, critical = false);
 
+macro_rules! impl_from_traits {
+    ($($uint:ty),+) => {
+        $(
+            impl TryFrom<$uint> for CrlNumber {
+                type Error = der::Error;
+
+                fn try_from(value: $uint) -> der::Result<Self> {
+                    Uint::try_from(value).map(Self)
+                }
+            }
+        )+
+    }
+}
+
+impl_from_traits!(u8, u16, u32, u64, u128);
+
 /// BaseCRLNumber as defined in [RFC 5280 Section 5.2.4].
 ///
 /// ```text

--- a/x509-cert/test-support/src/openssl.rs
+++ b/x509-cert/test-support/src/openssl.rs
@@ -1,7 +1,7 @@
 use std::{
-    fs::File,
+    fs::{self, File},
     io::{Read, Write},
-    process::{Command, Stdio},
+    process::{Command, ExitStatus, Stdio},
 };
 use tempfile::tempdir;
 
@@ -21,7 +21,7 @@ fn check_openssl_output(command_and_args: &[&str], pem: &[u8]) -> String {
         .stderr(Stdio::inherit())
         .stdout(Stdio::piped())
         .spawn()
-        .expect("zlint failed");
+        .expect("openssl failed");
     let mut stdout = child.stdout.take().unwrap();
     let exit_status = child.wait().expect("get openssl x509 status");
 
@@ -38,6 +38,53 @@ pub fn check_certificate(pem: &[u8]) -> String {
     check_openssl_output(&["x509"], pem)
 }
 
+pub fn check_crl(pem: &[u8]) -> String {
+    check_openssl_output(&["crl"], pem)
+}
+
 pub fn check_request(pem: &[u8]) -> String {
     check_openssl_output(&["req", "-verify"], pem)
+}
+
+pub fn verify(trust_anchor: &[u8], leaf: &[u8], crl: &[u8]) -> (ExitStatus, String, String) {
+    let tmp_dir = tempdir().expect("create tempdir");
+    let trust_anchor_path = tmp_dir.path().join("trust_anchor.pem");
+    let leaf_path = tmp_dir.path().join("leaf.pem");
+    let crl_path = tmp_dir.path().join("crl.pem");
+
+    fs::write(&trust_anchor_path, trust_anchor).expect("Write trust anchor");
+    fs::write(&leaf_path, leaf).expect("Write leaf");
+    fs::write(&crl_path, crl).expect("Write crl");
+
+    let mut child = Command::new("openssl")
+        .arg("verify")
+        .arg("-crl_check")
+        .arg("-CRLfile")
+        .arg(&crl_path)
+        .arg("-trusted")
+        .arg(&trust_anchor_path)
+        .arg("--")
+        .arg(&leaf_path)
+        .stderr(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("openssl failed");
+    let mut stdout = child.stdout.take().unwrap();
+    let mut stderr = child.stderr.take().unwrap();
+
+    let mut output_buf = Vec::new();
+    stdout
+        .read_to_end(&mut output_buf)
+        .expect("read openssl output");
+    let mut stderr_buf = Vec::new();
+    stderr
+        .read_to_end(&mut stderr_buf)
+        .expect("read openssl output");
+    let exit_status = child.wait().expect("get openssl verify status");
+
+    (
+        exit_status,
+        String::from_utf8(output_buf.clone()).unwrap(),
+        String::from_utf8(stderr_buf.clone()).unwrap(),
+    )
 }

--- a/x509-cert/tests/builder_crl.rs
+++ b/x509-cert/tests/builder_crl.rs
@@ -1,0 +1,181 @@
+#![cfg(all(feature = "builder", feature = "pem", feature = "std"))]
+
+use std::{
+    str::FromStr,
+    time::{Duration, SystemTime},
+};
+
+use der::{EncodePem, pem::LineEnding};
+use p256::{NistP256, ecdsa::DerSignature, pkcs8::DecodePrivateKey};
+use rand::rng;
+use x509_cert::{
+    SubjectPublicKeyInfo,
+    builder::{
+        Builder, CertificateBuilder, CrlBuilder,
+        profile::{self, cabf::tls::CertificateType},
+    },
+    crl::RevokedCert,
+    ext::{
+        AsExtension,
+        pkix::{CrlNumber, CrlReason, name::GeneralName},
+    },
+    name::Name,
+    serial_number::SerialNumber,
+    time::{Time, Validity},
+};
+use x509_cert_test_support::openssl;
+
+const PKCS8_PUBLIC_KEY_DER: &[u8] = include_bytes!("examples/p256-pub.der");
+const PKCS8_PRIVATE_KEY_DER: &[u8] = include_bytes!("examples/p256-priv.der");
+
+fn ecdsa_signer() -> ecdsa::SigningKey<NistP256> {
+    let secret_key = p256::SecretKey::from_pkcs8_der(PKCS8_PRIVATE_KEY_DER).unwrap();
+    ecdsa::SigningKey::from(secret_key)
+}
+
+#[test]
+fn crl_signer() {
+    let mut rng = rng();
+    let serial_number = SerialNumber::generate(&mut rng);
+    let validity = Validity::from_now(Duration::new(5, 0)).unwrap();
+    let subject =
+        Name::from_str("CN=World domination corporation,O=World domination Inc,C=US").unwrap();
+    let profile = profile::cabf::Root::new(false, subject).expect("create root profile");
+    let pub_key = SubjectPublicKeyInfo::try_from(PKCS8_PUBLIC_KEY_DER).expect("get ecdsa pub key");
+
+    let signer = ecdsa_signer();
+    let builder = CertificateBuilder::new(profile, serial_number, validity, pub_key)
+        .expect("Create certificate");
+
+    let ca_certificate = builder.build::<_, DerSignature>(&signer).unwrap();
+
+    let crl_number = CrlNumber::try_from(42u128).unwrap();
+
+    let builder = CrlBuilder::new(&ca_certificate, crl_number)
+        .unwrap()
+        .with_certificates(
+            vec![
+                RevokedCert {
+                    serial_number: SerialNumber::generate(&mut rng),
+                    revocation_date: Time::now().unwrap(),
+                    crl_entry_extensions: None,
+                },
+                RevokedCert {
+                    serial_number: SerialNumber::generate(&mut rng),
+                    revocation_date: Time::now().unwrap(),
+                    crl_entry_extensions: None,
+                },
+            ]
+            .into_iter(),
+        );
+
+    let crl = builder.build::<_, DerSignature>(&signer).unwrap();
+
+    let pem = crl.to_pem(LineEnding::LF).expect("generate pem");
+    println!("{}", openssl::check_crl(pem.as_bytes()));
+}
+
+/// Use `openssl verify` to run a mock certificate chain against a newly signed CRL.
+#[test]
+fn crl_verify() {
+    let mut rng = rng();
+    let signer = ecdsa_signer();
+
+    let serial_number = SerialNumber::generate(&mut rng);
+    let validity = Validity::from_now(Duration::new(60, 0)).unwrap();
+    let subject = Name::from_str("CN=root,O=World domination Inc,C=US").unwrap();
+    let profile = profile::cabf::Root::new(false, subject.clone()).expect("create root profile");
+    let pub_key = SubjectPublicKeyInfo::try_from(PKCS8_PUBLIC_KEY_DER).expect("get ecdsa pub key");
+
+    let builder = CertificateBuilder::new(profile, serial_number, validity, pub_key.clone())
+        .expect("Create certificate");
+
+    let ca_certificate = builder.build::<_, DerSignature>(&signer).unwrap();
+
+    let serial_number = SerialNumber::generate(&mut rng);
+    let delegated = Name::from_str("CN=example.com,O=World domination Inc,C=US").unwrap();
+    let profile = profile::cabf::tls::Subscriber {
+        certificate_type: CertificateType::domain_validated(
+            delegated.clone(),
+            vec![GeneralName::DirectoryName(delegated.clone())],
+        )
+        .expect("create domain validated"),
+        issuer: subject,
+        client_auth: true,
+        #[cfg(feature = "hazmat")]
+        tls12_options: Default::default(),
+        #[cfg(feature = "hazmat")]
+        enable_data_encipherment: false,
+    };
+
+    let builder = CertificateBuilder::new(profile, serial_number.clone(), validity, pub_key)
+        .expect("Create certificate");
+
+    let leaf_certificate = builder.build::<_, DerSignature>(&signer).unwrap();
+
+    let crl_number = CrlNumber::try_from(43u128).unwrap();
+
+    let revocation_date = SystemTime::now() - Duration::from_secs(5);
+
+    let builder = CrlBuilder::new(&ca_certificate, crl_number)
+        .unwrap()
+        .with_certificates(
+            vec![RevokedCert {
+                serial_number,
+                revocation_date: revocation_date.try_into().unwrap(),
+                crl_entry_extensions: Some(vec![
+                    CrlReason::Unspecified
+                        .to_extension(&delegated, &[])
+                        .unwrap(),
+                ]),
+            }]
+            .into_iter(),
+        );
+
+    let crl = builder.build::<_, DerSignature>(&signer).unwrap();
+
+    println!(
+        "{}",
+        openssl::check_certificate(
+            ca_certificate
+                .to_pem(LineEnding::LF)
+                .expect("ca: generate pem")
+                .as_bytes(),
+        )
+    );
+    println!(
+        "{}",
+        openssl::check_certificate(
+            leaf_certificate
+                .to_pem(LineEnding::LF)
+                .expect("ca: generate pem")
+                .as_bytes(),
+        )
+    );
+    println!(
+        "{}",
+        openssl::check_crl(
+            crl.to_pem(LineEnding::LF)
+                .expect("crl: generate pem")
+                .as_bytes(),
+        )
+    );
+
+    let (status, verification_output, verification_stderr) = openssl::verify(
+        ca_certificate
+            .to_pem(LineEnding::LF)
+            .expect("ca: generate pem")
+            .as_bytes(),
+        leaf_certificate
+            .to_pem(LineEnding::LF)
+            .expect("leaf: generate pem")
+            .as_bytes(),
+        crl.to_pem(LineEnding::LF)
+            .expect("crl: generate pem")
+            .as_bytes(),
+    );
+    assert_eq!(status.code(), Some(2));
+    println!("{}", verification_output);
+    println!("{}", verification_stderr);
+    assert!(verification_stderr.contains("certificate revoked"));
+}


### PR DESCRIPTION
This adds a builder interface for CRLs.

This would accept an iterator for the certificates to be revoked.
```rust
    let builder = CrlBuilder::new(&ca_certificate, crl_number)?
        .with_certificates(
            vec![
                RevokedCert {
                    serial_number: serial_number1,
                    revocation_date: Time::now()?,
                    crl_entry_extensions: None,
                },
                RevokedCert {
                    serial_number: serial_number2,
                    revocation_date: Time::now()?,
                    crl_entry_extensions: None,
                },
            ]
            .into_iter(),
        );

    let crl = builder.build(&signer)?;
```