### PR TITLE
cmpv2: make `PkiFailureInfoValues` a `u32`; fix `BadTime` variant 

### DIFF
--- a/cmpv2/src/status.rs
+++ b/cmpv2/src/status.rs
@@ -122,11 +122,11 @@ flags! {
     ///
     /// [RFC 4210 Section 5.2.3]: https://www.rfc-editor.org/rfc/rfc4210#section-5.2.3
     #[allow(missing_docs)]
-    pub enum PkiFailureInfoValues: u16 {
+    pub enum PkiFailureInfoValues: u32 {
         BadAlg = 0,
         BadMessageCheck = 1,
         BadRequest      = 2,
-        BadTime         = 2,
+        BadTime         = 3,
         BadCertId       = 4,
         BadDataFormat   = 5,
         WrongAuthority  = 6,


### PR DESCRIPTION
Hey all.
These changes are related to the cmpv2 crate:
1. When trying to decode an error message which has, e.g. `transactionIdInUse` set, parsing will fail with an error. The type of the `PkiFailureInfoValues` flagset should be a `u32` instead of a `u16`, there are currently 27 possible values for this enum (see [RFC 4210 section 5.2.3](https://datatracker.ietf.org/doc/html/rfc4210#section-5.2.3)).
2. The value of the `BadTime` variant must be 3 not 2, according to [RFC 4210 section 5.2.3](https://datatracker.ietf.org/doc/html/rfc4210#section-5.2.3).
