### PR TITLE
reunite workspace

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,4 +1,5 @@
 [advisories]
 ignore = [
     "RUSTSEC-2024-0436", #paste
+    "RUSTSEC-2023-0071", #rsa marvin attack - patched in 0.10, we're depending on 0.10.0-rc.0
 ] # advisory IDs to ignore e.g. ["RUSTSEC-2019-0001", ...]

--- a/.github/workflows/cmpv2.yml
+++ b/.github/workflows/cmpv2.yml
@@ -23,7 +23,6 @@ env:
 
 jobs:
   build:
-    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -49,7 +48,6 @@ jobs:
         working-directory: ${{ github.workflow }}
 
   test:
-    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/cms.yml
+++ b/.github/workflows/cms.yml
@@ -23,7 +23,6 @@ env:
 
 jobs:
   build:
-    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -54,7 +53,6 @@ jobs:
         nightly-cmd:
 
   test:
-    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/crmf.yml
+++ b/.github/workflows/crmf.yml
@@ -23,7 +23,6 @@ env:
 
 jobs:
   build:
-    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -49,7 +48,6 @@ jobs:
         working-directory: ${{ github.workflow }}
 
   test:
-    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/gss-api.yml
+++ b/.github/workflows/gss-api.yml
@@ -23,7 +23,6 @@ env:
 
 jobs:
   build:
-    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -49,7 +48,6 @@ jobs:
         working-directory: ${{ github.workflow }}
 
   test:
-    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/x509-cert.yml
+++ b/.github/workflows/x509-cert.yml
@@ -22,7 +22,6 @@ env:
 
 jobs:
   build:
-    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -50,7 +49,6 @@ jobs:
       install-zlint: true
 
   test:
-    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -74,7 +72,6 @@ jobs:
       - run: cargo test --all-features --release
 
   fuzz:
-    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/x509-ocsp.yml
+++ b/.github/workflows/x509-ocsp.yml
@@ -22,7 +22,6 @@ env:
 
 jobs:
   build:
-    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -48,7 +47,6 @@ jobs:
         working-directory: ${{ github.workflow }}
 
   test:
-    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/x509-tsp.yml
+++ b/.github/workflows/x509-tsp.yml
@@ -25,7 +25,6 @@ env:
 
 jobs:
   build:
-    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -51,7 +50,6 @@ jobs:
         working-directory: ${{ github.workflow }}
 
   test:
-    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "aead"
 version = "0.6.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -38,6 +53,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes-kw"
+version = "0.3.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ca68b29bb0493ce60e7b429074337ed28a419f919cb3702cd28c77561eac338"
+dependencies = [
+ "aes",
+ "const-oid",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,6 +76,15 @@ name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "ansi-x963-kdf"
+version = "0.1.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9724ead468937eebb4c515bcf5451da8fed48a26063dcf450cab078669c0d0d8"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "anstyle"
@@ -72,6 +106,21 @@ name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "backtrace"
+version = "0.3.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets",
+]
 
 [[package]]
 name = "base16ct"
@@ -255,13 +304,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
-name = "cms"
+name = "cmpv2"
 version = "0.3.0-pre.0"
 dependencies = [
  "const-oid",
+ "crmf",
  "der",
+ "digest",
+ "hex-literal",
  "spki",
  "x509-cert",
+]
+
+[[package]]
+name = "cms"
+version = "0.3.0-pre.0"
+dependencies = [
+ "aes",
+ "aes-kw",
+ "ansi-x963-kdf",
+ "cbc",
+ "cipher",
+ "const-oid",
+ "der",
+ "digest",
+ "ecdsa",
+ "elliptic-curve",
+ "getrandom 0.3.3",
+ "hex-literal",
+ "p256",
+ "pbkdf2",
+ "pem-rfc7468",
+ "pkcs5",
+ "rand 0.9.1",
+ "rsa",
+ "sha1",
+ "sha2",
+ "sha3",
+ "signature",
+ "spki",
+ "tokio",
+ "x509-cert",
+ "zeroize",
 ]
 
 [[package]]
