### PR TITLE
Cargo.toml: remove branches from `patch.crates-io`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,7 +523,7 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.17.0-rc.3"
-source = "git+https://github.com/RustCrypto/signatures.git?branch=der-error-fixups#80909c41ef37718c7f2dfb3b8cd6c828b907f1e6"
+source = "git+https://github.com/RustCrypto/signatures.git#6cc40e5c10b04dae44d91500d5a1afc4a3ff2b49"
 dependencies = [
  "der",
  "digest",
@@ -543,7 +543,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 [[package]]
 name = "elliptic-curve"
 version = "0.14.0-rc.7"
-source = "git+https://github.com/RustCrypto/traits.git?branch=elliptic-curve%2Fder-error-fixups#89dcefcba7896d1e6dd34871ad484c186909d2a9"
+source = "git+https://github.com/RustCrypto/traits.git#f517eff1f9821f7d67c0bbf9f9fe873ba12f3ab5"
 dependencies = [
  "base16ct",
  "crypto-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,10 +59,5 @@ x509-tsp = { path = "./x509-tsp" }
 x509-cert = { path = "./x509-cert" }
 x509-ocsp = { path = "./x509-ocsp" }
 
-[patch.crates-io.elliptic-curve]
-git = "https://github.com/RustCrypto/traits.git"
-branch = "elliptic-curve/der-error-fixups"
-
-[patch.crates-io.ecdsa]
-git = "https://github.com/RustCrypto/signatures.git"
-branch = "der-error-fixups"
+elliptic-curve = { git = "https://github.com/RustCrypto/traits.git" }
+ecdsa = { git = "https://github.com/RustCrypto/signatures.git" }

--- a/der/src/tag.rs
+++ b/der/src/tag.rs
@@ -7,7 +7,9 @@ mod number;
 
 pub use self::{class::Class, mode::TagMode, number::TagNumber};
 
-use crate::{Decode, DerOrd, Encode, Error, ErrorKind, Length, Reader, Result, Writer};
+use crate::{
+    Decode, DerOrd, Encode, EncodingRules, Error, ErrorKind, Length, Reader, Result, Writer,
+};
 use core::{cmp::Ordering, fmt};
 
 /// Indicator bit for constructed form encoding (i.e. vs primitive form)
@@ -318,6 +320,7 @@ impl<'a> Decode<'a> for Tag {
             0x1A => Tag::VisibleString,
             0x1B => Tag::GeneralString,
             0x1E => Tag::BmpString,
+            0x24 if reader.encoding_rules() == EncodingRules::Ber => Tag::OctetString,
             0x30 => Tag::Sequence, // constructed
             0x31 => Tag::Set,      // constructed
             0x40..=0x7F => {


### PR DESCRIPTION
The relevant branches have been merged