### PR TITLE
sec1: add `ctutils` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1451,6 +1451,7 @@ name = "sec1"
 version = "0.8.0-rc.10"
 dependencies = [
  "base16ct 1.0.0",
+ "ctutils",
  "der",
  "hex-literal",
  "hybrid-array",

--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -18,6 +18,7 @@ rust-version = "1.85"
 
 [dependencies]
 base16ct = { version = "1", optional = true, default-features = false }
+ctutils = { version = "0.3", optional = true }
 der = { version = "0.8.0-rc.10", optional = true, features = ["oid"] }
 hybrid-array = { version = "0.4", optional = true, default-features = false }
 serdect = { version = "0.4", optional = true, default-features = false, features = ["alloc"] }


### PR DESCRIPTION
Allows `ctutils` to be used as an alternative to `subtle`, following `crypto-bigint` making a similar migration