### PR TITLE
rand_core: upcoming API breaks

### DIFF
--- a/cms/src/builder/kari.rs
+++ b/cms/src/builder/kari.rs
@@ -8,7 +8,7 @@
 
 // Super imports
 use super::{
-    AlgorithmIdentifierOwned, CryptoRng, RecipientInfoBuilder, RecipientInfoType, Result,
+    AlgorithmIdentifierOwned, CryptoRng, RecipientInfoBuilder, RecipientInfoType, Result, RngCore,
     UserKeyingMaterial,
     utils::kw::{KeyWrapAlgorithm, WrappedKey},
 };
@@ -250,10 +250,9 @@ where
         })
     }
 }
-impl<R: ?Sized, C, KA, KW, Enc> RecipientInfoBuilder
-    for KeyAgreeRecipientInfoBuilder<R, C, KA, KW, Enc>
+impl<R, C, KA, KW, Enc> RecipientInfoBuilder for KeyAgreeRecipientInfoBuilder<R, C, KA, KW, Enc>
 where
-    R: CryptoRng,
+    R: CryptoRng + RngCore + ?Sized,
     KA: KeyAgreementAlgorithm + AssociatedOid,
     C: CurveArithmetic + AssociatedOid + PointCompression,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,

--- a/cms/tests/builder.rs
+++ b/cms/tests/builder.rs
@@ -23,7 +23,7 @@ use pem_rfc7468::LineEnding;
 use pkcs5::pbes2::Pbkdf2Params;
 use rand::rngs::SysRng;
 use rsa::pkcs1::DecodeRsaPrivateKey;
-use rsa::rand_core::{CryptoRng, TryRngCore};
+use rsa::rand_core::{CryptoRng, RngCore, TryRngCore};
 use rsa::{Pkcs1v15Encrypt, RsaPrivateKey, RsaPublicKey};
 use rsa::{pkcs1v15, pss};
 use sha2::Sha256;
