### PR TITLE
der: move `read_value` out of public API

### DIFF
--- a/der/src/asn1/any.rs
+++ b/der/src/asn1/any.rs
@@ -176,7 +176,7 @@ pub use self::allocating::Any;
 #[cfg(feature = "alloc")]
 mod allocating {
     use super::*;
-    use crate::{BytesOwned, referenced::*};
+    use crate::{BytesOwned, reader::read_value, referenced::*};
     use alloc::boxed::Box;
 
     /// ASN.1 `ANY`: represents any explicitly tagged ASN.1 value.
@@ -275,7 +275,7 @@ mod allocating {
 
         fn decode<R: Reader<'a>>(reader: &mut R) -> Result<Self, Error> {
             let header = Header::decode(reader)?;
-            reader.read_value(header, Self::decode_value)
+            read_value(reader, header, Self::decode_value)
         }
     }
 

--- a/der/src/asn1/internal_macros.rs
+++ b/der/src/asn1/internal_macros.rs
@@ -152,7 +152,7 @@ macro_rules! impl_custom_class {
                 }
 
                 // read_value checks if header matches decoded length
-                let value = reader.read_value(header, T::decode_value)?;
+                let value = crate::reader::read_value(reader, header, T::decode_value)?;
 
                 Ok(Some(Self {
                     tag_number,
@@ -189,7 +189,7 @@ macro_rules! impl_custom_class {
                     Tag::$class_enum_name { number, .. } => Ok(Self {
                         tag_number: number,
                         tag_mode: TagMode::default(),
-                        value: reader.read_value(header, |reader, _| {
+                        value: crate::reader::read_value(reader, header, |reader, _| {
                             // Decode inner tag-length-value of EXPLICIT
                             T::decode(reader)
                         })?,

--- a/der/src/decode.rs
+++ b/der/src/decode.rs
@@ -1,6 +1,6 @@
 //! Trait definition for [`Decode`].
 
-use crate::{EncodingRules, Error, FixedTag, Header, Reader, SliceReader};
+use crate::{EncodingRules, Error, FixedTag, Header, Reader, SliceReader, reader::read_value};
 use core::marker::PhantomData;
 
 #[cfg(feature = "pem")]
@@ -68,7 +68,7 @@ where
     fn decode<R: Reader<'a>>(reader: &mut R) -> Result<T, <T as DecodeValue<'a>>::Error> {
         let header = Header::decode(reader)?;
         header.tag.assert_eq(T::TAG)?;
-        reader.read_value(header, T::decode_value)
+        read_value(reader, header, T::decode_value)
     }
 }
 


### PR DESCRIPTION
Moves `Reader::read_value` out of the trait and into an internal free function