### PR TITLE
der: remove lifetime from `OctetStringRef`

### DIFF
--- a/cms/src/attr.rs
+++ b/cms/src/attr.rs
@@ -1,11 +1,11 @@
 //! Attribute-related types
+//!
 use alloc::{boxed::Box, vec};
+use core::borrow::Borrow;
 use der::{
     DecodeValue, EncodeValue, FixedTag, Length, Tag,
     asn1::{OctetString, OctetStringRef},
-    referenced::OwnedToRef,
 };
-
 use x509_cert::time::Time;
 
 use crate::signed_data::SignerInfo;
@@ -50,8 +50,8 @@ impl MessageDigest {
 
     /// Return an [`OctetStringRef`] pointing to the underlying data
     #[inline]
-    pub fn as_octet_string_ref<'a>(&'a self) -> OctetStringRef<'a> {
-        self.0.owned_to_ref()
+    pub fn as_octet_string_ref(&self) -> &OctetStringRef {
+        self.0.borrow()
     }
 }
 

--- a/cms/src/timestamped_data.rs
+++ b/cms/src/timestamped_data.rs
@@ -44,7 +44,7 @@ pub struct TimeStampedData<'a> {
     #[asn1(optional = "true")]
     pub meta_data: Option<MetaData>,
     #[asn1(optional = "true")]
-    pub content: Option<OctetStringRef<'a>>,
+    pub content: Option<&'a OctetStringRef>,
     pub temporal_evidence: Evidence,
 }
 

