### PR TITLE
mcf v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,7 +863,7 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "mcf"
-version = "0.2.0-pre"
+version = "0.2.0"
 dependencies = [
  "base64ct",
  "hex-literal",

--- a/mcf/CHANGELOG.md
+++ b/mcf/CHANGELOG.md
@@ -4,5 +4,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2025-09-07)
+### Added
+- `(Try)From` impls for `PasswordHash` <=> `String` ([#2027])
+- `(Try)From` impls for `PasswordHashRef` and `&str` ([#2028])
+- `PasswordHash::push_str` ([#2029])
+
+### Changed
+- Rename `McfHash::push_field_base64` to `McfHash::push_base64` ([#2030])
+- Rename `McfHash` => `PasswordHash` ([#2031])
+- Rename `McfHashRef` => `PasswordHashRef` ([#2031])
+- Make `base64` an optional (on-by-default) feature ([#2032])
+
+[#2027]: https://github.com/RustCrypto/formats/pull/2027
+[#2028]: https://github.com/RustCrypto/formats/pull/2028
+[#2029]: https://github.com/RustCrypto/formats/pull/2029
+[#2030]: https://github.com/RustCrypto/formats/pull/2030
+[#2031]: https://github.com/RustCrypto/formats/pull/2031
+[#2032]: https://github.com/RustCrypto/formats/pull/2032
+
 ## 0.1.0 (2025-07-09)
 - Initial release

--- a/mcf/Cargo.toml
+++ b/mcf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcf"
-version = "0.2.0-pre"
+version = "0.2.0"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"


### PR DESCRIPTION
### Added
- `(Try)From` impls for `PasswordHash` <=> `String` ([#2027])
- `(Try)From` impls for `PasswordHashRef` and `&str` ([#2028])
- `PasswordHash::push_str` ([#2029])

### Changed
- Rename `McfHash::push_field_base64` to `McfHash::push_base64` ([#2030])
- Rename `McfHash` => `PasswordHash` ([#2031])
- Rename `McfHashRef` => `PasswordHashRef` ([#2031])
- Make `base64` an optional (on-by-default) feature ([#2032])

[#2027]: https://github.com/RustCrypto/formats/pull/2027
[#2028]: https://github.com/RustCrypto/formats/pull/2028
[#2029]: https://github.com/RustCrypto/formats/pull/2029
[#2030]: https://github.com/RustCrypto/formats/pull/2030
[#2031]: https://github.com/RustCrypto/formats/pull/2031
[#2032]: https://github.com/RustCrypto/formats/pull/2032