### PR TITLE
base32ct: remove `std` feature; use `core::error::Error`

### DIFF
--- a/.github/workflows/base32ct.yml
+++ b/.github/workflows/base32ct.yml
@@ -40,12 +40,12 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
       - uses: RustCrypto/actions/cargo-hack-install@master
-      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features std
+      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset
 
   minimal-versions:
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
     with:
-        working-directory: ${{ github.workflow }}
+      working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,7 @@ checksum = "022dfe9eb35f19ebbcb51e0b40a5ab759f46ad60cadf7297e0bd085afb50e076"
 
 [[package]]
 name = "base32ct"
-version = "0.2.2"
+version = "0.3.0-pre"
 dependencies = [
  "base32",
  "proptest",

--- a/base32ct/Cargo.toml
+++ b/base32ct/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base32ct"
-version = "0.2.2"
+version = "0.3.0-pre"
 description = """
 Pure Rust implementation of Base32 (RFC 4648) which avoids any usages of
 data-dependent branches/LUTs and thereby provides portable "best effort"
@@ -23,7 +23,6 @@ proptest = { version = "1.6", default-features = false, features = ["std"] }
 
 [features]
 alloc = []
-std = ["alloc"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/base32ct/src/error.rs
+++ b/base32ct/src/error.rs
@@ -24,5 +24,4 @@ impl fmt::Display for Error {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}

--- a/base32ct/src/lib.rs
+++ b/base32ct/src/lib.rs
@@ -50,8 +50,6 @@
 #[cfg(feature = "alloc")]
 #[macro_use]
 extern crate alloc;
-#[cfg(feature = "std")]
-extern crate std;
 
 mod alphabet;
 mod encoding;


### PR DESCRIPTION
The only reason we had a `std` feature was for `std::error::Error`, but now the trait is available in `core`