### PR TITLE
Backport #1760

### DIFF
--- a/der/tests/derive.rs
+++ b/der/tests/derive.rs
@@ -226,7 +226,7 @@ mod sequence {
     // ```
     //
     // [RFC 5280 Section 5.2.5]: https://datatracker.ietf.org/doc/html/rfc5280#section-5.2.5
-    #[derive(Sequence)]
+    #[derive(Sequence, Default)]
     pub struct IssuingDistributionPointExample {
         // Omit distributionPoint and only_some_reasons because corresponding structs are not
         // available here and are not germane to the example
@@ -406,6 +406,28 @@ mod sequence {
         assert_eq!(idp.only_contains_cacerts, false);
         assert_eq!(idp.indirect_crl, false);
         assert_eq!(idp.only_contains_attribute_certs, true);
+    }
+
+    #[test]
+    fn idp_encode_twice() {
+        let mut vec_buf = Vec::new();
+
+        IssuingDistributionPointExample {
+            only_contains_user_certs: true,
+            ..Default::default()
+        }
+        .encode_to_vec(&mut vec_buf)
+        .unwrap();
+
+        // encode to the same vec by appending
+        IssuingDistributionPointExample {
+            only_contains_cacerts: true,
+            ..Default::default()
+        }
+        .encode_to_vec(&mut vec_buf)
+        .unwrap();
+
+        assert_eq!(vec_buf, hex!("30038101FF 30038201FF"));
     }
 
     // demonstrates default field that is not context specific


### PR DESCRIPTION
This is a request to backport #1760 to `der` v0.7 and a consequent point release.

Context: some parts of PKCS#11 require supplying ASN.1 encoded values. I spent quite some time until I figured out something is wrong with the encoding :sweat_smile:.