### PR TITLE
der/der_derive: cut new prereleases

### DIFF
--- a/.github/workflows/cmpv2.yml
+++ b/.github/workflows/cmpv2.yml
@@ -23,6 +23,7 @@ env:
 
 jobs:
   build:
+    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -48,6 +49,7 @@ jobs:
         working-directory: ${{ github.workflow }}
 
   test:
+    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/cms.yml
+++ b/.github/workflows/cms.yml
@@ -23,6 +23,7 @@ env:
 
 jobs:
   build:
+    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -53,6 +54,7 @@ jobs:
         nightly-cmd:
 
   test:
+    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/crmf.yml
+++ b/.github/workflows/crmf.yml
@@ -23,6 +23,7 @@ env:
 
 jobs:
   build:
+    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -48,6 +49,7 @@ jobs:
         working-directory: ${{ github.workflow }}
 
   test:
+    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/gss-api.yml
+++ b/.github/workflows/gss-api.yml
@@ -23,6 +23,7 @@ env:
 
 jobs:
   build:
+    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -48,6 +49,7 @@ jobs:
         working-directory: ${{ github.workflow }}
 
   test:
+    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/x509-cert.yml
+++ b/.github/workflows/x509-cert.yml
@@ -22,6 +22,7 @@ env:
 
 jobs:
   build:
+    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -49,6 +50,7 @@ jobs:
       install-zlint: true
 
   test:
+    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -72,6 +74,7 @@ jobs:
       - run: cargo test --all-features --release
 
   fuzz:
+    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/x509-ocsp.yml
+++ b/.github/workflows/x509-ocsp.yml
@@ -22,6 +22,7 @@ env:
 
 jobs:
   build:
+    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -47,6 +48,7 @@ jobs:
         working-directory: ${{ github.workflow }}
 
   test:
+    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/x509-tsp.yml
+++ b/.github/workflows/x509-tsp.yml
@@ -25,6 +25,7 @@ env:
 
 jobs:
   build:
+    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -50,6 +51,7 @@ jobs:
         working-directory: ${{ github.workflow }}
 
   test:
+    if: false # disabled while we migrate to digest newtypes
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,21 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "aead"
 version = "0.6.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,16 +38,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aes-kw"
-version = "0.3.0-rc.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca68b29bb0493ce60e7b429074337ed28a419f919cb3702cd28c77561eac338"
-dependencies = [
- "aes",
- "const-oid",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,15 +51,6 @@ name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
-
-[[package]]
-name = "ansi-x963-kdf"
-version = "0.1.0-rc.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9724ead468937eebb4c515bcf5451da8fed48a26063dcf450cab078669c0d0d8"
-dependencies = [
- "digest",
-]
 
 [[package]]
 name = "anstyle"
@@ -106,21 +72,6 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "backtrace"
-version = "0.3.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets",
-]
 
 [[package]]
 name = "base16ct"
@@ -298,48 +249,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
-name = "cmpv2"
-version = "0.3.0-pre.0"
-dependencies = [
- "const-oid",
- "crmf",
- "der",
- "digest",
- "hex-literal",
- "spki",
- "x509-cert",
-]
-
-[[package]]
 name = "cms"
 version = "0.3.0-pre.0"
 dependencies = [
- "aes",
- "aes-kw",
- "ansi-x963-kdf",
- "cbc",
- "cipher",
  "const-oid",
  "der",
- "digest",
- "ecdsa",
- "elliptic-curve",
- "getrandom",
- "hex-literal",
- "p256",
- "pbkdf2",
- "pem-rfc7468",
- "pkcs5",
- "rand",
- "rsa",
- "sha1",
- "sha2",
- "sha3",
- "signature",
  "spki",
- "tokio",
  "x509-cert",
- "zeroize",
 ]
 
 [[package]]
