### PR TITLE
CI: ignore `RUSTSEC-2023-0089` for `atomic-polyfill`

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,5 +1,6 @@
 [advisories]
 ignore = [
-    "RUSTSEC-2024-0436", #paste
-    "RUSTSEC-2023-0071", #rsa marvin attack - patched in 0.10, we're depending on 0.10.0-rc.0
+    "RUSTSEC-2023-0071", # rsa marvin attack - patched in 0.10, we're depending on 0.10.0-rc.0
+    "RUSTSEC-2023-0089", # atomic-polyfill unmaintained
+    "RUSTSEC-2024-0436", # paste unmaintained
 ] # advisory IDs to ignore e.g. ["RUSTSEC-2019-0001", ...]


### PR DESCRIPTION
This is a transitive dependency of `postcard` (itself a dev-dependency of `serdect`) by way of `heapless`.

We don't care it's unmaintained, the whole dependency chain is just for testing anyway.