### PR TITLE
x509-cert: allow serialnumbers to be stored in a database

### DIFF
--- a/x509-cert/src/certificate.rs
+++ b/x509-cert/src/certificate.rs
@@ -25,7 +25,7 @@ use crate::time::Time;
 /// [`Profile`] allows the consumer of this crate to customize the behavior when parsing
 /// certificates.
 /// By default, parsing will be made in a rfc5280-compliant manner.
-pub trait Profile: PartialEq + Debug + Eq + Clone + Copy + Default + 'static {
+pub trait Profile: PartialEq + Debug + Eq + Ord + Clone + Copy + Default + 'static {
     /// Checks to run when parsing serial numbers
     fn check_serial_number(serial: &SerialNumber<Self>) -> der::Result<()> {
         // See the note in `SerialNumber::new`: we permit lengths of 21 bytes here,
@@ -54,7 +54,7 @@ pub trait Profile: PartialEq + Debug + Eq + Clone + Copy + Default + 'static {
 }
 
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(Debug, PartialEq, Eq, Copy, Clone, Default)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Default)]
 /// Parse and serialize certificates in rfc5280-compliant manner
 pub struct Rfc5280;
 
@@ -62,7 +62,7 @@ impl Profile for Rfc5280 {}
 
 #[cfg(feature = "hazmat")]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(Debug, PartialEq, Eq, Copy, Clone, Default)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Default)]
 /// Parse raw x509 certificate and disable all the checks and modification to the underlying data.
 pub struct Raw;
 


### PR DESCRIPTION
When storing serialnumbers in a database, a btree or similar structure, the serial number could be required to implement Ord. This is useful for a CRL database for example.

This is only possible if the Profile itself implements Ord. As this is a very cheap requirement for the profile itself, this is now part of the Profile trait.