### PR TITLE
mcf: Modular Crypt Format implementation

### DIFF
--- a/.github/workflows/mcf.yml
+++ b/.github/workflows/mcf.yml
@@ -1,0 +1,58 @@
+name: mcf
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/mcf.yml"
+      - "mcf/**"
+      - "Cargo.*"
+  push:
+    branches: master
+
+defaults:
+  run:
+    working-directory: mcf
+
+env:
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: "-Dwarnings"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.85.0 # MSRV
+          - stable
+        target:
+          - thumbv7em-none-eabi
+          - wasm32-unknown-unknown
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+          targets: ${{ matrix.target }}
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset
+
+  minimal-versions:
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+      working-directory: ${{ github.workflow }}
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.85.0 # MSRV
+          - stable
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo hack test --feature-powerset

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,6 +848,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
+name = "mcf"
+version = "0.0.0"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "der",
     "der_derive",
     "gss-api",
+    "mcf",
     "pem-rfc7468",
     "pkcs1",
     "pkcs5",

--- a/mcf/CHANGELOG.md
+++ b/mcf/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.1.0 (2022-05-20)
+- Initial release

--- a/mcf/Cargo.toml
+++ b/mcf/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "mcf"
+version = "0.0.0"
+authors = ["RustCrypto Developers"]
+edition = "2024"
+rust-version = "1.85"
+readme = "README.md"
+repository = "https://github.com/RustCrypto/formats"
+license = "Apache-2.0 OR MIT"
+keywords = ["crypt", "crypto", "password-hash", "password-hashing"]
+categories = ["cryptography", "authentication", "encoding", "no-std", "parser-implementations"]
+description = """
+Pure Rust implementation of the Modular Crypt Format (MCF) which is used to store password hashes
+in the form `${id}$...`
+"""

