### PR TITLE
gss-api: change `NegHints::hint_name` to GeneralStringRef type

### DIFF
--- a/der/src/asn1.rs
+++ b/der/src/asn1.rs
@@ -11,6 +11,7 @@ mod bmp_string;
 mod boolean;
 mod choice;
 mod context_specific;
+mod general_string;
 mod generalized_time;
 mod ia5_string;
 mod integer;
@@ -35,6 +36,7 @@ pub use self::{
     bit_string::{BitStringIter, BitStringRef},
     choice::Choice,
     context_specific::{ContextSpecific, ContextSpecificRef},
+    general_string::GeneralStringRef,
     generalized_time::GeneralizedTime,
     ia5_string::Ia5StringRef,
     integer::{int::IntRef, uint::UintRef},

--- a/der/src/asn1/general_string.rs
+++ b/der/src/asn1/general_string.rs
@@ -1,0 +1,32 @@
+use crate::{DecodeValue, EncodeValue, FixedTag, Header, Length, Reader, Tag, Writer};
+
+use super::OctetStringRef;
+
+/// This is currently `OctetStringRef` as `GeneralString` is not part of the `der` crate
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct GeneralStringRef<'a> {
+    /// Raw contents, unchecked
+    #[doc(hidden)]
+    pub __contents: OctetStringRef<'a>,
+}
+impl FixedTag for GeneralStringRef<'_> {
+    const TAG: Tag = Tag::GeneralString;
+}
+impl<'a> DecodeValue<'a> for GeneralStringRef<'a> {
+    type Error = crate::Error;
+
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self, Self::Error> {
+        Ok(Self {
+            __contents: OctetStringRef::decode_value(reader, header)?,
+        })
+    }
+}
+impl EncodeValue for GeneralStringRef<'_> {
+    fn value_len(&self) -> crate::Result<Length> {
+        self.__contents.value_len()
+    }
+
+    fn encode_value(&self, encoder: &mut impl Writer) -> crate::Result<()> {
+        self.__contents.encode_value(encoder)
+    }
+}

--- a/der/src/asn1/general_string.rs
+++ b/der/src/asn1/general_string.rs
@@ -1,12 +1,18 @@
 use crate::{BytesRef, DecodeValue, EncodeValue, FixedTag, Header, Length, Reader, Tag, Writer};
 
-/// This is currently `OctetStringRef` internally, as `GeneralString` is not fully implemented yet
+/// This is currently `&[u8]` internally, as `GeneralString` is not fully implemented yet
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct GeneralStringRef<'a> {
     /// Raw contents, unchecked
-    #[doc(hidden)]
-    pub __contents: &'a [u8],
+    inner: BytesRef<'a>,
 }
+impl<'a> GeneralStringRef<'a> {
+    /// This is currently `&[u8]` internally, as `GeneralString` is not fully implemented yet
+    pub fn as_bytes(&self) -> &'a [u8] {
+        self.inner.as_slice()
+    }
+}
+
 impl FixedTag for GeneralStringRef<'_> {
     const TAG: Tag = Tag::GeneralString;
 }
@@ -15,16 +21,16 @@ impl<'a> DecodeValue<'a> for GeneralStringRef<'a> {
 
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self, Self::Error> {
         Ok(Self {
-            __contents: BytesRef::decode_value(reader, header)?.as_slice(),
+            inner: BytesRef::decode_value(reader, header)?,
         })
     }
 }
 impl EncodeValue for GeneralStringRef<'_> {
     fn value_len(&self) -> crate::Result<Length> {
-        BytesRef::new(self.__contents)?.value_len()
+        self.inner.value_len()
     }
 
     fn encode_value(&self, encoder: &mut impl Writer) -> crate::Result<()> {
-        BytesRef::new(self.__contents)?.encode_value(encoder)
+        self.inner.encode_value(encoder)
     }
 }

--- a/der/src/asn1/general_string.rs
+++ b/der/src/asn1/general_string.rs
@@ -2,7 +2,7 @@ use crate::{DecodeValue, EncodeValue, FixedTag, Header, Length, Reader, Tag, Wri
 
 use super::OctetStringRef;
 
-/// This is currently `OctetStringRef` as `GeneralString` is not part of the `der` crate
+/// This is currently `OctetStringRef` internally, as `GeneralString` is not fully implemented yet
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct GeneralStringRef<'a> {
     /// Raw contents, unchecked

--- a/der/src/asn1/general_string.rs
+++ b/der/src/asn1/general_string.rs
@@ -1,13 +1,11 @@
-use crate::{DecodeValue, EncodeValue, FixedTag, Header, Length, Reader, Tag, Writer};
-
-use super::OctetStringRef;
+use crate::{BytesRef, DecodeValue, EncodeValue, FixedTag, Header, Length, Reader, Tag, Writer};
 
 /// This is currently `OctetStringRef` internally, as `GeneralString` is not fully implemented yet
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct GeneralStringRef<'a> {
     /// Raw contents, unchecked
     #[doc(hidden)]
-    pub __contents: OctetStringRef<'a>,
+    pub __contents: &'a [u8],
 }
 impl FixedTag for GeneralStringRef<'_> {
     const TAG: Tag = Tag::GeneralString;
