### PR TITLE
der: simplify `Tag::peek_matches` in context-specific decoder

### DIFF
--- a/der/src/asn1/context_specific.rs
+++ b/der/src/asn1/context_specific.rs
@@ -47,7 +47,7 @@ impl<T> ContextSpecific<T> {
     where
         T: Decode<'a>,
     {
-        if !peek_tag_matches(reader, Class::ContextSpecific, tag_number)? {
+        if !Tag::peek_matches(reader, Class::ContextSpecific, tag_number)? {
             return Ok(None);
         }
         Ok(Some(Self::decode(reader)?))
@@ -67,7 +67,7 @@ impl<T> ContextSpecific<T> {
         T: DecodeValue<'a> + IsConstructed,
     {
         // Peek tag number
-        if !peek_tag_matches::<_, T::Error>(reader, Class::ContextSpecific, tag_number)? {
+        if !Tag::peek_matches(reader, Class::ContextSpecific, tag_number)? {
             return Ok(None);
         }
         // Decode IMPLICIT header
@@ -90,28 +90,6 @@ impl<T> ContextSpecific<T> {
             value,
         }))
     }
-}
-
-/// Returns true if given context-specific (or any given class) field
-/// should be decoded, based on peeked tag.
-fn peek_tag_matches<'a, R: Reader<'a>, E>(
-    reader: &mut R,
-    expected_class: Class,
-    expected_tag_number: TagNumber,
-) -> Result<bool, E>
-where
-    E: From<Error>,
-{
-    // Peek tag or ignore end of stream
-    let Some(tag) = Tag::peek_optional(reader)? else {
-        return Ok(false);
-    };
-    // Ignore tags with different numbers
-    if tag.class() != expected_class || tag.number() != expected_tag_number {
-        return Ok(false);
-    }
-    // Tag matches
-    Ok(true)
 }
 
 impl<'a, T> Choice<'a> for ContextSpecific<T>

--- a/der/src/tag.rs
+++ b/der/src/tag.rs
@@ -189,6 +189,24 @@ impl Tag {
         Err(ErrorKind::TagNumberInvalid.into())
     }
 
+    /// Returns true if given context-specific (or any given class) tag number matches the peeked tag.
+    pub(crate) fn peek_matches<'a, R: Reader<'a>>(
+        reader: &mut R,
+        expected_class: Class,
+        expected_tag_number: TagNumber,
+    ) -> Result<bool> {
+        // Peek tag or ignore end of stream
+        let Some(tag) = Tag::peek_optional(reader)? else {
+            return Ok(false);
+        };
+        // Ignore tags with different numbers
+        if tag.class() != expected_class || tag.number() != expected_tag_number {
+            return Ok(false);
+        }
+        // Tag matches
+        Ok(true)
+    }
+
     /// Assert that this [`Tag`] matches the provided expected tag.
     ///
     /// On mismatch, returns an [`Error`] with [`ErrorKind::TagUnexpected`].


### PR DESCRIPTION
Also removed generic `E: From<Error>`