### PR TITLE
base64ct v1.8.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,7 +133,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.8.1"
+version = "1.8.2"
 dependencies = [
  "base64",
  "proptest",

--- a/base64ct/CHANGELOG.md
+++ b/base64ct/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.8.2 (2026-01-03)
+### Changed
+- Deprecate `Base64Crypt` ([#2135])
+
+[#2135]: https://github.com/RustCrypto/formats/pull/2135
+
 ## 1.8.1 (2025-12-06)
 ### Added
 - Notes on `crypt(3)` alphabet variants ([#2073])

--- a/base64ct/Cargo.toml
+++ b/base64ct/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base64ct"
-version = "1.8.1"
+version = "1.8.2"
 description = """
 Pure Rust implementation of Base64 (RFC 4648) which avoids any usages of
 data-dependent branches/LUTs and thereby provides portable "best effort"


### PR DESCRIPTION
### Changed
- Deprecate `Base64Crypt` ([#2135])

[#2135]: https://github.com/RustCrypto/formats/pull/2135