### PR TITLE
pkcs5+pkcs12: migrate to the digest newtype api

### DIFF
--- a/.github/workflows/cmpv2.yml
+++ b/.github/workflows/cmpv2.yml
@@ -23,6 +23,7 @@ env:
 
 jobs:
   build:
+    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -48,6 +49,7 @@ jobs:
         working-directory: ${{ github.workflow }}
 
   test:
+    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/cms.yml
+++ b/.github/workflows/cms.yml
@@ -23,6 +23,7 @@ env:
 
 jobs:
   build:
+    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -53,6 +54,7 @@ jobs:
         nightly-cmd:
 
   test:
+    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/crmf.yml
+++ b/.github/workflows/crmf.yml
@@ -23,6 +23,7 @@ env:
 
 jobs:
   build:
+    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -48,6 +49,7 @@ jobs:
         working-directory: ${{ github.workflow }}
 
   test:
+    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/gss-api.yml
+++ b/.github/workflows/gss-api.yml
@@ -23,6 +23,7 @@ env:
 
 jobs:
   build:
+    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -48,6 +49,7 @@ jobs:
         working-directory: ${{ github.workflow }}
 
   test:
+    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/x509-cert.yml
+++ b/.github/workflows/x509-cert.yml
@@ -22,6 +22,7 @@ env:
 
 jobs:
   build:
+    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -49,6 +50,7 @@ jobs:
       install-zlint: true
 
   test:
+    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -72,6 +74,7 @@ jobs:
       - run: cargo test --all-features --release
 
   fuzz:
+    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/x509-ocsp.yml
+++ b/.github/workflows/x509-ocsp.yml
@@ -22,6 +22,7 @@ env:
 
 jobs:
   build:
+    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -47,6 +48,7 @@ jobs:
         working-directory: ${{ github.workflow }}
 
   test:
+    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/x509-tsp.yml
+++ b/.github/workflows/x509-tsp.yml
@@ -25,6 +25,7 @@ env:
 
 jobs:
   build:
+    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -50,6 +51,7 @@ jobs:
         working-directory: ${{ github.workflow }}
 
   test:
+    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,24 +3,9 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
-
-[[package]]
 name = "aead"
 version = "0.6.0-rc.0"
