### PR TITLE
der: fix panic in `value_cmp`: add `Iterator::size_hint` + tests

### DIFF
--- a/der/src/asn1/bit_string.rs
+++ b/der/src/asn1/bit_string.rs
@@ -573,6 +573,8 @@ where
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
+    use core::cmp::Ordering;
+
     use super::{BitStringRef, Result, Tag};
     use crate::asn1::AnyRef;
     use hex_literal::hex;
@@ -619,5 +621,14 @@ mod tests {
             parse_bitstring(&[0x03]).err().unwrap().kind(),
             Tag::BitString.value_error().kind()
         )
+    }
+
+    #[test]
+    fn bitstring_valueord_value_cmp() {
+        use crate::ord::DerOrd;
+
+        let bs1 = parse_bitstring(&hex!("00010204")).unwrap();
+        let bs2 = parse_bitstring(&hex!("00010203")).unwrap();
+        assert_eq!(bs1.der_cmp(&bs2), Ok(Ordering::Greater));
     }
 }

--- a/der/src/asn1/bit_string.rs
+++ b/der/src/asn1/bit_string.rs
@@ -472,6 +472,7 @@ impl Iterator for BitStringIter<'_> {
         self.position = self.position.checked_add(1)?;
         Some(byte & bit != 0)
     }
+
     fn size_hint(&self) -> (usize, Option<usize>) {
         let len = self.bit_string.bit_len().saturating_sub(self.position);
         (len, Some(len))

--- a/der/src/asn1/bit_string.rs
+++ b/der/src/asn1/bit_string.rs
@@ -472,6 +472,10 @@ impl Iterator for BitStringIter<'_> {
         self.position = self.position.checked_add(1)?;
         Some(byte & bit != 0)
     }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.bit_string.bit_len().saturating_sub(self.position);
+        (len, Some(len))
+    }
 }
 
 impl ExactSizeIterator for BitStringIter<'_> {

--- a/der/src/asn1/sequence_of.rs
+++ b/der/src/asn1/sequence_of.rs
@@ -125,6 +125,9 @@ impl<'a, T> Iterator for SequenceOfIter<'a, T> {
     fn next(&mut self) -> Option<&'a T> {
         self.inner.next()
     }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
 }
 
 impl<T> ExactSizeIterator for SequenceOfIter<'_, T> {}
@@ -237,5 +240,30 @@ where
 {
     fn value_cmp(&self, other: &Self) -> Result<Ordering, Error> {
         iter_cmp(self.iter(), other.iter())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::asn1::SequenceOf;
+    use crate::ord::DerOrd;
+
+    #[test]
+    fn setof_valueord_value_cmp() {
+        use core::cmp::Ordering;
+
+        let arr1 = {
+            let mut arr: SequenceOf<u16, 2> = SequenceOf::new();
+            arr.add(0u16).expect("element to be added");
+            arr.add(2u16).expect("element to be added");
+            arr
+        };
+        let arr2 = {
+            let mut arr: SequenceOf<u16, 2> = SequenceOf::new();
+            arr.add(0u16).expect("element to be added");
+            arr.add(1u16).expect("element to be added");
+            arr
+        };
+        assert_eq!(arr1.der_cmp(&arr2), Ok(Ordering::Greater));
     }
 }

--- a/der/src/asn1/sequence_of.rs
+++ b/der/src/asn1/sequence_of.rs
@@ -249,7 +249,7 @@ mod tests {
     use crate::ord::DerOrd;
 
     #[test]
-    fn setof_valueord_value_cmp() {
+    fn sequenceof_valueord_value_cmp() {
         use core::cmp::Ordering;
 
         let arr1 = {

--- a/der/src/asn1/sequence_of.rs
+++ b/der/src/asn1/sequence_of.rs
@@ -125,6 +125,7 @@ impl<'a, T> Iterator for SequenceOfIter<'a, T> {
     fn next(&mut self) -> Option<&'a T> {
         self.inner.next()
     }
+
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }

--- a/der/src/asn1/set_of.rs
+++ b/der/src/asn1/set_of.rs
@@ -191,6 +191,10 @@ impl<'a, T> Iterator for SetOfIter<'a, T> {
     fn next(&mut self) -> Option<&'a T> {
         self.inner.next()
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
 }
 
 impl<T> ExactSizeIterator for SetOfIter<'_, T> {}
@@ -495,7 +499,7 @@ mod tests {
     }
 
     #[test]
-    fn setof_valueord() {
+    fn setof_valueord_value_cmp() {
         use core::cmp::Ordering;
 
         let arr1 = [3u16, 2, 1, 5, 0];

--- a/der/src/asn1/set_of.rs
+++ b/der/src/asn1/set_of.rs
@@ -478,7 +478,7 @@ mod tests {
     use super::SetOf;
     #[cfg(feature = "alloc")]
     use super::SetOfVec;
-    use crate::ErrorKind;
+    use crate::{DerOrd, ErrorKind};
 
     #[test]
     fn setof_tryfrom_array() {
@@ -492,6 +492,17 @@ mod tests {
         let arr = [1u16, 1];
         let err = SetOf::try_from(arr).err().unwrap();
         assert_eq!(err.kind(), ErrorKind::SetDuplicate);
+    }
+
+    #[test]
+    fn setof_valueord() {
+        use core::cmp::Ordering;
+
+        let arr1 = [3u16, 2, 1, 5, 0];
+        let arr2 = [3u16, 2, 1, 4, 0];
+        let set1 = SetOf::try_from(arr1).unwrap();
+        let set2 = SetOf::try_from(arr2).unwrap();
+        assert_eq!(set1.der_cmp(&set2), Ok(Ordering::Greater));
     }
 
     #[cfg(feature = "alloc")]


### PR DESCRIPTION
The test was failing because:

```
 failures:

---- asn1::set_of::tests::setof_valueord stdout ----

thread 'asn1::set_of::tests::setof_valueord' panicked at core/src/iter/traits/exact_size.rs:122:9:
assertion `left == right` failed
  left: None
 right: Some(0)
```