### PR TITLE
der: test `Null` decode invalid length

### DIFF
--- a/der/src/asn1/null.rs
+++ b/der/src/asn1/null.rs
@@ -103,5 +103,6 @@ mod tests {
     #[test]
     fn reject_non_canonical() {
         assert!(Null::from_der(&[0x05, 0x81, 0x00]).is_err());
+        assert!(Null::from_der(&[0x05, 0x01, 0xAA]).is_err());
     }
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/62cec488-e0fa-46f4-94d1-d7273750a584)
