### PR TITLE
der: add `Hash` derive for `StringOwned` and `Ia5String`

### DIFF
--- a/der/src/asn1/ia5_string.rs
+++ b/der/src/asn1/ia5_string.rs
@@ -110,7 +110,7 @@ mod allocation {
     /// For UTF-8, use [`String`][`alloc::string::String`].
     ///
     /// [International Alphabet No. 5 (IA5)]: https://en.wikipedia.org/wiki/T.50_%28standard%29
-    #[derive(Clone, Eq, PartialEq, PartialOrd, Ord)]
+    #[derive(Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]
     pub struct Ia5String {
         /// Inner value
         inner: StringOwned,

--- a/der/src/string.rs
+++ b/der/src/string.rs
@@ -103,7 +103,7 @@ pub(crate) mod allocating {
     use core::{borrow::Borrow, ops::Deref, str};
 
     /// String newtype which respects the [`Length::max`] limit.
-    #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+    #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
     pub struct StringOwned {
         /// Inner value
         pub(crate) inner: String,


### PR DESCRIPTION
As previously cleared in #1971, this simple PR adds `std::hash::Hash` derives to `Ia5String` and `StringOwned`. `StringOwned` requires `Hash`, because it is used in `Ia5String`.