### PR TITLE
base64ct: fix benchmarks

### DIFF
--- a/base64ct/benches/mod.rs
+++ b/base64ct/benches/mod.rs
@@ -6,7 +6,7 @@ extern crate test;
 use base64ct::{Base64Unpadded, Encoding};
 use test::Bencher;
 
-const B64_LEN: usize = 100_002;
+const B64_LEN: usize = 100_000;
 const RAW_LEN: usize = (3 * B64_LEN) / 4;
 
 #[inline(never)]

--- a/base64ct/benches/mod.rs
+++ b/base64ct/benches/mod.rs
@@ -32,7 +32,7 @@ fn decode_bench(b: &mut Bencher) {
     let b64_data = get_b64_data();
     let mut buf = get_raw_data();
     b.iter(|| {
-        let out = Base64Unpadded::decode(&b64_data, &mut buf).unwrap();
+        let out = Base64Unpadded::decode(test::black_box(&b64_data), &mut buf).unwrap();
         test::black_box(out);
     });
     b.bytes = RAW_LEN as u64;
@@ -40,11 +40,11 @@ fn decode_bench(b: &mut Bencher) {
 
 #[bench]
 fn decode_in_place_bench(b: &mut Bencher) {
-    let mut b64_data = get_b64_data().into_bytes();
+    let b64_data = get_b64_data().into_bytes();
+    let mut buf = b64_data.clone();
     b.iter(|| {
-        // since it works on the same buffer over and over,
-        // almost always `out` will be an error
-        let out = Base64Unpadded::decode_in_place(&mut b64_data);
+        buf.copy_from_slice(&b64_data[..]);
+        let out = Base64Unpadded::decode_in_place(&mut buf);
         let _ = test::black_box(out);
     });
     b.bytes = RAW_LEN as u64;
@@ -55,7 +55,7 @@ fn encode_bench(b: &mut Bencher) {
     let mut buf = get_b64_data().into_bytes();
     let raw_data = get_raw_data();
     b.iter(|| {
-        let out = Base64Unpadded::encode(&raw_data, &mut buf).unwrap();
+        let out = Base64Unpadded::encode(test::black_box(&raw_data), &mut buf).unwrap();
         test::black_box(out);
     });
     b.bytes = RAW_LEN as u64;


### PR DESCRIPTION
Fixes:
```
running 3 tests
test decode_bench          ... FAILED

thread 'main' panicked at base64ct/benches/mod.rs:35:63:
called `Result::unwrap()` on an `Err` value: InvalidEncoding

```