### PR TITLE
chore(deps): bump `cmov` to `0.4.6`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,9 +281,9 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "cmov"
-version = "0.4.3"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c11ed919bd3bae4af5ab56372b627dfc32622aba6cec36906e8ab46746037c9d"
+checksum = "6d5ce5728ecb5285a5dd35f02a6a8e34e0828e0b38e8e632e249a3fe3f320211"
 
 [[package]]
 name = "cmpv2"


### PR DESCRIPTION
This fixes the use of vulnerable cmov versions

See https://github.com/RustCrypto/utils/security/advisories/GHSA-2gqc-6j2q-83qp