### PR TITLE
mcf: add `Base64::B64`

### DIFF
--- a/mcf/src/base64.rs
+++ b/mcf/src/base64.rs
@@ -2,7 +2,9 @@
 
 #![cfg(feature = "base64")]
 
-use base64ct::{Base64Bcrypt, Base64ShaCrypt, Encoding as _, Error as B64Error};
+use base64ct::{
+    Base64Bcrypt, Base64ShaCrypt, Base64Unpadded as B64, Encoding as _, Error as B64Error,
+};
 
 #[cfg(feature = "alloc")]
 use alloc::{string::String, vec::Vec};
@@ -11,6 +13,15 @@ use alloc::{string::String, vec::Vec};
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum Base64 {
+    /// "B64" encoding: standard Base64 without padding, as used by the PHC string format.
+    ///
+    /// ```text
+    /// [A-Z]      [a-z]      [0-9]      +     /
+    /// 0x41-0x5a, 0x61-0x7a, 0x30-0x39, 0x2b, 0x2f
+    /// ```
+    /// <https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md#b64>
+    B64,
+
     /// bcrypt encoding.
     ///
     /// ```text
@@ -40,6 +51,7 @@ impl Base64 {
     /// Decode a Base64 string into the provided destination buffer.
     pub fn decode(self, src: impl AsRef<[u8]>, dst: &mut [u8]) -> Result<&[u8], B64Error> {
         match self {
+            Self::B64 => B64::decode(src, dst),
             Self::Bcrypt => Base64Bcrypt::decode(src, dst),
             Self::Crypt => Base64ShaCrypt::decode(src, dst),
         }
@@ -49,6 +61,7 @@ impl Base64 {
     #[cfg(feature = "alloc")]
     pub fn decode_vec(self, input: &str) -> Result<Vec<u8>, B64Error> {
         match self {
+            Self::B64 => B64::decode_vec(input),
             Self::Bcrypt => Base64Bcrypt::decode_vec(input),
             Self::Crypt => Base64ShaCrypt::decode_vec(input),
         }
@@ -60,6 +73,7 @@ impl Base64 {
     /// ASCII-encoded Base64 string value.
     pub fn encode<'a>(self, src: &[u8], dst: &'a mut [u8]) -> Result<&'a str, B64Error> {
         match self {
+            Self::B64 => B64::encode(src, dst),
             Self::Bcrypt => Base64Bcrypt::encode(src, dst),
             Self::Crypt => Base64ShaCrypt::encode(src, dst),
         }
@@ -73,6 +87,7 @@ impl Base64 {
     #[cfg(feature = "alloc")]
     pub fn encode_string(self, input: &[u8]) -> String {
         match self {
+            Self::B64 => B64::encode_string(input),
             Self::Bcrypt => Base64Bcrypt::encode_string(input),
             Self::Crypt => Base64ShaCrypt::encode_string(input),
         }
@@ -81,6 +96,7 @@ impl Base64 {
     /// Get the length of Base64 produced by encoding the given bytes.
     pub fn encoded_len(self, bytes: &[u8]) -> usize {
         match self {
+            Self::B64 => B64::encoded_len(bytes),
             Self::Bcrypt => Base64Bcrypt::encoded_len(bytes),
             Self::Crypt => Base64ShaCrypt::encoded_len(bytes),
         }


### PR DESCRIPTION
Adds the variant of Base64 used by the PHC string format