### PR TITLE
base64ct v1.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,13 +148,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
-
-[[package]]
-name = "base64ct"
-version = "1.8.0-pre"
+version = "1.8.0"
 dependencies = [
  "base64",
  "proptest",
@@ -950,7 +944,7 @@ dependencies = [
 name = "pem-rfc7468"
 version = "1.0.0-rc.3"
 dependencies = [
- "base64ct 1.7.3",
+ "base64ct",
 ]
 
 [[package]]
@@ -1539,7 +1533,7 @@ name = "spki"
 version = "0.8.0-rc.2"
 dependencies = [
  "arbitrary",
- "base64ct 1.7.3",
+ "base64ct",
  "der",
  "digest",
  "hex-literal",

--- a/base64ct/CHANGELOG.md
+++ b/base64ct/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.8.0 (2025-06-04)
+### Changed
+- Bump edition to 2024; MSRV 1.85 ([#1839])
+
+[#1839]: https://github.com/RustCrypto/formats/pull/1839
+
 ## 1.7.3 (2025-03-13)
 ### Changed
 - Don't fail with `InvalidLength` when reading nothing at end of data ([#1716]).
@@ -27,8 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - derive additional traits on alphabets ([#1578])
 
 ### Changed
-- MSRV 1.85 // Edition 2024 ([#1670])
-- reject zero-length decode requests ([#1387])
+- ~~MSRV 1.85 // Edition 2024 ([#1670])~~
+- ~~reject zero-length decode requests ([#1387])~~
 - use `core::error::Error` ([#1681])
 
 [#1387]: https://github.com/RustCrypto/formats/pull/1387

--- a/base64ct/Cargo.toml
+++ b/base64ct/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base64ct"
-version = "1.8.0-pre"
+version = "1.8.0"
 description = """
 Pure Rust implementation of Base64 (RFC 4648) which avoids any usages of
 data-dependent branches/LUTs and thereby provides portable "best effort"


### PR DESCRIPTION
### Changed
- Bump edition to 2024; MSRV 1.85 ([#1839])

[#1839]: https://github.com/RustCrypto/formats/pull/1839