@@ -315,10 +399,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "crmf"
+version = "0.3.0-pre.0"
+dependencies = [
+ "cms",
+ "const-oid",
+ "der",
+ "spki",
+ "x509-cert",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+
+[[package]]
+name = "crypto-bigint"
+version = "0.7.0-pre.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edaae5fb9dac79a07260e0b2006799ff4f1d342ab243fd7d0892215113b27904"
+dependencies = [
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.9.3",
+ "serdect",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "crypto-common"
@@ -327,6 +436,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a23fa214dea9efd4dacee5a5614646b30216ae0f05d4bb51bafb50e9da1c5be"
 dependencies = [
  "hybrid-array",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "crypto-primes"
+version = "0.7.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae744b9f528151f8c440cf67498f24d2d1ac0ab536b5ce7b1f87a7a5961bd1c1"
+dependencies = [
+ "crypto-bigint",
+ "libm",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -406,10 +527,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecdsa"
+version = "0.17.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abbc927a7e946a78fbff19c283bc5d4f8960d9000049a7e2b0d84cb2730613c4"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.14.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bedd367b8649edac0efb2120e420460cffc41988f94eb55f009832484a45c46f"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "group",
+ "hkdf",
+ "hybrid-array",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.9.3",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "equivalent"
@@ -434,6 +591,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "ff"
+version = "0.14.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d42dd26f5790eda47c1a2158ea4120e32c35ddc9a7743c98a292accc01b54ef3"
+dependencies = [
+ "rand_core 0.9.3",
+ "subtle",
+]
+
+[[package]]
 name = "flagset"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,6 +611,49 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
 
 [[package]]
 name = "getrandom"
@@ -478,10 +688,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
 name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
+name = "group"
+version = "0.14.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ff6a0b2dd4b981b1ae9e3e6830ab146771f3660d31d57bafd9018805a91b0f1"
+dependencies = [
+ "ff",
+ "rand_core 0.9.3",
+ "subtle",
+]
+
+[[package]]
+name = "gss-api"
+version = "0.2.0-pre"
+dependencies = [
+ "der",
+ "hex-literal",
+ "spki",
+ "x509-cert",
+]
 
 [[package]]
 name = "half"
@@ -525,6 +762,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcaaec4551594c969335c98c903c1397853d4198408ea609190f420500f6be71"
 
 [[package]]
+name = "hkdf"
+version = "0.13.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6738bc5110ee31b066339f0c9454db29a93db3b0484bbf2afa8a7e9cebc62141"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
 name = "hmac"
 version = "0.13.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,6 +786,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891d15931895091dea5c47afa5b3c9a01ba634b311919fd4d41388fa0e3d76af"
 dependencies = [
  "typenum",
+ "zeroize",
 ]
 
 [[package]]
@@ -587,6 +834,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "keccak"
+version = "0.2.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7cdd4f0dc5807b9a2b25dd48a3f58e862606fe7bd47f41ecde36e97422d7e90"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,6 +855,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -609,6 +871,15 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+dependencies = [
+ "adler2",
+]
 
 [[package]]
 name = "num-conv"
@@ -626,6 +897,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -636,6 +916,19 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "p256"
+version = "0.14.0-pre.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "635e1f1e5af6fc13e6c6a587fa1455e17fa7c8b54ba74093be5254819e34713f"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primefield",
+ "primeorder",
+ "sha2",
+]
 
 [[package]]
 name = "paste"
@@ -659,6 +952,18 @@ version = "1.0.0-rc.3"
 dependencies = [
  "base64ct 1.7.3",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs1"
@@ -748,6 +1053,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "primefield"
+version = "0.14.0-pre.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bbeb92947a0d0d4b0cab5e2e6749acc44c81461eb3b1aff4dbb7acd0eb9f0ab"
+dependencies = [
+ "crypto-bigint",
+ "ff",
+ "rand_core 0.9.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2e45e9e037423d1d08cad23132bef43fda87481e362154fd145831028dcf3b8"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,8 +1103,8 @@ dependencies = [
  "bitflags",
  "lazy_static",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -804,8 +1140,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -816,6 +1162,16 @@ checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -875,6 +1231,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "rfc6979"
+version = "0.5.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f53f124bf3ec90be84ae97d7f52175ba938898525554c13c9017eb8f0a604146"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "rmp"
 version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -894,6 +1266,71 @@ dependencies = [
  "byteorder",
  "rmp",
  "serde",
+]
+
+[[package]]
+name = "rsa"
+version = "0.10.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f30f0ad781aea19fe741d7a901b2ad8b4271ac3516e7045b8ecff74e201968fe"
+dependencies = [
+ "const-oid",
+ "crypto-bigint",
+ "crypto-primes",
+ "digest",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.9.3",
+ "sha2",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rstest"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -971,6 +1408,12 @@ dependencies = [
  "tempfile",
  "zeroize",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
@@ -1060,6 +1503,35 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e6a92fd180fd205defdc0b78288ce847c7309d329fd6647a814567e67db50e"
+dependencies = [
+ "digest",
+ "keccak",
+]
+
+[[package]]
+name = "signature"
+version = "3.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7ae074ff622614874804868b07d9cb786223082c9fe726a6653608f32f37b02"
+dependencies = [
+ "digest",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1182,6 +1654,28 @@ dependencies = [
  "syn",
  "tls_codec",
  "trybuild",
+]
+
+[[package]]
+name = "tokio"
+version = "1.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+dependencies = [
+ "backtrace",
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1415,9 +1909,63 @@ dependencies = [
 name = "x509-cert"
 version = "0.3.0-pre.0"
 dependencies = [
+ "arbitrary",
  "const-oid",
  "der",
+ "digest",
+ "ecdsa",
+ "hex-literal",
+ "p256",
+ "rand 0.9.1",
+ "rsa",
+ "rstest",
+ "sha1",
+ "sha2",
+ "signature",
  "spki",
+ "tempfile",
+ "tls_codec",
+ "tokio",
+ "x509-cert-test-support",
+]
+
+[[package]]
+name = "x509-cert-test-support"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
+name = "x509-ocsp"
+version = "0.3.0-pre"
+dependencies = [
+ "const-oid",
+ "der",
+ "digest",
+ "hex-literal",
+ "lazy_static",
+ "rand 0.9.1",
+ "rand_core 0.9.3",
+ "rsa",
+ "sha1",
+ "sha2",
+ "signature",
+ "spki",
+ "x509-cert",
+]
+
+[[package]]
+name = "x509-tsp"
+version = "0.2.0-pre"
+dependencies = [
+ "cmpv2",
+ "cms",
+ "der",
+ "hex-literal",
+ "x509-cert",
 ]
 
 [[package]]
@@ -1459,19 +2007,3 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[patch.unused]]
-name = "cmpv2"
-version = "0.3.0-pre.0"
-
-[[patch.unused]]
-name = "crmf"
-version = "0.3.0-pre.0"
-
-[[patch.unused]]
-name = "x509-ocsp"
-version = "0.3.0-pre"
-
-[[patch.unused]]
-name = "x509-tsp"
-version = "0.2.0-pre"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,13 +4,13 @@ members = [
     "base16ct",
     "base32ct",
     "base64ct",
-    #"cmpv2",
-    #"cms",
+    "cmpv2",
+    "cms",
     "const-oid",
-    #"crmf",
+    "crmf",
     "der",
     "der_derive",
-    #"gss-api",
+    "gss-api",
     "pem-rfc7468",
     "pkcs1",
     "pkcs5",
@@ -22,10 +22,10 @@ members = [
     "tai64",
     "tls_codec",
     "tls_codec/derive",
-    #"x509-tsp",
-    #"x509-cert",
-    #"x509-cert/test-support",
-    #"x509-ocsp"
+    "x509-tsp",
+    "x509-cert",
+    "x509-cert/test-support",
+    "x509-ocsp"
 ]
 exclude = [
     "cmpv2",

--- a/cms/Cargo.toml
+++ b/cms/Cargo.toml
@@ -21,31 +21,31 @@ spki = { version = "0.8.0-rc.0" }
 x509-cert = { version = "=0.3.0-pre.0", default-features = false }
 
 # optional dependencies
-aes = { version = "=0.9.0-pre.3", optional = true }
-aes-kw = { version ="=0.3.0-pre", optional = true }
-ansi-x963-kdf = { version = "0.0.1", optional = true }
-cbc = { version = "=0.2.0-pre.2", optional = true }
-cipher = { version = "=0.5.0-pre.8", features = ["alloc", "block-padding", "rand_core"], optional = true }
-digest = { version = "0.11.0-pre.10", optional = true }
-elliptic-curve = { version = "=0.14.0-rc.1", optional = true }
-rsa = { version = "=0.10.0-pre.4", optional = true }
-sha1 = { version = "=0.11.0-pre.5", optional = true }
-sha2 = { version = "=0.11.0-pre.5", optional = true }
-sha3 = { version = "=0.11.0-pre.5", optional = true }
-signature = { version = "=3.0.0-pre", features = ["digest", "alloc"], optional = true }
+aes = { version = "0.9.0-rc.0", optional = true }
+aes-kw = { version ="0.3.0-rc.0", optional = true }
+ansi-x963-kdf = { version = "0.1.0-rc.0", optional = true }
+cbc = { version = "0.2.0-rc.0", optional = true }
+cipher = { version = "0.5.0-rc.0", features = ["alloc", "block-padding", "rand_core"], optional = true }
+digest = { version = "0.11.0-rc.0", optional = true }
+elliptic-curve = { version = "0.14.0-rc.2", optional = true }
+rsa = { version = "0.10.0-rc.0", optional = true }
+sha1 = { version = "0.11.0-rc.0", optional = true }
+sha2 = { version = "0.11.0-rc.0", optional = true }
+sha3 = { version = "0.11.0-rc.0", optional = true }
+signature = { version = "3.0.0-rc.0", features = ["digest", "alloc"], optional = true }
 zeroize = { version = "1.8.1", optional = true }
 
 [dev-dependencies]
-aes = "=0.9.0-pre.3"
+aes = "0.9.0-rc.0"
 getrandom = "0.3"
 hex-literal = "1"
 pem-rfc7468 = "1.0.0-rc.1"
-pkcs5 = "0.8.0-rc.1"
-pbkdf2 = "0.13.0-pre.0"
+pkcs5 = "0.8.0-rc.4"
+pbkdf2 = "0.13.0-rc.0"
 rand = "0.9"
-rsa = { version = "=0.10.0-pre.4", features = ["sha2"] }
-ecdsa = { version = "=0.17.0-pre.9", features = ["digest", "pem"] }
-p256 = "=0.14.0-pre.2"
+rsa = { version = "0.10.0-rc.0", features = ["sha2"] }
+ecdsa = { version = "0.17.0-rc.0", features = ["digest", "pem"] }
+p256 = "=0.14.0-pre.4"
 tokio = { version = "1.45.1", features = ["macros", "rt"] }
 x509-cert = { version = "=0.3.0-pre.0", features = ["pem"] }
 

--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -22,19 +22,19 @@ spki = { version = "0.8.0-rc.0", features = ["alloc"] }
 
 # optional dependencies
 arbitrary = { version = "1.4", features = ["derive"], optional = true }
-digest = { version = "0.11.0-pre.10", optional = true, default-features = false }
-sha1 = { version = "0.11.0-pre.5", default-features = false, optional = true }
-signature = { version = "=3.0.0-pre", features = ["rand_core"], optional = true }
+digest = { version = "0.11.0-rc.0", optional = true, default-features = false }
+sha1 = { version = "0.11.0-rc.0", default-features = false, optional = true }
+signature = { version = "3.0.0-rc.0", features = ["rand_core"], optional = true }
 tls_codec = { version = "0.4.0", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
 hex-literal = "1"
 rand = "0.9"
-rsa = { version = "=0.10.0-pre.4", features = ["sha2"] }
-ecdsa = { version = "=0.17.0-pre.9", features = ["digest", "pem"] }
-p256 = "=0.14.0-pre.2"
+rsa = { version = "0.10.0-rc.0", features = ["sha2"] }
+ecdsa = { version = "0.17.0-rc.0", features = ["digest", "pem"] }
+p256 = "=0.14.0-pre.4"
 rstest = "0.25"
-sha2 = { version = "=0.11.0-pre.5", features = ["oid"] }
+sha2 = { version = "0.11.0-rc.0", features = ["oid"] }
 tempfile = "3.5.0"
 tokio = { version = "1.45.1", features = ["macros", "rt"] }
 x509-cert-test-support = { path = "./test-support" }

--- a/x509-ocsp/Cargo.toml
+++ b/x509-ocsp/Cargo.toml
@@ -22,17 +22,17 @@ spki = { version = "0.8.0-rc.0", features = ["alloc"] }
 x509-cert = { version = "=0.3.0-pre.0", default-features = false }
 
 # Optional
-digest = { version = "=0.11.0-pre.10", optional = true, default-features = false, features = ["oid"] }
+digest = { version = "0.11.0-rc.0", optional = true, default-features = false, features = ["oid"] }
 rand_core = { version = "0.9", optional = true, default-features = false }
-signature = { version = "=3.0.0-pre", optional = true, default-features = false, features = ["digest", "rand_core"] }
+signature = { version = "3.0.0-rc.0", optional = true, default-features = false, features = ["digest", "rand_core"] }
 
 [dev-dependencies]
 hex-literal = "1"
 lazy_static = "1.5.0"
 rand = "0.9"
-rsa = { version = "=0.10.0-pre.4", default-features = false, features = ["sha2"] }
-sha1 = { version = "=0.11.0-pre.5", default-features = false, features = ["oid"] }
-sha2 = { version = "=0.11.0-pre.5", default-features = false, features = ["oid"] }
+rsa = { version = "0.10.0-rc.0", default-features = false, features = ["sha2"] }
+sha1 = { version = "0.11.0-rc.0", default-features = false, features = ["oid"] }
+sha2 = { version = "0.11.0-rc.0", default-features = false, features = ["oid"] }
 
 [features]
 rand = ["rand_core"]


### PR DESCRIPTION
We've split the workspace in https://github.com/RustCrypto/formats/pull/1847 to be able to release pkcs* crates and make a release of rsa.

This brings back the workspace together.