### PR TITLE
der_derive: decode_value_inner `#[doc(hidden)]`

### DIFF
--- a/der_derive/src/sequence.rs
+++ b/der_derive/src/sequence.rs
@@ -105,6 +105,7 @@ impl DeriveSequence {
 
         quote! {
             impl #impl_generics #ident #ty_generics #where_clause {
+                #[doc(hidden)]
                 fn decode_value_inner<R: ::der::Reader<#lifetime>>(reader: &mut R) -> ::core::result::Result<Self, #error> {
                     use ::der::{Decode as _, DecodeValue as _, Reader as _};
                     #(#decode_body)*


### PR DESCRIPTION
Forgot `#[doc(hidden)]` in #1802

I don't know if `#[automatically_derived]` is needed.