### PR TITLE
der: remove `Reader::read_value`

### DIFF
--- a/der/src/asn1/internal_macros.rs
+++ b/der/src/asn1/internal_macros.rs
@@ -151,8 +151,8 @@ macro_rules! impl_custom_class {
                     return Err(header.tag.non_canonical_error().into());
                 }
 
-                // read_value checks if header matches decoded length
-                let value = reader.read_value(header, |reader| {
+                // read_nested checks if header matches decoded length
+                let value = reader.read_nested(header.length, |reader| {
                     // Decode inner IMPLICIT value
                     T::decode_value(reader, header)
                 })?;
@@ -192,7 +192,7 @@ macro_rules! impl_custom_class {
                     Tag::$class_enum_name { number, .. } => Ok(Self {
                         tag_number: number,
                         tag_mode: TagMode::default(),
-                        value: reader.read_value(header, |reader| {
+                        value: reader.read_nested(header.length, |reader| {
                             // Decode inner tag-length-value of EXPLICIT
                             T::decode(reader)
                         })?,

--- a/der/src/decode.rs
+++ b/der/src/decode.rs
@@ -68,7 +68,7 @@ where
     fn decode<R: Reader<'a>>(reader: &mut R) -> Result<T, <T as DecodeValue<'a>>::Error> {
         let header = Header::decode(reader)?;
         header.tag.assert_eq(T::TAG)?;
-        reader.read_value(header, |r| T::decode_value(r, header))
+        reader.read_nested(header.length, |r| T::decode_value(r, header))
     }
 }
 

--- a/der/src/reader.rs
+++ b/der/src/reader.rs
@@ -32,18 +32,6 @@ pub trait Reader<'r>: Clone {
         E: From<Error>,
         F: FnOnce(&mut Self) -> Result<T, E>;
 
-    /// Read a value (i.e. the "V" part of a "TLV" field) using the provided header.
-    ///
-    /// This calls the provided function `f` with a nested reader created using
-    /// [`Reader::read_nested`].
-    fn read_value<T, F, E>(&mut self, header: Header, f: F) -> Result<T, E>
-    where
-        E: From<Error>,
-        F: FnOnce(&mut Self) -> Result<T, E>,
-    {
-        self.read_nested(header.length, f)
-    }
-
     /// Attempt to read data borrowed directly from the input as a slice,
     /// updating the internal cursor position.
     ///
@@ -204,7 +192,7 @@ pub trait Reader<'r>: Clone {
     {
         let header = Header::decode(self)?;
         header.tag.assert_eq(Tag::Sequence)?;
-        self.read_value(header, f)
+        self.read_nested(header.length, f)
     }
 
     /// Obtain a slice of bytes containing a complete TLV production suitable for parsing later.


### PR DESCRIPTION
This was added in #1877 but the real value of that PR was the automatic `read_nested` on `DecodeValue` impls. `Reader::read_value` isn't actually necessary for that at all.

It may be useful in the future if we introduce a BER reader that can handle decoding constructed e.g. strings from indefinite length encoding, but since we don't actually have anything like that yet, removing this avoids some unnecessary duplication and API surface for the `Reader`.