--- a/mcf/LICENSE-APACHE
+++ b/mcf/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/mcf/LICENSE-MIT
+++ b/mcf/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2025 The RustCrypto Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/mcf/README.md
+++ b/mcf/README.md
@@ -1,0 +1,75 @@
+# [RustCrypto]: Modular Crypt Format
+
+[![crate][crate-image]][crate-link]
+[![Docs][docs-image]][docs-link]
+[![Build Status][build-image]][build-link]
+![Apache2/MIT licensed][license-image]
+![Rust Version][rustc-image]
+[![Project Chat][chat-image]][chat-link]
+
+Pure Rust implementation of the Modular Crypt Format (MCF), which is used to store password hashes.
+
+## About
+
+Modular Crypt Format is the name for a bespoke set of formats that take the form `${id}$...`, where
+`{id}` is a short numeric or lower case alphanumeric algorithm identifier optionally containing a
+hyphen character (`-`), followed  by `$` as a delimiter, further followed by an algorithm-specific
+serialization of a password hash, typically  using a variant (often an algorithm-specific variant)
+of Base64.
+
+This algorithm-specific  serialization contains one or more fields `${first}[${second}]...`, where
+each field only uses characters in the regexp range `[A-Za-z0-9./+=,\-]`.
+
+Note that MCF has no official specification describing it, and no central registry of identifiers
+exists, nor are there more specific rules for the format than outlined above. MCF is more of an
+ad hoc idea of how to serialize password hashes rather than a standard.
+
+This crate provides types for working with Modular Crypt Format in as generic a manner as possible.
+
+For more information and history on MCF, see the [PassLib documentation].
+
+### Example (SHA-crypt w\ SHA-512):
+
+```text
+$6$rounds=100000$exn6tVc2j/MZD8uG$BI1Xh8qQSK9J4m14uwy7abn.ctj/TIAzlaVCto0MQrOFIeTXsc1iwzH16XEWo/a7c7Y9eVJvufVzYAs4EsPOy0
+```
+
+## Minimum Supported Rust Version
+
+This crate requires **Rust 1.85** at a minimum.
+
+We may change the MSRV in the future, but it will be accompanied by a minor
+version bump.
+
+## License
+
+Licensed under either of:
+
+ * [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+ * [MIT license](http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.
+
+[//]: # (badges)
+
+[crate-image]: https://img.shields.io/crates/v/mcf
+[crate-link]: https://crates.io/crates/mcf
+[docs-image]: https://docs.rs/mcf/badge.svg
+[docs-link]: https://docs.rs/mcf/
+[license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
+[chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
+[chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
+[build-image]: https://github.com/RustCrypto/formats/actions/workflows/mcf.yml/badge.svg
+[build-link]: https://github.com/RustCrypto/formats/actions/workflows/mcf.yml
+
+[//]: # (links)
+
+[RustCrypto]: https://github.com/rustcrypto
+[PassLib documentation]: https://passlib.readthedocs.io/en/stable/modular_crypt_format.html

--- a/mcf/src/lib.rs
+++ b/mcf/src/lib.rs
@@ -1,0 +1,217 @@
+#![no_std]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![doc = include_str!("../README.md")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
+)]
+#![forbid(unsafe_code)]
+#![warn(
+    clippy::mod_module_files,
+    clippy::unwrap_used,
+    missing_docs,
+    unused_qualifications
+)]
+
+extern crate alloc;
+
+use alloc::string::String;
+use core::{fmt, str};
+
+/// MCF field delimiter: `$`.
+pub const DELIMITER: char = '$';
+
+/// Debug message used in panics when invariants aren't properly held.
+const INVARIANT_MSG: &str = "should be ensured valid by constructor";
+
+/// Modular Crypt Format (MCF) serialized password hash.
+///
+/// Password hashes in this format take the form `${id}$...`, where `{id}` is a short numeric or
+/// alphanumeric algorithm identifier optionally containing a `-`, followed by `$` as a delimiter,
+/// further followed by an algorithm-specific serialization of a password hash, typically
+/// using a variant (often an algorithm-specific variant) of Base64. This algorithm-specific
+/// serialization contains one or more fields `${first}[${second}]...`, where each field only uses
+/// characters in the regexp range `[A-Za-z0-9./+=,\-]`.
+///
+/// Example (SHA-crypt w\ SHA-512):
+///
+/// ```text
+/// $6$rounds=100000$exn6tVc2j/MZD8uG$BI1Xh8qQSK9J4m14uwy7abn.ctj/TIAzlaVCto0MQrOFIeTXsc1iwzH16XEWo/a7c7Y9eVJvufVzYAs4EsPOy0
+/// ```
+pub struct McfHash(String);
+
+impl McfHash {
+    /// Parse the given input string, returning an [`McfHash`] if valid.
+    pub fn new(s: impl Into<String>) -> Result<McfHash> {
+        let s = s.into();
+        validate(&s)?;
+        Ok(Self(s))
+    }
+
+    /// Get the contained string as a `str`.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Get the algorithm identifier for this MCF hash.
+    pub fn id(&self) -> &str {
+        Fields::new(self.as_str())
+            .expect(INVARIANT_MSG)
+            .next()
+            .expect(INVARIANT_MSG)
+    }
+
+    /// Get an iterator over the parts of the password hash as delimited by `$`, excluding the
+    /// initial identifier.
+    pub fn fields(&self) -> Fields {
+        let mut fields = Fields::new(self.as_str()).expect(INVARIANT_MSG);
+
+        // Remove the leading identifier
+        let id = fields.next().expect(INVARIANT_MSG);
+        debug_assert_eq!(id, self.id());
+
+        fields
+    }
+}
+
+impl AsRef<str> for McfHash {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl fmt::Display for McfHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl str::FromStr for McfHash {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        Self::new(s)
+    }
+}
+
+/// Perform validations that the given string is well-formed MCF.
+fn validate(s: &str) -> Result<()> {
+    // Validates the hash begins with a leading `$`
+    let mut fields = Fields::new(s)?;
+
+    // Validate characters in the identifier field
+    let id = fields.next().ok_or(Error {})?;
+    validate_id(id)?;
+
+    // Validate the remaining fields have an appropriate format
+    let mut any = false;
+    for field in fields {
+        any = true;
+        validate_field(field)?;
+    }
+
+    // Must have at least one field.
+    if !any {
+        return Err(Error {});
+    }
+
+    Ok(())
+}
+
+/// Validate the password hash identifier is well-formed.
+///
+/// Allowed characters match the regex: `[a-z0-9\-]`, where the first and last characters do NOT
+/// contain a `-`.
+fn validate_id(id: &str) -> Result<()> {
+    let first = id.chars().next().ok_or(Error {})?;
+    let last = id.chars().last().ok_or(Error {})?;
+
+    for c in [first, last] {
+        match c {
+            'a'..='z' | '0'..='9' => (),
+            _ => return Err(Error {}),
+        }
+    }
+
+    for c in id.chars() {
+        match c {
+            'a'..='z' | '0'..='9' | '-' => (),
+            _ => return Err(Error {}),
+        }
+    }
+
+    Ok(())
+}
+
+/// Validate a field in the password hash is well-formed.
+///
+/// Fields include characters in the regexp range `[A-Za-z0-9./+=,\-]`.
+fn validate_field(field: &str) -> Result<()> {
+    if field.is_empty() {
+        return Err(Error {});
+    }
+
+    for c in field.chars() {
+        match c {
+            'A'..='Z' | 'a'..='z' | '0'..='9' | '.' | '/' | '+' | '=' | ',' | '-' => (),
+            _ => return Err(Error {}),
+        }
+    }
+
+    Ok(())
+}
+
+/// Iterator over the `$`-delimited fields of an MCF hash.
+pub struct Fields<'a>(&'a str);
+
+impl<'a> Fields<'a> {
+    /// Create a new field iterator from an MCF hash, returning an error in the event the hash
+    /// doesn't start with a leading `$` prefix.
+    fn new(s: &'a str) -> Result<Self> {
+        let mut ret = Self(s);
+
+        if ret.next() != Some("") {
+            return Err(Error {});
+        }
+
+        Ok(ret)
+    }
+}
+
+impl<'a> Iterator for Fields<'a> {
+    type Item = &'a str;
+
+    fn next(&mut self) -> Option<&'a str> {
+        if self.0.is_empty() {
+            return None;
+        }
+
+        match self.0.split_once(DELIMITER) {
+            Some((field, rest)) => {
+                self.0 = rest;
+                Some(field)
+            }
+            None => {
+                let ret = self.0;
+                self.0 = "";
+                Some(ret)
+            }
+        }
+    }
+}
+
+/// Result type for `mcf`.
+pub type Result<T> = core::result::Result<T, Error>;
+
+/// Error type.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct Error {}
+
+impl core::error::Error for Error {}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("modular crypt format error")
+    }
+}