@@ -690,7 +690,10 @@ fn test_create_password_recipient_info() {
         key_derivation_params: pkcs5::pbes2::Pbkdf2Params,
     }
     impl<'a> Aes128CbcPwriEncryptor<'a> {
-        pub fn new<R: CryptoRng + ?Sized>(challenge_password: &'a [u8], rng: &mut R) -> Self {
+        pub fn new<R: CryptoRng + RngCore + ?Sized>(
+            challenge_password: &'a [u8],
+            rng: &mut R,
+        ) -> Self {
             let mut key_encryption_iv = [0u8; 16];
             rng.fill_bytes(key_encryption_iv.as_mut_slice());
             let key_encryption_iv = key_encryption_iv.into();
@@ -708,7 +711,7 @@ fn test_create_password_recipient_info() {
     }
     impl PwriEncryptor for Aes128CbcPwriEncryptor<'_> {
         const BLOCK_LENGTH_BITS: usize = 128; // AES block length
-        fn encrypt_rfc3211<R: CryptoRng + ?Sized>(
+        fn encrypt_rfc3211<R: CryptoRng + RngCore + ?Sized>(
             &mut self,
             padded_content_encryption_key: &[u8],
             _rng: &mut R,

--- a/phc/src/salt.rs
+++ b/phc/src/salt.rs
@@ -8,7 +8,7 @@ use core::{
     str::{self, FromStr},
 };
 #[cfg(feature = "rand_core")]
-use rand_core::{CryptoRng, TryCryptoRng};
+use rand_core::{CryptoRng, RngCore, TryCryptoRng, TryRngCore};
 
 /// Error message used with `expect` for when internal invariants are violated
 /// (i.e. the contents of a [`Salt`] should always be valid)
@@ -117,14 +117,14 @@ impl Salt {
 
     /// Generate a random [`Salt`] from the given [`CryptoRng`].
     #[cfg(feature = "rand_core")]
-    pub fn from_rng<R: CryptoRng + ?Sized>(rng: &mut R) -> Self {
+    pub fn from_rng<R: CryptoRng + RngCore + ?Sized>(rng: &mut R) -> Self {
         let Ok(out) = Self::try_from_rng(rng);
         out
     }
 
     /// Generate a random [`Salt`] from the given [`TryCryptoRng`].
     #[cfg(feature = "rand_core")]
-    pub fn try_from_rng<R: TryCryptoRng + ?Sized>(
+    pub fn try_from_rng<R: TryCryptoRng + TryRngCore + ?Sized>(
         rng: &mut R,
     ) -> core::result::Result<Self, R::Error> {
         let mut bytes = [0u8; Self::RECOMMENDED_LENGTH];
@@ -256,14 +256,14 @@ impl SaltString {
 
     /// Generate a random B64-encoded [`SaltString`] from [`CryptoRng`].
     #[cfg(feature = "rand_core")]
-    pub fn from_rng<R: CryptoRng + ?Sized>(rng: &mut R) -> Self {
+    pub fn from_rng<R: CryptoRng + RngCore + ?Sized>(rng: &mut R) -> Self {
         let Ok(out) = Self::try_from_rng(rng);
         out
     }
 
     /// Generate a random B64-encoded [`SaltString`] from [`TryCryptoRng`].
     #[cfg(feature = "rand_core")]
-    pub fn try_from_rng<R: TryCryptoRng + ?Sized>(
+    pub fn try_from_rng<R: TryCryptoRng + TryRngCore + ?Sized>(
         rng: &mut R,
     ) -> core::result::Result<Self, R::Error> {
         Ok(Salt::try_from_rng(rng)?.to_salt_string())

--- a/pkcs5/src/pbes2.rs
+++ b/pkcs5/src/pbes2.rs
@@ -19,7 +19,7 @@ use der::{
 };
 
 #[cfg(feature = "rand_core")]
-use rand_core::CryptoRng;
+use rand_core::{CryptoRng, RngCore};
 
 #[cfg(all(feature = "alloc", feature = "pbes2"))]
 use alloc::vec::Vec;
@@ -106,7 +106,7 @@ impl Parameters {
     /// This is currently an alias for [`Parameters::scrypt`]. See that method
     /// for more information.
     #[cfg(all(feature = "pbes2", feature = "rand_core"))]
-    pub fn recommended<R: CryptoRng>(rng: &mut R) -> Self {
+    pub fn recommended<R: CryptoRng + RngCore + ?Sized>(rng: &mut R) -> Self {
         Self::scrypt(rng)
     }
 
@@ -118,7 +118,7 @@ impl Parameters {
     /// This will use AES-256-CBC as the encryption algorithm and SHA-256 as
     /// the hash function for PBKDF2.
     #[cfg(feature = "rand_core")]
-    pub fn pbkdf2<R: CryptoRng>(rng: &mut R) -> Self {
+    pub fn pbkdf2<R: CryptoRng + RngCore + ?Sized>(rng: &mut R) -> Self {
         let mut iv = [0u8; Self::DEFAULT_IV_LEN];
         rng.fill_bytes(&mut iv);
 
@@ -169,7 +169,7 @@ impl Parameters {
     ///
     /// [RustCrypto/formats#1205]: https://github.com/RustCrypto/formats/issues/1205
     #[cfg(all(feature = "pbes2", feature = "rand_core"))]
-    pub fn scrypt<R: CryptoRng>(rng: &mut R) -> Self {
+    pub fn scrypt<R: CryptoRng + RngCore + ?Sized>(rng: &mut R) -> Self {
         let mut iv = [0u8; Self::DEFAULT_IV_LEN];
         rng.fill_bytes(&mut iv);
 

--- a/pkcs8/src/encrypted_private_key_info.rs
+++ b/pkcs8/src/encrypted_private_key_info.rs
@@ -12,7 +12,10 @@ use pkcs5::EncryptionScheme;
 use der::{SecretDocument, asn1::OctetString};
 
 #[cfg(feature = "encryption")]
-use {pkcs5::pbes2, rand_core::CryptoRng};
+use {
+    pkcs5::pbes2,
+    rand_core::{CryptoRng, RngCore},
+};
 
 #[cfg(feature = "pem")]
 use der::pem::PemLabel;
@@ -64,7 +67,7 @@ where
     /// Encrypt the given ASN.1 DER document using a symmetric encryption key
     /// derived from the provided password.
     #[cfg(feature = "encryption")]
-    pub(crate) fn encrypt<R: CryptoRng>(
+    pub(crate) fn encrypt<R: CryptoRng + RngCore + ?Sized>(
         rng: &mut R,
         password: impl AsRef<[u8]>,
         doc: &[u8],

--- a/pkcs8/src/private_key_info.rs
+++ b/pkcs8/src/private_key_info.rs
@@ -17,7 +17,10 @@ use der::{
 
 #[cfg(feature = "encryption")]
 use {
-    crate::EncryptedPrivateKeyInfoRef, der::zeroize::Zeroizing, pkcs5::pbes2, rand_core::CryptoRng,
+    crate::EncryptedPrivateKeyInfoRef,
+    der::zeroize::Zeroizing,
+    pkcs5::pbes2,
+    rand_core::{CryptoRng, RngCore},
 };
 
 #[cfg(feature = "pem")]
@@ -148,7 +151,7 @@ where
     ///   - p: 1
     /// - Cipher: AES-256-CBC (best available option for PKCS#5 encryption)
     #[cfg(feature = "encryption")]
-    pub fn encrypt<R: CryptoRng>(
+    pub fn encrypt<R: CryptoRng + RngCore + ?Sized>(
         &self,
         rng: &mut R,
         password: impl AsRef<[u8]>,

--- a/pkcs8/src/traits.rs
+++ b/pkcs8/src/traits.rs
@@ -6,7 +6,10 @@ use crate::{Error, PrivateKeyInfoRef, Result};
 use der::SecretDocument;
 
 #[cfg(feature = "encryption")]
-use {crate::EncryptedPrivateKeyInfoRef, rand_core::CryptoRng};
+use {
+    crate::EncryptedPrivateKeyInfoRef,
+    rand_core::{CryptoRng, RngCore},
+};
 
 #[cfg(feature = "pem")]
 use {
@@ -101,7 +104,7 @@ pub trait EncodePrivateKey {
     /// Create an [`SecretDocument`] containing the ciphertext of
     /// a PKCS#8 encoded private key encrypted under the given `password`.
     #[cfg(feature = "encryption")]
-    fn to_pkcs8_encrypted_der<R: CryptoRng>(
+    fn to_pkcs8_encrypted_der<R: CryptoRng + RngCore + ?Sized>(
         &self,
         rng: &mut R,
         password: impl AsRef<[u8]>,
@@ -119,7 +122,7 @@ pub trait EncodePrivateKey {
     /// Serialize this private key as an encrypted PEM-encoded PKCS#8 private
     /// key using the `provided` to derive an encryption key.
     #[cfg(all(feature = "encryption", feature = "pem"))]
-    fn to_pkcs8_encrypted_pem<R: CryptoRng>(
+    fn to_pkcs8_encrypted_pem<R: CryptoRng + RngCore + ?Sized>(
         &self,
         rng: &mut R,
         password: impl AsRef<[u8]>,

--- a/x509-cert/src/builder.rs
+++ b/x509-cert/src/builder.rs
@@ -4,7 +4,8 @@ use alloc::vec;
 use core::fmt;
 use der::{Encode, asn1::BitString, referenced::OwnedToRef};
 use signature::{
-    AsyncRandomizedSigner, AsyncSigner, Keypair, RandomizedSigner, Signer, rand_core::CryptoRng,
+    AsyncRandomizedSigner, AsyncSigner, Keypair, RandomizedSigner, Signer,
+    rand_core::{CryptoRng, RngCore},
 };
 use spki::{
     DynSignatureAlgorithmIdentifier, EncodePublicKey, ObjectIdentifier, SignatureBitStringEncoding,
@@ -347,7 +348,7 @@ pub trait Builder: Sized {
         S: Keypair + DynSignatureAlgorithmIdentifier,
         S::VerifyingKey: EncodePublicKey,
         Signature: SignatureBitStringEncoding,
-        R: CryptoRng + ?Sized,
+        R: CryptoRng + RngCore + ?Sized,
     {
         let blob = self.finalize(signer)?;
 
@@ -539,7 +540,7 @@ pub trait AsyncBuilder: Sized {
         S: Keypair + DynSignatureAlgorithmIdentifier,
         S::VerifyingKey: EncodePublicKey,
         Signature: SignatureBitStringEncoding,
-        R: CryptoRng + ?Sized,
+        R: CryptoRng + RngCore + ?Sized,
     {
         let blob = self.finalize(signer)?;
 

--- a/x509-cert/src/serial_number.rs
+++ b/x509-cert/src/serial_number.rs
@@ -8,7 +8,10 @@ use der::{
     asn1::{self, Int},
 };
 #[cfg(feature = "builder")]
-use {alloc::vec, signature::rand_core::CryptoRng};
+use {
+    alloc::vec,
+    signature::rand_core::{CryptoRng, RngCore},
+};
 
 use crate::certificate::{Profile, Rfc5280};
 
@@ -77,7 +80,7 @@ impl<P: Profile> SerialNumber<P> {
     /// of output from the CSPRNG. This currently defaults to a 17-bytes long serial number.
     ///
     /// [ballot 164]: https://cabforum.org/2016/03/31/ballot-164/
-    pub fn generate<R: CryptoRng + ?Sized>(rng: &mut R) -> Self {
+    pub fn generate<R: CryptoRng + RngCore + ?Sized>(rng: &mut R) -> Self {
         Self::generate_with_prefix(&[], 17, rng)
             .expect("a random of 17 is acceptable, and rng may not fail")
     }
@@ -91,7 +94,7 @@ impl<P: Profile> SerialNumber<P> {
     /// equal or below 19 (to account for leading sign disambiguation, and the maximum length of 20).
     ///
     /// [ballot 164]: https://cabforum.org/2016/03/31/ballot-164/
-    pub fn generate_with_prefix<R: CryptoRng + ?Sized>(
+    pub fn generate_with_prefix<R: CryptoRng + RngCore + ?Sized>(
         prefix: &[u8],
         rand_len: usize,
         rng: &mut R,

--- a/x509-ocsp/src/builder/request.rs
+++ b/x509-ocsp/src/builder/request.rs
@@ -3,7 +3,7 @@
 use crate::{OcspRequest, Request, Signature, TbsRequest, Version, builder::Error};
 use alloc::vec::Vec;
 use der::Encode;
-use rand_core::CryptoRng;
+use rand_core::{CryptoRng, RngCore};
 use signature::{RandomizedSigner, Signer};
 use spki::{DynSignatureAlgorithmIdentifier, SignatureBitStringEncoding};
 use x509_cert::{
@@ -148,7 +148,7 @@ impl OcspRequestBuilder {
     where
         S: RandomizedSigner<Sig> + DynSignatureAlgorithmIdentifier,
         Sig: SignatureBitStringEncoding,
-        R: CryptoRng + ?Sized,
+        R: CryptoRng + RngCore + ?Sized,
     {
         let signature_algorithm = signer.signature_algorithm_identifier()?;
         let signature = signer

--- a/x509-ocsp/src/builder/response.rs
+++ b/x509-ocsp/src/builder/response.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use alloc::vec::Vec;
 use der::Encode;
-use rand_core::CryptoRng;
+use rand_core::{CryptoRng, RngCore};
 use signature::{RandomizedSigner, Signer};
 use spki::{DynSignatureAlgorithmIdentifier, SignatureBitStringEncoding};
 use x509_cert::{
@@ -168,7 +168,7 @@ impl OcspResponseBuilder {
     where
         S: RandomizedSigner<Sig> + DynSignatureAlgorithmIdentifier,
         Sig: SignatureBitStringEncoding,
-        R: CryptoRng + ?Sized,
+        R: CryptoRng + RngCore + ?Sized,
     {
         let tbs_response_data = self.into_response_data(produced_at);
         let signature_algorithm = signer.signature_algorithm_identifier()?;

--- a/x509-ocsp/src/ext.rs
+++ b/x509-ocsp/src/ext.rs
@@ -21,7 +21,7 @@ use x509_cert::{
 };
 
 #[cfg(feature = "rand")]
-use rand_core::CryptoRng;
+use rand_core::{CryptoRng, RngCore};
 
 // x509-cert's is not exported
 macro_rules! impl_extension {
@@ -64,7 +64,7 @@ impl Nonce {
     #[cfg(feature = "rand")]
     pub fn generate<R>(rng: &mut R, length: usize) -> Result<Self, der::Error>
     where
-        R: CryptoRng + ?Sized,
+        R: CryptoRng + RngCore + ?Sized,
     {
         let mut bytes = alloc::vec![0; length];
         rng.fill_bytes(&mut bytes);


### PR DESCRIPTION
A recent change in the upcoming rand_core 0.10.0-rc-4 dropped the implied `CryptoRng: RngCore` from the trait. This forces any consumer to make the requirement explicit. This commit prepares for that.