### PR TITLE
der: const `Any::to_ref`, `BytesOwned::to_ref`

### DIFF
--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -47,6 +47,15 @@ impl<'a> AnyRef<'a> {
         }
     }
 
+    /// Create a new [`AnyRef`] from the provided [`Any`] owned tag and bytes.
+    #[cfg(feature = "alloc")]
+    pub const fn from_owned(owned: &'a Any) -> Self {
+        AnyRef {
+            tag: owned.tag,
+            value: BytesRef::from_owned(&owned.value),
+        }
+    }
+
     /// Infallible creation of an [`AnyRef`] from a [`BytesRef`].
     pub(crate) fn from_tag_and_value(tag: Tag, value: BytesRef<'a>) -> Self {
         Self { tag, value }
@@ -174,10 +183,10 @@ mod allocating {
     #[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
     pub struct Any {
         /// Tag representing the type of the encoded value.
-        tag: Tag,
+        pub(super) tag: Tag,
 
         /// Inner value encoded as bytes.
-        value: BytesOwned,
+        pub(super) value: BytesOwned,
     }
 
     impl Any {
@@ -272,7 +281,7 @@ mod allocating {
     impl<'a> From<&'a Any> for AnyRef<'a> {
         fn from(any: &'a Any) -> AnyRef<'a> {
             // Ensured to parse successfully in constructor
-            AnyRef::new(any.tag, any.value.as_slice()).expect("invalid ANY")
+            AnyRef::from_owned(any)
         }
     }
 

--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -235,7 +235,7 @@ mod allocating {
         }
 
         /// Create a new [`AnyRef`] from the provided [`Any`] owned tag and bytes.
-        pub const fn to_ref<'a>(&'a self) -> AnyRef<'a> {
+        pub const fn to_ref(&self) -> AnyRef<'_> {
             AnyRef {
                 tag: self.tag,
                 value: self.value.to_ref(),

--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -47,15 +47,6 @@ impl<'a> AnyRef<'a> {
         }
     }
 
-    /// Create a new [`AnyRef`] from the provided [`Any`] owned tag and bytes.
-    #[cfg(feature = "alloc")]
-    pub const fn from_owned(owned: &'a Any) -> Self {
-        AnyRef {
-            tag: owned.tag,
-            value: BytesRef::from_owned(&owned.value),
-        }
-    }
-
     /// Infallible creation of an [`AnyRef`] from a [`BytesRef`].
     pub(crate) fn from_tag_and_value(tag: Tag, value: BytesRef<'a>) -> Self {
         Self { tag, value }
@@ -183,10 +174,10 @@ mod allocating {
     #[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
     pub struct Any {
         /// Tag representing the type of the encoded value.
-        pub(super) tag: Tag,
+        tag: Tag,
 
         /// Inner value encoded as bytes.
-        pub(super) value: BytesOwned,
+        value: BytesOwned,
     }
 
     impl Any {
@@ -242,6 +233,14 @@ mod allocating {
                 value: BytesOwned::default(),
             }
         }
+
+        /// Create a new [`AnyRef`] from the provided [`Any`] owned tag and bytes.
+        pub const fn to_ref<'a>(&'a self) -> AnyRef<'a> {
+            AnyRef {
+                tag: self.tag,
+                value: self.value.to_ref(),
+            }
+        }
     }
 
     impl Choice<'_> for Any {
@@ -281,7 +280,7 @@ mod allocating {
     impl<'a> From<&'a Any> for AnyRef<'a> {
         fn from(any: &'a Any) -> AnyRef<'a> {
             // Ensured to parse successfully in constructor
-            AnyRef::from_owned(any)
+            any.to_ref()
         }
     }
 

--- a/der/src/bytes_owned.rs
+++ b/der/src/bytes_owned.rs
@@ -46,7 +46,7 @@ impl BytesOwned {
     }
 
     /// Create [`BytesRef`] from allocated [`BytesOwned`].
-    pub const fn to_ref<'a>(&'a self) -> BytesRef<'a> {
+    pub const fn to_ref(&self) -> BytesRef<'_> {
         BytesRef {
             length: self.length,
             inner: &self.inner,

--- a/der/src/bytes_owned.rs
+++ b/der/src/bytes_owned.rs
@@ -44,6 +44,14 @@ impl BytesOwned {
     pub const fn is_empty(&self) -> bool {
         self.len().is_zero()
     }
+
+    /// Create [`BytesRef`] from allocated [`BytesOwned`].
+    pub const fn to_ref<'a>(&'a self) -> BytesRef<'a> {
+        BytesRef {
+            length: self.length,
+            inner: &self.inner,
+        }
+    }
 }
 
 impl AsRef<[u8]> for BytesOwned {

--- a/der/src/bytes_owned.rs
+++ b/der/src/bytes_owned.rs
@@ -31,18 +31,18 @@ impl BytesOwned {
     }
 
     /// Borrow the inner byte slice
-    pub fn as_slice(&self) -> &[u8] {
+    pub const fn as_slice(&self) -> &[u8] {
         &self.inner
     }
 
     /// Get the [`Length`] of this [`BytesRef`]
-    pub fn len(&self) -> Length {
+    pub const fn len(&self) -> Length {
         self.length
     }
 
     /// Is this [`BytesOwned`] empty?
-    pub fn is_empty(&self) -> bool {
-        self.len() == Length::ZERO
+    pub const fn is_empty(&self) -> bool {
+        self.len().is_zero()
     }
 }
 

--- a/der/src/bytes_ref.rs
+++ b/der/src/bytes_ref.rs
@@ -2,7 +2,8 @@
 //! library-level length limitation i.e. `Length::max()`.
 
 use crate::{
-    DecodeValue, DerOrd, EncodeValue, Error, Header, Length, Reader, Result, StrRef, Writer,
+    BytesOwned, DecodeValue, DerOrd, EncodeValue, Error, Header, Length, Reader, Result, StrRef,
+    Writer,
 };
 use core::cmp::Ordering;
 
@@ -35,6 +36,14 @@ impl<'a> BytesRef<'a> {
                 inner: slice,
             }),
             Err(err) => Err(err),
+        }
+    }
+    /// Create [`BytesRef`] from allocated [`BytesOwned`].
+    #[cfg(feature = "alloc")]
+    pub const fn from_owned(owned: &'a BytesOwned) -> Self {
+        Self {
+            length: owned.len(),
+            inner: owned.as_slice(),
         }
     }
 

--- a/der/src/bytes_ref.rs
+++ b/der/src/bytes_ref.rs
@@ -2,8 +2,7 @@
 //! library-level length limitation i.e. `Length::max()`.
 
 use crate::{
-    BytesOwned, DecodeValue, DerOrd, EncodeValue, Error, Header, Length, Reader, Result, StrRef,
-    Writer,
+    DecodeValue, DerOrd, EncodeValue, Error, Header, Length, Reader, Result, StrRef, Writer,
 };
 use core::cmp::Ordering;
 
@@ -36,14 +35,6 @@ impl<'a> BytesRef<'a> {
                 inner: slice,
             }),
             Err(err) => Err(err),
-        }
-    }
-    /// Create [`BytesRef`] from allocated [`BytesOwned`].
-    #[cfg(feature = "alloc")]
-    pub const fn from_owned(owned: &'a BytesOwned) -> Self {
-        Self {
-            length: owned.len(),
-            inner: owned.as_slice(),
         }
     }
 

--- a/der/src/length.rs
+++ b/der/src/length.rs
@@ -52,8 +52,9 @@ impl Length {
     }
 
     /// Is this length equal to zero?
-    pub fn is_zero(self) -> bool {
-        self == Self::ZERO
+    pub const fn is_zero(self) -> bool {
+        let value = self.0;
+        value == 0
     }
 
     /// Get the length of DER Tag-Length-Value (TLV) encoded data if `self`


### PR DESCRIPTION
Removes `expect`/`unwrap` in `AnyRef::from`