### PR TITLE
der: fix BER `IMPLICIT` constructed octet string

### DIFF
--- a/der/src/asn1/application.rs
+++ b/der/src/asn1/application.rs
@@ -1,8 +1,8 @@
 //! Application class field.
 
 use crate::{
-    Choice, Class, Decode, DecodeValue, DerOrd, Encode, EncodeValue, EncodeValueRef, Error, Header,
-    Length, Reader, Tag, TagMode, TagNumber, Tagged, ValueOrd, Writer, asn1::AnyRef,
+    Choice, Class, Decode, DecodeValue, DerOrd, Encode, EncodeValue, EncodeValueRef, EncodingRules,
+    Error, Header, Length, Reader, Tag, TagMode, TagNumber, Tagged, ValueOrd, Writer, asn1::AnyRef,
     tag::IsConstructed,
 };
 use core::cmp::Ordering;

--- a/der/src/asn1/context_specific.rs
+++ b/der/src/asn1/context_specific.rs
@@ -1,8 +1,8 @@
 //! Context-specific field.
 
 use crate::{
-    Choice, Class, Decode, DecodeValue, DerOrd, Encode, EncodeValue, EncodeValueRef, Error, Header,
-    Length, Reader, Tag, TagMode, TagNumber, Tagged, ValueOrd, Writer, asn1::AnyRef,
+    Choice, Class, Decode, DecodeValue, DerOrd, Encode, EncodeValue, EncodeValueRef, EncodingRules,
+    Error, Header, Length, Reader, Tag, TagMode, TagNumber, Tagged, ValueOrd, Writer, asn1::AnyRef,
     tag::IsConstructed,
 };
 use core::cmp::Ordering;

