### PR TITLE
Bump dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.5.0-rc.2"
+version = "0.5.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "155e4a260750fa4f7754649f049748aacc31db238a358d85fd721002f230f92f"
+checksum = "98d708bac5451350d56398433b19a7889022fa9187df1a769c0edbc3b2c03167"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -286,6 +286,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
+name = "cmov"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11ed919bd3bae4af5ab56372b627dfc32622aba6cec36906e8ab46746037c9d"
+
+[[package]]
 name = "cmpv2"
 version = "0.3.0-pre.0"
 dependencies = [
@@ -312,7 +318,7 @@ dependencies = [
  "digest",
  "ecdsa",
  "elliptic-curve",
- "getrandom 0.3.4",
+ "getrandom 0.4.0-rc.0",
  "hex-literal",
  "p256",
  "pbkdf2",
@@ -414,10 +420,12 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.10"
+version = "0.7.0-rc.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6715836b4946e8585016e80b79c7561476aff3b22f7b756778e7b109d86086c6"
+checksum = "b2bb4138de6db76c8155b4423e967049fbef2cf84ad6af7f552f73a161941b72"
 dependencies = [
+ "ctutils",
+ "getrandom 0.4.0-rc.0",
  "hybrid-array",
  "num-traits",
  "rand_core 0.10.0-rc-3",
@@ -428,9 +436,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919bd05924682a5480aec713596b9e2aabed3a0a6022fab6847f85a99e5f190a"
+checksum = "e6165b8029cdc3e765b74d3548f85999ee799d5124877ce45c2c85ca78e4d4aa"
 dependencies = [
  "hybrid-array",
  "rand_core 0.10.0-rc-3",
@@ -438,9 +446,8 @@ dependencies = [
 
 [[package]]
 name = "crypto-primes"
-version = "0.7.0-pre.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd9b2855017318a49714c07ee8895b89d3510d54fa6d86be5835de74c389609"
+version = "0.7.0-dev"
+source = "git+https://github.com/tarcieri/crypto-primes?branch=crypto-bigint%2Fv0.7.0-rc.13#f98697886371aa15446ca53ef5b9e9e44efbabf8"
 dependencies = [
  "crypto-bigint",
  "libm",
@@ -454,6 +461,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0ec605a95e78815a4c4b8040217d56d5a1ab37043851ee9e7e65b89afa00e3"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c67c81499f542d1dd38c6a2a2fe825f4dd4bca5162965dd2eea0c8119873d3c"
+dependencies = [
+ "cmov",
+ "subtle",
 ]
 
 [[package]]
@@ -513,9 +530,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.4"
+version = "0.11.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea390c940e465846d64775e55e3115d5dc934acb953de6f6e6360bc232fe2bf7"
+checksum = "ebf9423bafb058e4142194330c52273c343f8a5beb7176d052f0e73b17dd35b9"
 dependencies = [
  "block-buffer",
  "const-oid",
@@ -525,9 +542,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.9"
+version = "0.17.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e914ecb8e11a02f42cc05f6b43675d1e5aa4d446cd207f9f818903a1ab34f19f"
+checksum = "6378f4db5c3e64d1c0bbde7948849ec7aaa231632a7c0ba1cfca7543e34ce9f5"
 dependencies = [
  "der",
  "digest",
@@ -546,14 +563,14 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.17"
+version = "0.14.0-rc.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ecd2903524729de5d0cba7589121744513feadd56d71980cb480c48caceb11"
+checksum = "c8119dc256cd897f759f5b9d45dfd9b066af1c79e71688b7f0a6be989e8fbfbf"
 dependencies = [
  "base16ct 0.3.0",
  "crypto-bigint",
  "digest",
- "getrandom 0.3.4",
+ "getrandom 0.4.0-rc.0",
  "hkdf",
  "hybrid-array",
  "once_cell",
@@ -929,9 +946,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "p256"
-version = "0.14.0-rc.1"
+version = "0.14.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdbe8d6ac92e515ca2179ac331c1e4def09db2217d394683e73dace705c2f0c5"
+checksum = "627b64d2b280c7509b62060609926b1bbf8e5123b2b89dd99c6ee7a520d34260"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -1086,9 +1103,9 @@ dependencies = [
 
 [[package]]
 name = "primefield"
-version = "0.14.0-rc.1"
+version = "0.14.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c3ad342f52c70a953d95acb09a55450fdc07c2214283b81536c3f83f714568e"
+checksum = "9f4ec7ba23a4ad5298525e3208cdef746216a5a5a25614f5ea2c453dcc931092"
 dependencies = [
  "crypto-bigint",
  "rand_core 0.10.0-rc-3",
@@ -1099,9 +1116,9 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-rc.1"
+version = "0.14.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e84a5f07d7a7c85f299e17753a98d8a09f10799894a637c9ce08d834b6ca02"
+checksum = "17a5fb1336715a650d236e3461954e69725d61251fcbd68a9656e7a764d53d09"
 dependencies = [
  "elliptic-curve",
 ]
@@ -1288,8 +1305,7 @@ dependencies = [
 [[package]]
 name = "rsa"
 version = "0.10.0-rc.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e499c52862d75a86c0024cc99dcb6d7127d15af3beae7b03573d62fab7ade08a"
+source = "git+https://github.com/RustCrypto/RSA#aa54cd9b021af284ec10b1307607260f9f516369"
 dependencies = [
  "const-oid",
  "crypto-bigint",
@@ -1301,7 +1317,6 @@ dependencies = [
  "sha2",
  "signature",
  "spki",
- "subtle",
  "zeroize",
 ]
 
@@ -1582,9 +1597,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "3.0.0-rc.5"
+version = "3.0.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0251c9d6468f4ba853b6352b190fb7c1e405087779917c238445eb03993826"
+checksum = "597a96996ccff7dfa16f052bd995b4cecc72af22c35138738dc029f0ead6608d"
 dependencies = [
  "digest",
  "rand_core 0.10.0-rc-3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,4 +61,6 @@ x509-tsp = { path = "./x509-tsp" }
 x509-cert = { path = "./x509-cert" }
 x509-ocsp = { path = "./x509-ocsp" }
 
+crypto-primes = { git = "https://github.com/tarcieri/crypto-primes", branch = "crypto-bigint/v0.7.0-rc.13" }
 rand = { git = "https://github.com/rust-random/rand" }
+rsa = { git = "https://github.com/RustCrypto/RSA" }

--- a/cms/Cargo.toml
+++ b/cms/Cargo.toml
@@ -25,27 +25,27 @@ aes = { version = "0.9.0-rc.2", optional = true }
 aes-kw = { version = "0.3.0-rc.1", optional = true }
 ansi-x963-kdf = { version = "0.1.0-rc.1", optional = true }
 cbc = { version = "0.2.0-rc.2", optional = true }
-cipher = { version = "0.5.0-rc.2", features = ["alloc", "block-padding", "rand_core"], optional = true }
-digest = { version = "0.11.0-rc.4", optional = true }
-elliptic-curve = { version = "0.14.0-rc.16", optional = true }
+cipher = { version = "0.5.0-rc.3", features = ["alloc", "block-padding", "rand_core"], optional = true }
+digest = { version = "0.11.0-rc.5", optional = true }
+elliptic-curve = { version = "0.14.0-rc.18", optional = true }
 rsa = { version = "0.10.0-rc.10", optional = true }
 sha1 = { version = "0.11.0-rc.3", optional = true }
 sha2 = { version = "0.11.0-rc.3", optional = true }
 sha3 = { version = "0.11.0-rc.3", optional = true }
-signature = { version = "3.0.0-rc.5", features = ["digest", "alloc"], optional = true }
+signature = { version = "3.0.0-rc.6", features = ["digest", "alloc"], optional = true }
 zeroize = { version = "1.8.1", optional = true }
 
 [dev-dependencies]
 aes = "0.9.0-rc.2"
-getrandom = "0.3"
+getrandom = "0.4.0-rc.0"
 hex-literal = "1"
 pem-rfc7468 = "1"
 pkcs5 = "0.8.0-rc.10"
 pbkdf2 = "0.13.0-rc.2"
-rand = "0.10.0-rc.1"
+rand = "0.10.0-rc.5"
 rsa = { version = "0.10.0-rc.10", features = ["sha2"] }
-ecdsa = { version = "0.17.0-rc.6", features = ["digest", "pem"] }
-p256 = "0.14.0-rc.1"
+ecdsa = { version = "0.17.0-rc.9", features = ["digest", "pem"] }
+p256 = "0.14.0-rc.2"
 tokio = { version = "1.45.1", features = ["macros", "rt"] }
 x509-cert = { version = "0.3.0-rc.0", features = ["pem"] }
 

--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -29,10 +29,10 @@ tls_codec = { version = "0.4", default-features = false, features = ["derive"], 
 
 [dev-dependencies]
 hex-literal = "1"
-rand = "0.10.0-rc.1"
+rand = "0.10.0-rc.5"
 rsa = { version = "0.10.0-rc.10", features = ["sha2"] }
-ecdsa = { version = "0.17.0-rc.6", features = ["digest", "pem"] }
-p256 = "0.14.0-rc.1"
+ecdsa = { version = "0.17.0-rc.9", features = ["digest", "pem"] }
+p256 = "0.14.0-rc.2"
 rstest = "0.26"
 sha2 = { version = "0.11.0-rc.3", features = ["oid"] }
 tempfile = "3.5"


### PR DESCRIPTION
Updates the following dependencies:
- `cipher` v0.5.0-rc.3
- `crypto-bigint` v0.7.0-rc.13
- `crypto-common` v0.2.0-rc.8
- `crypto-primes` (via git)
- `digest` v0.11.0-rc.5
- `ecdsa` v0.17.0-rc.10
- `elliptic-curve` v0.14.0-rc.18
- `getrandom` v0.4.0-rc.0
- `p256` v0.14.0-rc.1
- `primefield` v0.14.0-rc.2
- `primeorder` v0.14.0-rc.2
- `rsa` (via git)
- `signature` v3.0.0-rc.6

Notably this involved updating `cms` to use the new `Generate` trait