### PR TITLE
der: improved internal ref types

### DIFF
--- a/der/src/asn1/general_string.rs
+++ b/der/src/asn1/general_string.rs
@@ -4,7 +4,7 @@ use crate::{BytesRef, DecodeValue, EncodeValue, FixedTag, Header, Length, Reader
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct GeneralStringRef<'a> {
     /// Raw contents, unchecked
-    inner: BytesRef<'a>,
+    inner: &'a BytesRef,
 }
 impl<'a> GeneralStringRef<'a> {
     /// This is currently `&[u8]` internally, as `GeneralString` is not fully implemented yet
@@ -21,7 +21,7 @@ impl<'a> DecodeValue<'a> for GeneralStringRef<'a> {
 
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self, Self::Error> {
         Ok(Self {
-            inner: BytesRef::decode_value(reader, header)?,
+            inner: <&'a BytesRef>::decode_value(reader, header)?,
         })
     }
 }

--- a/der/src/asn1/integer/int.rs
+++ b/der/src/asn1/integer/int.rs
@@ -102,7 +102,7 @@ impl_encoding_traits!(i8 => u8, i16 => u16, i32 => u32, i64 => u64, i128 => u128
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct IntRef<'a> {
     /// Inner value
-    inner: BytesRef<'a>,
+    inner: &'a BytesRef,
 }
 
 impl<'a> IntRef<'a> {
@@ -137,7 +137,7 @@ impl<'a> DecodeValue<'a> for IntRef<'a> {
     type Error = Error;
 
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
-        let bytes = BytesRef::decode_value(reader, header)?;
+        let bytes = <&'a BytesRef>::decode_value(reader, header)?;
         validate_canonical(bytes.as_slice())?;
 
         let result = Self::new(bytes.as_slice())?;
@@ -184,7 +184,7 @@ mod allocating {
         ord::OrdIsValueOrd,
         referenced::{OwnedToRef, RefToOwned},
     };
-    use alloc::vec::Vec;
+    use alloc::{borrow::ToOwned, vec::Vec};
 
     /// Signed arbitrary precision ASN.1 `INTEGER` type.
     ///
@@ -288,7 +288,7 @@ mod allocating {
     impl<'a> RefToOwned<'a> for IntRef<'a> {
         type Owned = Int;
         fn ref_to_owned(&self) -> Self::Owned {
-            let inner = self.inner.ref_to_owned();
+            let inner = self.inner.to_owned();
 
             Int { inner }
         }
@@ -297,7 +297,7 @@ mod allocating {
     impl OwnedToRef for Int {
         type Borrowed<'a> = IntRef<'a>;
         fn owned_to_ref(&self) -> Self::Borrowed<'_> {
-            let inner = self.inner.owned_to_ref();
+            let inner = self.inner.as_ref();
 
             IntRef { inner }
         }

--- a/der/src/asn1/integer/uint.rs
+++ b/der/src/asn1/integer/uint.rs
@@ -87,7 +87,7 @@ impl_encoding_traits!(u8, u16, u32, u64, u128);
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct UintRef<'a> {
     /// Inner value
-    inner: BytesRef<'a>,
+    inner: &'a BytesRef,
 }
 
 impl<'a> UintRef<'a> {
@@ -122,7 +122,7 @@ impl<'a> DecodeValue<'a> for UintRef<'a> {
     type Error = Error;
 
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
-        let bytes = BytesRef::decode_value(reader, header)?.as_slice();
+        let bytes = <&'a BytesRef>::decode_value(reader, header)?.as_slice();
         let result = Self::new(decode_to_slice(bytes)?)?;
 
         // Ensure we compute the same encoded length as the original any value.
@@ -170,6 +170,7 @@ mod allocating {
         ord::OrdIsValueOrd,
         referenced::{OwnedToRef, RefToOwned},
     };
+    use alloc::borrow::ToOwned;
 
     /// Unsigned arbitrary precision ASN.1 `INTEGER` type.
     ///
@@ -260,7 +261,7 @@ mod allocating {
     impl<'a> RefToOwned<'a> for UintRef<'a> {
         type Owned = Uint;
         fn ref_to_owned(&self) -> Self::Owned {
-            let inner = self.inner.ref_to_owned();
+            let inner = self.inner.to_owned();
 
             Uint { inner }
         }
@@ -269,7 +270,7 @@ mod allocating {
     impl OwnedToRef for Uint {
         type Borrowed<'a> = UintRef<'a>;
         fn owned_to_ref(&self) -> Self::Borrowed<'_> {
-            let inner = self.inner.owned_to_ref();
+            let inner = self.inner.as_ref();
 
             UintRef { inner }
         }

--- a/der/src/asn1/internal_macros.rs
+++ b/der/src/asn1/internal_macros.rs
@@ -51,7 +51,7 @@ macro_rules! impl_string_type {
                 type Error = $crate::Error;
 
                 fn decode_value<R: Reader<'__der>>(reader: &mut R, header: Header) -> $crate::Result<Self> {
-                    Self::new(BytesRef::decode_value(reader, header)?.as_slice())
+                    Self::new(<&'__der BytesRef>::decode_value(reader, header)?.as_slice())
                 }
             }
 

--- a/der/src/asn1/null.rs
+++ b/der/src/asn1/null.rs
@@ -41,7 +41,7 @@ impl OrdIsValueOrd for Null {}
 
 impl<'a> From<Null> for AnyRef<'a> {
     fn from(_: Null) -> AnyRef<'a> {
-        AnyRef::from_tag_and_value(Tag::Null, BytesRef::default())
+        AnyRef::from_tag_and_value(Tag::Null, BytesRef::EMPTY)
     }
 }
 

--- a/der/src/asn1/octet_string.rs
+++ b/der/src/asn1/octet_string.rs
@@ -13,7 +13,7 @@ use crate::{
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct OctetStringRef<'a> {
     /// Inner value
-    inner: BytesRef<'a>,
+    inner: &'a BytesRef,
 }
 
 impl<'a> OctetStringRef<'a> {
@@ -57,7 +57,7 @@ impl<'a> DecodeValue<'a> for OctetStringRef<'a> {
     type Error = Error;
 
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self, Error> {
-        let inner = BytesRef::decode_value(reader, header)?;
+        let inner = <&'a BytesRef>::decode_value(reader, header)?;
         Ok(Self { inner })
     }
 }
@@ -240,7 +240,7 @@ mod allocating {
     impl<'a> From<&'a OctetString> for OctetStringRef<'a> {
         fn from(octet_string: &'a OctetString) -> OctetStringRef<'a> {
             OctetStringRef {
-                inner: octet_string.inner.owned_to_ref(),
+                inner: octet_string.inner.as_ref(),
             }
         }
     }

--- a/der/src/asn1/real.rs
+++ b/der/src/asn1/real.rs
@@ -18,7 +18,7 @@ impl<'a> DecodeValue<'a> for f64 {
     type Error = Error;
 
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
-        let bytes = BytesRef::decode_value(reader, header)?.as_slice();
+        let bytes = <&'a BytesRef>::decode_value(reader, header)?.as_slice();
 
         if header.length == Length::ZERO {
             Ok(0.0)
@@ -76,7 +76,7 @@ impl<'a> DecodeValue<'a> for f64 {
             }
         } else {
             let astr = StringRef::from_bytes(&bytes[1..])?;
-            match astr.inner.parse::<f64>() {
+            match astr.as_str().parse::<f64>() {
                 Ok(val) => Ok(val),
                 // Real related error: encoding not supported or malformed
                 Err(_) => Err(reader.error(Tag::Real.value_error())),

--- a/der/src/asn1/sequence.rs
+++ b/der/src/asn1/sequence.rs
@@ -30,7 +30,7 @@ impl<'a, T> Sequence<'a> for Box<T> where T: Sequence<'a> {}
 /// This is a zero-copy reference type which borrows from the input data.
 pub struct SequenceRef<'a> {
     /// Body of the `SEQUENCE`.
-    body: BytesRef<'a>,
+    body: &'a BytesRef,
 }
 
 impl<'a> SequenceRef<'a> {
@@ -51,7 +51,7 @@ impl<'a> DecodeValue<'a> for SequenceRef<'a> {
 
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
         Ok(Self {
-            body: BytesRef::decode_value(reader, header)?,
+            body: <&'a BytesRef>::decode_value(reader, header)?,
         })
     }
 }

--- a/der/src/asn1/utf8_string.rs
+++ b/der/src/asn1/utf8_string.rs
@@ -29,7 +29,7 @@ use {
 #[derive(Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Utf8StringRef<'a> {
     /// Inner value
-    inner: StringRef<'a>,
+    inner: &'a StringRef,
 }
 
 impl<'a> Utf8StringRef<'a> {
@@ -40,15 +40,20 @@ impl<'a> Utf8StringRef<'a> {
     {
         StringRef::from_bytes(input.as_ref()).map(|inner| Self { inner })
     }
+
+    /// Borrow the inner `str`.
+    pub fn as_str(&self) -> &'a str {
+        self.inner.as_str()
+    }
 }
 
 impl_string_type!(Utf8StringRef<'a>, 'a);
 
 impl<'a> Deref for Utf8StringRef<'a> {
-    type Target = StringRef<'a>;
+    type Target = StringRef;
 
     fn deref(&self) -> &Self::Target {
-        &self.inner
+        self.inner
     }
 }
 
@@ -64,7 +69,7 @@ impl<'a> From<&Utf8StringRef<'a>> for Utf8StringRef<'a> {
 
 impl<'a> From<Utf8StringRef<'a>> for AnyRef<'a> {
     fn from(utf_string: Utf8StringRef<'a>) -> AnyRef<'a> {
-        AnyRef::from_tag_and_value(Tag::Utf8String, utf_string.inner.into())
+        AnyRef::from_tag_and_value(Tag::Utf8String, utf_string.inner.as_ref())
     }
 }
 

--- a/der/src/asn1/videotex_string.rs
+++ b/der/src/asn1/videotex_string.rs
@@ -20,7 +20,7 @@ use core::{fmt, ops::Deref};
 #[derive(Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub struct VideotexStringRef<'a> {
     /// Inner value
-    inner: StringRef<'a>,
+    inner: &'a StringRef,
 }
 
 impl<'a> VideotexStringRef<'a> {
@@ -46,10 +46,10 @@ impl<'a> VideotexStringRef<'a> {
 impl_string_type!(VideotexStringRef<'a>, 'a);
 
 impl<'a> Deref for VideotexStringRef<'a> {
-    type Target = StringRef<'a>;
+    type Target = StringRef;
 
     fn deref(&self) -> &Self::Target {
-        &self.inner
+        self.inner
     }
 }
 
@@ -64,14 +64,14 @@ impl<'a> From<&VideotexStringRef<'a>> for VideotexStringRef<'a> {
 }
 
 impl<'a> From<VideotexStringRef<'a>> for AnyRef<'a> {
-    fn from(printable_string: VideotexStringRef<'a>) -> AnyRef<'a> {
-        AnyRef::from_tag_and_value(Tag::VideotexString, printable_string.inner.into())
+    fn from(videotex_string: VideotexStringRef<'a>) -> AnyRef<'a> {
+        AnyRef::from_tag_and_value(Tag::VideotexString, videotex_string.inner.as_ref())
     }
 }
 
 impl<'a> From<VideotexStringRef<'a>> for &'a [u8] {
-    fn from(printable_string: VideotexStringRef<'a>) -> &'a [u8] {
-        printable_string.as_bytes()
+    fn from(videotex_string: VideotexStringRef<'a>) -> &'a [u8] {
+        videotex_string.inner.as_bytes()
     }
 }
 
@@ -93,7 +93,7 @@ mod tests {
             0x15, 0x0b, 0x54, 0x65, 0x73, 0x74, 0x20, 0x55, 0x73, 0x65, 0x72, 0x20, 0x31,
         ];
 
-        let printable_string = VideotexStringRef::from_der(example_bytes).unwrap();
-        assert_eq!(printable_string.as_str(), "Test User 1");
+        let videotex_string = VideotexStringRef::from_der(example_bytes).unwrap();
+        assert_eq!(videotex_string.as_str(), "Test User 1");
     }
 }

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -5,7 +5,7 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
 )]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)] // only allowed for transmuting newtype references
 #![warn(
     // TODO: re-enable this lint and fix its warnings
     // clippy::arithmetic_side_effects,

--- a/der/src/reader/slice.rs
+++ b/der/src/reader/slice.rs
@@ -6,7 +6,7 @@ use crate::{BytesRef, Decode, EncodingRules, Error, ErrorKind, Length, Reader};
 #[derive(Clone, Debug)]
 pub struct SliceReader<'a> {
     /// Byte slice being decoded.
-    bytes: BytesRef<'a>,
+    bytes: &'a BytesRef,
 
     /// Encoding rules to apply when decoding the input.
     encoding_rules: EncodingRules,

--- a/spki/src/algorithm.rs
+++ b/spki/src/algorithm.rs
@@ -161,10 +161,13 @@ impl<'a> AlgorithmIdentifierRef<'a> {
             self.oid,
             match self.parameters {
                 None => None,
-                Some(p) => match p {
-                    AnyRef::NULL => None,
-                    _ => Some(p.decode_as::<ObjectIdentifier>()?),
-                },
+                Some(p) => {
+                    if p.is_null() {
+                        None
+                    } else {
+                        Some(p.decode_as::<ObjectIdentifier>()?)
+                    }
+                }
             },
         ))
     }


### PR DESCRIPTION
Changes `BytesRef` and `StringRef` from types with an explicit lifetime which act as newtypes for inner `&'a [u8]` and `&'a str` types to being newtypes for `[u8]` and `str`.

This requires a very small amount of `unsafe` casting, but makes it possible to implement reference conversions entirely in terms of standard traits like `AsRef`, `Borrow`, `Deref`, and `ToOwned` as opposed to using our custom `RefToOwned` and OwnedToRef` traits. It makes it possible to use e.g. `Cow` as well.

This is the first step towards moving the entire crate to this pattern and eliminating the `OwnedToRef` and `RefToOwned` raits, replacing them instead with the standard `AsRef` and `ToOwned` traits.