### PR TITLE
der: remove `IndefiniteLength`

### DIFF
--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -374,7 +374,7 @@ pub use crate::{
     encoding_rules::EncodingRules,
     error::{Error, ErrorKind, Result},
     header::Header,
-    length::{IndefiniteLength, Length},
+    length::Length,
     ord::{DerOrd, ValueOrd},
     reader::{Reader, slice::SliceReader},
     tag::{Class, FixedTag, IsConstructed, Tag, TagMode, TagNumber, Tagged},


### PR DESCRIPTION
The original idea of this type was to have a type-safe distinction between DER lengths (`Length`) and potentially indefinite BER lengths (`IndefiniteLength`), but really what's needed is to make the `Length` type support idefinite lengths when `EncodingRules::Ber` are in use.

Otherwise, we need to change `Header` to use `IndefiniteLength`, which kind of defeats the point.