### PR TITLE
const-oid v0.10.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,7 +341,7 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "arbitrary",
  "hex-literal",

--- a/const-oid/CHANGELOG.md
+++ b/const-oid/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.2 (2026-01-07)
+### Added
+- `ObjectIdentifier::from_bytes_sized` which ensures OIDs use all available space in the backing
+  array ([#1852])
+- Microsoft and Kerberos OIDs ([#2035])
+
+### Fixed
+- Switch from `doc_auto_cfg` to `doc_cfg` ([#2072])
+
+[#1852]: https://github.com/RustCrypto/formats/pull/1852
+[#2035]: https://github.com/RustCrypto/formats/pull/2035
+[#2072]: https://github.com/RustCrypto/formats/pull/2072
+
 ## 0.10.1 (2025-04-08)
 ### Added
 - RFC9688 OIDs ([#1692])

--- a/const-oid/Cargo.toml
+++ b/const-oid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "const-oid"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """

--- a/const-oid/LICENSE-MIT
+++ b/const-oid/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2020-2025 The RustCrypto Project Developers
+Copyright (c) 2020-2026 The RustCrypto Project Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated


### PR DESCRIPTION
### Added
- `ObjectIdentifier::from_bytes_sized` which ensures OIDs use all available space in the backing array ([#1852])
- Microsoft and Kerberos OIDs ([#2035])

### Fixed
- Switch from `doc_auto_cfg` to `doc_cfg` ([#2072])

[#1852]: https://github.com/RustCrypto/formats/pull/1852
[#2035]: https://github.com/RustCrypto/formats/pull/2035
[#2072]: https://github.com/RustCrypto/formats/pull/2072