### PR TITLE
x509-cert: impl `DecodeValue` for `Time`

### DIFF
--- a/der_derive/src/asn1_type.rs
+++ b/der_derive/src/asn1_type.rs
@@ -61,10 +61,23 @@ impl Asn1Type {
         let type_path = self.type_path();
         quote!(#type_path::decode(reader)?)
     }
+
     /// Get a `der::Decoder` optional object for a particular ASN.1 type
     pub fn decoder_optional(self) -> TokenStream {
         let type_path = self.type_path();
         quote!(Option::<#type_path>::decode(reader)?)
+    }
+
+    /// Get a `der::DecodeValue` member object for a particular ASN.1 type
+    pub fn value_decoder(self) -> TokenStream {
+        let type_path = self.type_path();
+        quote!(#type_path::decode_value(reader, header)?)
+    }
+
+    /// Get a `der::DecodeValue` member object for a particular ASN.1 type
+    pub fn value_decoder_optional(self) -> TokenStream {
+        let type_path = self.type_path();
+        quote!(Option::<#type_path>::decode_value(reader, header)?)
     }
 
     /// Get a `der::Encoder` object for a particular ASN.1 type

--- a/x509-cert/src/ext/pkix/name/dirstr.rs
+++ b/x509-cert/src/ext/pkix/name/dirstr.rs
@@ -2,7 +2,7 @@ use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::string::ToString;
 use der::{
-    Choice, FixedTag, Header, Reader, ValueOrd,
+    Choice, ValueOrd,
     asn1::{Any, BmpString, PrintableString, TeletexString},
 };
 
@@ -66,27 +66,6 @@ impl<'a> TryFrom<&'a Any> for DirectoryString {
     }
 }
 
-impl<'a> der::DecodeValue<'a> for DirectoryString {
-    type Error = der::Error;
-
-    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self, Self::Error> {
-        match header.tag() {
-            PrintableString::TAG => {
-                PrintableString::decode_value(reader, header).map(Self::PrintableString)
-            }
-            TeletexString::TAG => {
-                TeletexString::decode_value(reader, header).map(Self::TeletexString)
-            }
-            String::TAG => String::decode_value(reader, header).map(Self::Utf8String),
-            BmpString::TAG => BmpString::decode_value(reader, header).map(Self::BmpString),
-            actual => Err(der::ErrorKind::TagUnexpected {
-                expected: None,
-                actual,
-            }
-            .into()),
-        }
-    }
-}
 impl DirectoryString {
     /// Returns `Borrowed` variant for UTF-8 compatible strings
     /// and `Owned` variant otherwise.

--- a/x509-cert/src/time.rs
+++ b/x509-cert/src/time.rs
@@ -2,7 +2,7 @@
 
 use core::{fmt, marker::PhantomData, str::FromStr, time::Duration};
 use der::asn1::{GeneralizedTime, UtcTime};
-use der::{Choice, DateTime, DecodeValue, Encode, Header, Length, Reader, Sequence, Tag, ValueOrd};
+use der::{Choice, DateTime, DecodeValue, Encode, Header, Length, Reader, Sequence, ValueOrd};
 
 #[cfg(feature = "std")]
 use std::time::SystemTime;
@@ -120,19 +120,6 @@ impl FromStr for Time {
         let datetime = DateTime::from_str(input)?;
 
         Ok(Self::from(datetime))
-    }
-}
-
-impl<'a> DecodeValue<'a> for Time {
-    type Error = der::Error;
-    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self, Self::Error> {
-        match header.tag() {
-            Tag::UtcTime => Ok(Self::UtcTime(UtcTime::decode_value(reader, header)?)),
-            Tag::GeneralizedTime => Ok(Self::GeneralTime(GeneralizedTime::decode_value(
-                reader, header,
-            )?)),
-            tag => Err(reader.error(tag.unexpected_error(None))),
-        }
     }
 }
 

--- a/x509-cert/src/time.rs
+++ b/x509-cert/src/time.rs
@@ -2,7 +2,7 @@
 
 use core::{fmt, marker::PhantomData, str::FromStr, time::Duration};
 use der::asn1::{GeneralizedTime, UtcTime};
-use der::{Choice, DateTime, DecodeValue, Encode, Header, Length, Reader, Sequence, ValueOrd};
+use der::{Choice, DateTime, DecodeValue, Encode, Header, Length, Reader, Sequence, Tag, ValueOrd};
 
 #[cfg(feature = "std")]
 use std::time::SystemTime;
@@ -120,6 +120,19 @@ impl FromStr for Time {
         let datetime = DateTime::from_str(input)?;
 
         Ok(Self::from(datetime))
+    }
+}
+
+impl<'a> DecodeValue<'a> for Time {
+    type Error = der::Error;
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self, Self::Error> {
+        match header.tag() {
+            Tag::UtcTime => Ok(Self::UtcTime(UtcTime::decode_value(reader, header)?)),
+            Tag::GeneralizedTime => Ok(Self::GeneralTime(GeneralizedTime::decode_value(
+                reader, header,
+            )?)),
+            tag => Err(reader.error(tag.unexpected_error(None))),
+        }
     }
 }
 


### PR DESCRIPTION
To deserialize SigningTime attributes from CMS, Time needs implement DecodeValue.

```
  -- rfc3852
  Attribute ::= SEQUENCE {
    attrType OBJECT IDENTIFIER,
    attrValues SET OF AttributeValue }

  AttributeValue ::= ANY

  -- rfc5911

  SigningTime  ::= Time

  Time ::= CHOICE {
      utcTime UTCTime,
      generalTime GeneralizedTime }

  aa-signingTime ATTRIBUTE ::=
      { TYPE SigningTime IDENTIFIED BY id-signingTime }
  id-signingTime OBJECT IDENTIFIER ::= { iso(1) member-body(2)
     us(840) rsadsi(113549) pkcs(1) pkcs9(9) 5 }
```

This adds the missing implementation.