--- a/cms/tests/builder.rs
+++ b/cms/tests/builder.rs
@@ -946,7 +946,7 @@ fn test_create_password_recipient_info() {
             .to_der()
             .unwrap();
         let iv = Iv::<cbc::Decryptor<Aes128>>::try_from(
-            OctetStringRef::from_der(algorithm_params_der.as_slice())
+            <&OctetStringRef>::from_der(algorithm_params_der.as_slice())
                 .unwrap()
                 .as_bytes(),
         )

--- a/cms/tests/tests_from_pkcs7_crate.rs
+++ b/cms/tests/tests_from_pkcs7_crate.rs
@@ -123,7 +123,7 @@ fn cms_decode_signed_der() {
         sd.encap_content_info
             .econtent
             .unwrap()
-            .decode_as::<OctetStringRef>()
+            .decode_as::<&OctetStringRef>()
             .unwrap()
             .as_bytes()
             .len(),

--- a/der/src/asn1.rs
+++ b/der/src/asn1.rs
@@ -44,7 +44,7 @@ pub use self::{
     ia5_string::Ia5StringRef,
     integer::{int::IntRef, uint::UintRef},
     null::Null,
-    octet_string::OctetStringRef,
+    octet_string::{OctetStringRef, OctetStringRef2},
     printable_string::PrintableStringRef,
     private::{Private, PrivateRef},
     sequence::{Sequence, SequenceRef},

--- a/der/src/asn1/octet_string.rs
+++ b/der/src/asn1/octet_string.rs
@@ -5,27 +5,43 @@ use crate::{
     Tag, Writer, asn1::AnyRef, ord::OrdIsValueOrd,
 };
 
+// TODO(tarcieri): custom derive hack until the logic is updated to support `&'a` reference types
+#[doc(hidden)]
+pub type OctetStringRef2<'a> = &'a OctetStringRef;
+
 /// ASN.1 `OCTET STRING` type: borrowed form.
 ///
 /// Octet strings represent contiguous sequences of octets, a.k.a. bytes.
 ///
 /// This is a zero-copy reference type which borrows from the input data.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
-pub struct OctetStringRef<'a> {
+#[derive(Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct OctetStringRef {
     /// Inner value
-    inner: &'a BytesRef,
+    inner: BytesRef,
 }
 
-impl<'a> OctetStringRef<'a> {
+impl OctetStringRef {
     /// Create a new ASN.1 `OCTET STRING` from a byte slice.
-    pub fn new(slice: &'a [u8]) -> Result<Self, Error> {
+    pub fn new(slice: &[u8]) -> Result<&Self, Error> {
         BytesRef::new(slice)
-            .map(|inner| Self { inner })
+            .map(Self::from_bytes_ref)
             .map_err(|_| ErrorKind::Length { tag: Self::TAG }.into())
     }
 
+    /// Create an [`OctetStringRef`] from a [`BytesRef`].
+    ///
+    /// Implemented as an inherent method to keep [`BytesRef`] out of the public API.
+    fn from_bytes_ref(bytes_ref: &BytesRef) -> &Self {
+        // SAFETY: `Self` is a `repr(transparent)` newtype for `BytesRef`
+        #[allow(unsafe_code)]
+        unsafe {
+            &*(bytes_ref.as_ptr() as *const Self)
+        }
+    }
+
     /// Borrow the inner byte slice.
-    pub fn as_bytes(&self) -> &'a [u8] {
+    pub fn as_bytes(&self) -> &[u8] {
         self.inner.as_slice()
     }
 
@@ -40,29 +56,28 @@ impl<'a> OctetStringRef<'a> {
     }
 
     /// Parse `T` from this `OCTET STRING`'s contents.
-    pub fn decode_into<T: Decode<'a>>(&self) -> Result<T, T::Error> {
+    pub fn decode_into<'a, T: Decode<'a>>(&'a self) -> Result<T, T::Error> {
         Decode::from_der(self.as_bytes())
     }
 }
 
-impl_any_conversions!(OctetStringRef<'a>, 'a);
+impl_any_conversions!(&'a OctetStringRef, 'a);
 
-impl AsRef<[u8]> for OctetStringRef<'_> {
+impl AsRef<[u8]> for OctetStringRef {
     fn as_ref(&self) -> &[u8] {
         self.as_bytes()
     }
 }
 
-impl<'a> DecodeValue<'a> for OctetStringRef<'a> {
+impl<'a> DecodeValue<'a> for &'a OctetStringRef {
     type Error = Error;
 
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self, Error> {
-        let inner = <&'a BytesRef>::decode_value(reader, header)?;
-        Ok(Self { inner })
+        <&'a BytesRef>::decode_value(reader, header).map(OctetStringRef::from_bytes_ref)
     }
 }
 
-impl EncodeValue for OctetStringRef<'_> {
+impl EncodeValue for &OctetStringRef {
     fn value_len(&self) -> Result<Length, Error> {
         self.inner.value_len()
     }
@@ -72,31 +87,28 @@ impl EncodeValue for OctetStringRef<'_> {
     }
 }
 
-impl FixedTag for OctetStringRef<'_> {
+impl FixedTag for OctetStringRef {
+    const TAG: Tag = Tag::OctetString;
+}
+impl FixedTag for &OctetStringRef {
     const TAG: Tag = Tag::OctetString;
 }
 
-impl OrdIsValueOrd for OctetStringRef<'_> {}
+impl OrdIsValueOrd for &OctetStringRef {}
 
-impl<'a> From<&OctetStringRef<'a>> for OctetStringRef<'a> {
-    fn from(value: &OctetStringRef<'a>) -> OctetStringRef<'a> {
-        *value
+impl<'a> From<&'a OctetStringRef> for AnyRef<'a> {
+    fn from(octet_string: &'a OctetStringRef) -> AnyRef<'a> {
+        AnyRef::from_tag_and_value(Tag::OctetString, &octet_string.inner)
     }
 }
 
-impl<'a> From<OctetStringRef<'a>> for AnyRef<'a> {
-    fn from(octet_string: OctetStringRef<'a>) -> AnyRef<'a> {
-        AnyRef::from_tag_and_value(Tag::OctetString, octet_string.inner)
-    }
-}
-
-impl<'a> From<OctetStringRef<'a>> for &'a [u8] {
-    fn from(octet_string: OctetStringRef<'a>) -> &'a [u8] {
+impl<'a> From<&'a OctetStringRef> for &'a [u8] {
+    fn from(octet_string: &'a OctetStringRef) -> &'a [u8] {
         octet_string.as_bytes()
     }
 }
 
-impl<'a> TryFrom<&'a [u8]> for OctetStringRef<'a> {
+impl<'a> TryFrom<&'a [u8]> for &'a OctetStringRef {
     type Error = Error;
 
     fn try_from(byte_slice: &'a [u8]) -> Result<Self, Error> {
@@ -105,7 +117,7 @@ impl<'a> TryFrom<&'a [u8]> for OctetStringRef<'a> {
 }
 
 /// Hack for simplifying the custom derive use case.
-impl<'a> TryFrom<&&'a [u8]> for OctetStringRef<'a> {
+impl<'a> TryFrom<&&'a [u8]> for &'a OctetStringRef {
     type Error = Error;
 
     fn try_from(byte_slice: &&'a [u8]) -> Result<Self, Error> {
@@ -113,7 +125,7 @@ impl<'a> TryFrom<&&'a [u8]> for OctetStringRef<'a> {
     }
 }
 
-impl<'a, const N: usize> TryFrom<&'a [u8; N]> for OctetStringRef<'a> {
+impl<'a, const N: usize> TryFrom<&'a [u8; N]> for &'a OctetStringRef {
     type Error = Error;
 
     fn try_from(byte_slice: &'a [u8; N]) -> Result<Self, Error> {
@@ -121,10 +133,10 @@ impl<'a, const N: usize> TryFrom<&'a [u8; N]> for OctetStringRef<'a> {
     }
 }
 
-impl<'a, const N: usize> TryFrom<OctetStringRef<'a>> for [u8; N] {
+impl<'a, const N: usize> TryFrom<&'a OctetStringRef> for [u8; N] {
     type Error = Error;
 
-    fn try_from(octet_string: OctetStringRef<'a>) -> Result<Self, Self::Error> {
+    fn try_from(octet_string: &'a OctetStringRef) -> Result<Self, Self::Error> {
         octet_string
             .as_bytes()
             .try_into()
@@ -133,10 +145,10 @@ impl<'a, const N: usize> TryFrom<OctetStringRef<'a>> for [u8; N] {
 }
 
 #[cfg(feature = "heapless")]
-impl<'a, const N: usize> TryFrom<OctetStringRef<'a>> for heapless::Vec<u8, N> {
+impl<const N: usize> TryFrom<&OctetStringRef> for heapless::Vec<u8, N> {
     type Error = Error;
 
-    fn try_from(octet_string: OctetStringRef<'a>) -> Result<Self, Self::Error> {
+    fn try_from(octet_string: &OctetStringRef) -> Result<Self, Self::Error> {
         octet_string
             .as_bytes()
             .try_into()
@@ -145,7 +157,7 @@ impl<'a, const N: usize> TryFrom<OctetStringRef<'a>> for heapless::Vec<u8, N> {
 }
 
 #[cfg(feature = "heapless")]
-impl<'a, const N: usize> TryFrom<&'a heapless::Vec<u8, N>> for OctetStringRef<'a> {
+impl<'a, const N: usize> TryFrom<&'a heapless::Vec<u8, N>> for &'a OctetStringRef {
     type Error = Error;
 
     fn try_from(byte_vec: &'a heapless::Vec<u8, N>) -> Result<Self, Error> {
@@ -159,8 +171,12 @@ pub use self::allocating::OctetString;
 #[cfg(feature = "alloc")]
 mod allocating {
     use super::*;
-    use crate::{BytesOwned, referenced::*};
-    use alloc::{borrow::Cow, boxed::Box, vec::Vec};
+    use crate::BytesOwned;
+    use alloc::{
+        borrow::{Borrow, Cow, ToOwned},
+        boxed::Box,
+        vec::Vec,
+    };
 
     /// ASN.1 `OCTET STRING` type: owned form.
     ///
@@ -214,6 +230,12 @@ mod allocating {
         }
     }
 
+    impl Borrow<OctetStringRef> for OctetString {
+        fn borrow(&self) -> &OctetStringRef {
+            OctetStringRef::from_bytes_ref(self.inner.as_ref())
+        }
+    }
+
     impl<'a> DecodeValue<'a> for OctetString {
         type Error = Error;
 
@@ -237,40 +259,30 @@ mod allocating {
         const TAG: Tag = Tag::OctetString;
     }
 
-    impl<'a> From<&'a OctetString> for OctetStringRef<'a> {
-        fn from(octet_string: &'a OctetString) -> OctetStringRef<'a> {
-            OctetStringRef {
-                inner: octet_string.inner.as_ref(),
-            }
-        }
-    }
-
     impl OrdIsValueOrd for OctetString {}
 
-    impl<'a> RefToOwned<'a> for OctetStringRef<'a> {
-        type Owned = OctetString;
-        fn ref_to_owned(&self) -> Self::Owned {
-            OctetString {
-                inner: self.inner.into(),
+    impl<'a> From<&'a OctetString> for &'a OctetStringRef {
+        fn from(octet_string: &'a OctetString) -> &'a OctetStringRef {
+            OctetStringRef::from_bytes_ref(octet_string.inner.as_ref())
+        }
+    }
+
+    impl From<&OctetStringRef> for OctetString {
+        fn from(octet_string_ref: &OctetStringRef) -> OctetString {
+            Self {
+                inner: octet_string_ref.inner.to_owned(),
             }
         }
     }
 
-    impl OwnedToRef for OctetString {
-        type Borrowed<'a> = OctetStringRef<'a>;
-        fn owned_to_ref(&self) -> Self::Borrowed<'_> {
-            self.into()
-        }
-    }
-
-    impl From<OctetStringRef<'_>> for Vec<u8> {
-        fn from(octet_string: OctetStringRef<'_>) -> Vec<u8> {
+    impl From<&OctetStringRef> for Vec<u8> {
+        fn from(octet_string: &OctetStringRef) -> Vec<u8> {
             Vec::from(octet_string.as_bytes())
         }
     }
 
     /// Hack for simplifying the custom derive use case.
-    impl<'a> TryFrom<&'a Vec<u8>> for OctetStringRef<'a> {
+    impl<'a> TryFrom<&'a Vec<u8>> for &'a OctetStringRef {
         type Error = Error;
 
         fn try_from(byte_vec: &'a Vec<u8>) -> Result<Self, Error> {
@@ -284,7 +296,15 @@ mod allocating {
         }
     }
 
-    impl<'a> TryFrom<&'a Cow<'a, [u8]>> for OctetStringRef<'a> {
+    impl ToOwned for OctetStringRef {
+        type Owned = OctetString;
+
+        fn to_owned(&self) -> OctetString {
+            self.into()
+        }
+    }
+
+    impl<'a> TryFrom<&'a Cow<'a, [u8]>> for &'a OctetStringRef {
         type Error = Error;
 
         fn try_from(byte_slice: &'a Cow<'a, [u8]>) -> Result<Self, Error> {
@@ -292,10 +312,10 @@ mod allocating {
         }
     }
 
-    impl<'a> TryFrom<OctetStringRef<'a>> for Cow<'a, [u8]> {
+    impl<'a> TryFrom<&'a OctetStringRef> for Cow<'a, [u8]> {
         type Error = Error;
 
-        fn try_from(octet_string: OctetStringRef<'a>) -> Result<Self, Self::Error> {
+        fn try_from(octet_string: &'a OctetStringRef) -> Result<Self, Self::Error> {
             Ok(Cow::Borrowed(octet_string.as_bytes()))
         }
     }
@@ -345,8 +365,8 @@ mod bytes {
         const TAG: Tag = Tag::OctetString;
     }
 
-    impl From<OctetStringRef<'_>> for Bytes {
-        fn from(octet_string: OctetStringRef<'_>) -> Bytes {
+    impl From<&OctetStringRef> for Bytes {
+        fn from(octet_string: &OctetStringRef) -> Bytes {
             Vec::from(octet_string).into()
         }
     }
@@ -361,7 +381,23 @@ mod bytes {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
-    use crate::asn1::{OctetStringRef, PrintableStringRef};
+    use crate::{
+        Decode,
+        asn1::{OctetStringRef, PrintableStringRef},
+    };
+    use hex_literal::hex;
+
+    #[test]
+    fn octet_string_decode() {
+        // PrintableString "hi"
+        const EXAMPLE: &[u8] = &hex!(
+            "040c" // primitive definite length OCTET STRING
+            "48656c6c6f2c20776f726c64" // "Hello, world"
+        );
+
+        let decoded = <&OctetStringRef>::from_der(EXAMPLE).unwrap();
+        assert_eq!(decoded.as_bytes(), b"Hello, world");
+    }
 
     #[test]
     fn octet_string_decode_into() {

--- a/der/src/bytes.rs
+++ b/der/src/bytes.rs
@@ -31,6 +31,11 @@ impl BytesRef {
         }
     }
 
+    /// Get a pointer to this [`BytesRef`].
+    pub(crate) const fn as_ptr(&self) -> *const BytesRef {
+        self as *const BytesRef
+    }
+
     /// Borrow the inner byte slice
     pub const fn as_slice(&self) -> &[u8] {
         &self.0

--- a/der_derive/src/asn1_type.rs
+++ b/der_derive/src/asn1_type.rs
@@ -93,7 +93,8 @@ impl Asn1Type {
             Asn1Type::BitString => quote!(::der::asn1::BitStringRef),
             Asn1Type::Ia5String => quote!(::der::asn1::Ia5StringRef),
             Asn1Type::GeneralizedTime => quote!(::der::asn1::GeneralizedTime),
-            Asn1Type::OctetString => quote!(::der::asn1::OctetStringRef),
+            // TODO(tarcieri): natively support `OctetStringRef`, remove `OctetStringRef2`
+            Asn1Type::OctetString => quote!(::der::asn1::OctetStringRef2),
             Asn1Type::PrintableString => quote!(::der::asn1::PrintableStringRef),
             Asn1Type::TeletexString => quote!(::der::asn1::TeletexStringRef),
             Asn1Type::VideotexString => quote!(::der::asn1::VideotexStringRef),

--- a/gss-api/src/negotiation.rs
+++ b/gss-api/src/negotiation.rs
@@ -89,13 +89,13 @@ pub struct NegTokenInit<'a> {
 
     /// This field, if present, contains the optimistic mechanism token.
     #[asn1(context_specific = "2", optional = "true", tag_mode = "IMPLICIT")]
-    pub mech_token: Option<OctetStringRef<'a>>,
+    pub mech_token: Option<&'a OctetStringRef>,
 
     /// This field, if present, contains an MIC token for the mechanism
     /// list in the initial negotiation message.  This MIC token is
     /// computed according to Section 5.
     #[asn1(context_specific = "3", optional = "true", tag_mode = "IMPLICIT")]
-    pub mech_list_mic: Option<OctetStringRef<'a>>,
+    pub mech_list_mic: Option<&'a OctetStringRef>,
 }
 
 /// `ContextFlags` as defined in [RFC 4178 Section 4.2.1].
@@ -172,7 +172,7 @@ pub struct NegTokenTarg<'a> {
     /// from the list has been selected by the target or to carry the
     /// tokens specific to the selected security mechanism.
     #[asn1(context_specific = "2", optional = "true", tag_mode = "EXPLICIT")]
-    pub response_token: Option<OctetStringRef<'a>>,
+    pub response_token: Option<&'a OctetStringRef>,
 
     /// If the selected mechanism is capable of integrity protection, this
     ///  field must be present in the last message of the negotiation,
@@ -182,7 +182,7 @@ pub struct NegTokenTarg<'a> {
     ///  allows to verify that the list initially sent by the initiator has
     ///  been received unmodified by the target.
     #[asn1(context_specific = "3", optional = "true", tag_mode = "EXPLICIT")]
-    pub mech_list_mic: Option<OctetStringRef<'a>>,
+    pub mech_list_mic: Option<&'a OctetStringRef>,
 }
 
 /// `NegResult` as defined in [RFC 2479 Section 3.2.1].
@@ -252,13 +252,13 @@ pub struct NegTokenResp<'a> {
     /// This field, if present, contains tokens specific to the mechanism
     /// selected.
     #[asn1(context_specific = "2", optional = "true", tag_mode = "EXPLICIT")]
-    pub response_token: Option<OctetStringRef<'a>>,
+    pub response_token: Option<&'a OctetStringRef>,
 
     /// This field, if present, contains an MIC token for the mechanism
     /// list in the initial negotiation message.  This MIC token is
     /// computed according to Section 5.
     #[asn1(context_specific = "3", optional = "true", tag_mode = "EXPLICIT")]
-    pub mech_list_mic: Option<OctetStringRef<'a>>,
+    pub mech_list_mic: Option<&'a OctetStringRef>,
 }
 
 #[derive(Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord, Enumerated)]
@@ -302,7 +302,7 @@ pub struct NegHints<'a> {
     ///
     /// [X690]: https://www.itu.int/rec/T-REC-X.690/
     #[asn1(context_specific = "1", optional = "true", tag_mode = "IMPLICIT")]
-    pub hint_address: Option<OctetStringRef<'a>>,
+    pub hint_address: Option<&'a OctetStringRef>,
 }
 
 /// `NegTokenInit2` as defined in [MS-SPNG Section 2.2.1].
@@ -337,7 +337,7 @@ pub struct NegTokenInit2<'a> {
     ///
     /// [RFC4178]: https://datatracker.ietf.org/doc/html/rfc4178
     #[asn1(context_specific = "2", optional = "true", tag_mode = "EXPLICIT")]
-    pub mech_token: Option<OctetStringRef<'a>>,
+    pub mech_token: Option<&'a OctetStringRef>,
 
     /// The server supplies the negotiation hints using a NegHints structure.
     #[asn1(context_specific = "3", optional = "true", tag_mode = "EXPLICIT")]
@@ -347,7 +347,7 @@ pub struct NegTokenInit2<'a> {
     ///
     /// [RFC4178]: https://datatracker.ietf.org/doc/html/rfc4178
     #[asn1(context_specific = "4", optional = "true", tag_mode = "EXPLICIT")]
-    pub mech_list_mic: Option<OctetStringRef<'a>>,
+    pub mech_list_mic: Option<&'a OctetStringRef>,
 }
 
 #[cfg(test)]

--- a/pkcs1/src/private_key.rs
+++ b/pkcs1/src/private_key.rs
@@ -170,10 +170,10 @@ impl<'a> TryFrom<&'a [u8]> for RsaPrivateKey<'a> {
     }
 }
 
-impl<'a> TryFrom<OctetStringRef<'a>> for RsaPrivateKey<'a> {
+impl<'a> TryFrom<&'a OctetStringRef> for RsaPrivateKey<'a> {
     type Error = Error;
 
-    fn try_from(bytes: OctetStringRef<'a>) -> Result<Self> {
+    fn try_from(bytes: &'a OctetStringRef) -> Result<Self> {
         Ok(Self::from_der(bytes.as_bytes())?)
     }
 }

--- a/pkcs1/tests/params.rs
+++ b/pkcs1/tests/params.rs
@@ -168,7 +168,7 @@ fn decode_oaep_param() {
             .p_source
             .parameters_any()
             .unwrap()
-            .decode_as::<OctetStringRef<'_>>()
+            .decode_as::<&OctetStringRef>()
             .unwrap()
             .is_empty(),
     );
@@ -224,7 +224,7 @@ fn decode_oaep_param_default() {
             .p_source
             .parameters_any()
             .unwrap()
-            .decode_as::<OctetStringRef<'_>>()
+            .decode_as::<&OctetStringRef>()
             .unwrap()
             .is_empty(),
     );

--- a/pkcs5/src/pbes1.rs
+++ b/pkcs5/src/pbes1.rs
@@ -154,7 +154,7 @@ impl TryFrom<AnyRef<'_>> for Parameters {
     fn try_from(any: AnyRef<'_>) -> der::Result<Parameters> {
         any.sequence(|reader| {
             Ok(Parameters {
-                salt: OctetStringRef::decode(reader)?
+                salt: <&OctetStringRef>::decode(reader)?
                     .as_bytes()
                     .try_into()
                     .map_err(|_| Tag::OctetString.value_error())?,

--- a/pkcs5/src/pbes2.rs
+++ b/pkcs5/src/pbes2.rs
@@ -449,7 +449,7 @@ impl TryFrom<AlgorithmIdentifierRef<'_>> for EncryptionScheme {
     fn try_from(alg: AlgorithmIdentifierRef<'_>) -> der::Result<Self> {
         // TODO(tarcieri): support for non-AES algorithms?
         let iv = match alg.parameters {
-            Some(params) => params.decode_as::<OctetStringRef<'_>>()?.as_bytes(),
+            Some(params) => params.decode_as::<&OctetStringRef>()?.as_bytes(),
             None => return Err(Tag::OctetString.value_error().into()),
         };
 

--- a/pkcs8/src/encrypted_private_key_info.rs
+++ b/pkcs8/src/encrypted_private_key_info.rs
@@ -175,7 +175,7 @@ impl<Data> PemLabel for EncryptedPrivateKeyInfo<Data> {
 }
 
 /// [`EncryptedPrivateKeyInfo`] with [`OctetStringRef`] encrypted data.
-pub type EncryptedPrivateKeyInfoRef<'a> = EncryptedPrivateKeyInfo<OctetStringRef<'a>>;
+pub type EncryptedPrivateKeyInfoRef<'a> = EncryptedPrivateKeyInfo<&'a OctetStringRef>;
 
 #[cfg(feature = "alloc")]
 /// [`EncryptedPrivateKeyInfo`] with [`OctetString`] encrypted data.

--- a/pkcs8/src/lib.rs
+++ b/pkcs8/src/lib.rs
@@ -70,7 +70,7 @@
 //! [PKCS#5v2 Password Based Encryption Scheme 2 (RFC 8018)]: https://tools.ietf.org/html/rfc8018#section-6.2
 //! [scrypt]: https://en.wikipedia.org/wiki/Scrypt
 
-#[cfg(feature = "pem")]
+#[cfg(feature = "alloc")]
 extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;

--- a/pkcs8/src/private_key_info.rs
+++ b/pkcs8/src/private_key_info.rs
@@ -367,7 +367,7 @@ where
 }
 
 /// [`PrivateKeyInfo`] with [`AnyRef`] algorithm parameters, and `&[u8]` key.
-pub type PrivateKeyInfoRef<'a> = PrivateKeyInfo<AnyRef<'a>, OctetStringRef<'a>, BitStringRef<'a>>;
+pub type PrivateKeyInfoRef<'a> = PrivateKeyInfo<AnyRef<'a>, &'a OctetStringRef, BitStringRef<'a>>;
 
 /// [`PrivateKeyInfo`] with [`Any`] algorithm parameters, and `Box<[u8]>` key.
 #[cfg(feature = "alloc")]
@@ -389,6 +389,8 @@ impl BitStringLike for BitStringRef<'_> {
 #[cfg(feature = "alloc")]
 mod allocating {
     use super::*;
+    use alloc::borrow::ToOwned;
+    use core::borrow::Borrow;
     use der::referenced::*;
 
     impl BitStringLike for BitString {
@@ -402,7 +404,7 @@ mod allocating {
         fn ref_to_owned(&self) -> Self::Owned {
             PrivateKeyInfoOwned {
                 algorithm: self.algorithm.ref_to_owned(),
-                private_key: self.private_key.ref_to_owned(),
+                private_key: self.private_key.to_owned(),
                 public_key: self.public_key.ref_to_owned(),
             }
         }
@@ -413,7 +415,7 @@ mod allocating {
         fn owned_to_ref(&self) -> Self::Borrowed<'_> {
             PrivateKeyInfoRef {
                 algorithm: self.algorithm.owned_to_ref(),
-                private_key: self.private_key.owned_to_ref(),
+                private_key: self.private_key.borrow(),
                 public_key: self.public_key.owned_to_ref(),
             }
         }

--- a/sec1/src/private_key.rs
+++ b/sec1/src/private_key.rs
@@ -102,7 +102,7 @@ impl<'a> DecodeValue<'a> for EcPrivateKey<'a> {
             return Err(reader.error(Tag::Integer.value_error()));
         }
 
-        let private_key = OctetStringRef::decode(reader)?.as_bytes();
+        let private_key = <&OctetStringRef>::decode(reader)?.as_bytes();
         let parameters = reader.context_specific(EC_PARAMETERS_TAG, TagMode::Explicit)?;
         let public_key = reader
             .context_specific::<BitStringRef<'_>>(PUBLIC_KEY_TAG, TagMode::Explicit)?

--- a/x509-cert/tests/name.rs
+++ b/x509-cert/tests/name.rs
@@ -1,11 +1,15 @@
 //! Name tests
 
 use const_oid::ObjectIdentifier;
-use der::asn1::{Ia5StringRef, OctetStringRef, PrintableStringRef, SetOfVec, Utf8StringRef};
-use der::{Any, Decode, Encode, Tag, Tagged};
+use der::{
+    Any, Decode, Encode, Tag, Tagged,
+    asn1::{Ia5StringRef, OctetStringRef, PrintableStringRef, SetOfVec, Utf8StringRef},
+};
 use hex_literal::hex;
-use x509_cert::attr::AttributeTypeAndValue;
-use x509_cert::name::{Name, RdnSequence, RelativeDistinguishedName};
+use x509_cert::{
+    attr::AttributeTypeAndValue,
+    name::{Name, RdnSequence, RelativeDistinguishedName},
+};
 
 #[test]
 fn decode_name() {


### PR DESCRIPTION
Following the pattern of #1921, removes the lifetime from the struct, instead changing `OctetStringRef` to a proper reference type to be used as `&OctetStringRef`.

This makes it possible to `impl Borrow<OctetStringRef> for OctetString` and `impl ToOwned for OctetStringRef`, so they can work with `Cow`.

cc @dishmaker