### PR TITLE
base64ct v1.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "base64",
  "proptest",

--- a/base64ct/CHANGELOG.md
+++ b/base64ct/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.8.1 (2025-12-06)
+### Added
+- Notes on `crypt(3)` alphabet variants ([#2073])
+
+### Fixed
+- Switch from `doc_auto_cfg` to `doc_cfg` ([#2072])
+
+[#2072]: https://github.com/RustCrypto/formats/pull/2072
+[#2073]: https://github.com/RustCrypto/formats/pull/2073
+
 ## 1.8.0 (2025-06-04)
 ### Changed
 - Bump edition to 2024; MSRV 1.85 ([#1839])

--- a/base64ct/Cargo.toml
+++ b/base64ct/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base64ct"
-version = "1.8.0"
+version = "1.8.1"
 description = """
 Pure Rust implementation of Base64 (RFC 4648) which avoids any usages of
 data-dependent branches/LUTs and thereby provides portable "best effort"


### PR DESCRIPTION
### Added
- Notes on `crypt(3)` alphabet variants ([#2073])

### Fixed
- Switch from `doc_auto_cfg` to `doc_cfg` ([#2072])

[#2072]: https://github.com/RustCrypto/formats/pull/2072
[#2073]: https://github.com/RustCrypto/formats/pull/2073