### PR TITLE
der: add `DecodeValueExt` trait with fn `from_der_value`

### DIFF
--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -364,7 +364,7 @@ pub use crate::{
     asn1::bit_string::allowed_len_bit_string::AllowedLenBitString,
     asn1::{AnyRef, Choice, Sequence},
     datetime::DateTime,
-    decode::{Decode, DecodeOwned, DecodeValue},
+    decode::{Decode, DecodeOwned, DecodeValue, DecodeValueExt},
     encode::{Encode, EncodeValue},
     encode_ref::{EncodeRef, EncodeValueRef},
     encoding_rules::EncodingRules,


### PR DESCRIPTION
Motivation: I didn't know about

```rust
AnyRef::new(tag, value)?.decode_as::<Self>()
```
trick, when writing https://github.com/RustCrypto/crypto-bigint/pull/851/files#diff-87fe87bbce5380197d3c659465e30daf47af5cac570bb4058f467a5b2dffa0b2R164