### PR TITLE
base64ct v1.8.3

### DIFF
--- a/.github/workflows/mcf.yml
+++ b/.github/workflows/mcf.yml
@@ -37,10 +37,11 @@ jobs:
       - uses: RustCrypto/actions/cargo-hack-install@master
       - run: cargo hack build --target ${{ matrix.target }} --feature-powerset
 
-  minimal-versions:
-    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
-    with:
-      working-directory: ${{ github.workflow }}
+  # TODO(tarcieri): re-enable after stable release
+  #minimal-versions:
+  #  uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+  #  with:
+  #    working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,7 +127,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.8.2"
+version = "1.8.3"
 dependencies = [
  "base64",
  "proptest",

--- a/base64ct/CHANGELOG.md
+++ b/base64ct/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.8.3 (2026-01-11)
+### Added
+- `Base64Pbkdf2` alphabet ([#2168])
+
+[#2168]: https://github.com/RustCrypto/formats/pull/2168
+
 ## 1.8.2 (2026-01-03)
 ### Changed
 - Deprecate `Base64Crypt` ([#2135])

--- a/base64ct/Cargo.toml
+++ b/base64ct/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base64ct"
-version = "1.8.2"
+version = "1.8.3"
 description = """
 Pure Rust implementation of Base64 (RFC 4648) which avoids any usages of
 data-dependent branches/LUTs and thereby provides portable "best effort"

--- a/mcf/Cargo.toml
+++ b/mcf/Cargo.toml
@@ -15,7 +15,7 @@ in the form `${id}$...`
 """
 
 [dependencies]
-base64ct = { version = "1.7", optional = true }
+base64ct = { version = "1.8.3", optional = true }
 
 [dev-dependencies]
 hex-literal = "1"


### PR DESCRIPTION
### Added
- `Base64Pbkdf2` alphabet ([#2168])

[#2168]: https://github.com/RustCrypto/formats/pull/2168