### PR TITLE
base16ct: remove `std` feature

### DIFF
--- a/.github/workflows/base16ct.yml
+++ b/.github/workflows/base16ct.yml
@@ -40,12 +40,12 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
       - uses: RustCrypto/actions/cargo-hack-install@master
-      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features std
+      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset
 
   minimal-versions:
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
     with:
-        working-directory: ${{ github.workflow }}
+      working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest

--- a/base16ct/Cargo.toml
+++ b/base16ct/Cargo.toml
@@ -19,7 +19,6 @@ rust-version = "1.85"
 
 [features]
 alloc = []
-std = ["alloc"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/base16ct/src/lib.rs
+++ b/base16ct/src/lib.rs
@@ -62,8 +62,6 @@
 #[cfg(feature = "alloc")]
 #[macro_use]
 extern crate alloc;
-#[cfg(feature = "std")]
-extern crate std;
 
 /// Function for decoding and encoding lower Base16 (hex)
 pub mod lower;


### PR DESCRIPTION
It's no longer used now that we support `core::error::Error`