### PR TITLE
der: bound `Decode(Value)::Error` on `core::error::Error`

### DIFF
--- a/der/src/decode.rs
+++ b/der/src/decode.rs
@@ -54,7 +54,7 @@ use crate::EncodingRules;
 )]
 pub trait Decode<'a>: Sized + 'a {
     /// Type returned in the event of a decoding error.
-    type Error: From<Error> + 'static;
+    type Error: core::error::Error + From<Error> + 'static;
 
     /// Attempt to decode this TLV message using the provided decoder.
     fn decode<R: Reader<'a>>(decoder: &mut R) -> Result<Self, Self::Error>;
@@ -193,7 +193,7 @@ impl<T: DecodeOwned<Error = Error> + PemLabel> DecodePem for T {
 /// ```
 pub trait DecodeValue<'a>: Sized {
     /// Type returned in the event of a decoding error.
-    type Error: From<Error> + 'static;
+    type Error: core::error::Error + From<Error> + 'static;
 
     /// Attempt to decode this value using the provided [`Reader`].
     fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self, Self::Error>;
@@ -217,7 +217,7 @@ where
     T: ToOwned + ?Sized,
     &'a T: DecodeValue<'a, Error = E>,
     T::Owned: for<'b> DecodeValue<'b, Error = E>,
-    E: From<Error> + 'static,
+    E: core::error::Error + From<Error> + 'static,
 {
     type Error = E;
 

--- a/der/tests/derive.rs
+++ b/der/tests/derive.rs
@@ -15,13 +15,21 @@
 #[allow(dead_code)]
 pub struct CustomError(der::Error);
 
+impl core::error::Error for CustomError {}
+
+impl core::fmt::Display for CustomError {
+    fn fmt(&self, _: &mut core::fmt::Formatter) -> core::fmt::Result {
+        unimplemented!()
+    }
+}
+
 impl From<der::Error> for CustomError {
     fn from(value: der::Error) -> Self {
         Self(value)
     }
 }
 
-impl From<std::convert::Infallible> for CustomError {
+impl From<core::convert::Infallible> for CustomError {
     fn from(_value: std::convert::Infallible) -> Self {
         unreachable!()
     }


### PR DESCRIPTION
Now that the `Error` trait is always available in `core`, we can use it as a bound for associated error types, which makes them more convenient to use in generic code.