### PR TITLE
der: have `read_value` pass through header sans EOC

### DIFF
--- a/der/src/asn1/internal_macros.rs
+++ b/der/src/asn1/internal_macros.rs
@@ -152,10 +152,7 @@ macro_rules! impl_custom_class {
                 }
 
                 // read_value checks if header matches decoded length
-                let value = reader.read_value(header, |reader| {
-                    // Decode inner IMPLICIT value
-                    T::decode_value(reader, header)
-                })?;
+                let value = reader.read_value(header, T::decode_value)?;
 
                 Ok(Some(Self {
                     tag_number,
@@ -192,7 +189,7 @@ macro_rules! impl_custom_class {
                     Tag::$class_enum_name { number, .. } => Ok(Self {
                         tag_number: number,
                         tag_mode: TagMode::default(),
-                        value: reader.read_value(header, |reader| {
+                        value: reader.read_value(header, |reader, _| {
                             // Decode inner tag-length-value of EXPLICIT
                             T::decode(reader)
                         })?,

--- a/der/src/decode.rs
+++ b/der/src/decode.rs
@@ -68,7 +68,7 @@ where
     fn decode<R: Reader<'a>>(reader: &mut R) -> Result<T, <T as DecodeValue<'a>>::Error> {
         let header = Header::decode(reader)?;
         header.tag.assert_eq(T::TAG)?;
-        reader.read_value(header, |r| T::decode_value(r, header))
+        reader.read_value(header, T::decode_value)
     }
 }
 


### PR DESCRIPTION
Changes `read_value`'s callback to accept a `Header` argument which includes the indefinite length without the trailing EOC marker.

Otherwise indefinite length decoders will run into the EOC marker.