### PR TITLE
Revert "rand_core: upcoming API breaks (#2175)"

### DIFF
--- a/cms/src/builder.rs
+++ b/cms/src/builder.rs
@@ -26,10 +26,8 @@ use alloc::{
     vec::Vec,
 };
 use cipher::{
-    BlockModeEncrypt, Iv, Key, KeyIvInit,
-    block_padding::Pkcs7,
-    crypto_common::Generate,
-    rand_core::{CryptoRng, RngCore},
+    BlockModeEncrypt, Iv, Key, KeyIvInit, block_padding::Pkcs7, crypto_common::Generate,
+    rand_core::CryptoRng,
 };
 use const_oid::ObjectIdentifier;
 use core::{cmp::Ordering, fmt, marker::PhantomData};
@@ -439,7 +437,7 @@ impl<'s> SignedDataBuilder<'s> {
         S: RandomizedSigner<Signature>,
         S::VerifyingKey: EncodePublicKey,
         Signature: SignatureBitStringEncoding,
-        R: CryptoRng + RngCore + ?Sized,
+        R: CryptoRng + ?Sized,
     {
         let signer_info = signer_info_builder
             .build_with_rng::<S, Signature, R>(signer, rng)
@@ -484,7 +482,7 @@ impl<'s> SignedDataBuilder<'s> {
         S: AsyncRandomizedSigner<Signature>,
         S::VerifyingKey: EncodePublicKey,
         Signature: SignatureBitStringEncoding,
-        R: CryptoRng + RngCore + ?Sized,
+        R: CryptoRng + ?Sized,
     {
         let signer_info = signer_info_builder
             .build_with_rng_async::<S, Signature, R>(signer, rng)
@@ -608,7 +606,7 @@ impl<'s> SignedDataBuilder<'s> {
 /// formats. All implementations must implement this trait.
 pub trait RecipientInfoBuilder {
     /// Associated Rng type
-    type Rng: CryptoRng + RngCore + ?Sized;
+    type Rng: CryptoRng + ?Sized;
 
     /// Return the recipient info type
     fn recipient_info_type(&self) -> RecipientInfoType;
@@ -670,9 +668,9 @@ impl<R> KeyTransRecipientInfoBuilder<R> {
     }
 }
 
-impl<R> RecipientInfoBuilder for KeyTransRecipientInfoBuilder<R>
+impl<R: ?Sized> RecipientInfoBuilder for KeyTransRecipientInfoBuilder<R>
 where
-    R: CryptoRng + RngCore + ?Sized,
+    R: CryptoRng,
 {
     type Rng = R;
 
@@ -741,9 +739,9 @@ impl<R> KekRecipientInfoBuilder<R> {
     }
 }
 
-impl<R> RecipientInfoBuilder for KekRecipientInfoBuilder<R>
+impl<R: ?Sized> RecipientInfoBuilder for KekRecipientInfoBuilder<R>
 where
-    R: CryptoRng + RngCore + ?Sized,
+    R: CryptoRng,
 {
     type Rng = R;
 
@@ -784,7 +782,7 @@ pub trait PwriEncryptor {
     /// including eventual parameters (e.g. the used iv).
     fn key_encryption_algorithm(&self) -> Result<AlgorithmIdentifierOwned>;
     /// Encrypt the padded content-encryption key twice following RFC 3211, § 2.3.1
-    fn encrypt_rfc3211<R: CryptoRng + RngCore + ?Sized>(
+    fn encrypt_rfc3211<R: CryptoRng + ?Sized>(
         &mut self,
         padded_content_encryption_key: &[u8],
         rng: &mut R,
@@ -832,10 +830,10 @@ where
     }
 }
 
-impl<P, R> PasswordRecipientInfoBuilder<P, R>
+impl<P, R: ?Sized> PasswordRecipientInfoBuilder<P, R>
 where
     P: PwriEncryptor,
-    R: CryptoRng + RngCore + ?Sized,
+    R: CryptoRng,
 {
     /// Wrap the content-encryption key according to [RFC 3211, §2.3.1]:
     ///     ....
@@ -876,7 +874,7 @@ where
 impl<P, R> RecipientInfoBuilder for PasswordRecipientInfoBuilder<P, R>
 where
     P: PwriEncryptor,
-    R: CryptoRng + RngCore + ?Sized,
+    R: CryptoRng + ?Sized,
 {
     type Rng = R;
 
@@ -935,7 +933,7 @@ impl<R> OtherRecipientInfoBuilder<R> {
 
 impl<R> RecipientInfoBuilder for OtherRecipientInfoBuilder<R>
 where
-    R: CryptoRng + RngCore + ?Sized,
+    R: CryptoRng + ?Sized,
 {
     type Rng = R;
 
@@ -1019,7 +1017,7 @@ impl<'c, R> EnvelopedDataBuilder<'c, R> {
 
 impl<'c, R> EnvelopedDataBuilder<'c, R>
 where
-    R: CryptoRng + RngCore + ?Sized,
+    R: CryptoRng + ?Sized,
 {
     /// Add recipient info. A builder is used, which generates a `RecipientInfo` according to
     /// RFC 5652 § 6.2, when `EnvelopedData` is built.
@@ -1216,7 +1214,7 @@ fn encrypt_data<R>(
     rng: &mut R,
 ) -> Result<(Vec<u8>, Vec<u8>, AlgorithmIdentifierOwned)>
 where
-    R: CryptoRng + RngCore + ?Sized,
+    R: CryptoRng + ?Sized,
 {
     match encryption_algorithm_identifier {
         ContentEncryptionAlgorithm::Aes128Cbc => encrypt_block_mode!(

--- a/cms/src/builder/kari.rs
+++ b/cms/src/builder/kari.rs
@@ -8,7 +8,7 @@
 
 // Super imports
 use super::{
-    AlgorithmIdentifierOwned, CryptoRng, RecipientInfoBuilder, RecipientInfoType, Result, RngCore,
+    AlgorithmIdentifierOwned, CryptoRng, RecipientInfoBuilder, RecipientInfoType, Result,
     UserKeyingMaterial,
     utils::kw::{KeyWrapAlgorithm, WrappedKey},
 };
@@ -250,9 +250,10 @@ where
         })
     }
 }
-impl<R, C, KA, KW, Enc> RecipientInfoBuilder for KeyAgreeRecipientInfoBuilder<R, C, KA, KW, Enc>
+impl<R: ?Sized, C, KA, KW, Enc> RecipientInfoBuilder
+    for KeyAgreeRecipientInfoBuilder<R, C, KA, KW, Enc>
 where
-    R: CryptoRng + RngCore + ?Sized,
+    R: CryptoRng,
     KA: KeyAgreementAlgorithm + AssociatedOid,
     C: CurveArithmetic + AssociatedOid + PointCompression,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,

--- a/cms/tests/builder.rs
+++ b/cms/tests/builder.rs
@@ -23,7 +23,7 @@ use pem_rfc7468::LineEnding;
 use pkcs5::pbes2::Pbkdf2Params;
 use rand::rngs::SysRng;
 use rsa::pkcs1::DecodeRsaPrivateKey;
-use rsa::rand_core::{CryptoRng, RngCore, TryRngCore};
+use rsa::rand_core::{CryptoRng, TryRngCore};
 use rsa::{Pkcs1v15Encrypt, RsaPrivateKey, RsaPublicKey};
 use rsa::{pkcs1v15, pss};
 use sha2::Sha256;
@@ -690,10 +690,7 @@ fn test_create_password_recipient_info() {
         key_derivation_params: pkcs5::pbes2::Pbkdf2Params,
     }
     impl<'a> Aes128CbcPwriEncryptor<'a> {
-        pub fn new<R: CryptoRng + RngCore + ?Sized>(
-            challenge_password: &'a [u8],
-            rng: &mut R,
-        ) -> Self {
+        pub fn new<R: CryptoRng + ?Sized>(challenge_password: &'a [u8], rng: &mut R) -> Self {
             let mut key_encryption_iv = [0u8; 16];
             rng.fill_bytes(key_encryption_iv.as_mut_slice());
             let key_encryption_iv = key_encryption_iv.into();
@@ -711,7 +708,7 @@ fn test_create_password_recipient_info() {
     }
     impl PwriEncryptor for Aes128CbcPwriEncryptor<'_> {
         const BLOCK_LENGTH_BITS: usize = 128; // AES block length
-        fn encrypt_rfc3211<R: CryptoRng + RngCore + ?Sized>(
+        fn encrypt_rfc3211<R: CryptoRng + ?Sized>(
             &mut self,
             padded_content_encryption_key: &[u8],
             _rng: &mut R,

--- a/phc/src/salt.rs
+++ b/phc/src/salt.rs
@@ -8,7 +8,7 @@ use core::{
     str::{self, FromStr},
 };
 #[cfg(feature = "rand_core")]
-use rand_core::{CryptoRng, RngCore, TryCryptoRng, TryRngCore};
+use rand_core::{CryptoRng, TryCryptoRng};
 
 /// Error message used with `expect` for when internal invariants are violated
 /// (i.e. the contents of a [`Salt`] should always be valid)
@@ -117,14 +117,14 @@ impl Salt {
 
     /// Generate a random [`Salt`] from the given [`CryptoRng`].
     #[cfg(feature = "rand_core")]
-    pub fn from_rng<R: CryptoRng + RngCore + ?Sized>(rng: &mut R) -> Self {
+    pub fn from_rng<R: CryptoRng + ?Sized>(rng: &mut R) -> Self {
         let Ok(out) = Self::try_from_rng(rng);
         out
     }
 
     /// Generate a random [`Salt`] from the given [`TryCryptoRng`].
     #[cfg(feature = "rand_core")]
-    pub fn try_from_rng<R: TryCryptoRng + TryRngCore + ?Sized>(
+    pub fn try_from_rng<R: TryCryptoRng + ?Sized>(
         rng: &mut R,
     ) -> core::result::Result<Self, R::Error> {
         let mut bytes = [0u8; Self::RECOMMENDED_LENGTH];
@@ -256,14 +256,14 @@ impl SaltString {
 
     /// Generate a random B64-encoded [`SaltString`] from [`CryptoRng`].
     #[cfg(feature = "rand_core")]
-    pub fn from_rng<R: CryptoRng + RngCore + ?Sized>(rng: &mut R) -> Self {
+    pub fn from_rng<R: CryptoRng + ?Sized>(rng: &mut R) -> Self {
         let Ok(out) = Self::try_from_rng(rng);
         out
     }
 
     /// Generate a random B64-encoded [`SaltString`] from [`TryCryptoRng`].
     #[cfg(feature = "rand_core")]
-    pub fn try_from_rng<R: TryCryptoRng + TryRngCore + ?Sized>(
+    pub fn try_from_rng<R: TryCryptoRng + ?Sized>(
         rng: &mut R,
     ) -> core::result::Result<Self, R::Error> {
         Ok(Salt::try_from_rng(rng)?.to_salt_string())

--- a/pkcs5/src/pbes2.rs
+++ b/pkcs5/src/pbes2.rs
@@ -19,7 +19,7 @@ use der::{
 };
 
 #[cfg(feature = "rand_core")]
-use rand_core::{CryptoRng, RngCore};
+use rand_core::CryptoRng;
 
 #[cfg(all(feature = "alloc", feature = "pbes2"))]
 use alloc::vec::Vec;
@@ -106,7 +106,7 @@ impl Parameters {
     /// This is currently an alias for [`Parameters::scrypt`]. See that method
     /// for more information.
     #[cfg(all(feature = "pbes2", feature = "rand_core"))]
-    pub fn recommended<R: CryptoRng + RngCore + ?Sized>(rng: &mut R) -> Self {
+    pub fn recommended<R: CryptoRng>(rng: &mut R) -> Self {
         Self::scrypt(rng)
     }
 
@@ -118,7 +118,7 @@ impl Parameters {
     /// This will use AES-256-CBC as the encryption algorithm and SHA-256 as
     /// the hash function for PBKDF2.
     #[cfg(feature = "rand_core")]
-    pub fn pbkdf2<R: CryptoRng + RngCore + ?Sized>(rng: &mut R) -> Self {
+    pub fn pbkdf2<R: CryptoRng>(rng: &mut R) -> Self {
         let mut iv = [0u8; Self::DEFAULT_IV_LEN];
         rng.fill_bytes(&mut iv);
 
@@ -169,7 +169,7 @@ impl Parameters {
     ///
     /// [RustCrypto/formats#1205]: https://github.com/RustCrypto/formats/issues/1205
     #[cfg(all(feature = "pbes2", feature = "rand_core"))]
-    pub fn scrypt<R: CryptoRng + RngCore + ?Sized>(rng: &mut R) -> Self {
+    pub fn scrypt<R: CryptoRng>(rng: &mut R) -> Self {
         let mut iv = [0u8; Self::DEFAULT_IV_LEN];
         rng.fill_bytes(&mut iv);
 

--- a/pkcs8/src/encrypted_private_key_info.rs
+++ b/pkcs8/src/encrypted_private_key_info.rs
@@ -12,10 +12,7 @@ use pkcs5::EncryptionScheme;
 use der::{SecretDocument, asn1::OctetString};
 
 #[cfg(feature = "encryption")]
-use {
-    pkcs5::pbes2,
-    rand_core::{CryptoRng, RngCore},
-};
+use {pkcs5::pbes2, rand_core::CryptoRng};
 
 #[cfg(feature = "pem")]
 use der::pem::PemLabel;
@@ -67,7 +64,7 @@ where
     /// Encrypt the given ASN.1 DER document using a symmetric encryption key
     /// derived from the provided password.
     #[cfg(feature = "encryption")]
-    pub(crate) fn encrypt<R: CryptoRng + RngCore + ?Sized>(
+    pub(crate) fn encrypt<R: CryptoRng>(
         rng: &mut R,
         password: impl AsRef<[u8]>,
         doc: &[u8],

--- a/pkcs8/src/private_key_info.rs
+++ b/pkcs8/src/private_key_info.rs
@@ -17,10 +17,7 @@ use der::{
 
 #[cfg(feature = "encryption")]
 use {
-    crate::EncryptedPrivateKeyInfoRef,
-    der::zeroize::Zeroizing,
-    pkcs5::pbes2,
-    rand_core::{CryptoRng, RngCore},
+    crate::EncryptedPrivateKeyInfoRef, der::zeroize::Zeroizing, pkcs5::pbes2, rand_core::CryptoRng,
 };
 
 #[cfg(feature = "pem")]
@@ -151,7 +148,7 @@ where
     ///   - p: 1
     /// - Cipher: AES-256-CBC (best available option for PKCS#5 encryption)
     #[cfg(feature = "encryption")]
-    pub fn encrypt<R: CryptoRng + RngCore + ?Sized>(
+    pub fn encrypt<R: CryptoRng>(
         &self,
         rng: &mut R,
         password: impl AsRef<[u8]>,

--- a/pkcs8/src/traits.rs
+++ b/pkcs8/src/traits.rs
@@ -6,10 +6,7 @@ use crate::{Error, PrivateKeyInfoRef, Result};
 use der::SecretDocument;
 
 #[cfg(feature = "encryption")]
-use {
-    crate::EncryptedPrivateKeyInfoRef,
-    rand_core::{CryptoRng, RngCore},
-};
+use {crate::EncryptedPrivateKeyInfoRef, rand_core::CryptoRng};
 
 #[cfg(feature = "pem")]
 use {
@@ -104,7 +101,7 @@ pub trait EncodePrivateKey {
     /// Create an [`SecretDocument`] containing the ciphertext of
     /// a PKCS#8 encoded private key encrypted under the given `password`.
     #[cfg(feature = "encryption")]
-    fn to_pkcs8_encrypted_der<R: CryptoRng + RngCore + ?Sized>(
+    fn to_pkcs8_encrypted_der<R: CryptoRng>(
         &self,
         rng: &mut R,
         password: impl AsRef<[u8]>,
@@ -122,7 +119,7 @@ pub trait EncodePrivateKey {
     /// Serialize this private key as an encrypted PEM-encoded PKCS#8 private
     /// key using the `provided` to derive an encryption key.
     #[cfg(all(feature = "encryption", feature = "pem"))]
-    fn to_pkcs8_encrypted_pem<R: CryptoRng + RngCore + ?Sized>(
+    fn to_pkcs8_encrypted_pem<R: CryptoRng>(
         &self,
         rng: &mut R,
         password: impl AsRef<[u8]>,

--- a/x509-cert/src/builder.rs
+++ b/x509-cert/src/builder.rs
@@ -4,8 +4,7 @@ use alloc::vec;
 use core::fmt;
 use der::{Encode, asn1::BitString, referenced::OwnedToRef};
 use signature::{
-    AsyncRandomizedSigner, AsyncSigner, Keypair, RandomizedSigner, Signer,
-    rand_core::{CryptoRng, RngCore},
+    AsyncRandomizedSigner, AsyncSigner, Keypair, RandomizedSigner, Signer, rand_core::CryptoRng,
 };
 use spki::{
     DynSignatureAlgorithmIdentifier, EncodePublicKey, ObjectIdentifier, SignatureBitStringEncoding,
@@ -348,7 +347,7 @@ pub trait Builder: Sized {
         S: Keypair + DynSignatureAlgorithmIdentifier,
         S::VerifyingKey: EncodePublicKey,
         Signature: SignatureBitStringEncoding,
-        R: CryptoRng + RngCore + ?Sized,
+        R: CryptoRng + ?Sized,
     {
         let blob = self.finalize(signer)?;
 
@@ -540,7 +539,7 @@ pub trait AsyncBuilder: Sized {
         S: Keypair + DynSignatureAlgorithmIdentifier,
         S::VerifyingKey: EncodePublicKey,
         Signature: SignatureBitStringEncoding,
-        R: CryptoRng + RngCore + ?Sized,
+        R: CryptoRng + ?Sized,
     {
         let blob = self.finalize(signer)?;
 

--- a/x509-cert/src/serial_number.rs
+++ b/x509-cert/src/serial_number.rs
@@ -8,10 +8,7 @@ use der::{
     asn1::{self, Int},
 };
 #[cfg(feature = "builder")]
-use {
-    alloc::vec,
-    signature::rand_core::{CryptoRng, RngCore},
-};
+use {alloc::vec, signature::rand_core::CryptoRng};
 
 use crate::certificate::{Profile, Rfc5280};
 
@@ -80,7 +77,7 @@ impl<P: Profile> SerialNumber<P> {
     /// of output from the CSPRNG. This currently defaults to a 17-bytes long serial number.
     ///
     /// [ballot 164]: https://cabforum.org/2016/03/31/ballot-164/
-    pub fn generate<R: CryptoRng + RngCore + ?Sized>(rng: &mut R) -> Self {
+    pub fn generate<R: CryptoRng + ?Sized>(rng: &mut R) -> Self {
         Self::generate_with_prefix(&[], 17, rng)
             .expect("a random of 17 is acceptable, and rng may not fail")
     }
@@ -94,7 +91,7 @@ impl<P: Profile> SerialNumber<P> {
     /// equal or below 19 (to account for leading sign disambiguation, and the maximum length of 20).
     ///
     /// [ballot 164]: https://cabforum.org/2016/03/31/ballot-164/
-    pub fn generate_with_prefix<R: CryptoRng + RngCore + ?Sized>(
+    pub fn generate_with_prefix<R: CryptoRng + ?Sized>(
         prefix: &[u8],
         rand_len: usize,
         rng: &mut R,

--- a/x509-ocsp/src/builder/request.rs
+++ b/x509-ocsp/src/builder/request.rs
@@ -3,7 +3,7 @@
 use crate::{OcspRequest, Request, Signature, TbsRequest, Version, builder::Error};
 use alloc::vec::Vec;
 use der::Encode;
-use rand_core::{CryptoRng, RngCore};
+use rand_core::CryptoRng;
 use signature::{RandomizedSigner, Signer};
 use spki::{DynSignatureAlgorithmIdentifier, SignatureBitStringEncoding};
 use x509_cert::{
@@ -148,7 +148,7 @@ impl OcspRequestBuilder {
     where
         S: RandomizedSigner<Sig> + DynSignatureAlgorithmIdentifier,
         Sig: SignatureBitStringEncoding,
-        R: CryptoRng + RngCore + ?Sized,
+        R: CryptoRng + ?Sized,
     {
         let signature_algorithm = signer.signature_algorithm_identifier()?;
         let signature = signer

--- a/x509-ocsp/src/builder/response.rs
+++ b/x509-ocsp/src/builder/response.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use alloc::vec::Vec;
 use der::Encode;
-use rand_core::{CryptoRng, RngCore};
+use rand_core::CryptoRng;
 use signature::{RandomizedSigner, Signer};
 use spki::{DynSignatureAlgorithmIdentifier, SignatureBitStringEncoding};
 use x509_cert::{
@@ -168,7 +168,7 @@ impl OcspResponseBuilder {
     where
         S: RandomizedSigner<Sig> + DynSignatureAlgorithmIdentifier,
         Sig: SignatureBitStringEncoding,
-        R: CryptoRng + RngCore + ?Sized,
+        R: CryptoRng + ?Sized,
     {
         let tbs_response_data = self.into_response_data(produced_at);
         let signature_algorithm = signer.signature_algorithm_identifier()?;

--- a/x509-ocsp/src/ext.rs
+++ b/x509-ocsp/src/ext.rs
@@ -21,7 +21,7 @@ use x509_cert::{
 };
 
 #[cfg(feature = "rand")]
-use rand_core::{CryptoRng, RngCore};
+use rand_core::CryptoRng;
 
 // x509-cert's is not exported
 macro_rules! impl_extension {
@@ -64,7 +64,7 @@ impl Nonce {
     #[cfg(feature = "rand")]
     pub fn generate<R>(rng: &mut R, length: usize) -> Result<Self, der::Error>
     where
-        R: CryptoRng + RngCore + ?Sized,
+        R: CryptoRng + ?Sized,
     {
         let mut bytes = alloc::vec![0; length];
         rng.fill_bytes(&mut bytes);


### PR DESCRIPTION
This reverts commit 08b22e560845f25ab89e432ece3f7fa4330007c9.

Those changes are no longer necessary after fixes made in rand_core 0.10.0-rc-5