### PR TITLE
base64ct: deprecate `Base64Crypt`

### DIFF
--- a/base64ct/src/alphabet/crypt.rs
+++ b/base64ct/src/alphabet/crypt.rs
@@ -1,16 +1,24 @@
 //! `crypt(3)` Base64 encoding.
 
+#![allow(deprecated)]
+
 use super::{Alphabet, DecodeStep, EncodeStep};
 
-/// `crypt(3)` Base64 encoding.
+/// DEPRECATED: non-standard big endian variant of the `crypt(3)` Base64 encoding.
 ///
 /// ```text
 /// [.-9]      [A-Z]      [a-z]
 /// 0x2e-0x39, 0x41-0x5a, 0x61-0x7a
 /// ```
 ///
-/// Note this encodes using a big endian variant of Base64. Most modern algorithms which can be
-/// used via `crypt(3)` use the little endian [`Base64ShaCrypt`][`crate::Base64ShaCrypt`] variant.
+/// <div class="warning">
+/// This encodes using a big endian variant of Base64. Most modern algorithms which can be
+/// used via `crypt(3)` use the [`Base64ShaCrypt`][`crate::Base64ShaCrypt`] encoding.
+/// </div>
+#[deprecated(
+    since = "1.8.2",
+    note = "non-standard encoding. Use Base64ShaCrypt for all crypt(3) algorithms"
+)]
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Base64Crypt;
 

--- a/base64ct/src/alphabet/shacrypt.rs
+++ b/base64ct/src/alphabet/shacrypt.rs
@@ -2,9 +2,9 @@
 
 use super::{Alphabet, DecodeStep, EncodeStep};
 
-/// Little endian variant of the `crypt(3)` Base64 encoding.
+/// `crypt(3)` Base64 encoding.
 ///
-/// Used by the following schemes:
+/// This is the standard Base64 encoding used by password hashes for the following schemes:
 /// - MD5-Crypt
 /// - scrypt
 /// - SHA1-Crypt
@@ -16,9 +16,6 @@ use super::{Alphabet, DecodeStep, EncodeStep};
 /// [.-9]      [A-Z]      [a-z]
 /// 0x2e-0x39, 0x41-0x5a, 0x61-0x7a
 /// ```
-///
-/// This uses the same alphabet as [`Base64Crypt`][`crate::Base64Crypt`], but uses a little endian
-/// variant of Base64.
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Base64ShaCrypt;
 

--- a/base64ct/src/lib.rs
+++ b/base64ct/src/lib.rs
@@ -89,7 +89,6 @@ mod test_vectors;
 pub use crate::{
     alphabet::{
         bcrypt::Base64Bcrypt,
-        crypt::Base64Crypt,
         shacrypt::Base64ShaCrypt,
         standard::{Base64, Base64Unpadded},
         url::{Base64Url, Base64UrlUnpadded},
@@ -100,6 +99,9 @@ pub use crate::{
     errors::{Error, InvalidEncodingError, InvalidLengthError},
     line_ending::LineEnding,
 };
+
+#[allow(deprecated)]
+pub use crate::alphabet::crypt::Base64Crypt;
 
 /// Minimum supported line width.
 const MIN_LINE_WIDTH: usize = 4;

--- a/base64ct/tests/crypt.rs
+++ b/base64ct/tests/crypt.rs
@@ -1,5 +1,7 @@
 //! `crypt(3)` Base64 tests
 
+#![allow(deprecated)]
+
 #[macro_use]
 mod common;
 


### PR DESCRIPTION
Closes #2133

`Base64ShaCrypt` is, as far as I can tell, the standard Base64 alphabet used by all `crypt(3)` hashes. The only exception is `bcrypt` which uses a completely different alphabet (`./A-Za-z0-9`).

As far as I can tell all algorithms that actually use the `./0-9A-Za-z` alphabet do so with the little endian packing implemented in `Base64ShaCrypt`. I'm uncertain about the provenance of the test vectors for `Base64Crypt` but as far as I can tell it's actually a non-standard packing for this particular alphabet.

As such, this deprecates `Base64Crypt`, steering people towards `Base64ShaCrypt` for now. Perhaps in the future we can find better names.