### PR TITLE
base64ct: add notes on `crypt(3)` alphabet variants

### DIFF
--- a/base64ct/src/alphabet/crypt.rs
+++ b/base64ct/src/alphabet/crypt.rs
@@ -8,6 +8,9 @@ use super::{Alphabet, DecodeStep, EncodeStep};
 /// [.-9]      [A-Z]      [a-z]
 /// 0x2e-0x39, 0x41-0x5a, 0x61-0x7a
 /// ```
+///
+/// Note this encodes using a big endian variant of Base64. Most modern algorithms which can be
+/// used via `crypt(3)` use the little endian [`Base64ShaCrypt`][`crate::Base64ShaCrypt`] variant.
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Base64Crypt;
 

--- a/base64ct/src/alphabet/shacrypt.rs
+++ b/base64ct/src/alphabet/shacrypt.rs
@@ -2,16 +2,23 @@
 
 use super::{Alphabet, DecodeStep, EncodeStep};
 
-/// `crypt(3)` Base64 encoding for the following schemes.
-///  * sha1_crypt,
-///  * sha256_crypt,
-///  * sha512_crypt,
-///  * md5_crypt
+/// Little endian variant of the `crypt(3)` Base64 encoding.
+///
+/// Used by the following schemes:
+/// - md5_crypt
+/// - scrypt
+/// - sha1_crypt
+/// - sha256_crypt
+/// - sha512_crypt
+/// - yescrypt
 ///
 /// ```text
 /// [.-9]      [A-Z]      [a-z]
 /// 0x2e-0x39, 0x41-0x5a, 0x61-0x7a
 /// ```
+///
+/// This uses the same alphabet as [`Base64Crypt`][`crate::Base64Crypt`], but uses a little endian
+/// variant of Base64.
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Base64ShaCrypt;
 


### PR DESCRIPTION
Notes some additional algorithms that use the `Base64ShaCrypt` alphabet including `scrypt` and `yescrypt`, and also notes it's a little endian variant of Base64.