### PR TITLE
pkcs1+sec1: remove `pkcs8` integration/feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -983,7 +983,6 @@ dependencies = [
  "const-oid",
  "der",
  "hex-literal",
- "pkcs8",
  "spki",
  "tempfile",
 ]
@@ -1252,8 +1251,7 @@ dependencies = [
 [[package]]
 name = "rsa"
 version = "0.10.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4825b570bf9949160f598b942df0d6abfa00b71a97c970fdd6e2647439634b8"
+source = "git+https://github.com/RustCrypto/RSA.git?branch=pkcs1%2Fremove-blanket-impl#3644e58d099e358f5891d75d8e54149bb2c7ba12"
 dependencies = [
  "const-oid",
  "crypto-bigint",
@@ -1383,7 +1381,6 @@ dependencies = [
  "der",
  "hex-literal",
  "hybrid-array",
- "pkcs8",
  "serdect",
  "subtle",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,3 +62,4 @@ x509-ocsp = { path = "./x509-ocsp" }
 
 elliptic-curve = { git = "https://github.com/RustCrypto/traits.git" }
 ecdsa = { git = "https://github.com/RustCrypto/signatures.git" }
+rsa = { git = "https://github.com/RustCrypto/RSA.git", branch = "pkcs1/remove-blanket-impl" }

--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -19,19 +19,20 @@ rust-version = "1.85"
 der = { version = "0.8.0-rc.6", features = ["oid"] }
 spki = { version = "0.8.0-rc.3" }
 
-# optional dependencies
-pkcs8 = { version = "0.11.0-rc.5", optional = true, default-features = false }
-
 [dev-dependencies]
 const-oid = { version = "0.10", features = ["db"] }
 hex-literal = "1"
 tempfile = "3"
 
 [features]
-zeroize = ["der/zeroize"]
-alloc = ["der/alloc", "zeroize", "pkcs8?/alloc"]
-pem = ["alloc", "der/pem", "pkcs8?/pem"]
+alloc = ["der/alloc", "zeroize"]
 std = ["der/std", "alloc"]
+
+pem = ["alloc", "der/pem"]
+zeroize = ["der/zeroize"]
+
+# TODO(tarcieri): stub! (for `rsa` crate for now) remove before release
+pkcs8 = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/pkcs1/src/error.rs
+++ b/pkcs1/src/error.rs
@@ -23,21 +23,30 @@ pub enum Error {
     /// a number expected to be a prime was not a prime.
     Crypto,
 
-    /// PKCS#8 errors.
-    #[cfg(feature = "pkcs8")]
-    Pkcs8(pkcs8::Error),
+    /// Malformed cryptographic key contained in a PKCS#1 document.
+    ///
+    /// This is intended for relaying errors when decoding fields of a PKCS#1 document.
+    KeyMalformed,
 
     /// Version errors
     Version,
+}
+
+impl core::error::Error for Error {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Error::Asn1(err) => Some(err),
+            _ => None,
+        }
+    }
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::Asn1(err) => write!(f, "PKCS#1 ASN.1 error: {err}"),
+            Error::KeyMalformed => f.write_str("PKCS#1 cryptographic key data malformed"),
             Error::Crypto => f.write_str("PKCS#1 cryptographic error"),
-            #[cfg(feature = "pkcs8")]
-            Error::Pkcs8(err) => write!(f, "{err}"),
             Error::Version => f.write_str("PKCS#1 version error"),
         }
     }
@@ -55,41 +64,3 @@ impl From<pem::Error> for Error {
         der::Error::from(err).into()
     }
 }
