### PR TITLE
sec1 v0.8.0-rc.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1366,7 +1366,7 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.8.0-rc.8"
+version = "0.8.0-rc.9"
 dependencies = [
  "base16ct",
  "der",

--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sec1"
-version = "0.8.0-rc.8"
+version = "0.8.0-rc.9"
 description = """
 Pure Rust implementation of SEC1: Elliptic Curve Cryptography encoding formats
 including ASN.1 DER-serialized private keys as well as the


### PR DESCRIPTION
Includes `hybrid-array` v0.4 support