### PR TITLE
der: add predicate methods to `EncodingRules`

### DIFF
--- a/der/src/asn1/application.rs
+++ b/der/src/asn1/application.rs
@@ -1,8 +1,8 @@
 //! Application class field.
 
 use crate::{
-    Choice, Class, Decode, DecodeValue, DerOrd, Encode, EncodeValue, EncodeValueRef, EncodingRules,
-    Error, Header, Length, Reader, Tag, TagMode, TagNumber, Tagged, ValueOrd, Writer, asn1::AnyRef,
+    Choice, Class, Decode, DecodeValue, DerOrd, Encode, EncodeValue, EncodeValueRef, Error, Header,
+    Length, Reader, Tag, TagMode, TagNumber, Tagged, ValueOrd, Writer, asn1::AnyRef,
     tag::IsConstructed,
 };
 use core::cmp::Ordering;

--- a/der/src/asn1/context_specific.rs
+++ b/der/src/asn1/context_specific.rs
@@ -1,8 +1,8 @@
 //! Context-specific field.
 
 use crate::{
-    Choice, Class, Decode, DecodeValue, DerOrd, Encode, EncodeValue, EncodeValueRef, EncodingRules,
-    Error, Header, Length, Reader, Tag, TagMode, TagNumber, Tagged, ValueOrd, Writer, asn1::AnyRef,
+    Choice, Class, Decode, DecodeValue, DerOrd, Encode, EncodeValue, EncodeValueRef, Error, Header,
+    Length, Reader, Tag, TagMode, TagNumber, Tagged, ValueOrd, Writer, asn1::AnyRef,
     tag::IsConstructed,
 };
 use core::cmp::Ordering;

--- a/der/src/asn1/internal_macros.rs
+++ b/der/src/asn1/internal_macros.rs
@@ -143,12 +143,13 @@ macro_rules! impl_custom_class {
                 if !Tag::peek_matches(reader, Class::$class_enum_name, tag_number)? {
                     return Ok(None);
                 }
+
                 // Decode IMPLICIT header
                 let header = Header::decode(reader)?;
 
                 // the encoding shall be constructed if the base encoding is constructed
                 if header.tag.is_constructed() != T::CONSTRUCTED
-                    && reader.encoding_rules() == EncodingRules::Der {
+                    && reader.encoding_rules().is_der() {
                     return Err(reader.error(header.tag.non_canonical_error()).into());
                 }
 

--- a/der/src/asn1/private.rs
+++ b/der/src/asn1/private.rs
@@ -1,8 +1,8 @@
 //! Private class field.
 
 use crate::{
-    Choice, Class, Decode, DecodeValue, DerOrd, Encode, EncodeValue, EncodeValueRef, EncodingRules,
-    Error, Header, Length, Reader, Tag, TagMode, TagNumber, Tagged, ValueOrd, Writer, asn1::AnyRef,
+    Choice, Class, Decode, DecodeValue, DerOrd, Encode, EncodeValue, EncodeValueRef, Error, Header,
+    Length, Reader, Tag, TagMode, TagNumber, Tagged, ValueOrd, Writer, asn1::AnyRef,
     tag::IsConstructed,
 };
 use core::cmp::Ordering;

--- a/der/src/bytes.rs
+++ b/der/src/bytes.rs
@@ -118,7 +118,7 @@ impl<'a> arbitrary::Arbitrary<'a> for &'a BytesRef {
 pub(crate) mod allocating {
     use super::BytesRef;
     #[cfg(feature = "ber")]
-    use crate::{EncodingRules, length::indefinite::read_constructed_vec};
+    use crate::length::indefinite::read_constructed_vec;
 
     use crate::{
         DecodeValue, DerOrd, EncodeValue, Error, Header, Length, Reader, Result, Tag, Writer,
@@ -156,7 +156,7 @@ pub(crate) mod allocating {
         ) -> Result<Self> {
             // Reassemble indefinite length string types
             #[cfg(feature = "ber")]
-            if reader.encoding_rules() == EncodingRules::Ber
+            if reader.encoding_rules().is_ber()
                 && header.length.is_indefinite()
                 && !inner_tag.is_constructed()
             {

--- a/der/src/encoding_rules.rs
+++ b/der/src/encoding_rules.rs
@@ -21,6 +21,19 @@ pub enum EncodingRules {
     Der,
 }
 
+impl EncodingRules {
+    /// Are we using Basic Encoding Rules?
+    #[cfg(feature = "ber")]
+    pub const fn is_ber(self) -> bool {
+        matches!(self, EncodingRules::Ber)
+    }
+
+    /// Are we using Distinguished Encoding Rules?
+    pub const fn is_der(self) -> bool {
+        matches!(self, EncodingRules::Der)
+    }
+}
+
 impl FromStr for EncodingRules {
     type Err = Error;
 

--- a/der/src/tag.rs
+++ b/der/src/tag.rs
@@ -8,10 +8,6 @@ mod number;
 pub use self::{class::Class, mode::TagMode, number::TagNumber};
 
 use crate::{Decode, DerOrd, Encode, Error, ErrorKind, Length, Reader, Result, Writer};
-
-#[cfg(feature = "ber")]
-use crate::EncodingRules;
-
 use core::{cmp::Ordering, fmt};
 
 /// Indicator bit for constructed form encoding (i.e. vs primitive form)
@@ -198,7 +194,7 @@ impl Tag {
             0x1B => Tag::GeneralString,
             0x1E => Tag::BmpString,
             #[cfg(feature = "ber")]
-            0x24 if reader.encoding_rules() == EncodingRules::Ber => Tag::OctetString,
+            0x24 if reader.encoding_rules().is_ber() => Tag::OctetString,
             0x30 => Tag::Sequence, // constructed
             0x31 => Tag::Set,      // constructed
             0x40..=0x7F => {


### PR DESCRIPTION
Adds `is_ber` and `is_der` to simplify these predicates and avoid having to import `EncodingRules`