### PR TITLE
x509-cert: default version should be v3

### DIFF
--- a/x509-cert/src/certificate.rs
+++ b/x509-cert/src/certificate.rs
@@ -90,13 +90,13 @@ impl Profile for Raw {
 #[derive(Default)]
 pub enum Version {
     /// Version 1 (default)
-    #[default]
     V1 = 0,
 
     /// Version 2
     V2 = 1,
 
     /// Version 3
+    #[default]
     V3 = 2,
 }
 


### PR DESCRIPTION
No new certificates should be built with anything but V3. I believe it should be the default.

Followup to #2057