### PR TITLE
mcf: add `PasswordHash::push_displayable`

### DIFF
--- a/mcf/src/lib.rs
+++ b/mcf/src/lib.rs
@@ -102,7 +102,7 @@ impl<'a> TryFrom<&'a str> for PasswordHashRef<'a> {
 #[cfg(feature = "alloc")]
 mod allocating {
     use crate::{Error, Field, Fields, PasswordHashRef, Result, fields, validate, validate_id};
-    use alloc::string::String;
+    use alloc::string::{String, ToString};
     use core::{fmt, str};
 
     #[cfg(feature = "base64")]
@@ -179,6 +179,13 @@ mod allocating {
         pub fn push_base64(&mut self, field: &[u8], base64_encoding: Base64) {
             self.0.push(fields::DELIMITER);
             self.0.push_str(&base64_encoding.encode_string(field));
+        }
+
+        /// Push a type which impls [`fmt::Display`], first adding a `$` delimiter and ensuring the
+        /// added characters comprise a valid field.
+        pub fn push_displayable<D: fmt::Display>(&mut self, displayable: D) -> Result<()> {
+            // TODO(tarcieri): avoid intermediate allocation?
+            self.push_str(&displayable.to_string())
         }
 
         /// Push an additional field onto the password hash string, first adding a `$` delimiter.

--- a/mcf/tests/mcf.rs
+++ b/mcf/tests/mcf.rs
@@ -74,9 +74,16 @@ fn parse_sha512_hash() {
 
 #[cfg(feature = "base64")]
 #[test]
-fn push_fields() {
+fn push_base64() {
     let mut hash = PasswordHash::new("$6$rounds=100000").unwrap();
     hash.push_base64(EXAMPLE_SALT, Base64::ShaCrypt);
     hash.push_base64(EXAMPLE_HASH, Base64::ShaCrypt);
     assert_eq!(SHA512_HASH, hash.as_str());
+}
+
+#[test]
+fn push_displayable() {
+    let mut hash = PasswordHash::from_id("6").unwrap();
+    hash.push_displayable("rounds=100000").unwrap();
+    assert_eq!("$6$rounds=100000", hash.as_str());
 }


### PR DESCRIPTION
Adds a method for pushing a field onto an MCF hash which impls the `fmt::Display` trait.

The idea is it can eventually avoid an intermediate allocation as an optimization, although it uses one for now (with a TODO).