### PR TITLE
der: rename `OctetStringRefDeriveHack`

### DIFF
--- a/der/src/asn1.rs
+++ b/der/src/asn1.rs
@@ -44,7 +44,7 @@ pub use self::{
     ia5_string::Ia5StringRef,
     integer::{int::IntRef, uint::UintRef},
     null::Null,
-    octet_string::{OctetStringRef, OctetStringRef2},
+    octet_string::{OctetStringRef, OctetStringRefDeriveHack},
     printable_string::PrintableStringRef,
     private::{Private, PrivateRef},
     sequence::{Sequence, SequenceRef},

--- a/der/src/asn1/octet_string.rs
+++ b/der/src/asn1/octet_string.rs
@@ -5,9 +5,12 @@ use crate::{
     Tag, Writer, asn1::AnyRef, ord::OrdIsValueOrd,
 };
 
-// TODO(tarcieri): custom derive hack until the logic is updated to support `&'a` reference types
+/// Custom derive hack until `der_derive` is updated to support `&'a MyRef` reference types.
+///
+/// This is not considered a stable part of the public API and may be removed without warning.
+// TODO(tarcieri): update `der_derive` to support `OctetStringRef` properly. See #2039
 #[doc(hidden)]
-pub type OctetStringRef2<'a> = &'a OctetStringRef;
+pub type OctetStringRefDeriveHack<'a> = &'a OctetStringRef;
 
 /// ASN.1 `OCTET STRING` type: borrowed form.
 ///

--- a/der_derive/src/asn1_type.rs
+++ b/der_derive/src/asn1_type.rs
@@ -93,8 +93,8 @@ impl Asn1Type {
             Asn1Type::BitString => quote!(::der::asn1::BitStringRef),
             Asn1Type::Ia5String => quote!(::der::asn1::Ia5StringRef),
             Asn1Type::GeneralizedTime => quote!(::der::asn1::GeneralizedTime),
-            // TODO(tarcieri): natively support `OctetStringRef`, remove `OctetStringRef2`
-            Asn1Type::OctetString => quote!(::der::asn1::OctetStringRef2),
+            // TODO(tarcieri): natively support `OctetStringRef`, remove `OctetStringRefDeriveHack`
+            Asn1Type::OctetString => quote!(::der::asn1::OctetStringRefDeriveHack),
             Asn1Type::PrintableString => quote!(::der::asn1::PrintableStringRef),
             Asn1Type::TeletexString => quote!(::der::asn1::TeletexStringRef),
             Asn1Type::VideotexString => quote!(::der::asn1::VideotexStringRef),


### PR DESCRIPTION
This is a temporary type introduced in #1998 until `der_derive` can be updated to use the new type shape (see #2039).