### PR TITLE
Bump `crypto-bigint` to v0.7.0-pre.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,9 +411,9 @@ checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-pre.4"
+version = "0.7.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edaae5fb9dac79a07260e0b2006799ff4f1d342ab243fd7d0892215113b27904"
+checksum = "a06a5e703b883b3744ddac8b7c5eade2d800d6559ef99760566f8103e3ad39bf"
 dependencies = [
  "hybrid-array",
  "num-traits",
@@ -522,9 +522,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.2"
+version = "0.17.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f386592dae0cda5d4bf90836794e096ef74f06e84ec309ad3a7e81e1053a0d2e"
+checksum = "908741ea702207ae9456173adf9aaa8fffdd3a057e55ca9c77f62a05b9ad08d1"
 dependencies = [
  "der",
  "digest",
@@ -543,9 +543,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.6"
+version = "0.14.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ccc36f4cfd3b96979b66a2162a10052eb0b98c9241ed1498273c79898d26a7"
+checksum = "eb5fad57f7e416b8f8e81df65daa6a87e402a4469990fd1ba36a8c79515a5fbf"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -902,9 +902,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "p256"
-version = "0.14.0-pre.7"
+version = "0.14.0-pre.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f895207881bb519f7e0746e5471f8a8b3ec01924008e8398b71b38bbf8d9ef"
+checksum = "ce3867083c909bbfd0ae070e20a9bb0f3dbce6f8e1fc4441cc01bda4951eeebe"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -1037,9 +1037,9 @@ dependencies = [
 
 [[package]]
 name = "primefield"
-version = "0.14.0-pre.2"
+version = "0.14.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bbeb92947a0d0d4b0cab5e2e6749acc44c81461eb3b1aff4dbb7acd0eb9f0ab"
+checksum = "0ad88338273bf095e74dc9b4fa9e68474980af715d4374ecffae09513ab85f6c"
 dependencies = [
  "crypto-bigint",
  "ff",
@@ -1050,9 +1050,9 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-pre.5"
+version = "0.14.0-pre.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceda4bcc4556f74ba324635498da05337996a0141ec3ba841d0b19c57e85b0d9"
+checksum = "c6e217447f8603744210c50e4c065b2e5a66b04f5d8279f33032fdb0fde6fabb"
 dependencies = [
  "elliptic-curve",
 ]
@@ -1223,9 +1223,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.10.0-rc.0"
+version = "0.10.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30f0ad781aea19fe741d7a901b2ad8b4271ac3516e7045b8ecff74e201968fe"
+checksum = "a4825b570bf9949160f598b942df0d6abfa00b71a97c970fdd6e2647439634b8"
 dependencies = [
  "const-oid",
  "crypto-bigint",

--- a/cms/Cargo.toml
+++ b/cms/Cargo.toml
@@ -22,7 +22,7 @@ x509-cert = { version = "0.3.0-rc.0", default-features = false }
 
 # optional dependencies
 aes = { version = "0.9.0-rc.0", optional = true }
-aes-kw = { version ="0.3.0-rc.0", optional = true }
+aes-kw = { version = "0.3.0-rc.0", optional = true }
 ansi-x963-kdf = { version = "0.1.0-rc.0", optional = true }
 cbc = { version = "0.2.0-rc.0", optional = true }
 cipher = { version = "0.5.0-rc.0", features = ["alloc", "block-padding", "rand_core"], optional = true }
@@ -32,7 +32,7 @@ rsa = { version = "0.10.0-rc.0", optional = true }
 sha1 = { version = "0.11.0-rc.0", optional = true }
 sha2 = { version = "0.11.0-rc.0", optional = true }
 sha3 = { version = "0.11.0-rc.0", optional = true }
-signature = { version = "3.0.0-rc.0", features = ["digest", "alloc"], optional = true }
+signature = { version = "3.0.0-rc.1", features = ["digest", "alloc"], optional = true }
 zeroize = { version = "1.8.1", optional = true }
 
 [dev-dependencies]
@@ -43,9 +43,9 @@ pem-rfc7468 = "1.0.0-rc.1"
 pkcs5 = "0.8.0-rc.4"
 pbkdf2 = "0.13.0-rc.0"
 rand = "0.9"
-rsa = { version = "0.10.0-rc.0", features = ["sha2"] }
-ecdsa = { version = "0.17.0-rc.2", features = ["digest", "pem"] }
-p256 = "=0.14.0-pre.7"
+rsa = { version = "0.10.0-rc.1", features = ["sha2"] }
+ecdsa = { version = "0.17.0-rc.3", features = ["digest", "pem"] }
+p256 = "=0.14.0-pre.8"
 tokio = { version = "1.45.1", features = ["macros", "rt"] }
 x509-cert = { version = "0.3.0-rc.0", features = ["pem"] }
 

--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -30,9 +30,9 @@ tls_codec = { version = "0.4.0", default-features = false, features = ["derive"]
 [dev-dependencies]
 hex-literal = "1"
 rand = "0.9"
-rsa = { version = "0.10.0-rc.0", features = ["sha2"] }
-ecdsa = { version = "0.17.0-rc.1", features = ["digest", "pem"] }
-p256 = "=0.14.0-pre.7"
+rsa = { version = "0.10.0-rc.1", features = ["sha2"] }
+ecdsa = { version = "0.17.0-rc.3", features = ["digest", "pem"] }
+p256 = "=0.14.0-pre.8"
 rstest = "0.25"
 sha2 = { version = "0.11.0-rc.0", features = ["oid"] }
 tempfile = "3.5.0"

--- a/x509-ocsp/Cargo.toml
+++ b/x509-ocsp/Cargo.toml
@@ -30,7 +30,7 @@ signature = { version = "3.0.0-rc.0", optional = true, default-features = false,
 hex-literal = "1"
 lazy_static = "1.5.0"
 rand = "0.9"
-rsa = { version = "0.10.0-rc.0", default-features = false, features = ["sha2"] }
+rsa = { version = "0.10.0-rc.1", default-features = false, features = ["sha2"] }
 sha1 = { version = "0.11.0-rc.0", default-features = false, features = ["oid"] }
 sha2 = { version = "0.11.0-rc.0", default-features = false, features = ["oid"] }
 


### PR DESCRIPTION
Also bumps: `ecdsa`, `rsa`, `p256`