### PR TITLE
der: docs: add `EncodeValue` trait example

### DIFF
--- a/der/src/decode.rs
+++ b/der/src/decode.rs
@@ -193,9 +193,6 @@ pub trait DecodeValue<'a>: Sized {
     type Error: From<Error> + 'static;
 
     /// Attempt to decode this value using the provided [`Reader`].
-    ///
-    /// Note: in this method, implementers should *not* check header tag (which can be
-    /// different from the usual object tag when using IMPLICIT tagging, for example).
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self, Self::Error>;
 }
 


### PR DESCRIPTION
```rust
use der::{Encode, EncodeValue, ErrorKind, FixedTag, Length, Tag, Writer};

/// 1-byte month
struct MyByteMonth(u8);

impl EncodeValue for MyByteMonth {

    fn value_len(&self) -> der::Result<Length> {
        Ok(Length::new(1))
    }

    fn encode_value(&self, writer: &mut impl Writer) -> der::Result<()> {
        writer.write_byte(self.0)?;
        Ok(())
    }
}

impl FixedTag for MyByteMonth {
    const TAG: Tag = Tag::OctetString;
}

let month = MyByteMonth(9);
let mut buf = [0u8; 16];
let month_der = month.encode_to_slice(&mut buf).expect("month to encode");

assert_eq!(month_der, b"\x04\x01\x09");
```
