### PR TITLE
workspace: bump dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,9 +522,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.1"
+version = "0.17.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ca18d8009d96ffc2a8b771c7432338233ffcfa05e4ca410ed77900a2a335a0b"
+checksum = "f386592dae0cda5d4bf90836794e096ef74f06e84ec309ad3a7e81e1053a0d2e"
 dependencies = [
  "der",
  "digest",
@@ -543,9 +543,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.5"
+version = "0.14.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "541598dba361b5ba0321caad955ba99ae82a604f4047c4f2743724996abf62f4"
+checksum = "92ccc36f4cfd3b96979b66a2162a10052eb0b98c9241ed1498273c79898d26a7"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -902,9 +902,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "p256"
-version = "0.14.0-pre.5"
+version = "0.14.0-pre.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42c06f1f28ff328cb76c95cb7aebd6734a8333b98bdac393bdc124d16561dcb"
+checksum = "10f895207881bb519f7e0746e5471f8a8b3ec01924008e8398b71b38bbf8d9ef"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -1050,9 +1050,9 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-pre.4"
+version = "0.14.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "979936340c6e8b108ad132b395a1682f02a0b179080ed3380320c2c888728429"
+checksum = "ceda4bcc4556f74ba324635498da05337996a0141ec3ba841d0b19c57e85b0d9"
 dependencies = [
  "elliptic-curve",
 ]

--- a/cms/Cargo.toml
+++ b/cms/Cargo.toml
@@ -27,7 +27,7 @@ ansi-x963-kdf = { version = "0.1.0-rc.0", optional = true }
 cbc = { version = "0.2.0-rc.0", optional = true }
 cipher = { version = "0.5.0-rc.0", features = ["alloc", "block-padding", "rand_core"], optional = true }
 digest = { version = "0.11.0-rc.0", optional = true }
-elliptic-curve = { version = "0.14.0-rc.5", optional = true }
+elliptic-curve = { version = "0.14.0-rc.6", optional = true }
 rsa = { version = "0.10.0-rc.0", optional = true }
 sha1 = { version = "0.11.0-rc.0", optional = true }
 sha2 = { version = "0.11.0-rc.0", optional = true }
@@ -44,8 +44,8 @@ pkcs5 = "0.8.0-rc.4"
 pbkdf2 = "0.13.0-rc.0"
 rand = "0.9"
 rsa = { version = "0.10.0-rc.0", features = ["sha2"] }
-ecdsa = { version = "0.17.0-rc.1", features = ["digest", "pem"] }
-p256 = "=0.14.0-pre.5"
+ecdsa = { version = "0.17.0-rc.2", features = ["digest", "pem"] }
+p256 = "=0.14.0-pre.7"
 tokio = { version = "1.45.1", features = ["macros", "rt"] }
 x509-cert = { version = "0.3.0-rc.0", features = ["pem"] }
 

--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -32,7 +32,7 @@ hex-literal = "1"
 rand = "0.9"
 rsa = { version = "0.10.0-rc.0", features = ["sha2"] }
 ecdsa = { version = "0.17.0-rc.1", features = ["digest", "pem"] }
-p256 = "=0.14.0-pre.5"
+p256 = "=0.14.0-pre.7"
 rstest = "0.25"
 sha2 = { version = "0.11.0-rc.0", features = ["oid"] }
 tempfile = "3.5.0"


### PR DESCRIPTION
This bumps:
 - `elliptic-curve` from `0.14.0-rc.5` to `0.14.0-rc.6`
 - `ecdsa` from `0.17.0-rc.1` to `0.17.0-rc.2`