### PR TITLE
Revert "mcf: improve Base64 comments"

### DIFF
--- a/mcf/src/base64.rs
+++ b/mcf/src/base64.rs
@@ -9,13 +9,11 @@ use alloc::{string::String, vec::Vec};
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum Base64 {
-    /// bcrypt encoding. Also used by the following schemes:
-    /// - scrypt
-    /// - yescrypt
+    /// bcrypt encoding.
     ///
     /// ```text
-    /// ./         [0-9]      [A-Z]      [a-z]
-    /// 0x2e-0x2f, 0x30-0x39, 0x41-0x5a, 0x61-0x7a
+    /// ./         [A-Z]      [a-z]      [0-9]
+    /// 0x2e-0x2f, 0x41-0x5a, 0x61-0x7a, 0x30-0x39
     /// ```
     Bcrypt,
 
@@ -27,7 +25,7 @@ pub enum Base64 {
     /// ```
     Crypt,
 
-    /// `crypt(3)` Base64 encoding. Used by the following schemes:
+    /// `crypt(3)` Base64 encoding for the following schemes:
     /// - sha1_crypt,
     /// - sha256_crypt,
     /// - sha512_crypt,


### PR DESCRIPTION
This reverts commit 731509599473441f91897314a482d1905b8d07f3 (#2025)

Though it confused me, the original text is correct about the ordering.