@@ -17,16 +15,16 @@ impl<'a> DecodeValue<'a> for GeneralStringRef<'a> {
 
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self, Self::Error> {
         Ok(Self {
-            __contents: OctetStringRef::decode_value(reader, header)?,
+            __contents: BytesRef::decode_value(reader, header)?.as_slice(),
         })
     }
 }
 impl EncodeValue for GeneralStringRef<'_> {
     fn value_len(&self) -> crate::Result<Length> {
-        self.__contents.value_len()
+        BytesRef::new(self.__contents)?.value_len()
     }
 
     fn encode_value(&self, encoder: &mut impl Writer) -> crate::Result<()> {
-        self.__contents.encode_value(encoder)
+        BytesRef::new(self.__contents)?.encode_value(encoder)
     }
 }

--- a/gss-api/src/negotiation.rs
+++ b/gss-api/src/negotiation.rs
@@ -296,7 +296,7 @@ pub enum NegState {
 pub struct NegHints<'a> {
     /// SHOULD<5> contain the string "not_defined_in_RFC4178@please_ignore".
     #[asn1(context_specific = "0", optional = "true")]
-    pub hint_name: Option<GeneralStringRef<'a>>, // TODO: der GeneralString
+    pub hint_name: Option<GeneralStringRef<'a>>,
 
     /// Never present. MUST be omitted by the sender. Note that the encoding rules, as specified in [X690], require that this structure not be present at all, not just be zero.
     ///

--- a/gss-api/src/negotiation.rs
+++ b/gss-api/src/negotiation.rs
@@ -383,7 +383,7 @@ mod tests {
         );
         assert_eq!(
             b"not_defined_in_RFC4178@please_ignore",
-            &neg_token.neg_hints.unwrap().hint_name.unwrap().__contents
+            &neg_token.neg_hints.unwrap().hint_name.unwrap().as_bytes()
         );
     }
 

--- a/gss-api/src/negotiation.rs
+++ b/gss-api/src/negotiation.rs
@@ -383,13 +383,7 @@ mod tests {
         );
         assert_eq!(
             b"not_defined_in_RFC4178@please_ignore",
-            &neg_token
-                .neg_hints
-                .unwrap()
-                .hint_name
-                .unwrap()
-                .__contents
-                .as_bytes()
+            &neg_token.neg_hints.unwrap().hint_name.unwrap().__contents
         );
     }
 

--- a/gss-api/src/negotiation.rs
+++ b/gss-api/src/negotiation.rs
@@ -1,7 +1,7 @@
 //! Negotiation-related types
 use der::{
-    Choice, DecodeValue, EncodeValue, Enumerated, FixedTag, Sequence, Tag,
-    asn1::{BitString, OctetStringRef},
+    Choice, Enumerated, Sequence,
+    asn1::{BitString, GeneralStringRef, OctetStringRef},
 };
 
 use crate::MechType;
@@ -350,37 +350,6 @@ pub struct NegTokenInit2<'a> {
     pub mech_list_mic: Option<OctetStringRef<'a>>,
 }
 
-/// This is currently `OctetStringRef` as `GeneralString` is not part of the `der` crate
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct GeneralStringRef<'a> {
-    /// Raw contents, unchecked
-    pub contents: OctetStringRef<'a>,
-}
-impl FixedTag for GeneralStringRef<'_> {
-    const TAG: Tag = Tag::GeneralString;
-}
-impl<'a> DecodeValue<'a> for GeneralStringRef<'a> {
-    type Error = der::Error;
-
-    fn decode_value<R: der::Reader<'a>>(
-        reader: &mut R,
-        header: der::Header,
-    ) -> Result<Self, Self::Error> {
-        Ok(Self {
-            contents: OctetStringRef::decode_value(reader, header)?,
-        })
-    }
-}
-impl EncodeValue for GeneralStringRef<'_> {
-    fn value_len(&self) -> der::Result<der::Length> {
-        self.contents.value_len()
-    }
-
-    fn encode_value(&self, encoder: &mut impl der::Writer) -> der::Result<()> {
-        self.contents.encode_value(encoder)
-    }
-}
-
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
@@ -419,7 +388,7 @@ mod tests {
                 .unwrap()
                 .hint_name
                 .unwrap()
-                .contents
+                .__contents
                 .as_bytes()
         );
     }


### PR DESCRIPTION
Better than using `AnyRef` and `.value()[2..]`