### PR TITLE
der: fix `Header::peek` + add tests

### DIFF
--- a/der/src/length.rs
+++ b/der/src/length.rs
@@ -340,11 +340,15 @@ mod tests {
             Length::from(0x10000u32),
             Length::from_der(&[0x83, 0x01, 0x00, 0x00]).unwrap()
         );
+        assert_eq!(
+            Length::from(0xFFFFFFFFu32),
+            Length::from_der(&[0x84, 0xFF, 0xFF, 0xFF, 0xFF]).unwrap()
+        );
     }
 
     #[test]
     fn encode() {
-        let mut buffer = [0u8; 4];
+        let mut buffer = [0u8; 5];
 
         assert_eq!(&[0x00], Length::ZERO.encode_to_slice(&mut buffer).unwrap());
 
@@ -374,6 +378,12 @@ mod tests {
                 .encode_to_slice(&mut buffer)
                 .unwrap()
         );
+        assert_eq!(
+            &[0x84, 0xFF, 0xFF, 0xFF, 0xFF],
+            Length::from(0xFFFFFFFFu32)
+                .encode_to_slice(&mut buffer)
+                .unwrap()
+        );
     }
 
     #[test]
@@ -388,5 +398,10 @@ mod tests {
     #[test]
     fn der_ord() {
         assert_eq!(Length::ONE.der_cmp(&Length::MAX).unwrap(), Ordering::Less);
+        assert_eq!(Length::ONE.der_cmp(&Length::ONE).unwrap(), Ordering::Equal);
+        assert_eq!(
+            Length::ONE.der_cmp(&Length::ZERO).unwrap(),
+            Ordering::Greater
+        );
     }
 }

--- a/der/src/tag.rs
+++ b/der/src/tag.rs
@@ -169,8 +169,8 @@ impl Tag {
 
     pub(crate) fn peek_optional<'a>(reader: &impl Reader<'a>) -> Result<Option<Self>> {
         let mut buf = [0u8; Self::MAX_SIZE];
-
         if reader.peek_into(&mut buf[0..1]).is_err() {
+            // Ignore empty buffer
             return Ok(None);
         }
 
@@ -750,8 +750,12 @@ mod tests {
     #[test]
     fn peek_long_tags() {
         let reader = SliceReader::new(&hex!("DF8FFFFFFF7F")).expect("valid reader");
+        let tag = Tag::peek(&reader).expect("peeked tag");
+        assert!(!tag.is_context_specific());
+        assert!(!tag.is_application());
+        assert!(tag.is_private());
         assert_eq!(
-            Tag::peek(&reader).expect("peeked tag"),
+            tag,
             Tag::Private {
                 constructed: false,
                 number: TagNumber(u32::MAX)


### PR DESCRIPTION
Bug: 11-byte peek read only 10 bytes previously