### PR TITLE
refactor(ext)!: improve extension API flexibility and ergonomics

### DIFF
--- a/x509-cert/src/builder.rs
+++ b/x509-cert/src/builder.rs
@@ -15,7 +15,7 @@ use crate::{
     certificate::{self, Certificate, TbsCertificate, Version},
     crl::{CertificateList, RevokedCert, TbsCertList},
     ext::{
-        AsExtension, Extensions,
+        Extensions, ToExtension,
         pkix::{AuthorityKeyIdentifier, CrlNumber, SubjectKeyIdentifier},
     },
     serial_number::SerialNumber,
@@ -216,12 +216,12 @@ where
 
     /// Add an extension to this certificate
     ///
-    /// Extensions need to implement [`AsExtension`], examples may be found in
-    /// in [`AsExtension` documentation](../ext/trait.AsExtension.html#examples) or
-    /// [the implementors](../ext/trait.AsExtension.html#implementors).
-    pub fn add_extension<E: AsExtension>(
+    /// Extensions need to implement [`ToExtension`], examples may be found in
+    /// in [`ToExtension` documentation](../ext/trait.ToExtension.html#examples) or
+    /// [the implementors](../ext/trait.ToExtension.html#implementors).
+    pub fn add_extension<E: ToExtension>(
         &mut self,
-        extension: &E,
+        extension: E,
     ) -> core::result::Result<(), E::Error> {
         let ext = extension.to_extension(&self.tbs.subject, &self.extensions)?;
         self.extensions.push(ext);

--- a/x509-cert/src/builder/profile/cabf.rs
+++ b/x509-cert/src/builder/profile/cabf.rs
@@ -8,7 +8,7 @@ use crate::{
     builder::{BuilderProfile, Error, Result},
     certificate::TbsCertificate,
     ext::{
-        AsExtension, Extension,
+        Extension, ToExtension,
         pkix::{
             AuthorityKeyIdentifier, BasicConstraints, KeyUsage, KeyUsages, SubjectKeyIdentifier,
         },

--- a/x509-cert/src/builder/profile/cabf/tls.rs
+++ b/x509-cert/src/builder/profile/cabf/tls.rs
@@ -16,7 +16,7 @@ use crate::{
     builder::{BuilderProfile, Result},
     certificate::TbsCertificate,
     ext::{
-        AsExtension, Extension,
+        Extension, ToExtension,
         pkix::{
             AuthorityKeyIdentifier, BasicConstraints, ExtendedKeyUsage, KeyUsage, KeyUsages,
             SubjectKeyIdentifier, name::GeneralNames,

--- a/x509-cert/src/builder/profile/devid.rs
+++ b/x509-cert/src/builder/profile/devid.rs
@@ -19,7 +19,7 @@ use crate::{
     builder::{BuilderProfile, Result},
     certificate::TbsCertificate,
     ext::{
-        AsExtension, Extension,
+        Extension, ToExtension,
         pkix::{
             AuthorityKeyIdentifier, KeyUsage, KeyUsages, SubjectAltName,
             name::{GeneralName, GeneralNames, HardwareModuleName, OtherName},

--- a/x509-cert/src/request/builder.rs
+++ b/x509-cert/src/request/builder.rs
@@ -8,7 +8,7 @@ use spki::{
 
 use crate::{
     builder::{Builder, Error, NULL_OID, Result},
-    ext::AsExtension,
+    ext::ToExtension,
     name::Name,
     request::{CertReq, CertReqInfo, ExtensionReq, attributes::AsAttribute},
 };
@@ -77,12 +77,12 @@ impl RequestBuilder {
 
     /// Add an extension to this certificate request
     ///
-    /// Extensions need to implement [`AsExtension`], examples may be found in
-    /// in [`AsExtension` documentation](../ext/trait.AsExtension.html#examples) or
-    /// [the implementors](../ext/trait.AsExtension.html#implementors).
-    pub fn add_extension<E: AsExtension>(
+    /// Extensions need to implement [`ToExtension`], examples may be found in
+    /// in [`ToExtension` documentation](../ext/trait.ToExtension.html#examples) or
+    /// [the implementors](../ext/trait.ToExtension.html#implementors).
+    pub fn add_extension<E: ToExtension>(
         &mut self,
-        extension: &E,
+        extension: E,
     ) -> core::result::Result<(), E::Error> {
         let ext = extension.to_extension(&self.info.subject, &self.extension_req.0)?;
 

--- a/x509-cert/tests/builder_crl.rs
+++ b/x509-cert/tests/builder_crl.rs
@@ -17,7 +17,7 @@ use x509_cert::{
     certificate::Rfc5280,
     crl::RevokedCert,
     ext::{
-        AsExtension,
+        ToExtension,
         pkix::{CrlNumber, CrlReason, name::GeneralName},
     },
     name::Name,

--- a/x509-ocsp/src/basic.rs
+++ b/x509-ocsp/src/basic.rs
@@ -130,7 +130,7 @@ mod builder {
     use const_oid::AssociatedOid;
     use digest::Digest;
     use x509_cert::{
-        Certificate, crl::CertificateList, ext::AsExtension, name::Name,
+        Certificate, crl::CertificateList, ext::ToExtension, name::Name,
         serial_number::SerialNumber,
     };
 
@@ -171,7 +171,7 @@ mod builder {
         /// extension encoding fails.
         ///
         /// [RFC 6960 Section 4.4]: https://datatracker.ietf.org/doc/html/rfc6960#section-4.4
-        pub fn with_extension<E: AsExtension>(mut self, ext: E) -> Result<Self, E::Error> {
+        pub fn with_extension<E: ToExtension>(mut self, ext: E) -> Result<Self, E::Error> {
             let ext = ext.to_extension(&Name::default(), &[])?;
             match self.single_extensions {
                 Some(ref mut exts) => exts.push(ext),

--- a/x509-ocsp/src/builder/request.rs
+++ b/x509-ocsp/src/builder/request.rs
@@ -9,7 +9,7 @@ use spki::{DynSignatureAlgorithmIdentifier, SignatureBitStringEncoding};
 use x509_cert::{
     Certificate,
     certificate::Rfc5280,
-    ext::{AsExtension, pkix::name::GeneralName},
+    ext::{ToExtension, pkix::name::GeneralName},
     name::Name,
 };
 
@@ -45,7 +45,7 @@ use x509_cert::{
 ///     .with_request(Request::from_issuer::<Sha1>(&issuer, SerialNumber::from(2usize)).unwrap())
 ///     .with_request(Request::from_issuer::<Sha1>(&issuer, SerialNumber::from(3usize)).unwrap())
 ///     .with_request(Request::from_issuer::<Sha1>(&issuer, SerialNumber::from(4usize)).unwrap())
-///     .with_extension(Nonce::generate(&mut rng, 32).unwrap())
+///     .with_extension(&Nonce::generate(&mut rng, 32).unwrap())
 ///     .unwrap()
 ///     .build();
 ///
@@ -53,7 +53,7 @@ use x509_cert::{
 /// let signer_cert_chain = vec![cert.clone()];
 /// let req = OcspRequestBuilder::default()
 ///     .with_request(Request::from_cert::<Sha1>(&issuer, &cert).unwrap())
-///     .with_extension(Nonce::generate(&mut rng, 32).unwrap())
+///     .with_extension(&Nonce::generate(&mut rng, 32).unwrap())
 ///     .unwrap()
 ///     .sign(&mut signer, Some(signer_cert_chain))
 ///     .unwrap();
@@ -96,7 +96,7 @@ impl OcspRequestBuilder {
     /// extension encoding fails.
     ///
     /// [RFC 6960 Section 4.4]: https://datatracker.ietf.org/doc/html/rfc6960#section-4.4
-    pub fn with_extension<E: AsExtension>(mut self, ext: E) -> Result<Self, E::Error> {
+    pub fn with_extension<E: ToExtension>(mut self, ext: E) -> Result<Self, E::Error> {
         let ext = ext.to_extension(&Name::default(), &[])?;
         match self.tbs.request_extensions {
             Some(ref mut exts) => exts.push(ext),

--- a/x509-ocsp/src/builder/response.rs
+++ b/x509-ocsp/src/builder/response.rs
@@ -11,7 +11,7 @@ use signature::{RandomizedSigner, Signer};
 use spki::{DynSignatureAlgorithmIdentifier, SignatureBitStringEncoding};
 use x509_cert::{
     Certificate,
-    ext::{AsExtension, Extensions},
+    ext::{Extensions, ToExtension},
     name::Name,
 };
 
@@ -53,7 +53,7 @@ use x509_cert::{
 ///     );
 ///
 /// if let Some(nonce) = req.nonce() {
-///     builder = builder.with_extension(nonce).unwrap();
+///     builder = builder.with_extension(&nonce).unwrap();
 /// }
 ///
 /// #[cfg(feature = "std")]
@@ -101,7 +101,7 @@ impl OcspResponseBuilder {
     /// extension encoding fails.
     ///
     /// [RFC 6960 Section 4.4]: https://datatracker.ietf.org/doc/html/rfc6960#section-4.4
-    pub fn with_extension<E: AsExtension>(mut self, ext: E) -> Result<Self, E::Error> {
+    pub fn with_extension<E: ToExtension>(mut self, ext: E) -> Result<Self, E::Error> {
         let ext = ext.to_extension(&Name::default(), &[])?;
         match self.response_extensions {
             Some(ref mut exts) => exts.push(ext),

--- a/x509-ocsp/src/request.rs
+++ b/x509-ocsp/src/request.rs
@@ -127,7 +127,7 @@ mod builder {
     use crate::{CertId, Request, builder::Error};
     use const_oid::AssociatedOid;
     use digest::Digest;
-    use x509_cert::{Certificate, ext::AsExtension, name::Name, serial_number::SerialNumber};
+    use x509_cert::{Certificate, ext::ToExtension, name::Name, serial_number::SerialNumber};
 
     impl Request {
         /// Returns a new `Request` with the specified `CertID`
@@ -172,7 +172,7 @@ mod builder {
         /// extension encoding fails.
         ///
         /// [RFC 6960 Section 4.4]: https://datatracker.ietf.org/doc/html/rfc6960#section-4.4
-        pub fn with_extension<E: AsExtension>(mut self, ext: E) -> Result<Self, E::Error> {
+        pub fn with_extension<E: ToExtension>(mut self, ext: E) -> Result<Self, E::Error> {
             let ext = ext.to_extension(&Name::default(), &[])?;
             match self.single_request_extensions {
                 Some(ref mut exts) => exts.push(ext),

--- a/x509-ocsp/tests/builder.rs
+++ b/x509-ocsp/tests/builder.rs
@@ -126,12 +126,12 @@ fn encode_ocsp_req_multiple_extensions() {
         .with_request(
             Request::from_issuer::<Sha1>(&ISSUER, SerialNumber::from(0x10001usize))
                 .unwrap()
-                .with_extension(single_ext1)
+                .with_extension(&single_ext1)
                 .unwrap(),
         )
-        .with_extension(ext1)
+        .with_extension(&ext1)
         .unwrap()
-        .with_extension(ext2)
+        .with_extension(&ext2)
         .unwrap()
         .build();
     assert_eq!(&req.to_der().unwrap(), &req_der);
@@ -296,12 +296,12 @@ fn encode_ocsp_resp_multiple_extensions() {
             .with_next_update(OcspGeneralizedTime::from(
                 DateTime::new(2020, 1, 1, 0, 0, 0).unwrap(),
             ))
-            .with_extension(single_ext1)
+            .with_extension(&single_ext1)
             .unwrap()
-            .with_extension(single_ext2)
+            .with_extension(&single_ext2)
             .unwrap(),
         )
-        .with_extension(ext1)
+        .with_extension(&ext1)
         .unwrap()
         .sign(
             &mut signer,


### PR DESCRIPTION
Redesigned the extension trait interface to support more flexible ownership patterns and use cases. The trait is renamed from AsExtension to ToExtension and now consumes values by default, with implementations for references and tuples like (OID, bool, &T) to allow direct control over criticality and OID. This makes the API more ergonomic for common scenarios while enabling advanced use cases that weren't previously possible.

BREAKING CHANGE: The AsExtension trait has been renamed to ToExtension, and to_extension now takes self by value. Users must update trait bounds from AsExtension to ToExtension and may need to adjust how extensions are passed to add_extension methods.