### PR TITLE
der: remove EOC bytes from decoded indefinite lengths

### DIFF
--- a/der/src/tag/number.rs
+++ b/der/src/tag/number.rs
@@ -62,6 +62,18 @@ impl TagNumber {
     }
 }
 
+impl From<u32> for TagNumber {
+    fn from(value: u32) -> TagNumber {
+        TagNumber(value)
+    }
+}
+
+impl From<TagNumber> for u32 {
+    fn from(number: TagNumber) -> u32 {
+        number.0
+    }
+}
+
 impl fmt::Display for TagNumber {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)


### PR DESCRIPTION
The bytes `00 00` are used as a marker that we've reached the end of an indefinite length field, and are not of interest to someone who wants the actual value contained in the field.