-
-#[cfg(feature = "pkcs8")]
-impl From<Error> for pkcs8::Error {
-    fn from(err: Error) -> pkcs8::Error {
-        match err {
-            Error::Asn1(e) => pkcs8::Error::Asn1(e),
-            Error::Crypto | Error::Version => pkcs8::Error::KeyMalformed,
-            Error::Pkcs8(e) => e,
-        }
-    }
-}
-
-#[cfg(feature = "pkcs8")]
-impl From<pkcs8::Error> for Error {
-    fn from(err: pkcs8::Error) -> Error {
-        Error::Pkcs8(err)
-    }
-}
-
-#[cfg(feature = "pkcs8")]
-impl From<Error> for spki::Error {
-    fn from(err: Error) -> spki::Error {
-        match err {
-            Error::Asn1(e) => spki::Error::Asn1(e),
-            _ => spki::Error::KeyMalformed,
-        }
-    }
-}
-
-#[cfg(feature = "pkcs8")]
-impl From<spki::Error> for Error {
-    fn from(err: spki::Error) -> Error {
-        Error::Pkcs8(pkcs8::Error::PublicKey(err))
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}

--- a/pkcs1/src/lib.rs
+++ b/pkcs1/src/lib.rs
@@ -51,12 +51,10 @@ pub use crate::{
 pub use der::pem::{self, LineEnding};
 
 /// `rsaEncryption` Object Identifier (OID)
-#[cfg(feature = "pkcs8")]
 pub const ALGORITHM_OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.1");
 
 /// `AlgorithmIdentifier` for RSA.
-#[cfg(feature = "pkcs8")]
-pub const ALGORITHM_ID: pkcs8::AlgorithmIdentifierRef<'static> = pkcs8::AlgorithmIdentifierRef {
+pub const ALGORITHM_ID: spki::AlgorithmIdentifierRef<'static> = spki::AlgorithmIdentifierRef {
     oid: ALGORITHM_OID,
     parameters: Some(der::asn1::AnyRef::NULL),
 };

--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -20,7 +20,6 @@ rust-version = "1.85"
 base16ct = { version = "0.2", optional = true, default-features = false }
 der = { version = "0.8.0-rc.6", optional = true, features = ["oid"] }
 hybrid-array = { version = "0.3", optional = true, default-features = false }
-pkcs8 = { version = "0.11.0-rc.5", optional = true, default-features = false }
 serdect = { version = "0.3", optional = true, default-features = false, features = ["alloc"] }
 subtle = { version = "2", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
@@ -31,11 +30,11 @@ tempfile = "3"
 
 [features]
 default = ["der", "point"]
-alloc = ["der?/alloc", "pkcs8?/alloc", "zeroize?/alloc"]
+alloc = ["der?/alloc", "zeroize?/alloc"]
 std = ["alloc", "der?/std"]
 
 der = ["dep:der", "zeroize"]
-pem = ["alloc", "der/pem", "pkcs8/pem"]
+pem = ["alloc", "der/pem"]
 point = ["dep:base16ct", "dep:hybrid-array"]
 serde = ["dep:serdect"]
 zeroize = ["dep:zeroize", "der?/zeroize"]

--- a/sec1/src/error.rs
+++ b/sec1/src/error.rs
@@ -24,10 +24,6 @@ pub enum Error {
     /// a number expected to be a prime was not a prime.
     Crypto,
 
-    /// PKCS#8 errors.
-    #[cfg(feature = "pkcs8")]
-    Pkcs8(pkcs8::Error),
-
     /// Errors relating to the `Elliptic-Curve-Point-to-Octet-String` or
     /// `Octet-String-to-Elliptic-Curve-Point` encodings.
     PointEncoding,
@@ -44,8 +40,6 @@ impl fmt::Display for Error {
             #[cfg(feature = "der")]
             Error::Asn1(err) => write!(f, "SEC1 ASN.1 error: {err}"),
             Error::Crypto => f.write_str("SEC1 cryptographic error"),
-            #[cfg(feature = "pkcs8")]
-            Error::Pkcs8(err) => write!(f, "{err}"),
             Error::PointEncoding => f.write_str("elliptic curve point encoding error"),
             Error::Version => f.write_str("SEC1 version error"),
         }
@@ -63,19 +57,5 @@ impl From<der::Error> for Error {
 impl From<pem::Error> for Error {
     fn from(err: pem::Error) -> Error {
         der::Error::from(err).into()
-    }
-}
-
-#[cfg(feature = "pkcs8")]
-impl From<pkcs8::Error> for Error {
-    fn from(err: pkcs8::Error) -> Error {
-        Error::Pkcs8(err)
-    }
-}
-
-#[cfg(feature = "pkcs8")]
-impl From<pkcs8::spki::Error> for Error {
-    fn from(err: pkcs8::spki::Error) -> Error {
-        Error::Pkcs8(pkcs8::Error::PublicKey(err))
     }
 }

--- a/sec1/src/lib.rs
+++ b/sec1/src/lib.rs
@@ -60,18 +60,14 @@ pub use crate::traits::EncodeEcPrivateKey;
 #[cfg(feature = "pem")]
 pub use der::pem::{self, LineEnding};
 
-#[cfg(feature = "pkcs8")]
-pub use pkcs8;
-
-#[cfg(feature = "pkcs8")]
-use pkcs8::ObjectIdentifier;
+#[cfg(feature = "der")]
+use der::asn1::ObjectIdentifier;
 
 #[cfg(all(doc, feature = "serde"))]
 use serdect::serde;
 
-/// Algorithm [`ObjectIdentifier`] for elliptic curve public key cryptography
-/// (`id-ecPublicKey`).
+/// Algorithm [`ObjectIdentifier`] for elliptic curve public key cryptography (`id-ecPublicKey`).
 ///
 /// <http://oid-info.com/get/1.2.840.10045.2.1>
-#[cfg(feature = "pkcs8")]
+#[cfg(feature = "der")]
 pub const ALGORITHM_OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.10045.2.1");

--- a/sec1/src/traits.rs
+++ b/sec1/src/traits.rs
@@ -8,17 +8,11 @@ use der::SecretDocument;
 #[cfg(feature = "pem")]
 use {crate::LineEnding, alloc::string::String, der::pem::PemLabel};
 
-#[cfg(feature = "pkcs8")]
-use {
-    crate::{ALGORITHM_OID, EcPrivateKey},
-    der::{Decode, asn1::OctetStringRef},
-};
-
 #[cfg(feature = "std")]
 use std::path::Path;
 
 #[cfg(feature = "pem")]
-use zeroize::Zeroizing;
+use {crate::EcPrivateKey, zeroize::Zeroizing};
 
 /// Parse an [`EcPrivateKey`] from a SEC1-encoded document.
 pub trait DecodeEcPrivateKey: Sized {
@@ -82,43 +76,5 @@ pub trait EncodeEcPrivateKey {
     fn write_sec1_pem_file(&self, path: impl AsRef<Path>, line_ending: LineEnding) -> Result<()> {
         let doc = self.to_sec1_der()?;
         Ok(doc.write_pem_file(path, EcPrivateKey::PEM_LABEL, line_ending)?)
-    }
-}
-
-#[cfg(feature = "pkcs8")]
-impl<T> DecodeEcPrivateKey for T
-where
-    T: for<'a> TryFrom<pkcs8::PrivateKeyInfoRef<'a>, Error = pkcs8::Error>,
-{
-    fn from_sec1_der(private_key: &[u8]) -> Result<Self> {
-        let params_oid = EcPrivateKey::from_der(private_key)?
-            .parameters
-            .and_then(|params| params.named_curve());
-
-        let algorithm = pkcs8::AlgorithmIdentifierRef {
-            oid: ALGORITHM_OID,
-            parameters: params_oid.as_ref().map(Into::into),
-        };
-
-        let private_key = OctetStringRef::new(private_key)?;
-
-        Ok(Self::try_from(pkcs8::PrivateKeyInfoRef {
-            algorithm,
-            private_key,
-            public_key: None,
-        })?)
-    }
-}
-
-#[cfg(all(feature = "alloc", feature = "pkcs8"))]
-impl<T: pkcs8::EncodePrivateKey> EncodeEcPrivateKey for T {
-    fn to_sec1_der(&self) -> Result<SecretDocument> {
-        let doc = self.to_pkcs8_der()?;
-        let pkcs8_key = pkcs8::PrivateKeyInfoRef::from_der(doc.as_bytes())?;
-        pkcs8_key.algorithm.assert_algorithm_oid(ALGORITHM_OID)?;
-
-        let mut pkcs1_key = EcPrivateKey::from_der(pkcs8_key.private_key.as_bytes())?;
-        pkcs1_key.parameters = Some(pkcs8_key.algorithm.parameters_oid()?.into());
-        pkcs1_key.try_into()
     }
 }

--- a/x509-ocsp/Cargo.toml
+++ b/x509-ocsp/Cargo.toml
@@ -30,7 +30,7 @@ signature = { version = "3.0.0-rc.0", optional = true, default-features = false,
 hex-literal = "1"
 lazy_static = "1.5.0"
 rand = "0.9"
-rsa = { version = "0.10.0-rc.1", default-features = false, features = ["sha2"] }
+rsa = { version = "0.10.0-rc.1", default-features = false, features = ["encoding", "sha2"] }
 sha1 = { version = "0.11.0-rc.0", default-features = false, features = ["oid"] }
 sha2 = { version = "0.11.0-rc.0", default-features = false, features = ["oid"] }
 


### PR DESCRIPTION
Both `pkcs1` and `sec1` used some "clever" tricks to write blanket impls of their traits for any types which impl the `pkcs8` traits.

However, we've received some complaints this makes the impls of these traits more confusing and less discoverable (#1611), and adds a maintenance burden in that the blanket impl relationship is fundamentally "backwards" in that PKCS#8 builds on PKCS#1 and SEC1, not the other way around.

These could potentially be replaced with a macro that writes impls of the `pkcs8` traits for types which impl the `pkcs1`/`sec1` traits. However, for now, each of these is only used in one place (i.e. the `rsa` and `elliptic-curve` crates respectively), so we can start by moving the relevant code there for now.