### PR TITLE
base16ct v1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,12 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 [[package]]
 name = "base16ct"
 version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b59d472eab27ade8d770dcb11da7201c11234bef9f82ce7aa517be028d462b"
+
+[[package]]
+name = "base16ct"
+version = "1.0.0"
 
 [[package]]
 name = "base32"
@@ -544,7 +550,7 @@ version = "0.14.0-rc.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ecd2903524729de5d0cba7589121744513feadd56d71980cb480c48caceb11"
 dependencies = [
- "base16ct",
+ "base16ct 0.3.0",
  "crypto-bigint",
  "digest",
  "getrandom 0.3.4",
@@ -1429,7 +1435,7 @@ dependencies = [
 name = "sec1"
 version = "0.8.0-rc.10"
 dependencies = [
- "base16ct",
+ "base16ct 1.0.0",
  "der",
  "hex-literal",
  "hybrid-array",
@@ -1517,10 +1523,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serdect"
 version = "0.4.1"
 dependencies = [
- "base16ct",
+ "base16ct 1.0.0",
  "ciborium",
  "hex-literal",
  "postcard",
@@ -1529,7 +1544,7 @@ dependencies = [
  "serde",
  "serde-json-core",
  "serde_json",
- "toml",
+ "toml 0.9.7",
  "zeroize",
 ]
 
@@ -1762,9 +1777,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00e5e5d9bf2475ac9d4f0d9edab68cc573dc2fd644b0dba36b0c30a92dd9eaa0"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.0.4",
+ "toml_datetime 0.7.2",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
@@ -1793,7 +1823,7 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
  "winnow",
@@ -1827,6 +1857,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "toml_writer"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+
+[[package]]
 name = "trybuild"
 version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1838,7 +1874,7 @@ dependencies = [
  "serde_json",
  "target-triple",
  "termcolor",
- "toml",
+ "toml 0.8.23",
 ]
 
 [[package]]

--- a/base16ct/CHANGELOG.md
+++ b/base16ct/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.0 (2026-01-03)
+### Fixed
+- Switch from `doc_auto_cfg` to `doc_cfg` ([#2072])
+
+[#2072]: https://github.com/RustCrypto/formats/pull/2072
+
 ## 0.3.0 (2025-08-20)
 ### Changed
 - Upgrade to 2024 edition; MSRV 1.85 ([#1670])

--- a/base16ct/Cargo.toml
+++ b/base16ct/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base16ct"
-version = "0.3.0"
+version = "1.0.0"
 description = """
 Pure Rust implementation of Base16 a.k.a hexadecimal (RFC 4648) which avoids
 any usages of data-dependent branches/LUTs and thereby provides portable

--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-base16ct = { version = "0.3", optional = true, default-features = false }
+base16ct = { version = "1", optional = true, default-features = false }
 der = { version = "0.8.0-rc.10", optional = true, features = ["oid"] }
 hybrid-array = { version = "0.4", optional = true, default-features = false }
 serdect = { version = "0.4", optional = true, default-features = false, features = ["alloc"] }

--- a/serdect/Cargo.toml
+++ b/serdect/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-base16ct = { version = "0.3", default-features = false }
+base16ct = { version = "1", default-features = false }
 serde = { version = "1.0.184", default-features = false }
 
 # optional features
@@ -31,7 +31,7 @@ rmp-serde = "1"
 serde = { version = "1.0.184", default-features = false, features = ["derive"] }
 serde_json = "1"
 serde-json-core = { version = "0.6", default-features = false, features = ["std"] }
-toml = "0.8"
+toml = "0.9"
 
 [features]
 default = ["alloc"]


### PR DESCRIPTION
### Fixed
- Switch from `doc_auto_cfg` to `doc_cfg` ([#2072])

[#2072]: https://github.com/RustCrypto/formats/pull/2072