### PR TITLE
der v0.8.0-rc.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,7 +456,7 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.8.0-rc.8"
+version = "0.8.0-rc.9"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "der_derive"
-version = "0.8.0-rc.4"
+version = "0.8.0-rc.5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cmpv2/Cargo.toml
+++ b/cmpv2/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.85"
 
 [dependencies]
 crmf = "=0.3.0-pre.0"
-der = { version = "0.8.0-rc.8", features = ["alloc", "derive", "flagset", "oid"] }
+der = { version = "0.8.0-rc.9", features = ["alloc", "derive", "flagset", "oid"] }
 spki = "0.8.0-rc.4"
 x509-cert = { version = "0.3.0-rc.0", default-features = false }
 

--- a/cms/Cargo.toml
+++ b/cms/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.85"
 
 [dependencies]
 const-oid = { version = "0.10", features = ["db"] }
-der = { version = "0.8.0-rc.8", features = ["ber", "derive", "oid"] }
+der = { version = "0.8.0-rc.9", features = ["ber", "derive", "oid"] }
 spki = "0.8.0-rc.4"
 x509-cert = { version = "0.3.0-rc.0", default-features = false }
 

--- a/crmf/Cargo.toml
+++ b/crmf/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.85"
 
 [dependencies]
 cms = "=0.3.0-pre.0"
-der = { version = "0.8.0-rc.8", features = ["alloc", "derive"] }
+der = { version = "0.8.0-rc.9", features = ["alloc", "derive"] }
 spki = "0.8.0-rc.3"
 x509-cert = { version = "0.3.0-rc.0", default-features = false }
 

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der"
-version = "0.8.0-rc.8"
+version = "0.8.0-rc.9"
 description = """
 Pure Rust embedded-friendly implementation of the Distinguished Encoding Rules
 (DER) for Abstract Syntax Notation One (ASN.1) as described in ITU X.690 with
@@ -20,7 +20,7 @@ rust-version = "1.85"
 arbitrary = { version = "1.4", features = ["derive"], optional = true }
 bytes = { version = "1", optional = true, default-features = false }
 const-oid = { version = "0.10", optional = true }
-der_derive = { version = "0.8.0-rc.4", optional = true }
+der_derive = { version = "0.8.0-rc.5", optional = true }
 flagset = { version = "0.4.7", optional = true }
 pem-rfc7468 = { version = "1.0.0-rc.3", optional = true, features = ["alloc"] }
 time = { version = "0.3.4", optional = true, default-features = false }

--- a/der_derive/Cargo.toml
+++ b/der_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der_derive"
-version = "0.8.0-rc.4"
+version = "0.8.0-rc.5"
 description = "Custom derive support for the `der` crate's `Choice` and `Sequence` traits"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"

--- a/gss-api/Cargo.toml
+++ b/gss-api/Cargo.toml
@@ -16,12 +16,12 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-der = { version = "0.8.0-rc.8", features = ["oid", "alloc"] }
+der = { version = "0.8.0-rc.9", features = ["oid", "alloc"] }
 spki = "0.8.0-rc.4"
 x509-cert = { version = "0.3.0-rc.0", default-features = false }
 
 [dev-dependencies]
-der = { version = "0.8.0-rc.8", features = ["oid", "pem", "alloc"] }
+der = { version = "0.8.0-rc.9", features = ["oid", "pem", "alloc"] }
 hex-literal = "1"
 x509-cert = { version = "0.3.0-rc.0", default-features = false, features = ["pem"] }
 

--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-der = { version = "0.8.0-rc.8", features = ["oid"] }
+der = { version = "0.8.0-rc.9", features = ["oid"] }
 spki = "0.8.0-rc.4"
 
 [dev-dependencies]

--- a/pkcs12/Cargo.toml
+++ b/pkcs12/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-der = { version = "0.8.0-rc.8", features = ["alloc", "derive", "oid"], default-features = false }
+der = { version = "0.8.0-rc.9", features = ["alloc", "derive", "oid"], default-features = false }
 spki = { version = "0.8.0-rc.4", default-features = false }
 x509-cert = { version = "0.3.0-rc.0", default-features = false }
 const-oid = { version = "0.10.0", features = ["db"], default-features = false }

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-der = { version = "0.8.0-rc.8", features = ["oid"] }
+der = { version = "0.8.0-rc.9", features = ["oid"] }
 spki = "0.8.0-rc.4"
 
 # optional dependencies

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-der = { version = "0.8.0-rc.8", features = ["oid"] }
+der = { version = "0.8.0-rc.9", features = ["oid"] }
 spki = "0.8.0-rc.4"
 
 # optional dependencies

--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.85"
 
 [dependencies]
 base16ct = { version = "0.3", optional = true, default-features = false }
-der = { version = "0.8.0-rc.8", optional = true, features = ["oid"] }
+der = { version = "0.8.0-rc.9", optional = true, features = ["oid"] }
 hybrid-array = { version = "0.4", optional = true, default-features = false }
 serdect = { version = "0.4", optional = true, default-features = false, features = ["alloc"] }
 subtle = { version = "2", optional = true, default-features = false }

--- a/spki/Cargo.toml
+++ b/spki/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-der = { version = "0.8.0-rc.8", features = ["oid"] }
+der = { version = "0.8.0-rc.9", features = ["oid"] }
 
 # Optional dependencies
 arbitrary = { version = "1.4", features = ["derive"], optional = true }

--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.85"
 
 [dependencies]
 const-oid = { version = "0.10", features = ["db"] }
-der = { version = "0.8.0-rc.8", features = ["alloc", "derive", "flagset", "oid"] }
+der = { version = "0.8.0-rc.9", features = ["alloc", "derive", "flagset", "oid"] }
 spki = { version = "0.8.0-rc.4", features = ["alloc"] }
 
 # optional dependencies

--- a/x509-ocsp/Cargo.toml
+++ b/x509-ocsp/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.85"
 
 [dependencies]
 const-oid = { version = "0.10.0-rc.0", default-features = false, features = ["db"] }
-der = { version = "0.8.0-rc.8", features = ["alloc", "derive", "oid"] }
+der = { version = "0.8.0-rc.9", features = ["alloc", "derive", "oid"] }
 spki = { version = "0.8.0-rc.4", features = ["alloc"] }
 x509-cert = { version = "0.3.0-rc.0", default-features = false }
 

--- a/x509-tsp/Cargo.toml
+++ b/x509-tsp/Cargo.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 rust-version = "1.85"
 
 [dependencies]
-der = { version = "0.8.0-rc.8", features = ["alloc", "derive", "oid", "pem"] }
+der = { version = "0.8.0-rc.9", features = ["alloc", "derive", "oid", "pem"] }
 cms = { version = "=0.3.0-pre.0" }
 cmpv2 = { version = "=0.3.0-pre.0", features = ["alloc"] }
 x509-cert = { version = "0.3.0-rc.0", default-features = false }


### PR DESCRIPTION
Also releases: `der_derive` v0.8.0-rc.5