### PR TITLE
der: add `diagnostic::on_unimplemented` attributes

### DIFF
--- a/der/src/decode.rs
+++ b/der/src/decode.rs
@@ -16,6 +16,9 @@ use alloc::boxed::Box;
 ///
 /// This trait provides the core abstraction upon which all decoding operations
 /// are based.
+#[diagnostic::on_unimplemented(
+    note = "Consider adding impls of `DecodeValue` and `FixedTag` to `{Self}`"
+)]
 pub trait Decode<'a>: Sized + 'a {
     /// Type returned in the event of a decoding error.
     type Error: From<Error> + 'static;
@@ -90,6 +93,9 @@ where
 /// to first decode data from Base64.
 ///
 /// This trait is inspired by the [`DeserializeOwned` trait from `serde`](https://docs.rs/serde/latest/serde/de/trait.DeserializeOwned.html).
+#[diagnostic::on_unimplemented(
+    note = "`DecodeOwned` is auto-impl'd for all lifetime-free types which impl `Decode`"
+)]
 pub trait DecodeOwned: for<'a> Decode<'a> {}
 
 impl<T> DecodeOwned for T where T: for<'a> Decode<'a> {}
@@ -99,6 +105,9 @@ impl<T> DecodeOwned for T where T: for<'a> Decode<'a> {}
 /// This trait is automatically impl'd for any type which impls both
 /// [`DecodeOwned`] and [`PemLabel`].
 #[cfg(feature = "pem")]
+#[diagnostic::on_unimplemented(
+    note = "`DecodePem` is auto-impl'd for all lifetime-free types which impl both `Decode` and `PemLabel`"
+)]
 pub trait DecodePem: DecodeOwned + PemLabel {
     /// Try to decode this type from PEM.
     fn from_pem(pem: impl AsRef<[u8]>) -> Result<Self, <Self as Decode<'static>>::Error>;

--- a/der/src/encode.rs
+++ b/der/src/encode.rs
@@ -20,6 +20,9 @@ use crate::ErrorKind;
 use crate::Tag;
 
 /// Encoding trait.
+#[diagnostic::on_unimplemented(
+    note = "Consider adding impls of `EncodeValue` and `FixedTag` to `{Self}`"
+)]
 pub trait Encode {
     /// Compute the length of this value in bytes when encoded as ASN.1 DER.
     fn encoded_len(&self) -> Result<Length>;
@@ -102,6 +105,9 @@ where
 /// This trait is automatically impl'd for any type which impls both
 /// [`Encode`] and [`PemLabel`].
 #[cfg(feature = "pem")]
+#[diagnostic::on_unimplemented(
+    note = "`EncodePem` is auto-impl'd for types which impl both `Encode` and `PemLabel`"
+)]
 pub trait EncodePem: Encode + PemLabel {
     /// Try to encode this type as PEM.
     fn to_pem(&self, line_ending: LineEnding) -> Result<String>;

--- a/der/src/tag.rs
+++ b/der/src/tag.rs
@@ -20,6 +20,7 @@ pub trait FixedTag {
 }
 
 /// Types which have an ASN.1 [`Tag`].
+#[diagnostic::on_unimplemented(note = "Consider adding impl of `FixedTag` to `{Self}`")]
 pub trait Tagged {
     /// Get the ASN.1 tag that this type is encoded with.
     fn tag(&self) -> Tag;
@@ -35,6 +36,7 @@ impl<T: FixedTag + ?Sized> Tagged for T {
 /// Types which have a constant ASN.1 constructed bit.
 ///
 /// Auto-implemented on all types that implement [`FixedTag`].
+#[diagnostic::on_unimplemented(note = "Consider adding impl of `FixedTag` to `{Self}`")]
 pub trait IsConstructed {
     /// ASN.1 constructed bit
     const CONSTRUCTED: bool;


### PR DESCRIPTION
Adds some `note` attributes to help people figure out blanket impls where applicable