### PR TITLE
base32ct v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,7 @@ checksum = "022dfe9eb35f19ebbcb51e0b40a5ab759f46ad60cadf7297e0bd085afb50e076"
 
 [[package]]
 name = "base32ct"
-version = "0.3.0-pre"
+version = "0.3.0"
 dependencies = [
  "base32",
  "proptest",

--- a/base32ct/CHANGELOG.md
+++ b/base32ct/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2025-08-20)
+### Changed
+- Upgrade to 2024 edition; MSRV 1.85 ([#1670])
+- Use `core::error::Error` ([#2006])
+
+### Removed
+- `std` feature ([#2006])
+
+[#1670]: https://github.com/RustCrypto/formats/pull/1670
+[#2006]: https://github.com/RustCrypto/formats/pull/2006
+
 ## 0.2.2 (2025-02-23)
 ### Added
 - `const fn` for `encoded_len` ([#1424])

--- a/base32ct/Cargo.toml
+++ b/base32ct/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base32ct"
-version = "0.3.0-pre"
+version = "0.3.0"
 description = """
 Pure Rust implementation of Base32 (RFC 4648) which avoids any usages of
 data-dependent branches/LUTs and thereby provides portable "best effort"


### PR DESCRIPTION
### Changed
- Upgrade to 2024 edition; MSRV 1.85 ([#1670])
- Use `core::error::Error` ([#2006])

### Removed
- `std` feature ([#2006])

[#1670]: https://github.com/RustCrypto/formats/pull/1670
[#2006]: https://github.com/RustCrypto/formats/pull/2006