### PR TITLE
cms: impl From<Certificate> for SignerIdentifier

### DIFF
--- a/cms/src/signed_data.rs
+++ b/cms/src/signed_data.rs
@@ -8,9 +8,9 @@ use core::cmp::Ordering;
 use der::asn1::{ObjectIdentifier, OctetString, SetOfVec};
 use der::{Any, Choice, DerOrd, Sequence, ValueOrd};
 use spki::AlgorithmIdentifierOwned;
-use x509_cert::attr::Attributes;
-use x509_cert::ext::pkix::SubjectKeyIdentifier;
-use x509_cert::impl_newtype;
+use x509_cert::{
+    attr::Attributes, certificate::Certificate, ext::pkix::SubjectKeyIdentifier, impl_newtype,
+};
 
 /// The `SignedData` type is defined in [RFC 5652 Section 5.1].
 ///
@@ -178,6 +178,23 @@ impl ValueOrd for SignerIdentifier {
     fn value_cmp(&self, other: &Self) -> der::Result<Ordering> {
         use der::Encode;
         self.to_der()?.der_cmp(&other.to_der()?)
+    }
+}
+
+impl From<Certificate> for SignerIdentifier {
+    fn from(cert: Certificate) -> Self {
+        let tbs = cert.tbs_certificate();
+
+        match tbs.get_extension::<SubjectKeyIdentifier>() {
+            Ok(Some((_critical, ski))) => Self::SubjectKeyIdentifier(ski),
+            _ => {
+                let isn = IssuerAndSerialNumber {
+                    issuer: tbs.issuer().clone(),
+                    serial_number: tbs.serial_number().clone(),
+                };
+                Self::IssuerAndSerialNumber(isn)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This one is a bit problematic, the [RFC] would read the `SignerIdentifier` is to reuse the `SubjectKeyIdentifier` (SKI) for X.509 exclusively:
```
      sid specifies the signer's certificate (and thereby the signer's
      public key).  The signer's public key is needed by the recipient
      to verify the signature.  SignerIdentifier provides two
      alternatives for specifying the signer's public key.  The
      issuerAndSerialNumber alternative identifies the signer's
      certificate by the issuer's distinguished name and the certificate
      serial number; the subjectKeyIdentifier identifies the signer's
      certificate by a key identifier.  When an X.509 certificate is
      referenced, the key identifier matches the X.509
      subjectKeyIdentifier extension value.  When other certificate
      formats are referenced, the documents that specify the certificate
      format and their use with the CMS must include details on matching
      the key identifier to the appropriate certificate field.
      Implementations MUST support the reception of the
      issuerAndSerialNumber and subjectKeyIdentifier forms of
      SignerIdentifier.  When generating a SignerIdentifier,
      implementations MAY support one of the forms (either
      issuerAndSerialNumber or subjectKeyIdentifier) and always use it,
      or implementations MAY arbitrarily mix the two forms.  However,
      subjectKeyIdentifier MUST be used to refer to a public key
      contained in a non-X.509 certificate.
```

While the CABF, in the [CodeSigning BR], is fairly explicit that the SKI should no longer be included in the certificate.

The best option I've found would be to use the SKI when present, and otherwise rely on the `IssuerAndSerialNumber`

[RFC]: https://datatracker.ietf.org/doc/html/rfc5652#section-5.3
[CodeSigning BR]: https://github.com/cabforum/code-signing/blob/main/docs/CSBR.md#7123-code-signing-and-timestamp-certificate