### PR TITLE
base32ct: Fix a panic when decoding inputs; enforce lengths.

### DIFF
--- a/base32ct/src/encoding.rs
+++ b/base32ct/src/encoding.rs
@@ -101,11 +101,15 @@ impl<T: Alphabet> Encoding for T {
             c[6] = Self::decode_5bits(src_rem[6]);
         };
 
-        if !src_rem.is_empty() {
+        err |= (src_rem.len() == 1) as u8;
+        err |= (src_rem.len() == 3) as u8;
+        err |= (src_rem.len() == 6) as u8;
+
+        if src_rem.len() >= 2 {
             dst_rem[0] = (((c[0] << 3) | (c[1] >> 2)) & 0xff) as u8;
         }
 
-        if src_rem.len() >= 3 {
+        if src_rem.len() >= 4 {
             dst_rem[1] = (((c[1] << 6) | (c[2] << 1) | (c[3] >> 4)) & 0xff) as u8;
         }
 
@@ -113,7 +117,7 @@ impl<T: Alphabet> Encoding for T {
             dst_rem[2] = (((c[3] << 4) | (c[4] >> 1)) & 0xff) as u8;
         }
 
-        if src_rem.len() >= 6 {
+        if src_rem.len() >= 7 {
             dst_rem[3] = (((c[4] << 7) | (c[5] << 2) | (c[6] >> 3)) & 0xff) as u8;
         }
 

--- a/base32ct/tests/vectors.rs
+++ b/base32ct/tests/vectors.rs
@@ -185,3 +185,16 @@ fn encode_base32() {
         );
     }
 }
+
+#[test]
+fn decode_unpadded_truncated() {
+    let string = "foobarba";
+    for length in 1..=7 {
+        let s = &string[..length];
+        let s_padded: String = s.chars().chain(std::iter::repeat('=')).take(8).collect();
+        assert!(s_padded.starts_with(s));
+        assert_eq!(s_padded.len(), 8);
+        assert_eq!(Base32::decode_vec(s), Err(base32ct::Error::InvalidEncoding));
+        assert_eq!(Base32Unpadded::decode_vec(s), Base32::decode_vec(&s_padded));
+    }
+}


### PR DESCRIPTION
Formerly, Encoding::decode would write beyond the end of `dst` when the input (ignoring padding) had (length%8) == 1, 3, or 6.

These lengths are not valid base32, so we now reject them.

I've included a unit test to make sure that we now give equivalent outputs for truncated and non-truncated cases.  Formerly, this test would panic for inputs of the wrong lengths.  To reproduce the panic, try running:

```
let _ = Base32::decode_vec("fre=====");
```

----

I have _not_ verified that rejecting inputs with impossible base32 lengths is the same behavior as the base32 crate.

I have _not_ fuzzed the decoders to verify that no other panics are possible.