### PR TITLE
Fix: Update CAB Forum Code Signing Baseline Requirements v2.8 link

### DIFF
--- a/x509-cert/src/builder/profile/cabf.rs
+++ b/x509-cert/src/builder/profile/cabf.rs
@@ -212,7 +212,7 @@ impl BuilderProfile for Root {
 pub mod tls;
 
 pub mod codesigning {
-    //! <https://cabforum.org/wp-content/uploads/Baseline-Requirements-for-the-Issuance-and-Management-of-Code-Signing.v2.8.pdf>
+    //! <https://cabforum.org/uploads/Baseline-Requirements-for-the-Issuance-and-Management-of-Code-Signing.v2.8.pdf>
     // TODO
 }
 


### PR DESCRIPTION
Replaced the outdated and broken URL for the CAB Forum Baseline Requirements for the Issuance and Management of Code Signing (v2.8) with the correct, working link from the official CAB Forum website. This ensures that documentation references are accurate and accessible for future readers and maintainers.