### PR TITLE
Bump `rand_core` to v0.10.0-rc-2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aead"
-version = "0.6.0-rc.2"
+version = "0.6.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac8202ab55fcbf46ca829833f347a82a2a4ce0596f0304ac322c2d100030cd56"
+checksum = "03d2d54c4d9e7006f132f615a167865bff927a79ca63d8f637237575ce0a9795"
 dependencies = [
  "crypto-common",
  "inout",
@@ -29,9 +29,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.9.0-rc.1"
+version = "0.9.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e713c57c2a2b19159e7be83b9194600d7e8eb3b7c2cd67e671adf47ce189a05"
+checksum = "fd9e1c818b25efb32214df89b0ec22f01aa397aaeb718d1022bf0635a3bfd1a8"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -40,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.11.0-rc.1"
+version = "0.11.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0686ba04dc80c816104c96cd7782b748f6ad58c5dd4ee619ff3258cf68e83d54"
+checksum = "7f5c07f414d7dc0755870f84c7900425360288d24e0eae4836f9dee19a30fa5f"
 dependencies = [
  "aead",
  "aes",
@@ -79,9 +79,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "ansi-x963-kdf"
-version = "0.1.0-rc.0"
+version = "0.1.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9724ead468937eebb4c515bcf5451da8fed48a26063dcf450cab078669c0d0d8"
+checksum = "092f613e595bafbe1cfbed4affec29003c3d4ed08aebcaeb5c7529563330c8ca"
 dependencies = [
  "digest",
 ]
@@ -195,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "block-padding"
-version = "0.4.0-rc.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e59c1aab3e6c5e56afe1b7e8650be9b5a791cb997bdea449194ae62e4bf8c73"
+checksum = "41d28ed5f5f65056148fd25e1a596b5b6d9e772270abf9a9085d7cbfbf26c563"
 dependencies = [
  "hybrid-array",
 ]
@@ -222,9 +222,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cbc"
-version = "0.2.0-rc.1"
+version = "0.2.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dbf9e5b071e9de872e32b73f485e8f644ff47c7011d95476733e7482ee3e5c3"
+checksum = "3c34a745c272d1f6124df3006881364190a8f033ff3857ce196a17aa4a753096"
 dependencies = [
  "cipher",
 ]
@@ -234,6 +234,17 @@ name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3585020fc6766ef7ff5c58d69819dbca16a19008ae347bb5d3e4e145c495eb38"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.0-rc-2",
+]
 
 [[package]]
 name = "ciborium"
@@ -264,9 +275,9 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.5.0-rc.1"
+version = "0.5.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e12a13eb01ded5d32ee9658d94f553a19e804204f2dc811df69ab4d9e0cb8c7"
+checksum = "155e4a260750fa4f7754649f049748aacc31db238a358d85fd721002f230f92f"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -331,7 +342,7 @@ dependencies = [
  "pbkdf2",
  "pem-rfc7468",
  "pkcs5",
- "rand",
+ "rand 0.10.0-rc.1",
  "rsa",
  "sha1",
  "sha2",
@@ -412,13 +423,13 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.8"
+version = "0.7.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4113edbc9f68c0a64d5b911f803eb245d04bb812680fd56776411f69c670f3e0"
+checksum = "6715836b4946e8585016e80b79c7561476aff3b22f7b756778e7b109d86086c6"
 dependencies = [
  "hybrid-array",
  "num-traits",
- "rand_core",
+ "rand_core 0.10.0-rc-2",
  "serdect",
  "subtle",
  "zeroize",
@@ -426,30 +437,29 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.4"
+version = "0.2.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8235645834fbc6832939736ce2f2d08192652269e11010a6240f61b908a1c6"
+checksum = "919bd05924682a5480aec713596b9e2aabed3a0a6022fab6847f85a99e5f190a"
 dependencies = [
  "hybrid-array",
- "rand_core",
+ "rand_core 0.10.0-rc-2",
 ]
 
 [[package]]
 name = "crypto-primes"
 version = "0.7.0-pre.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f2523fbb68811c8710829417ad488086720a6349e337c38d12fa81e09e50bf"
+source = "git+https://github.com/baloo/crypto-primes.git?branch=baloo%2Frand_core%2F0.10.0-rc.2#620edda8ea6be672697b0e2ce44f1c72091aaad9"
 dependencies = [
  "crypto-bigint",
  "libm",
- "rand_core",
+ "rand_core 0.10.0-rc-2",
 ]
 
 [[package]]
 name = "ctr"
-version = "0.10.0-rc.1"
+version = "0.10.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27e41d01c6f73b9330177f5cf782ae5b581b5f2c7840e298e0275ceee5001434"
+checksum = "3d0ec605a95e78815a4c4b8040217d56d5a1ab37043851ee9e7e65b89afa00e3"
 dependencies = [
  "cipher",
 ]
@@ -502,18 +512,18 @@ dependencies = [
 
 [[package]]
 name = "des"
-version = "0.9.0-rc.1"
+version = "0.9.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f51594a70805988feb1c85495ddec0c2052e4fbe59d9c0bb7f94bfc164f4f90"
+checksum = "512ca722eff02fa73c43e5136f440c46f861d41f9dd7761c1f2817a5ca5d9ad7"
 dependencies = [
  "cipher",
 ]
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.3"
+version = "0.11.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac89f8a64533a9b0eaa73a68e424db0fb1fd6271c74cc0125336a05f090568d"
+checksum = "ea390c940e465846d64775e55e3115d5dc934acb953de6f6e6360bc232fe2bf7"
 dependencies = [
  "block-buffer",
  "const-oid",
@@ -523,9 +533,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.7"
+version = "0.17.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ab355ec063f7a110eb627471058093aba00eb7f4e70afbd15e696b79d1077b"
+checksum = "b56e025680b64794fad81dd46019037773eeb5268a990c5d4cca05bf351c7f0f"
 dependencies = [
  "der",
  "digest",
@@ -544,9 +554,8 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e3be87c458d756141f3b6ee188828132743bf90c7d14843e2835d6443e5fb03"
+version = "0.14.0-rc.16"
+source = "git+https://github.com/RustCrypto/traits#1c34c140fda01c501c109d6efefe0ea58ba88369"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -558,7 +567,7 @@ dependencies = [
  "once_cell",
  "pem-rfc7468",
  "pkcs8",
- "rand_core",
+ "rand_core 0.10.0-rc-2",
  "sec1",
  "subtle",
  "zeroize",
@@ -589,10 +598,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 [[package]]
 name = "ff"
 version = "0.14.0-pre.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d42dd26f5790eda47c1a2158ea4120e32c35ddc9a7743c98a292accc01b54ef3"
+source = "git+https://github.com/tarcieri/ff?branch=rand_core%2Fv0.10.0-rc-2#470e52fa35f7f6cb59f1f005003a14ac50b50cfd"
 dependencies = [
- "rand_core",
+ "rand_core 0.10.0-rc-2",
  "subtle",
 ]
 
@@ -665,9 +673,9 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.6.0-rc.2"
+version = "0.6.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f88107cb02ed63adcc4282942e60c4d09d80208d33b360ce7c729ce6dae1739"
+checksum = "333de57ed9494a40df4bbb866752b100819dde0d18f2264c48f5a08a85fe673d"
 dependencies = [
  "polyval",
 ]
@@ -687,11 +695,10 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 [[package]]
 name = "group"
 version = "0.14.0-pre.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ff6a0b2dd4b981b1ae9e3e6830ab146771f3660d31d57bafd9018805a91b0f1"
+source = "git+https://github.com/tarcieri/group?branch=rand_core%2Fv0.10.0-rc-2#50640b46d5f7eff37aee24d76e991c18444f372e"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.10.0-rc-2",
  "subtle",
 ]
 
@@ -748,18 +755,18 @@ checksum = "bcaaec4551594c969335c98c903c1397853d4198408ea609190f420500f6be71"
 
 [[package]]
 name = "hkdf"
-version = "0.13.0-rc.2"
+version = "0.13.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8ef30358b03ca095a5b910547f4f8d4b9f163e4057669c5233ef595b1ecf008"
+checksum = "cfbb4225acf2b5cc4e12d384672cd6d1f0cb980ff5859ffcf144db25b593a24d"
 dependencies = [
  "hmac",
 ]
 
 [[package]]
 name = "hmac"
-version = "0.13.0-rc.2"
+version = "0.13.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3fd4dc94c318c1ede8a2a48341c250d6ddecd3ba793da2820301a9f92417ad9"
+checksum = "f1c597ac7d6cc8143e30e83ef70915e7f883b18d8bec2e2b2bce47f5bbb06d57"
 dependencies = [
  "digest",
 ]
@@ -787,9 +794,9 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.2.0-rc.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1603f76010ff924b616c8f44815a42eb10fb0b93d308b41deaa8da6d4251fd4b"
+checksum = "c7357b6e7aa75618c7864ebd0634b115a7218b0615f4cb1df33ac3eca23943d4"
 dependencies = [
  "block-padding",
  "hybrid-array",
@@ -935,9 +942,8 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "p256"
-version = "0.14.0-pre.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81b374901df34ee468167a58e2a49e468cb059868479cafebeb804f6b855423d"
+version = "0.14.0-rc.0"
+source = "git+https://github.com/RustCrypto/elliptic-curves#c145e37a3cdd16e0903295b2b91e48fdbda11943"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -954,9 +960,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pbkdf2"
-version = "0.13.0-rc.1"
+version = "0.13.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3fc18bb4460ac250ba6b75dfa7cf9d0b2273e3e623f660bd6ce2c3e902342e"
+checksum = "5f4c07efb9394d8d0057793c35483868c2b8102e287e9d2d4328da0da36bcb4d"
 dependencies = [
  "digest",
  "hmac",
@@ -1021,7 +1027,7 @@ dependencies = [
  "des",
  "hex-literal",
  "pbkdf2",
- "rand_core",
+ "rand_core 0.10.0-rc-2",
  "scrypt",
  "sha1",
  "sha2",
@@ -1035,7 +1041,7 @@ dependencies = [
  "der",
  "hex-literal",
  "pkcs5",
- "rand_core",
+ "rand_core 0.10.0-rc-2",
  "spki",
  "subtle",
  "tempfile",
@@ -1043,9 +1049,9 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.7.0-rc.2"
+version = "0.7.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffd40cc99d0fbb02b4b3771346b811df94194bc103983efa0203c8893755085"
+checksum = "1ad60831c19edda4b20878a676595c357e93a9b4e6dca2ba98d75b01066b317b"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1069,22 +1075,21 @@ dependencies = [
 
 [[package]]
 name = "primefield"
-version = "0.14.0-pre.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fcd4a163053332fd93f39b81c133e96a98567660981654579c90a99062fbf5"
+version = "0.14.0-rc.0"
+source = "git+https://github.com/RustCrypto/elliptic-curves#c145e37a3cdd16e0903295b2b91e48fdbda11943"
 dependencies = [
  "crypto-bigint",
  "ff",
- "rand_core",
+ "rand_core 0.10.0-rc-2",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-pre.9"
+version = "0.14.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c36e8766fcd270fa9c665b9dc364f570695f5a59240949441b077a397f15b74"
+checksum = "36714e8f5443e0cc1497f71972788dd95f75bf7253a4393c9f33f3ff9f556cc9"
 dependencies = [
  "elliptic-curve",
 ]
@@ -1118,7 +1123,7 @@ dependencies = [
  "bitflags",
  "lazy_static",
  "num-traits",
- "rand",
+ "rand 0.9.2",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -1155,7 +1160,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e7d245ced4538f0406b1579d3d4a6515a2ff1bdf20733492e2e4fc90a648769"
+dependencies = [
+ "chacha20",
+ "getrandom",
+ "rand_core 0.10.0-rc-2",
 ]
 
 [[package]]
@@ -1165,7 +1181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1178,12 +1194,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.0-rc-2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "104a23e4e8b77312a823b6b5613edbac78397e2f34320bc7ac4277013ec4478e"
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1223,9 +1245,9 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "rfc6979"
-version = "0.5.0-rc.1"
+version = "0.5.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d369f9c4f79388704648e7bcb92749c0d6cf4397039293a9b747694fa4fb4bae"
+checksum = "63b8e2323084c987a72875b2fd682b7307d5cf14d47e3875bb5e89948e8809d4"
 dependencies = [
  "hmac",
  "subtle",
@@ -1256,8 +1278,7 @@ dependencies = [
 [[package]]
 name = "rsa"
 version = "0.10.0-rc.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf8955ab399f6426998fde6b76ae27233cce950705e758a6c17afd2f6d0e5d52"
+source = "git+https://github.com/RustCrypto/RSA#e85e9711a085671db4b21b848df281635de0576a"
 dependencies = [
  "const-oid",
  "crypto-bigint",
@@ -1265,7 +1286,7 @@ dependencies = [
  "digest",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.10.0-rc-2",
  "sha2",
  "signature",
  "spki",
@@ -1488,9 +1509,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e046edf639aa2e7afb285589e5405de2ef7e61d4b0ac1e30256e3eab911af9"
+checksum = "aa1ae819b9870cadc959a052363de870944a1646932d274a4e270f64bf79e5ef"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1499,9 +1520,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1e3878ab0f98e35b2df35fe53201d088299b41a6bb63e3e34dada2ac4abd924"
+checksum = "19d43dc0354d88b791216bb5c1bfbb60c0814460cc653ae0ebd71f286d0bd927"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1520,12 +1541,12 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "3.0.0-rc.4"
+version = "3.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc280a6ff65c79fbd6622f64d7127f32b85563bca8c53cd2e9141d6744a9056d"
+checksum = "2a0251c9d6468f4ba853b6352b190fb7c1e405087779917c238445eb03993826"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.10.0-rc-2",
 ]
 
 [[package]]
@@ -1790,9 +1811,9 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "universal-hash"
-version = "0.6.0-rc.2"
+version = "0.6.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55be643b40a21558f44806b53ee9319595bc7ca6896372e4e08e5d7d83c9cd6"
+checksum = "9ad6682ddb0189a4d3c2a5c54b8920ab6231ae911db53fc61a0709507bf1713b"
 dependencies = [
  "crypto-common",
  "subtle",
@@ -1834,9 +1855,9 @@ dependencies = [
 
 [[package]]
 name = "whirlpool"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bac3805e93e64eb045b29c2e892653dc03ac856c2e21bb4be2eb025c63e8d42"
+checksum = "cc9c11a2ebed7575871cb4d0ffd752b98d91d008445fbb354e26bf6b193a6208"
 dependencies = [
  "digest",
 ]
@@ -1958,7 +1979,7 @@ dependencies = [
  "ecdsa",
  "hex-literal",
  "p256",
- "rand",
+ "rand 0.10.0-rc.1",
  "rsa",
  "rstest",
  "sha1",
@@ -1989,8 +2010,8 @@ dependencies = [
  "digest",
  "hex-literal",
  "lazy_static",
- "rand",
- "rand_core",
+ "rand 0.10.0-rc.1",
+ "rand_core 0.10.0-rc-2",
  "rsa",
  "sha1",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,3 +59,11 @@ tls_codec_derive = { path = "./tls_codec/derive" }
 x509-tsp = { path = "./x509-tsp" }
 x509-cert = { path = "./x509-cert" }
 x509-ocsp = { path = "./x509-ocsp" }
+
+elliptic-curve = { git = "https://github.com/RustCrypto/traits" }
+crypto-primes = { git = "https://github.com/baloo/crypto-primes.git", branch = "baloo/rand_core/0.10.0-rc.2" }
+ff = { git = "https://github.com/tarcieri/ff", branch = "rand_core/v0.10.0-rc-2" }
+group = { git = "https://github.com/tarcieri/group", branch = "rand_core/v0.10.0-rc-2" }
+p256 = { git = "https://github.com/RustCrypto/elliptic-curves " }
+primefield = { git = "https://github.com/RustCrypto/elliptic-curves " }
+rsa = { git = "https://github.com/RustCrypto/RSA" }

--- a/cmpv2/Cargo.toml
+++ b/cmpv2/Cargo.toml
@@ -21,10 +21,11 @@ der = { version = "0.8.0-rc.9", features = ["alloc", "derive", "flagset", "oid"]
 spki = "0.8.0-rc.4"
 x509-cert = { version = "0.3.0-rc.0", default-features = false }
 
-digest = { version = "0.11.0-pre.10", optional = true, default-features = false }
+# optional features
+digest = { version = "0.11.0-rc.4", optional = true, default-features = false }
 
 [dev-dependencies]
-const-oid = { version = "0.10.0-rc.0", features = ["db"] }
+const-oid = { version = "0.10", features = ["db"] }
 hex-literal = "1"
 
 [features]

--- a/cms/Cargo.toml
+++ b/cms/Cargo.toml
@@ -21,31 +21,31 @@ spki = "0.8.0-rc.4"
 x509-cert = { version = "0.3.0-rc.2", default-features = false }
 
 # optional dependencies
-aes = { version = "0.9.0-rc.1", optional = true }
-aes-kw = { version = "0.3.0-rc.0", optional = true }
-ansi-x963-kdf = { version = "0.1.0-rc.0", optional = true }
-cbc = { version = "0.2.0-rc.1", optional = true }
-cipher = { version = "0.5.0-rc.1", features = ["alloc", "block-padding", "rand_core"], optional = true }
-digest = { version = "0.11.0-rc.1", optional = true }
-elliptic-curve = { version = "0.14.0-rc.14", optional = true }
-rsa = { version = "0.10.0-rc.8", optional = true }
-sha1 = { version = "0.11.0-rc.2", optional = true }
-sha2 = { version = "0.11.0-rc.2", optional = true }
+aes = { version = "0.9.0-rc.2", optional = true }
+aes-kw = { version = "0.3.0-rc.1", optional = true }
+ansi-x963-kdf = { version = "0.1.0-rc.1", optional = true }
+cbc = { version = "0.2.0-rc.2", optional = true }
+cipher = { version = "0.5.0-rc.2", features = ["alloc", "block-padding", "rand_core"], optional = true }
+digest = { version = "0.11.0-rc.4", optional = true }
+elliptic-curve = { version = "0.14.0-rc.16", optional = true }
+rsa = { version = "0.10.0-rc.9", optional = true }
+sha1 = { version = "0.11.0-rc.3", optional = true }
+sha2 = { version = "0.11.0-rc.3", optional = true }
 sha3 = { version = "0.11.0-rc.3", optional = true }
-signature = { version = "3.0.0-rc.3", features = ["digest", "alloc"], optional = true }
+signature = { version = "3.0.0-rc.5", features = ["digest", "alloc"], optional = true }
 zeroize = { version = "1.8.1", optional = true }
 
 [dev-dependencies]
-aes = "0.9.0-rc.1"
+aes = "0.9.0-rc.2"
 getrandom = "0.3"
 hex-literal = "1"
 pem-rfc7468 = "1.0.0-rc.1"
 pkcs5 = "0.8.0-rc.6"
 pbkdf2 = "0.13.0-rc.1"
-rand = "0.9"
+rand = "0.10.0-rc.1"
 rsa = { version = "0.10.0-rc.6", features = ["sha2"] }
 ecdsa = { version = "0.17.0-rc.6", features = ["digest", "pem"] }
-p256 = "=0.14.0-pre.11"
+p256 = "0.14.0-rc.0"
 tokio = { version = "1.45.1", features = ["macros", "rt"] }
 x509-cert = { version = "0.3.0-rc.0", features = ["pem"] }
 

--- a/crmf/Cargo.toml
+++ b/crmf/Cargo.toml
@@ -22,7 +22,7 @@ spki = "0.8.0-rc.3"
 x509-cert = { version = "0.3.0-rc.0", default-features = false }
 
 [dev-dependencies]
-const-oid = "0.10.0-rc.0"
+const-oid = "0.10"
 
 [features]
 alloc = ["der/alloc"]

--- a/pkcs12/Cargo.toml
+++ b/pkcs12/Cargo.toml
@@ -19,19 +19,19 @@ rust-version = "1.85"
 der = { version = "0.8.0-rc.9", features = ["alloc", "derive", "oid"], default-features = false }
 spki = { version = "0.8.0-rc.4", default-features = false }
 x509-cert = { version = "0.3.0-rc.0", default-features = false }
-const-oid = { version = "0.10.0", features = ["db"], default-features = false }
+const-oid = { version = "0.10", features = ["db"], default-features = false }
 cms = { version = "=0.3.0-pre.0", default-features = false }
 
 # optional dependencies
-digest = { version = "0.11.0-rc.0", features = ["alloc"], optional = true }
+digest = { version = "0.11.0-rc.4", features = ["alloc"], optional = true }
 zeroize = { version = "1.8.1", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "1"
-pkcs8 = { version = "0.11.0-rc.6", features = ["pkcs5", "getrandom"] }
+pkcs8 = { version = "0.11.0-rc.7", features = ["pkcs5"] }
 pkcs5 = { version = "0.8.0-rc.6", features = ["pbes2", "3des"] }
-sha2 = "0.11.0-rc.0"
-whirlpool = "0.11.0-rc.0"
+sha2 = "0.11.0-rc.3"
+whirlpool = "0.11.0-rc.3"
 
 [features]
 default = ["pem"]

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -20,15 +20,15 @@ der = { version = "0.8.0-rc.9", features = ["oid"] }
 spki = "0.8.0-rc.4"
 
 # optional dependencies
-cbc = { version = "0.2.0-rc.1", optional = true }
-aes = { version = "0.9.0-rc.1", optional = true, default-features = false }
-aes-gcm = { version = "0.11.0-rc.1", optional = true, default-features = false, features = ["aes"] }
-des = { version = "0.9.0-rc.1", optional = true, default-features = false }
-pbkdf2 = { version = "0.13.0-rc.1", optional = true, default-features = false, features = ["hmac"] }
-rand_core = { version = "0.9", optional = true, default-features = false }
+cbc = { version = "0.2.0-rc.2", optional = true }
+aes = { version = "0.9.0-rc.2", optional = true, default-features = false }
+aes-gcm = { version = "0.11.0-rc.2", optional = true, default-features = false, features = ["aes"] }
+des = { version = "0.9.0-rc.2", optional = true, default-features = false }
+pbkdf2 = { version = "0.13.0-rc.2", optional = true, default-features = false, features = ["hmac"] }
+rand_core = { version = "0.10.0-rc-2", optional = true, default-features = false }
 scrypt = { version = "0.12.0-rc.2", optional = true, default-features = false }
-sha1 = { version = "0.11.0-rc.2", optional = true, default-features = false }
-sha2 = { version = "0.11.0-rc.2", optional = true, default-features = false }
+sha1 = { version = "0.11.0-rc.3", optional = true, default-features = false }
+sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "1"
@@ -39,7 +39,6 @@ std = []
 
 3des = ["dep:des", "pbes2"]
 des-insecure = ["dep:des", "pbes2"]
-getrandom = ["rand_core/os_rng"]
 pbes2 = ["dep:aes", "dep:cbc", "dep:pbkdf2", "dep:scrypt", "dep:sha2", "dep:aes-gcm"]
 sha1-insecure = ["dep:sha1", "pbes2"]
 

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -21,7 +21,7 @@ der = { version = "0.8.0-rc.9", features = ["oid"] }
 spki = "0.8.0-rc.4"
 
 # optional dependencies
-rand_core = { version = "0.9", optional = true, default-features = false }
+rand_core = { version = "0.10.0-rc-2", optional = true, default-features = false }
 pkcs5 = { version = "0.8.0-rc.8", optional = true, features = ["rand_core"] }
 subtle = { version = "2", optional = true, default-features = false }
 
@@ -36,7 +36,6 @@ std = ["alloc", "der/std", "spki/std"]
 3des = ["encryption", "pkcs5/3des"]
 des-insecure = ["encryption", "pkcs5/des-insecure"]
 encryption = ["alloc", "pkcs5/alloc", "pkcs5/pbes2", "rand_core"]
-getrandom = ["rand_core/os_rng"]
 pem = ["alloc", "der/pem", "spki/pem"]
 sha1-insecure = ["encryption", "pkcs5/sha1-insecure"]
 

--- a/spki/Cargo.toml
+++ b/spki/Cargo.toml
@@ -21,8 +21,8 @@ der = { version = "0.8.0-rc.9", features = ["oid"] }
 # Optional dependencies
 arbitrary = { version = "1.4", features = ["derive"], optional = true }
 base64ct = { version = "1", optional = true, default-features = false }
-digest = { version = "0.11.0-rc.0", optional = true, default-features = false }
-sha2 = { version = "0.11.0-rc.0", optional = true, default-features = false }
+digest = { version = "0.11.0-rc.4", optional = true, default-features = false }
+sha2 = { version = "0.11.0-rc.2", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "1"

--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -22,19 +22,19 @@ spki = { version = "0.8.0-rc.4", features = ["alloc"] }
 
 # optional dependencies
 arbitrary = { version = "1.4", features = ["derive"], optional = true }
-digest = { version = "0.11.0-rc.0", optional = true, default-features = false }
-sha1 = { version = "0.11.0-rc.2", default-features = false, optional = true }
-signature = { version = "3.0.0-rc.3", features = ["rand_core"], optional = true }
+digest = { version = "0.11.0-rc.4", optional = true, default-features = false }
+sha1 = { version = "0.11.0-rc.3", default-features = false, optional = true }
+signature = { version = "3.0.0-rc.5", features = ["rand_core"], optional = true }
 tls_codec = { version = "0.4", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
 hex-literal = "1"
-rand = "0.9"
+rand = "0.10.0-rc.1"
 rsa = { version = "0.10.0-rc.8", features = ["sha2"] }
 ecdsa = { version = "0.17.0-rc.6", features = ["digest", "pem"] }
-p256 = "=0.14.0-pre.11"
+p256 = "0.14.0-rc.0"
 rstest = "0.26"
-sha2 = { version = "0.11.0-rc.2", features = ["oid"] }
+sha2 = { version = "0.11.0-rc.3", features = ["oid"] }
 tempfile = "3.5"
 tokio = { version = "1.45", features = ["macros", "rt"] }
 x509-cert-test-support = { path = "./test-support" }

--- a/x509-ocsp/Cargo.toml
+++ b/x509-ocsp/Cargo.toml
@@ -16,23 +16,23 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-const-oid = { version = "0.10.0-rc.0", default-features = false, features = ["db"] }
+const-oid = { version = "0.10", default-features = false, features = ["db"] }
 der = { version = "0.8.0-rc.9", features = ["alloc", "derive", "oid"] }
 spki = { version = "0.8.0-rc.4", features = ["alloc"] }
 x509-cert = { version = "0.3.0-rc.0", default-features = false }
 
 # Optional
-digest = { version = "0.11.0-rc.0", optional = true, default-features = false, features = ["oid"] }
-rand_core = { version = "0.9", optional = true, default-features = false }
-signature = { version = "3.0.0-rc.0", optional = true, default-features = false, features = ["digest", "rand_core"] }
+digest = { version = "0.11.0-rc.4", optional = true, default-features = false, features = ["oid"] }
+rand_core = { version = "0.10.0-rc-2", optional = true, default-features = false }
+signature = { version = "3.0.0-rc.5", optional = true, default-features = false, features = ["digest", "rand_core"] }
 
 [dev-dependencies]
 hex-literal = "1"
 lazy_static = "1.5.0"
-rand = "0.9"
+rand = "0.10.0-rc.1"
 rsa = { version = "0.10.0-rc.1", default-features = false, features = ["encoding", "sha2"] }
-sha1 = { version = "0.11.0-rc.0", default-features = false, features = ["oid"] }
-sha2 = { version = "0.11.0-rc.0", default-features = false, features = ["oid"] }
+sha1 = { version = "0.11.0-rc.3", default-features = false, features = ["oid"] }
+sha2 = { version = "0.11.0-rc.3", default-features = false, features = ["oid"] }
 
 [features]
 rand = ["rand_core"]


### PR DESCRIPTION
This also accordingly bumps all of the underlying crates to versions which (transitively) depend on the `rand`/`rand_core` v0.10 release series