### PR TITLE
der: improve constructed bit handling

### DIFF
--- a/der/src/header.rs
+++ b/der/src/header.rs
@@ -36,8 +36,7 @@ impl<'a> Decode<'a> for Header {
     type Error = Error;
 
     fn decode<R: Reader<'a>>(reader: &mut R) -> Result<Header> {
-        let is_constructed = Tag::peek_is_constructed(reader)?;
-        let tag = Tag::decode(reader)?;
+        let (tag, is_constructed) = Tag::decode_with_constructed_bit(reader)?;
 
         let length = Length::decode(reader).map_err(|e| {
             if e.kind() == ErrorKind::Overlength {


### PR DESCRIPTION
Adds an internal decoding method which returns the constructed bit in addition to the `Tag`. This replaces the previous method of peeking at the tag in addition to decoding it.

This is currently used for validating the constructed bit at decode time, however in future work it might be interesting to retain, either on the `Tag` type (where we do store it for certain variants) or in the `Header` type.