### PR TITLE
pem-rfc7468 v1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "1.0.0-rc.3"
+version = "1.0.0"
 dependencies = [
  "base64ct",
 ]

--- a/cms/Cargo.toml
+++ b/cms/Cargo.toml
@@ -39,7 +39,7 @@ zeroize = { version = "1.8.1", optional = true }
 aes = "0.9.0-rc.2"
 getrandom = "0.3"
 hex-literal = "1"
-pem-rfc7468 = "1.0.0-rc.1"
+pem-rfc7468 = "1"
 pkcs5 = "0.8.0-rc.9"
 pbkdf2 = "0.13.0-rc.2"
 rand = "0.10.0-rc.1"

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -22,7 +22,7 @@ bytes = { version = "1", optional = true, default-features = false }
 const-oid = { version = "0.10", optional = true }
 der_derive = { version = "0.8.0-rc.6", optional = true }
 flagset = { version = "0.4.7", optional = true }
-pem-rfc7468 = { version = "1.0.0-rc.3", optional = true, features = ["alloc"] }
+pem-rfc7468 = { version = "1", optional = true, features = ["alloc"] }
 time = { version = "0.3.4", optional = true, default-features = false }
 zeroize = { version = "1.8", optional = true, default-features = false }
 heapless = { version = "0.8", optional = true, default-features = false }

--- a/pem-rfc7468/CHANGELOG.md
+++ b/pem-rfc7468/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.0 (2025-11-08)
+### Added
+- `detect_base64_line_width` and `new_detect_wrap` ([#1464])
+
+### Changed
+- Use `core::error::Error` ([#1571])
+- Upgrade to Rust 2024 edition; MSRV 1.85 ([#1670])
+
+[#1464]: https://github.com/RustCrypto/formats/pull/1464
+[#1571]: https://github.com/RustCrypto/formats/pull/1571
+[#1670]: https://github.com/RustCrypto/formats/pull/1670
+
 ## 0.7.0 (2023-02-26)
 ### Changed
 - MSRV 1.60 ([#802])

--- a/pem-rfc7468/Cargo.toml
+++ b/pem-rfc7468/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pem-rfc7468"
-version = "1.0.0-rc.3"
+version = "1.0.0"
 description = """
 PEM Encoding (RFC 7468) for PKIX, PKCS, and CMS Structures, implementing a
 strict subset of the original Privacy-Enhanced Mail encoding intended


### PR DESCRIPTION
### Added
- `detect_base64_line_width` and `new_detect_wrap` ([#1464])

### Changed
- Use `core::error::Error` ([#1571])
- Upgrade to Rust 2024 edition; MSRV 1.85 ([#1670])

[#1464]: https://github.com/RustCrypto/formats/pull/1464
[#1571]: https://github.com/RustCrypto/formats/pull/1571
[#1670]: https://github.com/RustCrypto/formats/pull/1670