-source = "git+https://github.com/RustCrypto/traits.git#439fc8c28c61b09eff35349b4c091a5586d70ea7"
+source = "git+https://github.com/RustCrypto/traits.git#915474f1ed5be0a19fd102d5f75ef8e04c765416"
 dependencies = [
  "crypto-common",
  "inout",
@@ -51,15 +36,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aes-kw"
-version = "0.3.0-pre"
-source = "git+https://github.com/RustCrypto/key-wraps.git#15f7dd084793ea67360a8f66f771a8e420c1657f"
-dependencies = [
- "aes",
- "const-oid",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,14 +49,6 @@ name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
-
-[[package]]
-name = "ansi-x963-kdf"
-version = "0.0.1"
-source = "git+https://github.com/RustCrypto/KDFs.git#b1d7fe67b3053deef498563adcf415ec631d1cd8"
-dependencies = [
- "digest",
-]
 
 [[package]]
 name = "anstyle"
@@ -102,21 +70,6 @@ name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
-
-[[package]]
-name = "backtrace"
-version = "0.3.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets",
-]
 
 [[package]]
 name = "base16ct"
@@ -299,48 +252,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
-name = "cmpv2"
-version = "0.3.0-pre.0"
-dependencies = [
- "const-oid",
- "crmf",
- "der",
- "digest",
- "hex-literal",
- "spki",
- "x509-cert",
-]
-
-[[package]]
 name = "cms"
 version = "0.3.0-pre.0"
 dependencies = [
- "aes",
- "aes-kw",
- "ansi-x963-kdf",
- "cbc",
- "cipher",
  "const-oid",
  "der",
- "digest",
- "ecdsa",
- "elliptic-curve",
- "getrandom 0.3.3",
- "hex-literal",
- "p256",
- "pbkdf2",
- "pem-rfc7468",
- "pkcs5",
- "rand 0.9.1",
- "rsa",
- "sha1",
- "sha2",
- "sha3",
- "signature",
  "spki",
- "tokio",
  "x509-cert",
- "zeroize",
 ]
 
 [[package]]
@@ -394,52 +312,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "crmf"
-version = "0.3.0-pre.0"
-dependencies = [
- "cms",
- "const-oid",
- "der",
- "spki",
- "x509-cert",
-]
-
-[[package]]
 name = "crunchy"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
-name = "crypto-bigint"
-version = "0.7.0-pre.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87a5061ea0870b06f7fdd5a0f7268e30c04de1932c148cca0ce5c79a88d18bed"
-dependencies = [
- "hybrid-array",
- "num-traits",
- "rand_core 0.9.3",
- "serdect",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.2.0-rc.2"
-source = "git+https://github.com/RustCrypto/traits.git#439fc8c28c61b09eff35349b4c091a5586d70ea7"
+source = "git+https://github.com/RustCrypto/traits.git#915474f1ed5be0a19fd102d5f75ef8e04c765416"
 dependencies = [
  "hybrid-array",
- "rand_core 0.9.3",
-]
-
-[[package]]
-name = "crypto-primes"
-version = "0.7.0-dev"
-source = "git+https://github.com/entropyxyz/crypto-primes.git#541a5eb1c05664385aaff2697faf72c7200a9786"
-dependencies = [
- "crypto-bigint",
- "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -508,8 +391,7 @@ dependencies = [
 [[package]]
 name = "digest"
 version = "0.11.0-pre.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c478574b20020306f98d61c8ca3322d762e1ff08117422ac6106438605ea516"
+source = "git+https://github.com/RustCrypto/traits.git#915474f1ed5be0a19fd102d5f75ef8e04c765416"
 dependencies = [
  "block-buffer",
  "const-oid",
@@ -518,44 +400,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ecdsa"
-version = "0.17.0-pre.9"
-source = "git+https://github.com/RustCrypto/signatures.git#b66adc00be5c4cf594331c091da8ea71e5f5f32d"
-dependencies = [
- "der",
- "digest",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
- "zeroize",
-]
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "elliptic-curve"
-version = "0.14.0-rc.1"
-source = "git+https://github.com/RustCrypto/traits.git#439fc8c28c61b09eff35349b4c091a5586d70ea7"
-dependencies = [
- "base16ct",
- "crypto-bigint",
- "digest",
- "ff",
- "group",
- "hkdf",
- "hybrid-array",
- "pem-rfc7468",
- "pkcs8",
- "rand_core 0.9.3",
- "sec1",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "equivalent"
@@ -580,16 +428,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "ff"
-version = "0.14.0-pre.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d42dd26f5790eda47c1a2158ea4120e32c35ddc9a7743c98a292accc01b54ef3"
-dependencies = [
- "rand_core 0.9.3",
- "subtle",
-]
-
-[[package]]
 name = "flagset"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,49 +438,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "futures-core"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "futures-task"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
-
-[[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
-
-[[package]]
-name = "futures-util"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
-dependencies = [
- "futures-core",
- "futures-macro",
- "futures-task",
- "pin-project-lite",
- "pin-utils",
- "slab",
-]
 
 [[package]]
 name = "getrandom"
@@ -678,37 +473,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
 name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
-
-[[package]]
-name = "group"
-version = "0.14.0-pre.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ff6a0b2dd4b981b1ae9e3e6830ab146771f3660d31d57bafd9018805a91b0f1"
-dependencies = [
- "ff",
- "rand_core 0.9.3",
- "subtle",
-]
-
-[[package]]
-name = "gss-api"
-version = "0.2.0-pre"
-dependencies = [
- "der",
- "hex-literal",
- "spki",
- "x509-cert",
-]
 
 [[package]]
 name = "half"
@@ -752,19 +520,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcaaec4551594c969335c98c903c1397853d4198408ea609190f420500f6be71"
 
 [[package]]
-name = "hkdf"
-version = "0.13.0-pre.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aaa7579d1176645cee5dc206aa74873b5b3be479af9606025f9b8905bcf597b"
-dependencies = [
- "hmac",
-]
-
-[[package]]
 name = "hmac"
 version = "0.13.0-pre.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62c11fc82c6b89c906b4d26b7b5a305d0b3aebd4b458dd1bd0a7ed98c548a28e"
+source = "git+https://github.com/RustCrypto/MACs.git#64d671d5c375838173d18e30bc14dffc80c13e51"
 dependencies = [
  "digest",
 ]
@@ -776,7 +534,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891d15931895091dea5c47afa5b3c9a01ba634b311919fd4d41388fa0e3d76af"
 dependencies = [
  "typenum",
- "zeroize",
 ]
 
 [[package]]
@@ -824,15 +581,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
-name = "keccak"
-version = "0.2.0-pre.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cdd4f0dc5807b9a2b25dd48a3f58e862606fe7bd47f41ecde36e97422d7e90"
-dependencies = [
- "cpufeatures",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -857,15 +605,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
-dependencies = [
- "adler2",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -878,15 +617,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -908,18 +638,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "p256"
-version = "0.14.0-pre.2"
-source = "git+https://github.com/RustCrypto/elliptic-curves.git#e31132665d2d8440d806cb249c109e5f4b788708"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primefield",
- "primeorder",
- "sha2",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,7 +646,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 [[package]]
 name = "pbkdf2"
 version = "0.13.0-pre.1"
-source = "git+https://github.com/RustCrypto/password-hashes.git#0b8ff354d6e42730ee45c9d7d5e582c58b3f5a8c"
+source = "git+https://github.com/RustCrypto/password-hashes.git#aaf653989744a0c791d0d932bd6eb7fca8c154a6"
 dependencies = [
  "digest",
  "hmac",
@@ -940,18 +658,6 @@ version = "1.0.0-rc.2"
 dependencies = [
  "base64ct 1.7.3",
 ]
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs1"
@@ -1042,35 +748,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "primefield"
-version = "0.14.0-pre.0"
-source = "git+https://github.com/RustCrypto/elliptic-curves.git#e31132665d2d8440d806cb249c109e5f4b788708"
-dependencies = [
- "crypto-bigint",
- "ff",
- "rand_core 0.9.3",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "primeorder"
-version = "0.14.0-pre.2"
-source = "git+https://github.com/RustCrypto/elliptic-curves.git#e31132665d2d8440d806cb249c109e5f4b788708"
-dependencies = [
- "elliptic-curve",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
-dependencies = [
- "toml_edit",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1090,8 +767,8 @@ dependencies = [
  "bitflags",
  "lazy_static",
  "num-traits",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand",
+ "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -1127,18 +804,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1149,16 +816,6 @@ checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1218,21 +875,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
-name = "relative-path"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
-
-[[package]]
-name = "rfc6979"
-version = "0.5.0-pre.4"
-source = "git+https://github.com/RustCrypto/signatures.git#b66adc00be5c4cf594331c091da8ea71e5f5f32d"
-dependencies = [
- "hmac",
- "subtle",
-]
-
-[[package]]
 name = "rmp"
 version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1252,70 +894,6 @@ dependencies = [
  "byteorder",
  "rmp",
  "serde",
-]
-
-[[package]]
-name = "rsa"
-version = "0.10.0-pre.4"
-source = "git+https://github.com/RustCrypto/RSA.git#01c9228a547b9aaf761a768593bcb07552459440"
-dependencies = [
- "const-oid",
- "crypto-bigint",
- "crypto-primes",
- "digest",
- "pkcs1",
- "pkcs8",
- "rand_core 0.9.3",
- "sha2",
- "signature",
- "spki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rstest"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
-dependencies = [
- "futures-timer",
- "futures-util",
- "rstest_macros",
- "rustc_version",
-]
-
-[[package]]
-name = "rstest_macros"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
-dependencies = [
- "cfg-if",
- "glob",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "regex",
- "relative-path",
- "rustc_version",
- "syn",
- "unicode-ident",
-]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-
-[[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
 ]
 
 [[package]]
@@ -1370,7 +948,7 @@ dependencies = [
 [[package]]
 name = "scrypt"
 version = "0.12.0-pre.2"
-source = "git+https://github.com/RustCrypto/password-hashes.git#0b8ff354d6e42730ee45c9d7d5e582c58b3f5a8c"
+source = "git+https://github.com/RustCrypto/password-hashes.git#aaf653989744a0c791d0d932bd6eb7fca8c154a6"
 dependencies = [
  "pbkdf2",
  "salsa20",
@@ -1391,12 +969,6 @@ dependencies = [
  "tempfile",
  "zeroize",
 ]
-
-[[package]]
-name = "semver"
-version = "1.0.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
@@ -1469,8 +1041,7 @@ dependencies = [
 [[package]]
 name = "sha1"
 version = "0.11.0-pre.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55f44e40722caefdd99383c25d3ae52a1094a1951215ae76f68837ece4e7f566"
+source = "git+https://github.com/RustCrypto/hashes.git#7d44caf065dbeb3f10a372a26a8b9f1c927f8433"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1480,40 +1051,11 @@ dependencies = [
 [[package]]
 name = "sha2"
 version = "0.11.0-pre.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b4241d1a56954dce82cecda5c8e9c794eef6f53abe5e5216bac0a0ea71ffa7"
+source = "git+https://github.com/RustCrypto/hashes.git#7d44caf065dbeb3f10a372a26a8b9f1c927f8433"
 dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
-]
-
-[[package]]
-name = "sha3"
-version = "0.11.0-pre.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bc997d7a5fa67cc1e352b2001124d28edb948b4e7a16567f9b3c1e51952524"
-dependencies = [
- "digest",
- "keccak",
-]
-
-[[package]]
-name = "signature"
-version = "3.0.0-pre"
-source = "git+https://github.com/RustCrypto/traits.git#439fc8c28c61b09eff35349b4c091a5586d70ea7"
-dependencies = [
- "digest",
- "rand_core 0.9.3",
-]
-
-[[package]]
-name = "slab"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -1639,28 +1181,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.45.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
-dependencies = [
- "backtrace",
- "pin-project-lite",
- "tokio-macros",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "toml"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1781,8 +1301,7 @@ dependencies = [
 [[package]]
 name = "whirlpool"
 version = "0.11.0-pre.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fbe8695cb6a786fed7267063bda1ad9be6d3d9067b071e6e4cc6d8ac19b176"
+source = "git+https://github.com/RustCrypto/hashes.git#7d44caf065dbeb3f10a372a26a8b9f1c927f8433"
 dependencies = [
  "digest",
 ]
@@ -1891,63 +1410,9 @@ dependencies = [
 name = "x509-cert"
 version = "0.3.0-pre.0"
 dependencies = [
- "arbitrary",
  "const-oid",
  "der",
- "digest",
- "ecdsa",
- "hex-literal",
- "p256",
- "rand 0.9.1",
- "rsa",
- "rstest",
- "sha1",
- "sha2",
- "signature",
  "spki",
- "tempfile",
- "tls_codec",
- "tokio",
- "x509-cert-test-support",
-]
-
-[[package]]
-name = "x509-cert-test-support"
-version = "0.1.0"
-dependencies = [
- "serde",
- "serde_json",
- "tempfile",
-]
-
-[[package]]
-name = "x509-ocsp"
-version = "0.3.0-pre"
-dependencies = [
- "const-oid",
- "der",
- "digest",
- "hex-literal",
- "lazy_static",
- "rand 0.9.1",
- "rand_core 0.9.3",
- "rsa",
- "sha1",
- "sha2",
- "signature",
- "spki",
- "x509-cert",
-]
-
-[[package]]
-name = "x509-tsp"
-version = "0.2.0-pre"
-dependencies = [
- "cmpv2",
- "cms",
- "der",
- "hex-literal",
- "x509-cert",
 ]
 
 [[package]]
@@ -1989,3 +1454,64 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[patch.unused]]
+name = "aes-kw"
+version = "0.3.0-pre"
+source = "git+https://github.com/RustCrypto/key-wraps.git#15f7dd084793ea67360a8f66f771a8e420c1657f"
+
+[[patch.unused]]
+name = "ansi-x963-kdf"
+version = "0.0.1"
+source = "git+https://github.com/RustCrypto/KDFs.git#b1d7fe67b3053deef498563adcf415ec631d1cd8"
+
+[[patch.unused]]
+name = "cmpv2"
+version = "0.3.0-pre.0"
+
+[[patch.unused]]
+name = "crmf"
+version = "0.3.0-pre.0"
+
+[[patch.unused]]
+name = "crypto-primes"
+version = "0.7.0-dev"
+source = "git+https://github.com/entropyxyz/crypto-primes.git#541a5eb1c05664385aaff2697faf72c7200a9786"
+
+[[patch.unused]]
+name = "ecdsa"
+version = "0.17.0-pre.9"
+source = "git+https://github.com/RustCrypto/signatures.git#b66adc00be5c4cf594331c091da8ea71e5f5f32d"
+
+[[patch.unused]]
+name = "elliptic-curve"
+version = "0.14.0-rc.1"
+source = "git+https://github.com/RustCrypto/traits.git#915474f1ed5be0a19fd102d5f75ef8e04c765416"
+
+[[patch.unused]]
+name = "p256"
+version = "0.14.0-pre.2"
+source = "git+https://github.com/RustCrypto/elliptic-curves.git#e31132665d2d8440d806cb249c109e5f4b788708"
+
+[[patch.unused]]
+name = "rfc6979"
+version = "0.5.0-pre.4"
+source = "git+https://github.com/RustCrypto/signatures.git#b66adc00be5c4cf594331c091da8ea71e5f5f32d"
+
+[[patch.unused]]
+name = "rsa"
+version = "0.10.0-pre.4"
+source = "git+https://github.com/RustCrypto/RSA.git#01c9228a547b9aaf761a768593bcb07552459440"
+
+[[patch.unused]]
+name = "signature"
+version = "3.0.0-pre"
+source = "git+https://github.com/RustCrypto/traits.git#915474f1ed5be0a19fd102d5f75ef8e04c765416"
+
+[[patch.unused]]
+name = "x509-ocsp"
+version = "0.3.0-pre"
+
+[[patch.unused]]
+name = "x509-tsp"
+version = "0.2.0-pre"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,13 +4,13 @@ members = [
     "base16ct",
     "base32ct",
     "base64ct",
-    "cmpv2",
-    "cms",
+    #"cmpv2",
+    #"cms",
     "const-oid",
-    "crmf",
+    #"crmf",
     "der",
     "der_derive",
-    "gss-api",
+    #"gss-api",
     "pem-rfc7468",
     "pkcs1",
     "pkcs5",
@@ -22,6 +22,16 @@ members = [
     "tai64",
     "tls_codec",
     "tls_codec/derive",
+    #"x509-tsp",
+    #"x509-cert",
+    #"x509-cert/test-support",
+    #"x509-ocsp"
+]
+exclude = [
+    "cmpv2",
+    "cms",
+    "crmf",
+    "gss-api",
     "x509-tsp",
     "x509-cert",
     "x509-cert/test-support",
@@ -79,6 +89,7 @@ crypto-common = { git = "https://github.com/RustCrypto/traits.git" }
 elliptic-curve = { git = "https://github.com/RustCrypto/traits.git" }
 signature = { git = "https://github.com/RustCrypto/traits.git" }
 aead = { git = "https://github.com/RustCrypto/traits.git" }
+digest = { git = "https://github.com/RustCrypto/traits.git" }
 
 # https://github.com/RustCrypto/RSA/pull/478
 # https://github.com/RustCrypto/RSA/pull/504
@@ -86,6 +97,7 @@ rsa = { git = "https://github.com/RustCrypto/RSA.git" }
 
 # https://github.com/RustCrypto/password-hashes/pull/577
 # https://github.com/RustCrypto/password-hashes/pull/578
+# https://github.com/RustCrypto/password-hashes/pull/592
 pbkdf2 = { git = "https://github.com/RustCrypto/password-hashes.git" }
 scrypt = { git = "https://github.com/RustCrypto/password-hashes.git" }
 
@@ -99,3 +111,9 @@ cbc = { git = "https://github.com/RustCrypto/block-modes.git" }
 ctr = { git = "https://github.com/RustCrypto/block-modes.git" }
 aes-gcm = { git = "https://github.com/RustCrypto/AEADs.git" }
 salsa20 = { git = "https://github.com/RustCrypto/stream-ciphers.git" }
+
+sha1 = { git = "https://github.com/RustCrypto/hashes.git" }
+sha2 = { git = "https://github.com/RustCrypto/hashes.git" }
+whirlpool = { git = "https://github.com/RustCrypto/hashes.git" }
+
+hmac = { git = "https://github.com/RustCrypto/MACs.git" }

--- a/pkcs12/src/kdf.rs
+++ b/pkcs12/src/kdf.rs
@@ -16,7 +16,7 @@
 
 use alloc::{vec, vec::Vec};
 use der::asn1::BmpString;
-use digest::{Digest, FixedOutputReset, OutputSizeUser, Update, core_api::BlockSizeUser};
+use digest::{Digest, FixedOutputReset, OutputSizeUser, Update, block_api::BlockSizeUser};
 use zeroize::{Zeroize, Zeroizing};
 
 /// Specify the usage type of the generated key

--- a/pkcs5/src/pbes2/encryption.rs
+++ b/pkcs5/src/pbes2/encryption.rs
@@ -9,12 +9,11 @@ use cbc::cipher::{
 };
 use pbkdf2::{
     hmac::{
-        EagerHash,
+        block_api::EagerHash,
         digest::{
-            HashMarker,
-            block_buffer::Eager,
-            core_api::{BlockSizeUser, BufferKindUser, FixedOutputCore, UpdateCore},
-            typenum::{IsLess, Le, NonZero, U12, U16, U256},
+            FixedOutput, HashMarker, Update,
+            block_api::BlockSizeUser,
+            typenum::{IsLess, NonZero, True, U12, U16, U256},
         },
     },
     pbkdf2_hmac,
@@ -231,16 +230,9 @@ impl EncryptionKey {
     /// Derive key using PBKDF2.
     fn derive_with_pbkdf2<D>(password: &[u8], params: &Pbkdf2Params, length: usize) -> Self
     where
-        D: EagerHash,
-        D::Core: Sync
-            + HashMarker
-            + UpdateCore
-            + FixedOutputCore
-            + BufferKindUser<BufferKind = Eager>
-            + Default
-            + Clone,
-        <D::Core as BlockSizeUser>::BlockSize: IsLess<U256>,
-        Le<<D::Core as BlockSizeUser>::BlockSize, U256>: NonZero,
+        D: EagerHash + HashMarker + Update + FixedOutput + Default + Clone,
+        <D as EagerHash>::Core: Sync,
+        <D as BlockSizeUser>::BlockSize: IsLess<U256, Output = True> + NonZero,
     {
         let mut buffer = [0u8; MAX_KEY_LEN];
 


### PR DESCRIPTION
Sadly there is some API breaks and we need to split the workspace again to be able to have pkcs5 pass the break first, and then pull RSA, and then we will be able to bring back the workspace together.

Depends:
 - https://github.com/RustCrypto/password-hashes/pull/592