### PR TITLE
Cut new prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.8.0-rc.6"
+version = "0.8.0-rc.7"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -978,7 +978,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs1"
-version = "0.8.0-rc.2"
+version = "0.8.0-rc.3"
 dependencies = [
  "const-oid",
  "der",
@@ -1007,7 +1007,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs5"
-version = "0.8.0-rc.5"
+version = "0.8.0-rc.6"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1025,7 +1025,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.11.0-rc.5"
+version = "0.11.0-rc.6"
 dependencies = [
  "der",
  "hex-literal",
@@ -1375,7 +1375,7 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.8.0-rc.6"
+version = "0.8.0-rc.8"
 dependencies = [
  "base16ct",
  "der",
@@ -1511,7 +1511,7 @@ checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
 
 [[package]]
 name = "spki"
-version = "0.8.0-rc.3"
+version = "0.8.0-rc.4"
 dependencies = [
  "arbitrary",
  "base64ct",

--- a/cmpv2/Cargo.toml
+++ b/cmpv2/Cargo.toml
@@ -17,8 +17,8 @@ rust-version = "1.85"
 
 [dependencies]
 crmf = "=0.3.0-pre.0"
-der = { version = "0.8.0-rc.6", features = ["alloc", "derive", "flagset", "oid"] }
-spki = { version = "0.8.0-rc.3" }
+der = { version = "0.8.0-rc.7", features = ["alloc", "derive", "flagset", "oid"] }
+spki = "0.8.0-rc.4"
 x509-cert = { version = "0.3.0-rc.0", default-features = false }
 
 digest = { version = "0.11.0-pre.10", optional = true, default-features = false }

--- a/cms/Cargo.toml
+++ b/cms/Cargo.toml
@@ -16,8 +16,8 @@ rust-version = "1.85"
 
 [dependencies]
 const-oid = { version = "0.10", features = ["db"] }
-der = { version = "0.8.0-rc.6", features = ["alloc", "derive", "oid"] }
-spki = { version = "0.8.0-rc.3" }
+der = { version = "0.8.0-rc.7", features = ["alloc", "derive", "oid"] }
+spki = "0.8.0-rc.4"
 x509-cert = { version = "0.3.0-rc.0", default-features = false }
 
 # optional dependencies
@@ -40,7 +40,7 @@ aes = "0.9.0-rc.0"
 getrandom = "0.3"
 hex-literal = "1"
 pem-rfc7468 = "1.0.0-rc.1"
-pkcs5 = "0.8.0-rc.5"
+pkcs5 = "0.8.0-rc.6"
 pbkdf2 = "0.13.0-rc.0"
 rand = "0.9"
 rsa = { version = "0.10.0-rc.1", features = ["sha2"] }

--- a/crmf/Cargo.toml
+++ b/crmf/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.85"
 
 [dependencies]
 cms = "=0.3.0-pre.0"
-der = { version = "0.8.0-rc.6", features = ["alloc", "derive"] }
+der = { version = "0.8.0-rc.7", features = ["alloc", "derive"] }
 spki = "0.8.0-rc.3"
 x509-cert = { version = "0.3.0-rc.0", default-features = false }
 

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der"
-version = "0.8.0-rc.6"
+version = "0.8.0-rc.7"
 description = """
 Pure Rust embedded-friendly implementation of the Distinguished Encoding Rules
 (DER) for Abstract Syntax Notation One (ASN.1) as described in ITU X.690 with

--- a/gss-api/Cargo.toml
+++ b/gss-api/Cargo.toml
@@ -16,12 +16,12 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-der = { version = "0.8.0-rc.6", features = ["oid", "alloc"] }
-spki = { version = "0.8.0-rc.3" }
+der = { version = "0.8.0-rc.7", features = ["oid", "alloc"] }
+spki = "0.8.0-rc.4"
 x509-cert = { version = "0.3.0-rc.0", default-features = false }
 
 [dev-dependencies]
-der = { version = "0.8.0-rc.6", features = ["oid", "pem", "alloc"] }
+der = { version = "0.8.0-rc.7", features = ["oid", "pem", "alloc"] }
 hex-literal = "1"
 x509-cert = { version = "0.3.0-rc.0", default-features = false, features = ["pem"] }
 

--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs1"
-version = "0.8.0-rc.2"
+version = "0.8.0-rc.3"
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #1:
 RSA Cryptography Specifications Version 2.2 (RFC 8017)
@@ -16,8 +16,8 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-der = { version = "0.8.0-rc.6", features = ["oid"] }
-spki = { version = "0.8.0-rc.3" }
+der = { version = "0.8.0-rc.7", features = ["oid"] }
+spki = "0.8.0-rc.4"
 
 [dev-dependencies]
 const-oid = { version = "0.10", features = ["db"] }

--- a/pkcs12/Cargo.toml
+++ b/pkcs12/Cargo.toml
@@ -16,8 +16,8 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-der = { version = "0.8.0-rc.6", features = ["alloc", "derive", "oid"], default-features = false }
-spki = { version = "0.8.0-rc.3", default-features = false }
+der = { version = "0.8.0-rc.7", features = ["alloc", "derive", "oid"], default-features = false }
+spki = { version = "0.8.0-rc.4", default-features = false }
 x509-cert = { version = "0.3.0-rc.0", default-features = false }
 const-oid = { version = "0.10.0", features = ["db"], default-features = false }
 cms = { version = "=0.3.0-pre.0", default-features = false }
@@ -28,8 +28,8 @@ zeroize = { version = "1.8.1", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "1"
-pkcs8 = { version = "0.11.0-rc.5", features = ["pkcs5", "getrandom"] }
-pkcs5 = { version = "0.8.0-rc.5", features = ["pbes2", "3des"] }
+pkcs8 = { version = "0.11.0-rc.6", features = ["pkcs5", "getrandom"] }
+pkcs5 = { version = "0.8.0-rc.6", features = ["pbes2", "3des"] }
 sha2 = "0.11.0-rc.0"
 whirlpool = "0.11.0-rc.0"
 

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs5"
-version = "0.8.0-rc.5"
+version = "0.8.0-rc.6"
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #5:
 Password-Based Cryptography Specification Version 2.1 (RFC 8018)
@@ -16,8 +16,8 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-der = { version = "0.8.0-rc.6", features = ["oid"] }
-spki = { version = "0.8.0-rc.3" }
+der = { version = "0.8.0-rc.7", features = ["oid"] }
+spki = "0.8.0-rc.4"
 
 # optional dependencies
 cbc = { version = "0.2.0-rc.0", optional = true }

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs8"
-version = "0.11.0-rc.5"
+version = "0.11.0-rc.6"
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #8:
 Private-Key Information Syntax Specification (RFC 5208), with additional
@@ -17,12 +17,12 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-der = { version = "0.8.0-rc.6", features = ["oid"] }
-spki = { version = "0.8.0-rc.3" }
+der = { version = "0.8.0-rc.7", features = ["oid"] }
+spki = "0.8.0-rc.4"
 
 # optional dependencies
 rand_core = { version = "0.9", optional = true, default-features = false }
-pkcs5 = { version = "0.8.0-rc.5", optional = true, features = ["rand_core"] }
+pkcs5 = { version = "0.8.0-rc.6", optional = true, features = ["rand_core"] }
 subtle = { version = "2", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sec1"
-version = "0.8.0-rc.6"
+version = "0.8.0-rc.8"
 description = """
 Pure Rust implementation of SEC1: Elliptic Curve Cryptography encoding formats
 including ASN.1 DER-serialized private keys as well as the
@@ -18,7 +18,7 @@ rust-version = "1.85"
 
 [dependencies]
 base16ct = { version = "0.2", optional = true, default-features = false }
-der = { version = "0.8.0-rc.6", optional = true, features = ["oid"] }
+der = { version = "0.8.0-rc.7", optional = true, features = ["oid"] }
 hybrid-array = { version = "0.3", optional = true, default-features = false }
 serdect = { version = "0.3", optional = true, default-features = false, features = ["alloc"] }
 subtle = { version = "2", optional = true, default-features = false }

--- a/spki/Cargo.toml
+++ b/spki/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spki"
-version = "0.8.0-rc.3"
+version = "0.8.0-rc.4"
 description = """
 X.509 Subject Public Key Info (RFC5280) describing public keys as well as their
 associated AlgorithmIdentifiers (i.e. OIDs)
@@ -16,7 +16,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-der = { version = "0.8.0-rc.6", features = ["oid"] }
+der = { version = "0.8.0-rc.7", features = ["oid"] }
 
 # Optional dependencies
 arbitrary = { version = "1.4", features = ["derive"], optional = true }

--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -17,8 +17,8 @@ rust-version = "1.85"
 
 [dependencies]
 const-oid = { version = "0.10.0", features = ["db"] }
-der = { version = "0.8.0-rc.6", features = ["alloc", "derive", "flagset", "oid"] }
-spki = { version = "0.8.0-rc.3", features = ["alloc"] }
+der = { version = "0.8.0-rc.7", features = ["alloc", "derive", "flagset", "oid"] }
+spki = { version = "0.8.0-rc.4", features = ["alloc"] }
 
 # optional dependencies
 arbitrary = { version = "1.4", features = ["derive"], optional = true }

--- a/x509-ocsp/Cargo.toml
+++ b/x509-ocsp/Cargo.toml
@@ -17,8 +17,8 @@ rust-version = "1.85"
 
 [dependencies]
 const-oid = { version = "0.10.0-rc.0", default-features = false, features = ["db"] }
-der = { version = "0.8.0-rc.6", features = ["alloc", "derive", "oid"] }
-spki = { version = "0.8.0-rc.3", features = ["alloc"] }
+der = { version = "0.8.0-rc.7", features = ["alloc", "derive", "oid"] }
+spki = { version = "0.8.0-rc.4", features = ["alloc"] }
 x509-cert = { version = "0.3.0-rc.0", default-features = false }
 
 # Optional

--- a/x509-tsp/Cargo.toml
+++ b/x509-tsp/Cargo.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 rust-version = "1.85"
 
 [dependencies]
-der = { version = "0.8.0-rc.6", features = ["alloc", "derive", "oid", "pem"] }
+der = { version = "0.8.0-rc.7", features = ["alloc", "derive", "oid", "pem"] }
 cms = { version = "=0.3.0-pre.0" }
 cmpv2 = { version = "=0.3.0-pre.0", features = ["alloc"] }
 x509-cert = { version = "0.3.0-rc.0", default-features = false }


### PR DESCRIPTION
Releases the following:
- `der` v0.8.0-rc.7
- `pkcs1` v0.8.0-rc.3
- `pkcs5` v0.8.0-rc.6
- `pkcs8` v0.11.0-rc.6
- `sec1` v0.8.0-rc.8
- `spki` v0.8.0-rc.4