### PR TITLE
Use crate releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,9 +411,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-pre.5"
+version = "0.7.0-pre.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06a5e703b883b3744ddac8b7c5eade2d800d6559ef99760566f8103e3ad39bf"
+checksum = "98dc20cae677f0af161d98f18463804b680f9af060f6dbe6d4249bd7e838bca1"
 dependencies = [
  "hybrid-array",
  "num-traits",
@@ -522,8 +522,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.3"
-source = "git+https://github.com/RustCrypto/signatures.git#6cc40e5c10b04dae44d91500d5a1afc4a3ff2b49"
+version = "0.17.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a71089a4626a0efab7561890b599f7c6c9138c0d02b5c2739a8c07ef87101270"
 dependencies = [
  "der",
  "digest",
@@ -542,8 +543,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.7"
-source = "git+https://github.com/RustCrypto/traits.git#f517eff1f9821f7d67c0bbf9f9fe873ba12f3ab5"
+version = "0.14.0-rc.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28ecec37eea07ab976cea93c7ce8b36d561cf161f6767925c1edc51024b0ad3"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -930,9 +932,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "p256"
-version = "0.14.0-pre.8"
+version = "0.14.0-pre.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce3867083c909bbfd0ae070e20a9bb0f3dbce6f8e1fc4441cc01bda4951eeebe"
+checksum = "1be97a30a85c829fdac914cebb89ef05e109f9e5eb6510f46f623be91bc39ded"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -1064,9 +1066,9 @@ dependencies = [
 
 [[package]]
 name = "primefield"
-version = "0.14.0-pre.3"
+version = "0.14.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad88338273bf095e74dc9b4fa9e68474980af715d4374ecffae09513ab85f6c"
+checksum = "adc85f9f75dc05486f61bc61858535c0501a0ca81ca3117ab17befbead13c110"
 dependencies = [
  "crypto-bigint",
  "ff",
@@ -1077,9 +1079,9 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-pre.6"
+version = "0.14.0-pre.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e217447f8603744210c50e4c065b2e5a66b04f5d8279f33032fdb0fde6fabb"
+checksum = "af12dd34fc62d04416de85af032f4595369437fb7b0143d36ae60cecaf5cdddf"
 dependencies = [
  "elliptic-curve",
 ]
@@ -1250,8 +1252,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.10.0-rc.1"
-source = "git+https://github.com/RustCrypto/RSA.git?branch=pkcs1%2Fremove-blanket-impl#3644e58d099e358f5891d75d8e54149bb2c7ba12"
+version = "0.10.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8cb237ca3624409eda7d73de0d423815c9d91175ed5a62a8dd6549d2408cc2"
 dependencies = [
  "const-oid",
  "crypto-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,3 @@ tls_codec_derive = { path = "./tls_codec/derive" }
 x509-tsp = { path = "./x509-tsp" }
 x509-cert = { path = "./x509-cert" }
 x509-ocsp = { path = "./x509-ocsp" }
-
-elliptic-curve = { git = "https://github.com/RustCrypto/traits.git" }
-ecdsa = { git = "https://github.com/RustCrypto/signatures.git" }
-rsa = { git = "https://github.com/RustCrypto/RSA.git", branch = "pkcs1/remove-blanket-impl" }

--- a/cms/Cargo.toml
+++ b/cms/Cargo.toml
@@ -28,7 +28,7 @@ cbc = { version = "0.2.0-rc.0", optional = true }
 cipher = { version = "0.5.0-rc.0", features = ["alloc", "block-padding", "rand_core"], optional = true }
 digest = { version = "0.11.0-rc.0", optional = true }
 elliptic-curve = { version = "0.14.0-rc.6", optional = true }
-rsa = { version = "0.10.0-rc.0", optional = true }
+rsa = { version = "0.10.0-rc.3", optional = true }
 sha1 = { version = "0.11.0-rc.0", optional = true }
 sha2 = { version = "0.11.0-rc.0", optional = true }
 sha3 = { version = "0.11.0-rc.0", optional = true }
@@ -43,9 +43,9 @@ pem-rfc7468 = "1.0.0-rc.1"
 pkcs5 = "0.8.0-rc.6"
 pbkdf2 = "0.13.0-rc.0"
 rand = "0.9"
-rsa = { version = "0.10.0-rc.1", features = ["sha2"] }
-ecdsa = { version = "0.17.0-rc.3", features = ["digest", "pem"] }
-p256 = "=0.14.0-pre.8"
+rsa = { version = "0.10.0-rc.3", features = ["sha2"] }
+ecdsa = { version = "0.17.0-rc.4", features = ["digest", "pem"] }
+p256 = "=0.14.0-pre.9"
 tokio = { version = "1.45.1", features = ["macros", "rt"] }
 x509-cert = { version = "0.3.0-rc.0", features = ["pem"] }
 

--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -30,9 +30,9 @@ tls_codec = { version = "0.4.0", default-features = false, features = ["derive"]
 [dev-dependencies]
 hex-literal = "1"
 rand = "0.9"
-rsa = { version = "0.10.0-rc.1", features = ["sha2"] }
-ecdsa = { version = "0.17.0-rc.3", features = ["digest", "pem"] }
-p256 = "=0.14.0-pre.8"
+rsa = { version = "0.10.0-rc.3", features = ["sha2"] }
+ecdsa = { version = "0.17.0-rc.4", features = ["digest", "pem"] }
+p256 = "=0.14.0-pre.9"
 rstest = "0.25"
 sha2 = { version = "0.11.0-rc.0", features = ["oid"] }
 tempfile = "3.5.0"


### PR DESCRIPTION
Removes git-based dependencies and uses latest releases of `ecdsa`, `p256`, and `rsa`.