### PR TITLE
x509-cert: domain validated should accept CN even though not recommended

### DIFF
--- a/x509-cert/src/builder/profile/cabf/tls.rs
+++ b/x509-cert/src/builder/profile/cabf/tls.rs
@@ -149,7 +149,10 @@ impl CertificateType {
             .filter_map(|rdn| {
                 let out = SetOfVec::<AttributeTypeAndValue>::from_iter(
                     rdn.iter()
-                        .filter(|attr_value| attr_value.oid == rfc4519::COUNTRY_NAME)
+                        .filter(|attr_value| {
+                            attr_value.oid == rfc4519::COUNTRY_NAME
+                                || attr_value.oid == rfc4519::COMMON_NAME
+                        })
                         .cloned(),
                 )
                 .ok()?;


### PR DESCRIPTION
Relevant CABF profile:
https://github.com/cabforum/servercert/blob/main/docs/BR.md#71272-domain-validated