### PR TITLE
mcf: add `push_field*` methods to `McfHash`

### DIFF
--- a/mcf/src/lib.rs
+++ b/mcf/src/lib.rs
@@ -85,6 +85,18 @@ impl McfHash {
 
         fields
     }
+
+    /// Push an additional field onto the password hash string.
+    pub fn push_field(&mut self, field: Field<'_>) {
+        self.0.push(fields::DELIMITER);
+        self.0.push_str(field.as_str());
+    }
+
+    /// Push an additional field onto the password hash string, encoding it first as Base64.
+    pub fn push_field_base64(&mut self, field: &[u8], base64_encoding: Base64) {
+        self.0.push(fields::DELIMITER);
+        self.0.push_str(&base64_encoding.encode_string(field));
+    }
 }
 
 #[cfg(feature = "alloc")]

--- a/mcf/tests/mcf.rs
+++ b/mcf/tests/mcf.rs
@@ -5,6 +5,13 @@
 use hex_literal::hex;
 use mcf::{Base64, McfHash};
 
+const SHA512_HASH: &str = "$6$rounds=100000$exn6tVc2j/MZD8uG$BI1Xh8qQSK9J4m14uwy7abn.ctj/TIAzlaVCto0MQrOFIeTXsc1iwzH16XEWo/a7c7Y9eVJvufVzYAs4EsPOy0";
+
+const EXAMPLE_SALT: &[u8] = &hex!("6a3f237988126f80958fa24b");
+const EXAMPLE_HASH: &[u8] = &hex!(
+    "0d358cad62739eb554863c183aef27e6390368fe061fc5fcb1193a392d60dcad4594fa8d383ab8fc3f0dc8088974602668422e6a58edfa1afe24831b10be69be"
+);
+
 #[test]
 fn parse_malformed() {
     assert!("Hello, world!".parse::<McfHash>().is_err());
@@ -20,8 +27,7 @@ fn parse_malformed() {
 
 #[test]
 fn parse_sha512_hash() {
-    let s = "$6$rounds=100000$exn6tVc2j/MZD8uG$BI1Xh8qQSK9J4m14uwy7abn.ctj/TIAzlaVCto0MQrOFIeTXsc1iwzH16XEWo/a7c7Y9eVJvufVzYAs4EsPOy0";
-    let hash: McfHash = s.parse().unwrap();
+    let hash: McfHash = SHA512_HASH.parse().unwrap();
     assert_eq!("6", hash.id());
 
     let mut fields = hash.fields();
@@ -31,7 +37,7 @@ fn parse_sha512_hash() {
     assert_eq!("exn6tVc2j/MZD8uG", salt.as_str());
 
     let salt_bytes = salt.decode_base64(Base64::ShaCrypt).unwrap();
-    assert_eq!(&hex!("6a3f237988126f80958fa24b"), salt_bytes.as_slice());
+    assert_eq!(EXAMPLE_SALT, salt_bytes.as_slice());
 
     let hash = fields.next().unwrap();
     assert_eq!(
@@ -40,12 +46,15 @@ fn parse_sha512_hash() {
     );
 
     let hash_bytes = hash.decode_base64(Base64::ShaCrypt).unwrap();
-    assert_eq!(
-        &hex!(
-            "0d358cad62739eb554863c183aef27e6390368fe061fc5fcb1193a392d60dcad4594fa8d383ab8fc3f0dc8088974602668422e6a58edfa1afe24831b10be69be"
-        ),
-        hash_bytes.as_slice()
-    );
+    assert_eq!(EXAMPLE_HASH, hash_bytes.as_slice());
 
     assert_eq!(None, fields.next());
+}
+
+#[test]
+fn push_fields() {
+    let mut hash = McfHash::new("$6$rounds=100000").unwrap();
+    hash.push_field_base64(EXAMPLE_SALT, Base64::ShaCrypt);
+    hash.push_field_base64(EXAMPLE_HASH, Base64::ShaCrypt);
+    assert_eq!(SHA512_HASH, hash.as_str());
 }


### PR DESCRIPTION
Support for pushing additional fields onto an MCF hash string:

- `push_field`: pushes a `Field`
- `push_field_base64`: encodes a `&[u8]` using the given Base64 alphabet