### PR TITLE
chore(deps): bump rstest from 0.25.0 to 0.26.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1268,21 +1268,20 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
 dependencies = [
  "futures-timer",
  "futures-util",
  "rstest_macros",
- "rustc_version",
 ]
 
 [[package]]
 name = "rstest_macros"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
 dependencies = [
  "cfg-if",
  "glob",

--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -33,7 +33,7 @@ rand = "0.9"
 rsa = { version = "0.10.0-rc.3", features = ["sha2"] }
 ecdsa = { version = "0.17.0-rc.4", features = ["digest", "pem"] }
 p256 = "=0.14.0-pre.9"
-rstest = "0.25"
+rstest = "0.26"
 sha2 = { version = "0.11.0-rc.0", features = ["oid"] }
 tempfile = "3.5"
 tokio = { version = "1.45", features = ["macros", "rt"] }


### PR DESCRIPTION
Not sure why dependabot hasn’t proposed this yet, but I’m preparing to patch the `rstest` dev-dependency [downstream in Fedora](https://src.fedoraproject.org/rpms/rust-x509-cert), so this PR suggests the same change upstream.

I verified that `cargo test` still passes in `x509-cert/`, and I didn’t see anything in https://github.com/la10736/rstest/blob/v0.26.1/CHANGELOG.md that seemed like it should impact this project.