### PR TITLE
mcf: rename `McfHash::push_field_base64` to `McfHash::push_base64`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,7 +863,7 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "mcf"
-version = "0.1.0"
+version = "0.2.0-pre"
 dependencies = [
  "base64ct",
  "hex-literal",

--- a/mcf/Cargo.toml
+++ b/mcf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcf"
-version = "0.1.0"
+version = "0.2.0-pre"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/mcf/src/lib.rs
+++ b/mcf/src/lib.rs
@@ -160,21 +160,21 @@ mod allocating {
             self.as_mcf_hash_ref().fields()
         }
 
-        /// Push an additional field onto the password hash string, first adding a leading `$`.
+        /// Encode the given data as the specified variant of Base64 and push it onto the password
+        /// hash string, first adding a `$` delimiter.
+        pub fn push_base64(&mut self, field: &[u8], base64_encoding: Base64) {
+            self.0.push(fields::DELIMITER);
+            self.0.push_str(&base64_encoding.encode_string(field));
+        }
+
+        /// Push an additional field onto the password hash string, first adding a `$` delimiter.
         pub fn push_field(&mut self, field: Field<'_>) {
             self.0.push(fields::DELIMITER);
             self.0.push_str(field.as_str());
         }
 
-        /// Push an additional field onto the password hash string, adding a leading `$` and then
-        /// encoding it into the specified variant of Base64.
-        pub fn push_field_base64(&mut self, field: &[u8], base64_encoding: Base64) {
-            self.0.push(fields::DELIMITER);
-            self.0.push_str(&base64_encoding.encode_string(field));
-        }
-
-        /// Push a raw string onto the MCF hash, ensuring it validates as a [`Field`] and also
-        /// adding a leading `$`.
+        /// Push a raw string onto the MCF hash, first adding a `$` delimiter and also ensuring it
+        /// validates as a [`Field`].
         ///
         /// # Errors
         /// - If the provided `str` fails to validate as a [`Field`] (i.e. contains characters

--- a/mcf/tests/mcf.rs
+++ b/mcf/tests/mcf.rs
@@ -65,7 +65,7 @@ fn parse_sha512_hash() {
 #[test]
 fn push_fields() {
     let mut hash = McfHash::new("$6$rounds=100000").unwrap();
-    hash.push_field_base64(EXAMPLE_SALT, Base64::ShaCrypt);
-    hash.push_field_base64(EXAMPLE_HASH, Base64::ShaCrypt);
+    hash.push_base64(EXAMPLE_SALT, Base64::ShaCrypt);
+    hash.push_base64(EXAMPLE_HASH, Base64::ShaCrypt);
     assert_eq!(SHA512_HASH, hash.as_str());
 }


### PR DESCRIPTION
Slightly shorter and matches the other methods, also it doesn't act on a `Field` type so the old name was slightly confusing.