--- a/der/src/asn1/integer/int.rs
+++ b/der/src/asn1/integer/int.rs
@@ -231,7 +231,7 @@ mod allocating {
         type Error = Error;
 
         fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
-            let bytes = BytesOwned::decode_value(reader, header)?;
+            let bytes = BytesOwned::decode_value_parts(reader, header, Self::TAG)?;
             validate_canonical(bytes.as_slice())?;
 
             let result = Self::new(bytes.as_slice())?;

--- a/der/src/asn1/integer/uint.rs
+++ b/der/src/asn1/integer/uint.rs
@@ -217,7 +217,7 @@ mod allocating {
         type Error = Error;
 
         fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
-            let bytes = BytesOwned::decode_value(reader, header)?;
+            let bytes = BytesOwned::decode_value_parts(reader, header, Self::TAG)?;
             let result = Self::new(decode_to_slice(bytes.as_slice())?)?;
 
             // Ensure we compute the same encoded length as the original any value.

--- a/der/src/asn1/internal_macros.rs
+++ b/der/src/asn1/internal_macros.rs
@@ -147,7 +147,7 @@ macro_rules! impl_custom_class {
                 let header = Header::decode(reader)?;
 
                 // the encoding shall be constructed if the base encoding is constructed
-                if header.tag.is_constructed() != T::CONSTRUCTED {
+                if header.tag.is_constructed() != T::CONSTRUCTED && reader.encoding_rules() == EncodingRules::Der {
                     return Err(reader.error(header.tag.non_canonical_error()).into());
                 }
 

--- a/der/src/asn1/internal_macros.rs
+++ b/der/src/asn1/internal_macros.rs
@@ -147,7 +147,8 @@ macro_rules! impl_custom_class {
                 let header = Header::decode(reader)?;
 
                 // the encoding shall be constructed if the base encoding is constructed
-                if header.tag.is_constructed() != T::CONSTRUCTED && reader.encoding_rules() == EncodingRules::Der {
+                if header.tag.is_constructed() != T::CONSTRUCTED
+                    && reader.encoding_rules() == EncodingRules::Der {
                     return Err(reader.error(header.tag.non_canonical_error()).into());
                 }
 

--- a/der/src/asn1/octet_string.rs
+++ b/der/src/asn1/octet_string.rs
@@ -372,7 +372,7 @@ mod tests {
         const EXAMPLE_BER: &[u8] = &hex!(
             "2480" // Constructed indefinite length OCTET STRING
             "040648656c6c6f2c" // Segment containing "Hello,"
-            "040620776f726c64" // Segment containing world
+            "040620776f726c64" // Segment containing "world"
             "0000" // End-of-contents marker
         );
 
@@ -396,19 +396,19 @@ mod tests {
                 "A080" // indefinite length explicit tag
                 "2480" // Constructed indefinite length OCTET STRING
                 "040648656c6c6f2c" // Segment containing "Hello,"
-                "040620776f726c64" // Segment containing world
+                "040620776f726c64" // Segment containing "world"
                 "0000" // End-of-contents marker
                 "0000" // End-of-contents marker
             );
 
             let mut reader =
                 SliceReader::new_with_encoding_rules(EXAMPLE_BER, EncodingRules::Ber).unwrap();
-    
+
             let decoded = ContextSpecific::<OctetString>::decode_explicit(&mut reader, tag_number)
                 .unwrap()
                 .unwrap()
                 .value;
-    
+
             assert_eq!(decoded.as_bytes(), b"Hello, world");
         }
 
@@ -422,12 +422,12 @@ mod tests {
 
             let mut reader =
                 SliceReader::new_with_encoding_rules(EXAMPLE_BER, EncodingRules::Ber).unwrap();
-    
+
             let decoded = ContextSpecific::<OctetString>::decode_implicit(&mut reader, tag_number)
                 .unwrap()
                 .unwrap()
                 .value;
-    
+
             assert_eq!(decoded.as_bytes(), b"Hello, world");
         }
     }

--- a/der/src/asn1/octet_string.rs
+++ b/der/src/asn1/octet_string.rs
@@ -364,6 +364,16 @@ mod tests {
     use crate::asn1::{OctetStringRef, PrintableStringRef};
 
     #[test]
+    fn octet_string_decode_into() {
+        // PrintableString "hi"
+        let der = b"\x13\x02\x68\x69";
+        let oct = OctetStringRef::new(der).unwrap();
+
+        let res = oct.decode_into::<PrintableStringRef<'_>>().unwrap();
+        assert_eq!(AsRef::<str>::as_ref(&res), "hi");
+    }
+
+    #[test]
     #[cfg(feature = "alloc")]
     fn decode_ber() {
         use crate::{Decode, asn1::OctetString};
@@ -425,7 +435,7 @@ mod tests {
         const EXAMPLE_BER: &[u8] = &hex!(
             "A080" // implicit tag, constructed indefinite length OCTET STRING
             "040648656c6c6f2c" // Segment containing "Hello,"
-            "040620776f726c64" // Segment containing world
+            "040620776f726c64" // Segment containing "world"
             "0000" // End-of-contents marker
         );
 
@@ -438,15 +448,5 @@ mod tests {
             .value;
 
         assert_eq!(decoded.as_bytes(), b"Hello, world");
-    }
-
-    #[test]
-    fn octet_string_decode_into() {
-        // PrintableString "hi"
-        let der = b"\x13\x02\x68\x69";
-        let oct = OctetStringRef::new(der).unwrap();
-
-        let res = oct.decode_into::<PrintableStringRef<'_>>().unwrap();
-        assert_eq!(AsRef::<str>::as_ref(&res), "hi");
     }
 }

--- a/der/src/asn1/octet_string.rs
+++ b/der/src/asn1/octet_string.rs
@@ -381,6 +381,58 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "alloc")]
+    fn decode_context_specific_ber() {
+        use crate::{
+            EncodingRules, SliceReader, TagNumber,
+            asn1::{ContextSpecific, OctetString},
+        };
+        use hex_literal::hex;
+
+        let tag_number = TagNumber(0);
+
+        {
+            const EXAMPLE_BER: &[u8] = &hex!(
+                "A080" // indefinite length explicit tag
+                "2480" // Constructed indefinite length OCTET STRING
+                "040648656c6c6f2c" // Segment containing "Hello,"
+                "040620776f726c64" // Segment containing world
+                "0000" // End-of-contents marker
+                "0000" // End-of-contents marker
+            );
+
+            let mut reader =
+                SliceReader::new_with_encoding_rules(EXAMPLE_BER, EncodingRules::Ber).unwrap();
+    
+            let decoded = ContextSpecific::<OctetString>::decode_explicit(&mut reader, tag_number)
+                .unwrap()
+                .unwrap()
+                .value;
+    
+            assert_eq!(decoded.as_bytes(), b"Hello, world");
+        }
+
+        {
+            const EXAMPLE_BER: &[u8] = &hex!(
+                "A080" // implicit tag, constructed indefinite length OCTET STRING
+                "040648656c6c6f2c" // Segment containing "Hello,"
+                "040620776f726c64" // Segment containing world
+                "0000" // End-of-contents marker
+            );
+
+            let mut reader =
+                SliceReader::new_with_encoding_rules(EXAMPLE_BER, EncodingRules::Ber).unwrap();
+    
+            let decoded = ContextSpecific::<OctetString>::decode_implicit(&mut reader, tag_number)
+                .unwrap()
+                .unwrap()
+                .value;
+    
+            assert_eq!(decoded.as_bytes(), b"Hello, world");
+        }
+    }
+
+    #[test]
     fn octet_string_decode_into() {
         // PrintableString "hi"
         let der = b"\x13\x02\x68\x69";

--- a/der/src/asn1/private.rs
+++ b/der/src/asn1/private.rs
@@ -1,8 +1,8 @@
 //! Private class field.
 
 use crate::{
-    Choice, Class, Decode, DecodeValue, DerOrd, Encode, EncodeValue, EncodeValueRef, Error, Header,
-    Length, Reader, Tag, TagMode, TagNumber, Tagged, ValueOrd, Writer, asn1::AnyRef,
+    Choice, Class, Decode, DecodeValue, DerOrd, Encode, EncodeValue, EncodeValueRef, EncodingRules,
+    Error, Header, Length, Reader, Tag, TagMode, TagNumber, Tagged, ValueOrd, Writer, asn1::AnyRef,
     tag::IsConstructed,
 };
 use core::cmp::Ordering;

--- a/der/src/bytes.rs
+++ b/der/src/bytes.rs
@@ -156,7 +156,7 @@ pub(crate) mod allocating {
                 && header.length.is_indefinite()
                 && !inner_tag.is_constructed()
             {
-                return Self::new(read_constructed_vec(reader, header, inner_tag)?);
+                return Self::new(read_constructed_vec(reader, header.length, inner_tag)?);
             }
 
             Self::decode_value(reader, header)

--- a/der/src/bytes.rs
+++ b/der/src/bytes.rs
@@ -152,7 +152,10 @@ pub(crate) mod allocating {
             inner_tag: Tag,
         ) -> Result<Self> {
             // Reassemble indefinite length string types
-            if reader.encoding_rules() == EncodingRules::Ber && header.length.is_indefinite() {
+            if reader.encoding_rules() == EncodingRules::Ber
+                && header.length.is_indefinite()
+                && !inner_tag.is_constructed()
+            {
                 return Self::new(read_constructed_vec(reader, header, inner_tag)?);
             }
 

--- a/der/src/bytes.rs
+++ b/der/src/bytes.rs
@@ -184,7 +184,7 @@ pub(crate) mod allocating {
 
         fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
             // Reassemble indefinite length string types
-            if header.length.is_indefinite() && !header.tag.is_constructed() {
+            if header.length.is_indefinite() && header.tag.is_constructed() {
                 return Self::new(read_constructed_vec(reader, header)?);
             }
 

--- a/der/src/bytes.rs
+++ b/der/src/bytes.rs
@@ -118,8 +118,8 @@ impl<'a> arbitrary::Arbitrary<'a> for &'a BytesRef {
 pub(crate) mod allocating {
     use super::BytesRef;
     use crate::{
-        DecodeValue, DerOrd, EncodeValue, Error, Header, Length, Reader, Result, Writer,
-        length::indefinite::read_constructed_vec,
+        DecodeValue, DerOrd, EncodeValue, EncodingRules, Error, Header, Length, Reader, Result,
+        Writer, length::indefinite::read_constructed_vec,
     };
     use alloc::{borrow::ToOwned, boxed::Box, vec::Vec};
     use core::{borrow::Borrow, cmp::Ordering, ops::Deref};
@@ -184,7 +184,10 @@ pub(crate) mod allocating {
 
         fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
             // Reassemble indefinite length string types
-            if header.length.is_indefinite() && header.tag.is_constructed() {
+            if reader.encoding_rules() == EncodingRules::Ber
+                && header.length.is_indefinite()
+                && !header.tag.is_constructed()
+            {
                 return Self::new(read_constructed_vec(reader, header)?);
             }
 

--- a/der/src/bytes.rs
+++ b/der/src/bytes.rs
@@ -119,7 +119,7 @@ pub(crate) mod allocating {
     use super::BytesRef;
     use crate::{
         DecodeValue, DerOrd, EncodeValue, EncodingRules, Error, Header, Length, Reader, Result,
-        Writer, length::indefinite::read_constructed_vec,
+        Tag, Writer, length::indefinite::read_constructed_vec,
     };
     use alloc::{borrow::ToOwned, boxed::Box, vec::Vec};
     use core::{borrow::Borrow, cmp::Ordering, ops::Deref};
@@ -144,6 +144,19 @@ pub(crate) mod allocating {
                 length: Length::try_from(inner.len())?,
                 inner,
             })
+        }
+        /// Decodes [`BytesOwned`] as DER, or from parts, when using a BER reader.
+        pub fn decode_value_parts<'a, R: Reader<'a>>(
+            reader: &mut R,
+            header: Header,
+            inner_tag: Tag,
+        ) -> Result<Self> {
+            // Reassemble indefinite length string types
+            if reader.encoding_rules() == EncodingRules::Ber && header.length.is_indefinite() {
+                return Self::new(read_constructed_vec(reader, header, inner_tag)?);
+            }
+
+            Self::decode_value(reader, header)
         }
     }
 
@@ -183,14 +196,6 @@ pub(crate) mod allocating {
         type Error = Error;
 
         fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self> {
-            // Reassemble indefinite length string types
-            if reader.encoding_rules() == EncodingRules::Ber
-                && header.length.is_indefinite()
-                && !header.tag.is_constructed()
-            {
-                return Self::new(read_constructed_vec(reader, header)?);
-            }
-
             reader.read_vec(header.length).and_then(Self::new)
         }
     }

--- a/der/src/length/indefinite.rs
+++ b/der/src/length/indefinite.rs
@@ -22,6 +22,9 @@
 use crate::{Decode, ErrorKind, Header, Length, Reader};
 
 #[cfg(feature = "alloc")]
+use crate::Tag;
+
+#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
 /// Octet identifying an indefinite length as described in X.690 Section
@@ -81,6 +84,7 @@ pub(crate) fn read_eoc<'a>(reader: &mut impl Reader<'a>) -> crate::Result<()> {
 pub(crate) fn read_constructed_vec<'r, R: Reader<'r>>(
     reader: &mut R,
     header: Header,
+    inner_tag: Tag,
 ) -> crate::Result<Vec<u8>> {
     if !header.length.is_indefinite() {
         return Err(reader.error(ErrorKind::IndefiniteLength));
@@ -91,7 +95,7 @@ pub(crate) fn read_constructed_vec<'r, R: Reader<'r>>(
 
     while !reader.is_finished() {
         let h = Header::decode(reader)?;
-        h.tag.assert_eq(header.tag)?;
+        h.tag.assert_eq(inner_tag)?;
 
         // Indefinite length headers can't be indefinite
         if h.length.is_indefinite() {

--- a/der/src/length/indefinite.rs
+++ b/der/src/length/indefinite.rs
@@ -83,14 +83,14 @@ pub(crate) fn read_eoc<'a>(reader: &mut impl Reader<'a>) -> crate::Result<()> {
 #[cfg(feature = "alloc")]
 pub(crate) fn read_constructed_vec<'r, R: Reader<'r>>(
     reader: &mut R,
-    header: Header,
+    length: Length,
     inner_tag: Tag,
 ) -> crate::Result<Vec<u8>> {
-    if !header.length.is_indefinite() {
+    if !length.is_indefinite() {
         return Err(reader.error(ErrorKind::IndefiniteLength));
     }
 
-    let mut bytes = Vec::with_capacity(header.length.try_into()?);
+    let mut bytes = Vec::with_capacity(length.try_into()?);
     let mut offset = 0;
 
     while !reader.is_finished() {


### PR DESCRIPTION
Ignores `the encoding shall be constructed if the base encoding is constructed` when using BER.

Issue reported in #779