### PR TITLE
x509-cert: ensure pem reader accept preambles

### DIFF
--- a/x509-cert/tests/certificate.rs
+++ b/x509-cert/tests/certificate.rs
@@ -479,3 +479,10 @@ fn decode_cert_bmpstring() {
         "WDKTestCert 混沌,133906716390833193"
     );
 }
+
+#[cfg(feature = "pem")]
+#[test]
+fn decode_cert_with_comments() {
+    let pem_encoded_cert = include_bytes!("examples/lenovo_pk.pem");
+    Certificate::from_pem(pem_encoded_cert).expect("parse certificate with comments in the header");
+}

--- a/x509-cert/tests/examples/lenovo_pk.pem
+++ b/x509-cert/tests/examples/lenovo_pk.pem
@@ -1,0 +1,80 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            eb:b5:13:d4:6b:b1:dc:6e
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = JP, ST = Kanagawa, L = Yokohama, O = Lenovo Ltd., CN = Lenovo Ltd. PK CA 2012
+        Validity
+            Not Before: Jun 29 10:34:36 2012 GMT
+            Not After : Jun 24 10:34:36 2032 GMT
+        Subject: C = JP, ST = Kanagawa, L = Yokohama, O = Lenovo Ltd., CN = Lenovo Ltd. PK CA 2012
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:b6:9c:5d:62:63:d3:d1:77:52:66:99:5f:d8:22:
+                    12:86:71:1b:1e:ae:14:3a:18:4b:ff:0c:54:fd:fb:
+                    f2:be:5a:49:d4:a1:a7:52:1e:7f:6c:4b:c7:60:0a:
+                    ce:c2:bc:7d:ab:13:b6:66:e9:12:c3:7c:75:f3:de:
+                    c0:f3:32:19:b8:5e:f2:9c:cb:58:98:66:d9:73:14:
+                    e8:9b:6f:2a:b2:64:34:16:3f:07:9b:b8:19:fa:2c:
+                    c9:d6:06:55:4e:77:b5:21:e5:73:6c:02:a5:40:b1:
+                    f4:b2:31:87:d3:53:24:f8:2c:aa:6d:42:aa:5c:b4:
+                    bb:a5:ec:ce:05:29:c5:42:93:5a:1c:d4:e7:ab:df:
+                    5e:83:70:87:77:a8:59:78:33:d4:ca:f1:46:6a:c0:
+                    9e:9c:04:3f:03:9e:13:52:0f:0a:13:3c:db:94:6b:
+                    5d:4c:14:09:73:17:1a:0b:3a:e6:ec:a1:45:1d:3a:
+                    a5:aa:9a:f4:de:b4:b3:15:f1:07:c8:d6:fa:e0:a8:
+                    30:99:b7:8e:a3:d0:ff:3b:f2:c9:f9:88:8b:31:b6:
+                    a2:fd:0a:4d:f4:ff:28:ae:c5:b5:da:3e:42:93:26:
+                    9a:9a:bd:aa:0e:54:58:fe:87:af:20:a0:77:cc:3d:
+                    e1:96:52:f2:98:4e:32:14:2e:b2:e8:ed:3b:01:7a:
+                    d8:93
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier:
+                FF:77:DF:4B:17:4C:71:8B:74:F9:17:9D:EC:34:3D:8D:19:0E:94:48
+            X509v3 Authority Key Identifier:
+                FF:77:DF:4B:17:4C:71:8B:74:F9:17:9D:EC:34:3D:8D:19:0E:94:48
+            X509v3 Basic Constraints:
+                CA:TRUE
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        70:65:af:af:90:25:ad:55:d6:91:a5:e6:df:91:a0:89:ef:8f:
+        32:4b:b5:ee:c6:d5:8e:bb:13:8e:43:5d:3d:72:4e:3a:4f:26:
+        a6:67:b0:28:56:cf:6a:1c:ea:30:ee:08:61:2d:7d:42:8c:fa:
+        de:d6:ee:d5:3b:94:0c:28:61:df:4f:4f:f0:fe:21:db:a6:cd:
+        78:8a:0f:07:28:5f:d5:dd:b5:d7:93:72:98:c9:6e:65:88:f2:
+        a5:b7:a9:c3:75:0e:65:12:bc:d5:32:d4:5d:ce:c2:d1:65:5e:
+        b9:6c:4e:a8:00:07:ba:28:78:30:8a:0c:70:b5:54:58:50:b5:
+        22:23:3e:df:61:4f:e0:91:ee:60:1b:47:84:72:f7:ea:69:a5:
+        28:ca:4f:f5:3a:b7:18:0e:3e:bf:87:31:87:0a:10:d9:c5:34:
+        ab:00:7d:10:07:e9:ba:c2:ed:41:a9:41:c0:bf:ea:9e:82:fb:
+        54:9d:85:b9:81:36:5f:01:f1:9c:1a:b9:b8:5c:b1:16:c9:e9:
+        4c:80:12:78:41:79:07:e8:f9:6d:11:ed:2c:88:8e:3d:0d:bd:
+        6c:23:17:60:1c:d6:47:1b:f6:2b:51:b4:b6:82:51:7c:c9:5e:
+        d2:60:25:59:3c:79:65:33:1f:3a:90:80:23:ca:c1:98:2e:6e:
+        14:8e:91:76
+-----BEGIN CERTIFICATE-----
+MIIDpzCCAo+gAwIBAgIJAOu1E9RrsdxuMA0GCSqGSIb3DQEBCwUAMGoxCzAJBgNV
+BAYTAkpQMREwDwYDVQQIDAhLYW5hZ2F3YTERMA8GA1UEBwwIWW9rb2hhbWExFDAS
+BgNVBAoMC0xlbm92byBMdGQuMR8wHQYDVQQDDBZMZW5vdm8gTHRkLiBQSyBDQSAy
+MDEyMB4XDTEyMDYyOTEwMzQzNloXDTMyMDYyNDEwMzQzNlowajELMAkGA1UEBhMC
+SlAxETAPBgNVBAgMCEthbmFnYXdhMREwDwYDVQQHDAhZb2tvaGFtYTEUMBIGA1UE
+CgwLTGVub3ZvIEx0ZC4xHzAdBgNVBAMMFkxlbm92byBMdGQuIFBLIENBIDIwMTIw
+ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC2nF1iY9PRd1JmmV/YIhKG
+cRserhQ6GEv/DFT9+/K+WknUoadSHn9sS8dgCs7CvH2rE7Zm6RLDfHXz3sDzMhm4
+XvKcy1iYZtlzFOibbyqyZDQWPwebuBn6LMnWBlVOd7Uh5XNsAqVAsfSyMYfTUyT4
+LKptQqpctLul7M4FKcVCk1oc1Oer316DcId3qFl4M9TK8UZqwJ6cBD8DnhNSDwoT
+PNuUa11MFAlzFxoLOubsoUUdOqWqmvTetLMV8QfI1vrgqDCZt46j0P878sn5iIsx
+tqL9Ck30/yiuxbXaPkKTJpqavaoOVFj+h68goHfMPeGWUvKYTjIULrLo7TsBetiT
+AgMBAAGjUDBOMB0GA1UdDgQWBBT/d99LF0xxi3T5F53sND2NGQ6USDAfBgNVHSME
+GDAWgBT/d99LF0xxi3T5F53sND2NGQ6USDAMBgNVHRMEBTADAQH/MA0GCSqGSIb3
+DQEBCwUAA4IBAQBwZa+vkCWtVdaRpebfkaCJ748yS7XuxtWOuxOOQ109ck46Tyam
+Z7AoVs9qHOow7ghhLX1CjPre1u7VO5QMKGHfT0/w/iHbps14ig8HKF/V3bXXk3KY
+yW5liPKlt6nDdQ5lErzVMtRdzsLRZV65bE6oAAe6KHgwigxwtVRYULUiIz7fYU/g
+ke5gG0eEcvfqaaUoyk/1OrcYDj6/hzGHChDZxTSrAH0QB+m6wu1BqUHAv+qegvtU
+nYW5gTZfAfGcGrm4XLEWyelMgBJ4QXkH6PltEe0siI49Db1sIxdgHNZHG/YrUbS2
+glF8yV7SYCVZPHllMx86kIAjysGYLm4UjpF2
+-----END CERTIFICATE-----


### PR DESCRIPTION
It is convenient to have the text form alongside a certificate for debug purpose.

This test ensures we can accpt them.