### PR TITLE
der: constructed `OctetString` support

### DIFF
--- a/der/src/bytes_ref.rs
+++ b/der/src/bytes_ref.rs
@@ -2,7 +2,8 @@
 //! library-level length limitation i.e. `Length::max()`.
 
 use crate::{
-    DecodeValue, DerOrd, EncodeValue, Error, Header, Length, Reader, Result, StrRef, Writer,
+    DecodeValue, DerOrd, EncodeValue, Error, ErrorKind, Header, Length, Reader, Result, StrRef,
+    Writer,
 };
 use core::cmp::Ordering;
 
@@ -74,6 +75,10 @@ impl<'a> DecodeValue<'a> for BytesRef<'a> {
     type Error = Error;
 
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
+        if header.length.is_indefinite() && !header.tag.is_constructed() {
+            return Err(reader.error(ErrorKind::IndefiniteLength));
+        }
+
         reader.read_slice(header.length).and_then(Self::new)
     }
 }

--- a/x509-ocsp/src/ext.rs
+++ b/x509-ocsp/src/ext.rs
@@ -1,7 +1,7 @@
 //! OCSP Extensions
 
 use crate::OcspGeneralizedTime;
-use alloc::vec::Vec;
+use alloc::{boxed::Box, vec::Vec};
 use const_oid::{
     AssociatedOid,
     db::rfc6960::{
@@ -49,7 +49,7 @@ impl AssociatedOid for Nonce {
 
 impl Nonce {
     /// Creates a Nonce object given the bytes
-    pub fn new(bytes: impl Into<Vec<u8>>) -> Result<Self, der::Error> {
+    pub fn new(bytes: impl Into<Box<[u8]>>) -> Result<Self, der::Error> {
         Ok(Self(OctetString::new(bytes)?))
     }
 


### PR DESCRIPTION
Converts `OctetString` to use `BytesOwned` internally and adds an initial decoder for constructed indefinite length data to `BytesOwned`.

This should be reusable for other constructed string types as well, although they'll need to receive a similar treatment.