### PR TITLE
der: have `PemReader` decode to `Cow::Owned`

### DIFF
--- a/der/src/reader.rs
+++ b/der/src/reader.rs
@@ -20,6 +20,9 @@ use crate::length::indefinite::read_eoc;
 
 /// Reader trait which reads DER-encoded input.
 pub trait Reader<'r>: Clone {
+    /// Does this reader support the `read_slice` method? (i.e. can it borrow from his input?)
+    const CAN_READ_SLICE: bool;
+
     /// Get the [`EncodingRules`] which should be applied when decoding the input.
     fn encoding_rules(&self) -> EncodingRules;
 

--- a/der/src/reader/pem.rs
+++ b/der/src/reader/pem.rs
@@ -43,6 +43,8 @@ impl<'i> PemReader<'i> {
 
 #[cfg(feature = "pem")]
 impl<'i> Reader<'i> for PemReader<'i> {
+    const CAN_READ_SLICE: bool = false;
+
     fn encoding_rules(&self) -> EncodingRules {
         self.encoding_rules
     }

--- a/der/src/reader/slice.rs
+++ b/der/src/reader/slice.rs
@@ -71,6 +71,8 @@ impl<'a> SliceReader<'a> {
 }
 
 impl<'a> Reader<'a> for SliceReader<'a> {
+    const CAN_READ_SLICE: bool = true;
+
     fn encoding_rules(&self) -> EncodingRules {
         self.encoding_rules
     }


### PR DESCRIPTION
Adds an associated `CAN_READ_SLICE` boolean flag to the `Reader` trait.

When false, `Cow` decodes the owned type rather than the borrow one.

This makes it possible to use `Cow` with `PemReader`, where it will automatically decode the owned type.