### PR TITLE
x509-cert: draft: `TbsCertificateInner` generic over `DerMemory` trait

### DIFF
--- a/der/src/asn1.rs
+++ b/der/src/asn1.rs
@@ -36,7 +36,7 @@ mod videotex_string;
 pub use self::{
     any::AnyRef,
     application::{Application, ApplicationRef},
-    bit_string::{BitStringIter, BitStringRef},
+    bit_string::{AsBitStringRef, BitStringIter, BitStringRef},
     choice::Choice,
     context_specific::{ContextSpecific, ContextSpecificRef},
     general_string::GeneralStringRef,

--- a/der/src/asn1/bit_string.rs
+++ b/der/src/asn1/bit_string.rs
@@ -241,6 +241,17 @@ impl<'a> arbitrary::Arbitrary<'a> for BitStringRef<'a> {
         arbitrary::size_hint::and(u8::size_hint(depth), BytesRef::size_hint(depth))
     }
 }
+/// How write it better? Like `AsRef<BitStringRef<'a>>`
+pub trait AsBitStringRef<'a> {
+    /// Implemented on BitString and BitStringRef
+    fn as_bitstring_ref(&'a self) -> BitStringRef<'a>;
+}
+
+impl<'a> AsBitStringRef<'a> for BitStringRef<'a> {
+    fn as_bitstring_ref(&'a self) -> BitStringRef<'a> {
+        self.clone()
+    }
+}
 
 #[cfg(feature = "alloc")]
 pub use self::allocating::BitString;
@@ -444,6 +455,12 @@ mod allocating {
     impl OwnedToRef for BitString {
         type Borrowed<'a> = BitStringRef<'a>;
         fn owned_to_ref(&self) -> Self::Borrowed<'_> {
+            self.into()
+        }
+    }
+
+    impl<'a> AsBitStringRef<'a> for BitString {
+        fn as_bitstring_ref(&'a self) -> BitStringRef<'a> {
             self.into()
         }
     }


### PR DESCRIPTION
Main idea: have a trait that describes a few types in owned/`*Ref` form.
```rust
pub trait DerMemory {
    type BITSTRING<'m>: FixedTag
        + DecodeValue<'m, Error = der::Error>
        + EncodeValue
        + DerOrd
        + Clone
        + Debug
        + Eq
        + PartialEq
        + AsBitStringRef<'m>;
    // ... and more
}
```


Im stuck on `invariant` lifetime.

```
lifetime may not live long enough
requirement occurs because of the type `CertificateInner<'_, AllocDerMemory, P>`, which makes the generic argument `'_` invariant
the struct `CertificateInner<'m, MEM, P>` is invariant over the parameter `'m`
see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance

anchor.rs(94, 6): lifetime `'__der_lifetime` defined here
```

Adding `der::Cow` looks easier, i think :thinking: 
