### PR TITLE
mcf: rename `PasswordHash`/`PasswordHashRef`

### DIFF
--- a/mcf/tests/mcf.rs
+++ b/mcf/tests/mcf.rs
@@ -3,7 +3,7 @@
 #![cfg(feature = "alloc")]
 
 use hex_literal::hex;
-use mcf::{Base64, McfHash};
+use mcf::{Base64, PasswordHash};
 
 const SHA512_HASH: &str = "$6$rounds=100000$exn6tVc2j/MZD8uG$BI1Xh8qQSK9J4m14uwy7abn.ctj/TIAzlaVCto0MQrOFIeTXsc1iwzH16XEWo/a7c7Y9eVJvufVzYAs4EsPOy0";
 
@@ -14,31 +14,31 @@ const EXAMPLE_HASH: &[u8] = &hex!(
 
 #[test]
 fn from_id() {
-    let mcf_hash = McfHash::from_id("6").unwrap();
+    let mcf_hash = PasswordHash::from_id("6").unwrap();
     assert_eq!("$6", mcf_hash.as_str());
 }
 
 #[test]
 fn parse_malformed() {
-    assert!("Hello, world!".parse::<McfHash>().is_err());
-    assert!("$".parse::<McfHash>().is_err());
-    assert!("$$".parse::<McfHash>().is_err());
-    assert!("$$foo".parse::<McfHash>().is_err());
-    assert!("$foo$".parse::<McfHash>().is_err());
-    assert!("$-$foo".parse::<McfHash>().is_err());
-    assert!("$foo-$bar".parse::<McfHash>().is_err());
-    assert!("$-foo$bar".parse::<McfHash>().is_err());
+    assert!("Hello, world!".parse::<PasswordHash>().is_err());
+    assert!("$".parse::<PasswordHash>().is_err());
+    assert!("$$".parse::<PasswordHash>().is_err());
+    assert!("$$foo".parse::<PasswordHash>().is_err());
+    assert!("$foo$".parse::<PasswordHash>().is_err());
+    assert!("$-$foo".parse::<PasswordHash>().is_err());
+    assert!("$foo-$bar".parse::<PasswordHash>().is_err());
+    assert!("$-foo$bar".parse::<PasswordHash>().is_err());
 }
 
 #[test]
 fn parse_id_only() {
-    let hash: McfHash = "$6".parse().unwrap();
+    let hash: PasswordHash = "$6".parse().unwrap();
     assert_eq!("6", hash.id());
 }
 
 #[test]
 fn parse_sha512_hash() {
-    let hash: McfHash = SHA512_HASH.parse().unwrap();
+    let hash: PasswordHash = SHA512_HASH.parse().unwrap();
     assert_eq!("6", hash.id());
 
     let mut fields = hash.fields();
@@ -64,7 +64,7 @@ fn parse_sha512_hash() {
 
 #[test]
 fn push_fields() {
-    let mut hash = McfHash::new("$6$rounds=100000").unwrap();
+    let mut hash = PasswordHash::new("$6$rounds=100000").unwrap();
     hash.push_base64(EXAMPLE_SALT, Base64::ShaCrypt);
     hash.push_base64(EXAMPLE_HASH, Base64::ShaCrypt);
     assert_eq!(SHA512_HASH, hash.as_str());


### PR DESCRIPTION
Renames the following:
- `McfHash` => `PasswordHash`
- `McfHashRef` => `PasswordHashRef`

This makes it much clearer the types represent password hash strings