@@ -393,35 +309,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "crmf"
-version = "0.3.0-pre.0"
-dependencies = [
- "cms",
- "const-oid",
- "der",
- "spki",
- "x509-cert",
-]
-
-[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
-
-[[package]]
-name = "crypto-bigint"
-version = "0.7.0-pre.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98dc20cae677f0af161d98f18463804b680f9af060f6dbe6d4249bd7e838bca1"
-dependencies = [
- "hybrid-array",
- "num-traits",
- "rand_core",
- "serdect",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "crypto-common"
@@ -430,18 +321,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a23fa214dea9efd4dacee5a5614646b30216ae0f05d4bb51bafb50e9da1c5be"
 dependencies = [
  "hybrid-array",
- "rand_core",
-]
-
-[[package]]
-name = "crypto-primes"
-version = "0.7.0-pre.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae744b9f528151f8c440cf67498f24d2d1ac0ab536b5ce7b1f87a7a5961bd1c1"
-dependencies = [
- "crypto-bigint",
- "libm",
- "rand_core",
 ]
 
 [[package]]
@@ -521,45 +400,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ecdsa"
-version = "0.17.0-rc.5"
-source = "git+https://github.com/dwhjames/RustCrypto-signatures?branch=tmp_der_header_refactor#ea347624f952f64b5364b8473e76d607bfcce4d0"
-dependencies = [
- "der",
- "digest",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
- "zeroize",
-]
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "elliptic-curve"
-version = "0.14.0-rc.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28ecec37eea07ab976cea93c7ce8b36d561cf161f6767925c1edc51024b0ad3"
-dependencies = [
- "base16ct",
- "crypto-bigint",
- "digest",
- "ff",
- "group",
- "hkdf",
- "hybrid-array",
- "pem-rfc7468",
- "pkcs8",
- "rand_core",
- "sec1",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "equivalent"
@@ -584,16 +428,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "ff"
-version = "0.14.0-pre.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d42dd26f5790eda47c1a2158ea4120e32c35ddc9a7743c98a292accc01b54ef3"
-dependencies = [
- "rand_core",
- "subtle",
-]
-
-[[package]]
 name = "flagset"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,49 +440,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "futures-core"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "futures-task"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
-
-[[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
-
-[[package]]
-name = "futures-util"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
-dependencies = [
- "futures-core",
- "futures-macro",
- "futures-task",
- "pin-project-lite",
- "pin-utils",
- "slab",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -657,7 +448,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasi",
 ]
 
 [[package]]
@@ -670,37 +461,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
 name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
-
-[[package]]
-name = "group"
-version = "0.14.0-pre.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ff6a0b2dd4b981b1ae9e3e6830ab146771f3660d31d57bafd9018805a91b0f1"
-dependencies = [
- "ff",
- "rand_core",
- "subtle",
-]
-
-[[package]]
-name = "gss-api"
-version = "0.2.0-pre"
-dependencies = [
- "der",
- "hex-literal",
- "spki",
- "x509-cert",
-]
 
 [[package]]
 name = "half"
@@ -744,15 +508,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcaaec4551594c969335c98c903c1397853d4198408ea609190f420500f6be71"
 
 [[package]]
-name = "hkdf"
-version = "0.13.0-rc.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6738bc5110ee31b066339f0c9454db29a93db3b0484bbf2afa8a7e9cebc62141"
-dependencies = [
- "hmac",
-]
-
-[[package]]
 name = "hmac"
 version = "0.13.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,7 +523,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891d15931895091dea5c47afa5b3c9a01ba634b311919fd4d41388fa0e3d76af"
 dependencies = [
  "typenum",
- "zeroize",
 ]
 
 [[package]]
@@ -789,17 +543,6 @@ checksum = "c774c86bce20ea04abe1c37cf0051c5690079a3a28ef5fdac2a5a0412b3d7d74"
 dependencies = [
  "block-padding",
  "hybrid-array",
-]
-
-[[package]]
-name = "io-uring"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
-dependencies = [
- "bitflags",
- "cfg-if",
- "libc",
 ]
 
 [[package]]
@@ -827,15 +570,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
-name = "keccak"
-version = "0.2.0-pre.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cdd4f0dc5807b9a2b25dd48a3f58e862606fe7bd47f41ecde36e97422d7e90"
-dependencies = [
- "cpufeatures",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -846,12 +580,6 @@ name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
-
-[[package]]
-name = "libm"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "linux-raw-sys"
@@ -874,26 +602,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
-]
-
-[[package]]
-name = "mio"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
-dependencies = [
- "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,15 +617,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,19 +627,6 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
-
-[[package]]
-name = "p256"
-version = "0.14.0-pre.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1be97a30a85c829fdac914cebb89ef05e109f9e5eb6510f46f623be91bc39ded"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primefield",
- "primeorder",
- "sha2",
-]
 
 [[package]]
 name = "paste"
@@ -964,18 +650,6 @@ version = "1.0.0-rc.3"
 dependencies = [
  "base64ct",
 ]
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs1"
@@ -1061,37 +735,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "primefield"
-version = "0.14.0-pre.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc85f9f75dc05486f61bc61858535c0501a0ca81ca3117ab17befbead13c110"
-dependencies = [
- "crypto-bigint",
- "ff",
- "rand_core",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "primeorder"
-version = "0.14.0-pre.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af12dd34fc62d04416de85af032f4595369437fb7b0143d36ae60cecaf5cdddf"
-dependencies = [
- "elliptic-curve",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
-dependencies = [
- "toml_edit",
 ]
 
 [[package]]
@@ -1212,22 +855,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
-name = "relative-path"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
-
-[[package]]
-name = "rfc6979"
-version = "0.5.0-rc.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f53f124bf3ec90be84ae97d7f52175ba938898525554c13c9017eb8f0a604146"
-dependencies = [
- "hmac",
- "subtle",
-]
-
-[[package]]
 name = "rmp"
 version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1247,71 +874,6 @@ dependencies = [
  "byteorder",
  "rmp",
  "serde",
-]
-
-[[package]]
-name = "rsa"
-version = "0.10.0-rc.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8cb237ca3624409eda7d73de0d423815c9d91175ed5a62a8dd6549d2408cc2"
-dependencies = [
- "const-oid",
- "crypto-bigint",
- "crypto-primes",
- "digest",
- "pkcs1",
- "pkcs8",
- "rand_core",
- "sha2",
- "signature",
- "spki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rstest"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
-dependencies = [
- "futures-timer",
- "futures-util",
- "rstest_macros",
- "rustc_version",
-]
-
-[[package]]
-name = "rstest_macros"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
-dependencies = [
- "cfg-if",
- "glob",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "regex",
- "relative-path",
- "rustc_version",
- "syn",
- "unicode-ident",
-]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
-
-[[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
 ]
 
 [[package]]
@@ -1388,12 +950,6 @@ dependencies = [
  "tempfile",
  "zeroize",
 ]
-
-[[package]]
-name = "semver"
-version = "1.0.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
@@ -1484,32 +1040,6 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
-
-[[package]]
-name = "sha3"
-version = "0.11.0-rc.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e6a92fd180fd205defdc0b78288ce847c7309d329fd6647a814567e67db50e"
-dependencies = [
- "digest",
- "keccak",
-]
-
-[[package]]
-name = "signature"
-version = "3.0.0-rc.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4835c3b5ecb10171941a4998a95a3a76ecac1c5ae8e6954f2ad030acd1c7e8ab"
-dependencies = [
- "digest",
- "rand_core",
-]
-
-[[package]]
-name = "slab"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
 
 [[package]]
 name = "spki"
@@ -1634,32 +1164,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.46.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
-dependencies = [
- "backtrace",
- "io-uring",
- "libc",
- "mio",
- "pin-project-lite",
- "slab",
- "tokio-macros",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1761,12 +1265,6 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -1890,63 +1388,9 @@ dependencies = [
 name = "x509-cert"
 version = "0.3.0-rc.1"
 dependencies = [
- "arbitrary",
  "const-oid",
  "der",
- "digest",
- "ecdsa",
- "hex-literal",
- "p256",
- "rand",
- "rsa",
- "rstest",
- "sha1",
- "sha2",
- "signature",
  "spki",
- "tempfile",
- "tls_codec",
- "tokio",
- "x509-cert-test-support",
-]
-
-[[package]]
-name = "x509-cert-test-support"
-version = "0.1.0"
-dependencies = [
- "serde",
- "serde_json",
- "tempfile",
-]
-
-[[package]]
-name = "x509-ocsp"
-version = "0.3.0-pre"
-dependencies = [
- "const-oid",
- "der",
- "digest",
- "hex-literal",
- "lazy_static",
- "rand",
- "rand_core",
- "rsa",
- "sha1",
- "sha2",
- "signature",
- "spki",
- "x509-cert",
-]
-
-[[package]]
-name = "x509-tsp"
-version = "0.2.0-pre"
-dependencies = [
- "cmpv2",
- "cms",
- "der",
- "hex-literal",
- "x509-cert",
 ]
 
 [[package]]
@@ -1988,3 +1432,19 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[patch.unused]]
+name = "cmpv2"
+version = "0.3.0-pre.0"
+
+[[patch.unused]]
+name = "crmf"
+version = "0.3.0-pre.0"
+
+[[patch.unused]]
+name = "x509-ocsp"
+version = "0.3.0-pre"
+
+[[patch.unused]]
+name = "x509-tsp"
+version = "0.2.0-pre"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,7 +334,7 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.8.0-rc.7"
+version = "0.8.0-rc.8"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -351,7 +351,7 @@ dependencies = [
 
 [[package]]
 name = "der_derive"
-version = "0.8.0-rc.3"
+version = "0.8.0-rc.4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml.orig
+++ b/Cargo.toml.orig
@@ -4,13 +4,13 @@ members = [
     "base16ct",
     "base32ct",
     "base64ct",
-    #"cmpv2",
-    #"cms",
+    "cmpv2",
+    "cms",
     "const-oid",
-    #"crmf",
+    "crmf",
     "der",
     "der_derive",
-    #"gss-api",
+    "gss-api",
     "mcf",
     "pem-rfc7468",
     "pkcs1",
@@ -23,16 +23,6 @@ members = [
     "tai64",
     "tls_codec",
     "tls_codec/derive",
-    #"x509-tsp",
-    #"x509-cert",
-    #"x509-cert/test-support",
-    #"x509-ocsp"
-]
-exclude = [
-    "cmpv2",
-    "cms",
-    "crmf",
-    "gss-api",
     "x509-tsp",
     "x509-cert",
     "x509-cert/test-support",
@@ -69,3 +59,5 @@ tls_codec_derive = { path = "./tls_codec/derive" }
 x509-tsp = { path = "./x509-tsp" }
 x509-cert = { path = "./x509-cert" }
 x509-ocsp = { path = "./x509-ocsp" }
+
+ecdsa = { git = "https://github.com/dwhjames/RustCrypto-signatures", branch = "tmp_der_header_refactor" }

--- a/Cargo.toml.rej
+++ b/Cargo.toml.rej
@@ -1,0 +1,46 @@
+--- Cargo.toml
++++ Cargo.toml
+@@ -4,13 +4,13 @@ members = [
+     "base16ct",
+     "base32ct",
+     "base64ct",
+-    "cmpv2",
+-    "cms",
++    #"cmpv2",
++    #"cms",
+     "const-oid",
+-    "crmf",
++    #"crmf",
+     "der",
+     "der_derive",
+-    "gss-api",
++    #"gss-api",
+     "pem-rfc7468",
+     "pkcs1",
+     "pkcs5",
+@@ -89,6 +99,7 @@ crypto-common = { git = "https://github.com/RustCrypto/traits.git" }
+ elliptic-curve = { git = "https://github.com/RustCrypto/traits.git" }
+ signature = { git = "https://github.com/RustCrypto/traits.git" }
+ aead = { git = "https://github.com/RustCrypto/traits.git" }
++digest = { git = "https://github.com/RustCrypto/traits.git" }
+ 
+ # https://github.com/RustCrypto/RSA/pull/478
+ # https://github.com/RustCrypto/RSA/pull/504
+@@ -96,6 +107,7 @@ rsa = { git = "https://github.com/RustCrypto/RSA.git" }
+ 
+ # https://github.com/RustCrypto/password-hashes/pull/577
+ # https://github.com/RustCrypto/password-hashes/pull/578
++# https://github.com/RustCrypto/password-hashes/pull/592
+ pbkdf2 = { git = "https://github.com/RustCrypto/password-hashes.git" }
+ scrypt = { git = "https://github.com/RustCrypto/password-hashes.git" }
+ 
+@@ -109,3 +121,9 @@ cbc = { git = "https://github.com/RustCrypto/block-modes.git" }
+ ctr = { git = "https://github.com/RustCrypto/block-modes.git" }
+ aes-gcm = { git = "https://github.com/RustCrypto/AEADs.git" }
+ salsa20 = { git = "https://github.com/RustCrypto/stream-ciphers.git" }
++
++sha1 = { git = "https://github.com/RustCrypto/hashes.git" }
++sha2 = { git = "https://github.com/RustCrypto/hashes.git" }
++whirlpool = { git = "https://github.com/RustCrypto/hashes.git" }
++
++hmac = { git = "https://github.com/RustCrypto/MACs.git" }

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der"
-version = "0.8.0-rc.7"
+version = "0.8.0-rc.8"
 description = """
 Pure Rust embedded-friendly implementation of the Distinguished Encoding Rules
 (DER) for Abstract Syntax Notation One (ASN.1) as described in ITU X.690 with
@@ -20,7 +20,7 @@ rust-version = "1.85"
 arbitrary = { version = "1.4", features = ["derive"], optional = true }
 bytes = { version = "1", optional = true, default-features = false }
 const-oid = { version = "0.10", optional = true }
-der_derive = { version = "0.8.0-rc.3", optional = true }
+der_derive = { version = "0.8.0-rc.4", optional = true }
 flagset = { version = "0.4.7", optional = true }
 pem-rfc7468 = { version = "1.0.0-rc.3", optional = true, features = ["alloc"] }
 time = { version = "0.3.4", optional = true, default-features = false }

--- a/der_derive/Cargo.toml
+++ b/der_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der_derive"
-version = "0.8.0-rc.3"
+version = "0.8.0-rc.4"
 description = "Custom derive support for the `der` crate's `Choice` and `Sequence` traits"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
- `der` v0.8.0-rc-8
- `der_derive` v0.8.0-rc.4


This splits the workspace temporarily to get over the API break of der.