### PR TITLE
der: v0.7.10

### DIFF
--- a/der/CHANGELOG.md
+++ b/der/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.10 (2024-04-18)
+### Fixed
+- append in `Encode::encode_to_vec` (backport [#1760])
+
+[#1760]: https://github.com/RustCrypto/formats/pull/1760
+
 ## 0.7.9 (2024-04-01)
 ### Changed
 - ignore RUSTSEC-2023-0071 (backport [#1276])

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der"
-version = "0.7.9"
+version = "0.7.10"
 description = """
 Pure Rust embedded-friendly implementation of the Distinguished Encoding Rules
 (DER) for Abstract Syntax Notation One (ASN.1) as described in ITU X.690 with


### PR DESCRIPTION
Fixed:
- append in `Encode::encode_to_vec` (backport [#1760])

[#1760]: https://github.com/RustCrypto/formats/pull/1760