--- a/mcf/tests/mcf.rs
+++ b/mcf/tests/mcf.rs
@@ -1,0 +1,32 @@
+//! Modular Crypt Format integration tests.
+
+use mcf::McfHash;
+
+#[test]
+fn parse_malformed() {
+    assert!("Hello, world!".parse::<McfHash>().is_err());
+    assert!("$".parse::<McfHash>().is_err());
+    assert!("$foo".parse::<McfHash>().is_err());
+    assert!("$$".parse::<McfHash>().is_err());
+    assert!("$$foo".parse::<McfHash>().is_err());
+    assert!("$foo$".parse::<McfHash>().is_err());
+    assert!("$-$foo".parse::<McfHash>().is_err());
+    assert!("$foo-$bar".parse::<McfHash>().is_err());
+    assert!("$-foo$bar".parse::<McfHash>().is_err());
+}
+
+#[test]
+fn parse_sha512_hash() {
+    let s = "$6$rounds=100000$exn6tVc2j/MZD8uG$BI1Xh8qQSK9J4m14uwy7abn.ctj/TIAzlaVCto0MQrOFIeTXsc1iwzH16XEWo/a7c7Y9eVJvufVzYAs4EsPOy0";
+    let hash: McfHash = s.parse().unwrap();
+    assert_eq!("6", hash.id());
+
+    let mut fields = hash.fields();
+    assert_eq!("rounds=100000", fields.next().unwrap());
+    assert_eq!("exn6tVc2j/MZD8uG", fields.next().unwrap());
+    assert_eq!(
+        "BI1Xh8qQSK9J4m14uwy7abn.ctj/TIAzlaVCto0MQrOFIeTXsc1iwzH16XEWo/a7c7Y9eVJvufVzYAs4EsPOy0",
+        fields.next().unwrap()
+    );
+    assert_eq!(None, fields.next());
+}


### PR DESCRIPTION
Initial implementation of the MCF pseudo-format as described at: https://passlib.readthedocs.io/en/stable/modular_crypt_format.html

Note that MCF is less a specification than an ad hoc set of conventions.

As MCF lacks the kind of rigidly specified sizes of its various components, a heapless `no_std` implementation isn't really possible like it is with the PHC format, and so this implementation has a hard dependency on `alloc` (though it should be possible to extract an `alloc`-free reference type which borrows from its input).