### PR TITLE
der: add `ber` feature

### DIFF
--- a/cms/Cargo.toml
+++ b/cms/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.85"
 
 [dependencies]
 const-oid = { version = "0.10", features = ["db"] }
-der = { version = "0.8.0-rc.7", features = ["alloc", "derive", "oid"] }
+der = { version = "0.8.0-rc.7", features = ["ber", "derive", "oid"] }
 spki = "0.8.0-rc.4"
 x509-cert = { version = "0.3.0-rc.0", default-features = false }
 

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -41,6 +41,7 @@ derive = ["dep:der_derive"]
 oid = ["dep:const-oid"]
 pem = ["dep:pem-rfc7468", "alloc", "zeroize"]
 real = []
+ber = ["alloc"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/der/src/asn1/octet_string.rs
+++ b/der/src/asn1/octet_string.rs
@@ -374,7 +374,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "alloc")]
+    #[cfg(feature = "ber")]
     fn decode_ber() {
         use crate::{Decode, asn1::OctetString};
         use hex_literal::hex;
@@ -391,7 +391,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "alloc")]
+    #[cfg(feature = "ber")]
     fn decode_context_specific_ber_explicit() {
         use crate::{
             EncodingRules, SliceReader, TagNumber,
@@ -422,7 +422,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "alloc")]
+    #[cfg(feature = "ber")]
     fn decode_context_specific_ber_implicit() {
         use crate::{
             EncodingRules, SliceReader, TagNumber,

--- a/der/src/decode.rs
+++ b/der/src/decode.rs
@@ -1,6 +1,7 @@
 //! Trait definition for [`Decode`].
 
-use crate::{EncodingRules, Error, FixedTag, Header, Reader, SliceReader, reader::read_value};
+use crate::{Error, FixedTag, Header, Reader, SliceReader, reader::read_value};
+
 use core::marker::PhantomData;
 
 #[cfg(feature = "pem")]
@@ -11,6 +12,9 @@ use crate::{ErrorKind, Length, Tag};
 
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;
+
+#[cfg(feature = "ber")]
+use crate::EncodingRules;
 
 /// Decoding trait.
 ///
@@ -30,6 +34,7 @@ pub trait Decode<'a>: Sized + 'a {
     ///
     /// Note that most usages should probably use [`Decode::from_der`]. This method allows some
     /// BER productions which are not allowed under DER.
+    #[cfg(feature = "ber")]
     fn from_ber(bytes: &'a [u8]) -> Result<Self, Self::Error> {
         let mut reader = SliceReader::new_with_encoding_rules(bytes, EncodingRules::Ber)?;
         let result = Self::decode(&mut reader)?;

--- a/der/src/encoding_rules.rs
+++ b/der/src/encoding_rules.rs
@@ -13,6 +13,7 @@ use core::{fmt, str::FromStr};
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]
 pub enum EncodingRules {
     /// Basic Encoding Rules.
+    #[cfg(feature = "ber")]
     Ber,
 
     /// Distinguished Encoding Rules.
@@ -25,6 +26,7 @@ impl FromStr for EncodingRules {
 
     fn from_str(s: &str) -> Result<Self, Error> {
         match s {
+            #[cfg(feature = "ber")]
             "ber" | "BER" => Ok(EncodingRules::Ber),
             "der" | "DER" => Ok(EncodingRules::Der),
             _ => Err(ErrorKind::EncodingRules.into()),
@@ -35,6 +37,7 @@ impl FromStr for EncodingRules {
 impl fmt::Display for EncodingRules {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
+            #[cfg(feature = "ber")]
             Self::Ber => "BER",
             Self::Der => "DER",
         })
@@ -50,13 +53,16 @@ mod tests {
     #[test]
     fn display() {
         use alloc::string::ToString;
+        #[cfg(feature = "ber")]
         assert_eq!(EncodingRules::Ber.to_string(), "BER");
         assert_eq!(EncodingRules::Der.to_string(), "DER");
     }
 
     #[test]
     fn parse() {
+        #[cfg(feature = "ber")]
         assert_eq!(EncodingRules::Ber, "ber".parse().unwrap());
+        #[cfg(feature = "ber")]
         assert_eq!(EncodingRules::Ber, "BER".parse().unwrap());
         assert_eq!(EncodingRules::Der, "der".parse().unwrap());
         assert_eq!(EncodingRules::Der, "DER".parse().unwrap());

--- a/der/src/header.rs
+++ b/der/src/header.rs
@@ -1,8 +1,9 @@
 //! ASN.1 DER headers.
 
-use crate::{
-    Decode, DerOrd, Encode, EncodingRules, Error, ErrorKind, Length, Reader, Result, Tag, Writer,
-};
+#[cfg(feature = "ber")]
+use crate::EncodingRules;
+use crate::{Decode, DerOrd, Encode, Error, ErrorKind, Length, Reader, Result, Tag, Writer};
+
 use core::cmp::Ordering;
 
 /// ASN.1 DER headers: tag + length component of TLV-encoded values
@@ -46,10 +47,14 @@ impl<'a> Decode<'a> for Header {
             }
         })?;
 
+        #[cfg(feature = "ber")]
         if length.is_indefinite() && !is_constructed {
             debug_assert_eq!(reader.encoding_rules(), EncodingRules::Ber);
             return Err(reader.error(ErrorKind::IndefiniteLength));
         }
+
+        #[cfg(not(feature = "ber"))]
+        debug_assert_eq!(is_constructed, tag.is_constructed());
 
         Ok(Self { tag, length })
     }

--- a/der/src/length.rs
+++ b/der/src/length.rs
@@ -1,8 +1,15 @@
 //! Length calculations for encoded ASN.1 DER values
 
+#[cfg(feature = "ber")]
 pub(crate) mod indefinite;
 
-use self::indefinite::INDEFINITE_LENGTH_OCTET;
+/// Octet identifying an indefinite length as described in X.690 Section
+/// 8.1.3.6.1:
+///
+/// > The single octet shall have bit 8 set to one, and bits 7 to
+/// > 1 set to zero.
+pub(super) const INDEFINITE_LENGTH_OCTET: u8 = 0b10000000; // 0x80
+
 use crate::{Decode, DerOrd, Encode, EncodingRules, Error, ErrorKind, Reader, Result, Tag, Writer};
 use core::{
     cmp::Ordering,
@@ -20,6 +27,7 @@ pub struct Length {
     /// Flag bit which specifies whether the length was indeterminate when decoding ASN.1 BER.
     ///
     /// This should always be false when working with DER.
+    #[cfg(feature = "ber")]
     indefinite: bool,
 }
 
@@ -34,6 +42,7 @@ impl Length {
     pub const MAX: Self = Self::new(u32::MAX);
 
     /// Length of end-of-content octets (i.e. `00 00`).
+    #[cfg(feature = "ber")]
     pub(crate) const EOC_LEN: Self = Self::new(2);
 
     /// Maximum number of octets in a DER encoding of a [`Length`] using the
@@ -46,6 +55,8 @@ impl Length {
     pub const fn new(value: u32) -> Self {
         Self {
             inner: value,
+
+            #[cfg(feature = "ber")]
             indefinite: false,
         }
     }
@@ -68,6 +79,7 @@ impl Length {
     }
 
     /// Was this length decoded from an indefinite length when decoding BER?
+    #[cfg(feature = "ber")]
     pub(crate) const fn is_indefinite(self) -> bool {
         self.indefinite
     }
@@ -94,6 +106,7 @@ impl Length {
     /// Otherwise (as should always be the case with DER), the length is unchanged.
     ///
     /// This method notably preserves the `indefinite` flag when performing arithmetic.
+    #[cfg(feature = "ber")]
     pub(crate) fn sans_eoc(self) -> Self {
         if self.indefinite {
             // We expect EOC to be present when this is called.
@@ -104,6 +117,7 @@ impl Length {
                 indefinite: true,
             }
         } else {
+            // Return DER length
             self
         }
     }
@@ -250,6 +264,7 @@ impl<'a> Decode<'a> for Length {
             // Note: per X.690 Section 8.1.3.6.1 the byte 0x80 encodes indefinite lengths
             INDEFINITE_LENGTH_OCTET => match reader.encoding_rules() {
                 // Indefinite lengths are allowed when decoding BER
+                #[cfg(feature = "ber")]
                 EncodingRules::Ber => indefinite::decode_indefinite_length(&mut reader.clone()),
                 // Indefinite lengths are disallowed when decoding DER
                 EncodingRules::Der => Err(reader.error(ErrorKind::IndefiniteLength)),
@@ -333,11 +348,12 @@ impl DerOrd for Length {
 
 impl fmt::Debug for Length {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        #[cfg(feature = "ber")]
         if self.indefinite {
-            write!(f, "Length({self} [indefinite])")
-        } else {
-            f.debug_tuple("Length").field(&self.inner).finish()
+            return write!(f, "Length([indefinite])");
         }
+
+        f.debug_tuple("Length").field(&self.inner).finish()
     }
 }
 

--- a/der/src/length/indefinite.rs
+++ b/der/src/length/indefinite.rs
@@ -27,13 +27,6 @@ use crate::Tag;
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
-/// Octet identifying an indefinite length as described in X.690 Section
-/// 8.1.3.6.1:
-///
-/// > The single octet shall have bit 8 set to one, and bits 7 to
-/// > 1 set to zero.
-pub(super) const INDEFINITE_LENGTH_OCTET: u8 = 0b10000000; // 0x80
-
 /// The end-of-contents octets can be considered as the encoding of a value whose tag is
 /// universal class, whose form is primitive, whose number of the tag is zero, and whose
 /// contents are absent.

--- a/der/src/reader.rs
+++ b/der/src/reader.rs
@@ -9,11 +9,14 @@ mod position;
 
 use crate::{
     Decode, DecodeValue, Encode, EncodingRules, Error, ErrorKind, FixedTag, Header, Length, Tag,
-    TagMode, TagNumber, asn1::ContextSpecific, length::indefinite::read_eoc,
+    TagMode, TagNumber, asn1::ContextSpecific,
 };
 
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
+
+#[cfg(feature = "ber")]
+use crate::length::indefinite::read_eoc;
 
 /// Reader trait which reads DER-encoded input.
 pub trait Reader<'r>: Clone {
@@ -207,16 +210,22 @@ pub trait Reader<'r>: Clone {
 ///
 /// This calls the provided function `f` with a nested reader created using
 /// [`Reader::read_nested`].
-pub(crate) fn read_value<'r, R, T, F, E>(reader: &mut R, mut header: Header, f: F) -> Result<T, E>
+pub(crate) fn read_value<'r, R, T, F, E>(reader: &mut R, header: Header, f: F) -> Result<T, E>
 where
     R: Reader<'r>,
     E: From<Error>,
     F: FnOnce(&mut R, Header) -> Result<T, E>,
 {
-    header.length = header.length.sans_eoc();
+    #[cfg(feature = "ber")]
+    let header = Header {
+        length: header.length.sans_eoc(),
+        tag: header.tag,
+    };
+
     let ret = reader.read_nested(header.length, |r| f(r, header))?;
 
     // Consume EOC marker if the length is indefinite.
+    #[cfg(feature = "ber")]
     if header.length.is_indefinite() {
         read_eoc(reader)?;
     }

--- a/der/src/tag.rs
+++ b/der/src/tag.rs
@@ -7,9 +7,11 @@ mod number;
 
 pub use self::{class::Class, mode::TagMode, number::TagNumber};
 
-use crate::{
-    Decode, DerOrd, Encode, EncodingRules, Error, ErrorKind, Length, Reader, Result, Writer,
-};
+use crate::{Decode, DerOrd, Encode, Error, ErrorKind, Length, Reader, Result, Writer};
+
+#[cfg(feature = "ber")]
+use crate::EncodingRules;
+
 use core::{cmp::Ordering, fmt};
 
 /// Indicator bit for constructed form encoding (i.e. vs primitive form)
@@ -191,6 +193,7 @@ impl Tag {
             0x1A => Tag::VisibleString,
             0x1B => Tag::GeneralString,
             0x1E => Tag::BmpString,
+            #[cfg(feature = "ber")]
             0x24 if reader.encoding_rules() == EncodingRules::Ber => Tag::OctetString,
             0x30 => Tag::Sequence, // constructed
             0x31 => Tag::Set,      // constructed


### PR DESCRIPTION
As noted in #1934, there is noticeable performance impact of adding `indefinite: bool` field to `Length`.

This PR allows to disable BER decoder.