### PR TITLE
x509-cert: Fix underflow on empty input in Certificate::load_pem_chain

### DIFF
--- a/x509-cert/src/certificate.rs
+++ b/x509-cert/src/certificate.rs
@@ -411,7 +411,7 @@ impl<P: Profile> CertificateInner<P> {
             }
         }
 
-        while position < input.len() - 1 {
+        while position + 1 < input.len() {
             let rest = &input[position..];
             let end_pos = find_boundary(rest, end_boundary)
                 .ok_or(pem::Error::PostEncapsulationBoundary)?


### PR DESCRIPTION
`input.len() - 1` (a usize) underflows when the input is empty.