### PR TITLE
mcf: introduce basic no-`alloc` profile

### DIFF
--- a/mcf/Cargo.toml
+++ b/mcf/Cargo.toml
@@ -13,3 +13,7 @@ description = """
 Pure Rust implementation of the Modular Crypt Format (MCF) which is used to store password hashes
 in the form `${id}$...`
 """
+
+[features]
+default = ["alloc"]
+alloc = []

--- a/mcf/README.md
+++ b/mcf/README.md
@@ -58,7 +58,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/mcf
+[crate-image]: https://img.shields.io/crates/v/mcf?logo=rust
 [crate-link]: https://crates.io/crates/mcf
 [docs-image]: https://docs.rs/mcf/badge.svg
 [docs-link]: https://docs.rs/mcf/

--- a/mcf/src/fields.rs
+++ b/mcf/src/fields.rs
@@ -12,7 +12,7 @@ pub struct Fields<'a>(&'a str);
 impl<'a> Fields<'a> {
     /// Create a new field iterator from an MCF hash, returning an error in the event the hash
     /// doesn't start with a leading `$` prefix.
-    pub(crate) fn new(s: &'a str) -> Result<Self> {
+    pub fn new(s: &'a str) -> Result<Self> {
         let mut ret = Self(s);
 
         if ret.next() != Some(Field("")) {

--- a/mcf/src/lib.rs
+++ b/mcf/src/lib.rs
@@ -13,16 +13,20 @@
     unused_qualifications
 )]
 
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 mod fields;
 
 pub use fields::{Field, Fields};
 
-use alloc::string::String;
-use core::{fmt, str};
+use core::fmt;
+
+#[cfg(feature = "alloc")]
+use {alloc::string::String, core::str};
 
 /// Debug message used in panics when invariants aren't properly held.
+#[cfg(feature = "alloc")]
 const INVARIANT_MSG: &str = "should be ensured valid by constructor";
 
 /// Modular Crypt Format (MCF) serialized password hash.
@@ -39,8 +43,10 @@ const INVARIANT_MSG: &str = "should be ensured valid by constructor";
 /// ```text
 /// $6$rounds=100000$exn6tVc2j/MZD8uG$BI1Xh8qQSK9J4m14uwy7abn.ctj/TIAzlaVCto0MQrOFIeTXsc1iwzH16XEWo/a7c7Y9eVJvufVzYAs4EsPOy0
 /// ```
+#[cfg(feature = "alloc")]
 pub struct McfHash(String);
 
+#[cfg(feature = "alloc")]
 impl McfHash {
     /// Parse the given input string, returning an [`McfHash`] if valid.
     pub fn new(s: impl Into<String>) -> Result<McfHash> {
@@ -76,18 +82,21 @@ impl McfHash {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl AsRef<str> for McfHash {
     fn as_ref(&self) -> &str {
         self.as_str()
     }
 }
 
+#[cfg(feature = "alloc")]
 impl fmt::Display for McfHash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
     }
 }
 
+#[cfg(feature = "alloc")]
 impl str::FromStr for McfHash {
     type Err = Error;
 
@@ -97,6 +106,7 @@ impl str::FromStr for McfHash {
 }
 
 /// Perform validations that the given string is well-formed MCF.
+#[cfg(feature = "alloc")]
 fn validate(s: &str) -> Result<()> {
     // Validates the hash begins with a leading `$`
     let mut fields = Fields::new(s)?;
@@ -124,6 +134,7 @@ fn validate(s: &str) -> Result<()> {
 ///
 /// Allowed characters match the regex: `[a-z0-9\-]`, where the first and last characters do NOT
 /// contain a `-`.
+#[cfg(feature = "alloc")]
 fn validate_id(id: &str) -> Result<()> {
     let first = id.chars().next().ok_or(Error {})?;
     let last = id.chars().last().ok_or(Error {})?;

--- a/mcf/tests/mcf.rs
+++ b/mcf/tests/mcf.rs
@@ -1,5 +1,7 @@
 //! Modular Crypt Format integration tests.
 
+#![cfg(feature = "alloc")]
+
 use mcf::McfHash;
 
 #[test]


### PR DESCRIPTION
Support for using the `Fields`/`Field` types in heapless environments.

Ideally we'd support something like `McfHashRef` for parsing MCF from a `str` input, but this PR doesn't add that for now.