### PR TITLE
fix(x509-tsp): add proper no-std support

### DIFF
--- a/x509-tsp/Cargo.toml
+++ b/x509-tsp/Cargo.toml
@@ -15,10 +15,25 @@ readme = "README.md"
 rust-version = "1.85"
 
 [dependencies]
-der = { version = "0.8.0-rc.7", features = ["alloc", "derive", "oid", "pem"] }
-cms = { version = "=0.3.0-pre.0" }
-cmpv2 = { version = "=0.3.0-pre.0", features = ["alloc"] }
+der = { version = "0.8.0-rc.7", default-features = false, features = ["derive", "oid"] }
+cms = { version = "=0.3.0-pre.0", default-features = false }
+cmpv2 = { version = "=0.3.0-pre.0", default-features = false }
 x509-cert = { version = "0.3.0-rc.0", default-features = false }
+
+[features]
+default = ["std"]
+std = [
+    "der/std",
+    "cms/std", 
+    "cmpv2/std",
+    "x509-cert/std",
+    "alloc"
+]
+alloc = [
+    "der/alloc",
+    "cmpv2/alloc"
+]
+pem = ["der/pem"]
 
 [dev-dependencies]
 hex-literal = "1"


### PR DESCRIPTION
# x509-tsp: Add proper no-std support

## Summary

The `x509-tsp` crate does not properly support no-std environments, despite being part of the RustCrypto ecosystem where no-std support is a core principle. Even when using `default-features = false`, the crate forces std features on its dependencies, making it unusable in embedded systems, WASM, and other no-std environments.

## Current Behavior

When adding `x509-tsp` as a dependency with `default-features = false`:

```toml
[dependencies]
x509-tsp = { version = "0.1", default-features = false }
```

The dependency tree shows that std features are still enabled:

```
x509-tsp v0.1.0
├── cmpv2 feature "std"
│   ├── der feature "std"
│   └── spki feature "std"
└── cms feature "std"
    └── der feature "std"
```

## Expected Behavior

The crate should respect `default-features = false` and work in no-std environments, following the pattern established by other RustCrypto crates.

## Root Cause

Looking at the `Cargo.toml` (both v0.1.0 and current master), the dependencies are declared without `default-features = false`:

```toml
[dependencies]
der = { version = "0.8.0-rc.7", features = ["alloc", "derive", "oid", "pem"] }
cms = { version = "=0.3.0-pre.0" }
cmpv2 = { version = "=0.3.0-pre.0", features = ["alloc"] }
x509-cert = { version = "0.3.0-rc.0", default-features = false }
```

Note that only `x509-cert` properly uses `default-features = false`.