### PR TITLE
[WIP] cms: test decoding of `cms_ber.bin`

### DIFF
--- a/cms/tests/tests_from_pkcs7_crate.rs
+++ b/cms/tests/tests_from_pkcs7_crate.rs
@@ -141,3 +141,13 @@ fn cms_decode_signed_der() {
     // should match the original
     assert_eq!(reencoded_der_signed_data_in_ci, der_signed_data_in_ci)
 }
+
+#[test]
+fn cms_decode_signed_ber() {
+    let cms_ber = include_bytes!("../tests/examples/cms_ber.bin");
+    let _ci_ber = ContentInfo::from_ber(cms_ber).unwrap();
+
+    // let cms_der = include_bytes!("../tests/examples/cms_der.bin");
+    // let ci_der = ContentInfo::from_der(cms_der).unwrap();
+    // assert_eq!(ci_ber, ci_der);
+}


### PR DESCRIPTION
The files `cms_ber.bin` and `cms_der.bin` already checked into `cms/tests` contain test vectors showing a BER encoding with indefinite lengths and its DER equivalent.

The decoder now seems to be handling indefinite lengths, but can't handle decoding a constructed `OCTET STRING` with indefinite length (currently failing on the tag).