### PR TITLE
serdect v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,7 +423,7 @@ dependencies = [
  "hybrid-array",
  "num-traits",
  "rand_core",
- "serdect",
+ "serdect 0.3.0",
  "subtle",
  "zeroize",
 ]
@@ -1383,7 +1383,7 @@ dependencies = [
  "der",
  "hex-literal",
  "hybrid-array",
- "serdect",
+ "serdect 0.4.0",
  "subtle",
  "tempfile",
  "zeroize",
@@ -1449,6 +1449,16 @@ dependencies = [
 [[package]]
 name = "serdect"
 version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f42f67da2385b51a5f9652db9c93d78aeaf7610bf5ec366080b6de810604af53"
+dependencies = [
+ "base16ct 0.2.0",
+ "serde",
+]
+
+[[package]]
+name = "serdect"
+version = "0.4.0"
 dependencies = [
  "base16ct 0.2.0",
  "bincode",

--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -20,7 +20,7 @@ rust-version = "1.85"
 base16ct = { version = "0.2", optional = true, default-features = false }
 der = { version = "0.8.0-rc.8", optional = true, features = ["oid"] }
 hybrid-array = { version = "0.3", optional = true, default-features = false }
-serdect = { version = "0.3", optional = true, default-features = false, features = ["alloc"] }
+serdect = { version = "0.4", optional = true, default-features = false, features = ["alloc"] }
 subtle = { version = "2", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 

--- a/serdect/CHANGELOG.md
+++ b/serdect/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2025-08-20)
+### Changed
+- Upgrade to the 2024 edition; MSRV 1.85 ([#1670])
+
+[#1670]: https://github.com/RustCrypto/formats/pull/1670
+
 ## 0.3.0 (2025-01-06)
 
 NOTE: this release includes major breaking changes to the wire format, namely

--- a/serdect/Cargo.toml
+++ b/serdect/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Constant-time serde serializer/deserializer helpers for data that potentially
 contains secrets (e.g. cryptographic keys)
 """
-version = "0.3.0"
+version = "0.4.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 homepage = "https://github.com/RustCrypto/formats/tree/master/serdect"


### PR DESCRIPTION
### Changed
- Upgrade to the 2024 edition; MSRV 1.85 ([#1670])

NOTE: under the old MSRV policy, changing the MSRV was considered breaking, however it has been updated in this release to note it can change in the future in patch releases

[#1670]: https://github.com/RustCrypto/formats/pull/1670