### PR TITLE
base16ct v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,12 @@ dependencies = [
 [[package]]
 name = "base16ct"
 version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base16ct"
+version = "0.3.0"
 
 [[package]]
 name = "base32"
@@ -544,7 +550,7 @@ name = "elliptic-curve"
 version = "0.14.0-rc.12"
 source = "git+https://github.com/RustCrypto/traits.git#40508e0480c748542358c620e055b12aa858b042"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
  "crypto-bigint",
  "digest",
  "ff",
@@ -1373,7 +1379,7 @@ dependencies = [
 name = "sec1"
 version = "0.8.0-rc.8"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
  "der",
  "hex-literal",
  "hybrid-array",
@@ -1444,7 +1450,7 @@ dependencies = [
 name = "serdect"
 version = "0.3.0"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
  "bincode",
  "ciborium",
  "hex-literal",

--- a/base16ct/CHANGELOG.md
+++ b/base16ct/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2025-08-20)
+### Changed
+- Upgrade to 2024 edition; MSRV 1.85 ([#1670])
+- Use `core::error:Error` ([#1842])
+
+### Removed
+- `std` feature ([#2004])
+
+[#1670]: https://github.com/RustCrypto/formats/pull/1670
+[#1842]: https://github.com/RustCrypto/formats/pull/1842
+[#2004]: https://github.com/RustCrypto/formats/pull/2004
+
 ## 0.2.0 (2023-02-26)
 ### Changed
 - MSRV 1.60 ([#802])

--- a/base16ct/Cargo.toml
+++ b/base16ct/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base16ct"
-version = "0.2.0"
+version = "0.3.0"
 description = """
 Pure Rust implementation of Base16 a.k.a hexadecimal (RFC 4648) which avoids
 any usages of data-dependent branches/LUTs and thereby provides portable


### PR DESCRIPTION
### Changed
- Upgrade to 2024 edition; MSRV 1.85 ([#1670])
- Use `core::error:Error` ([#1842])

### Removed
- `std` feature ([#2004])

[#1670]: https://github.com/RustCrypto/formats/pull/1670
[#1842]: https://github.com/RustCrypto/formats/pull/1842
[#2004]: https://github.com/RustCrypto/formats/pull/2004