### PR TITLE
chore(deps): bump `rand_core` to `0.10.0-rc-5`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,13 +207,13 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0-rc.6"
+version = "0.10.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f895fb33c1ad22da4bc79d37c0bddff8aee2ba4575705345eb73b8ffbc386074"
+checksum = "31cd65b2ca03198c223cd9a8fa1152c4ec251cd79049f6dc584152ad3fb5ba9d"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "rand_core 0.10.0-rc-3",
+ "rand_core 0.10.0-rc-5",
 ]
 
 [[package]]
@@ -281,9 +281,9 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "cmov"
-version = "0.4.6"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d5ce5728ecb5285a5dd35f02a6a8e34e0828e0b38e8e632e249a3fe3f320211"
+checksum = "de0758edba32d61d1fd9f4d69491b47604b91ee2f7e6b33de7e54ca4ebe55dc3"
 
 [[package]]
 name = "cmpv2"
@@ -318,7 +318,7 @@ dependencies = [
  "pbkdf2",
  "pem-rfc7468",
  "pkcs5",
- "rand 0.10.0-rc.6",
+ "rand 0.10.0-rc.7",
  "rsa",
  "sha1",
  "sha2",
@@ -414,15 +414,15 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.16"
+version = "0.7.0-rc.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbd828c64d6fecf364ec127641e5ce0f8d6e3264a6c466b4a4bdcbec5b038b9e"
+checksum = "f9f9a78b88bb8255ec59a81423aa92ada22f96883f9ae59dcb68613907636ae5"
 dependencies = [
  "ctutils",
  "getrandom 0.4.0-rc.0",
  "hybrid-array",
  "num-traits",
- "rand_core 0.10.0-rc-3",
+ "rand_core 0.10.0-rc-5",
  "serdect",
  "subtle",
  "zeroize",
@@ -430,24 +430,24 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.9"
+version = "0.2.0-rc.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b8986f836d4aeb30ccf4c9d3bd562fd716074cfd7fc4a2948359fbd21ed809"
+checksum = "7d2bcc93d5cde6659e8649fc412894417ebc14dee54cfc6ee439c683a4a58342"
 dependencies = [
  "getrandom 0.4.0-rc.0",
  "hybrid-array",
- "rand_core 0.10.0-rc-3",
+ "rand_core 0.10.0-rc-5",
 ]
 
 [[package]]
 name = "crypto-primes"
-version = "0.7.0-pre.6"
+version = "0.7.0-pre.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79c98a281f9441200b24e3151407a629bfbe720399186e50516da939195e482"
+checksum = "c6372ba15f988d7cd77e9cfbc42b269601c006f2f16a21a72b886136caf04bfb"
 dependencies = [
  "crypto-bigint",
  "libm",
- "rand_core 0.10.0-rc-3",
+ "rand_core 0.10.0-rc-5",
 ]
 
 [[package]]
@@ -461,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "ctutils"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c67c81499f542d1dd38c6a2a2fe825f4dd4bca5162965dd2eea0c8119873d3c"
+checksum = "1005a6d4446f5120ef475ad3d2af2b30c49c2c9c6904258e3bb30219bebed5e4"
 dependencies = [
  "cmov",
  "subtle",
@@ -526,9 +526,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.5"
+version = "0.11.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebf9423bafb058e4142194330c52273c343f8a5beb7176d052f0e73b17dd35b9"
+checksum = "ca14c221bd9052fd2da7c34a2eeb5ae54732db28be47c35937be71793d675422"
 dependencies = [
  "block-buffer",
  "const-oid",
@@ -538,9 +538,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.12"
+version = "0.17.0-rc.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18ccb2afbad0782e073b602a7d59dd08966d2b1173e08f96ebffb5446f8446d"
+checksum = "9b41c78c24288ec2644aeb00ebc58bf8cd5ff7e9a6e2a2081ed80fa7e1262dc7"
 dependencies = [
  "der",
  "digest",
@@ -559,9 +559,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.21"
+version = "0.14.0-rc.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee4530cd12af66979d89bf0e555c66d04ed1dc58479d7a69d93c98a650fb738"
+checksum = "660a2eb4d46d49d4c0b122a8cad1fa7926b0e3e99913796243a7dc280021eadc"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -573,7 +573,7 @@ dependencies = [
  "once_cell",
  "pem-rfc7468",
  "pkcs8",
- "rand_core 0.10.0-rc-3",
+ "rand_core 0.10.0-rc-5",
  "rustcrypto-ff",
  "rustcrypto-group",
  "sec1",
@@ -691,7 +691,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "rand_core 0.10.0-rc-3",
+ "rand_core 0.10.0-rc-5",
  "wasip2",
 ]
 
@@ -943,9 +943,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "p256"
-version = "0.14.0-rc.4"
+version = "0.14.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb1056e093c065babf1e9b0e28a630bee540cd9f5b905230ddc475175f5e9c8"
+checksum = "a23920bdbd723052dc68186e64d2c8c2a3b2998b42d61df716f67ef771ce358b"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -977,7 +977,7 @@ version = "0.6.0-rc.1"
 dependencies = [
  "base64ct",
  "getrandom 0.4.0-rc.0",
- "rand_core 0.10.0-rc-3",
+ "rand_core 0.10.0-rc-5",
  "subtle",
 ]
 
@@ -1033,7 +1033,7 @@ dependencies = [
  "des",
  "hex-literal",
  "pbkdf2",
- "rand_core 0.10.0-rc-3",
+ "rand_core 0.10.0-rc-5",
  "scrypt",
  "sha1",
  "sha2",
@@ -1047,7 +1047,7 @@ dependencies = [
  "der",
  "hex-literal",
  "pkcs5",
- "rand_core 0.10.0-rc-3",
+ "rand_core 0.10.0-rc-5",
  "spki",
  "subtle",
  "tempfile",
@@ -1094,13 +1094,13 @@ dependencies = [
 
 [[package]]
 name = "primefield"
-version = "0.14.0-rc.4"
+version = "0.14.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf1f23afb6185c65efc97605dea2d667f6fef71cb9d3198992c1e9002e349f40"
+checksum = "a90de6476b10bedc43e91337d44440bec88d9c253a1676a046438ba3f5b1d81e"
 dependencies = [
  "crypto-bigint",
  "crypto-common",
- "rand_core 0.10.0-rc-3",
+ "rand_core 0.10.0-rc-5",
  "rustcrypto-ff",
  "subtle",
  "zeroize",
@@ -1108,9 +1108,9 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-rc.4"
+version = "0.14.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12459f4bdd430002b812017c3e99f5a27a2c2689f1b140cb82a73c23431b71e0"
+checksum = "e77e56adc743d5601fe3a8534fc7c25a28fbbb7470a4f13700e8fdc6817d3a0a"
 dependencies = [
  "elliptic-curve",
 ]
@@ -1185,13 +1185,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0-rc.6"
+version = "0.10.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bccc05ac8fad6ee391f3cc6725171817eed960345e2fb42ad229d486c1ca2d98"
+checksum = "9d3e6a909ceda8ceb12ef039b675ecf4bbe6def127e773cac109ab8347633766"
 dependencies = [
  "chacha20",
  "getrandom 0.4.0-rc.0",
- "rand_core 0.10.0-rc-3",
+ "rand_core 0.10.0-rc-5",
 ]
 
 [[package]]
@@ -1215,9 +1215,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0-rc-3"
+version = "0.10.0-rc-5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66ee92bc15280519ef199a274fe0cafff4245d31bc39aaa31c011ad56cb1f05"
+checksum = "05a06e03bd1f2ae861ab9e7498b6c64ed3dadb9ce175c0464a2522a5f23c0045"
 
 [[package]]
 name = "rand_xorshift"
@@ -1294,9 +1294,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.10.0-rc.12"
+version = "0.10.0-rc.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a2b1eacbc34fbaf77f6f1db1385518446008d49b9f9f59dc9d1340fce4ca9e"
+checksum = "8ff85dd219e338d42a2eada54ad71fe515717e08d53f728a8803de33b83f80b8"
 dependencies = [
  "const-oid",
  "crypto-bigint",
@@ -1304,7 +1304,7 @@ dependencies = [
  "digest",
  "pkcs1",
  "pkcs8",
- "rand_core 0.10.0-rc-3",
+ "rand_core 0.10.0-rc-5",
  "sha2",
  "signature",
  "spki",
@@ -1355,7 +1355,7 @@ version = "0.14.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9cd37111549306f79b09aa2618e15b1e8241b7178c286821e3dd71579db4db"
 dependencies = [
- "rand_core 0.10.0-rc-3",
+ "rand_core 0.10.0-rc-5",
  "subtle",
 ]
 
@@ -1365,7 +1365,7 @@ version = "0.14.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e394cd734b5f97dfc3484fa42aad7acd912961c2bcd96c99aa05b3d6cab7cafd"
 dependencies = [
- "rand_core 0.10.0-rc-3",
+ "rand_core 0.10.0-rc-5",
  "rustcrypto-ff",
  "subtle",
 ]
@@ -1440,9 +1440,7 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.8.0-rc.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2568531a8ace88b848310caa98fb2115b151ef924d54aa523e659c21b9d32d71"
+version = "0.8.0-rc.12"
 dependencies = [
  "base16ct",
  "ctutils",
@@ -1581,12 +1579,12 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "3.0.0-rc.6"
+version = "3.0.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a96996ccff7dfa16f052bd995b4cecc72af22c35138738dc029f0ead6608d"
+checksum = "c04b70a14ee5f15e2e0c785a5fdb2e9a51138dfe13ba3cf8eab037a9e60b1879"
 dependencies = [
  "digest",
- "rand_core 0.10.0-rc-3",
+ "rand_core 0.10.0-rc-5",
 ]
 
 [[package]]
@@ -1950,7 +1948,7 @@ dependencies = [
  "ecdsa",
  "hex-literal",
  "p256",
- "rand 0.10.0-rc.6",
+ "rand 0.10.0-rc.7",
  "rsa",
  "rstest",
  "sha1",
@@ -1981,8 +1979,8 @@ dependencies = [
  "digest",
  "hex-literal",
  "lazy_static",
- "rand 0.10.0-rc.6",
- "rand_core 0.10.0-rc-3",
+ "rand 0.10.0-rc.7",
+ "rand_core 0.10.0-rc-5",
  "rsa",
  "sha1",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
     "pkcs5",
     "pkcs8",
     "pkcs12",
-#    "sec1",
+    "sec1",
     "serdect",
     "spki",
     "tai64",
@@ -29,7 +29,6 @@ members = [
     "x509-cert/test-support",
     "x509-ocsp"
 ]
-exclude = ["sec1"]
 
 [profile.dev]
 opt-level = 2
@@ -52,7 +51,7 @@ pkcs1 = { path = "./pkcs1" }
 pkcs5 = { path = "./pkcs5" }
 pkcs8 = { path = "./pkcs8" }
 pkcs12 = { path = "./pkcs12" }
-#sec1 = { path = "./sec1" }
+sec1 = { path = "./sec1" }
 serdect = { path = "./serdect" }
 spki = { path = "./spki" }
 tai64 = { path = "./tai64" }

--- a/cms/Cargo.toml
+++ b/cms/Cargo.toml
@@ -28,7 +28,7 @@ cbc = { version = "0.2.0-rc.2", optional = true }
 cipher = { version = "0.5.0-rc.3", features = ["alloc", "block-padding", "rand_core"], optional = true }
 digest = { version = "0.11.0-rc.5", optional = true }
 elliptic-curve = { version = "0.14.0-rc.21", optional = true }
-rsa = { version = "0.10.0-rc.11", optional = true }
+rsa = { version = "0.10.0-rc.13", optional = true }
 sha1 = { version = "0.11.0-rc.3", optional = true }
 sha2 = { version = "0.11.0-rc.3", optional = true }
 sha3 = { version = "0.11.0-rc.3", optional = true }
@@ -42,10 +42,10 @@ hex-literal = "1"
 pem-rfc7468 = "1"
 pkcs5 = "0.8.0-rc.12"
 pbkdf2 = "0.13.0-rc.6"
-rand = "0.10.0-rc.6"
-rsa = { version = "0.10.0-rc.11", features = ["sha2"] }
-ecdsa = { version = "0.17.0-rc.12", features = ["digest", "pem"] }
-p256 = "0.14.0-rc.4"
+rand = "0.10.0-rc.7"
+rsa = { version = "0.10.0-rc.13", features = ["sha2"] }
+ecdsa = { version = "0.17.0-rc.13", features = ["digest", "pem"] }
+p256 = "0.14.0-rc.5"
 tokio = { version = "1.45.1", features = ["macros", "rt"] }
 x509-cert = { version = "0.3.0-rc.3", features = ["pem"] }
 

--- a/cms/src/builder.rs
+++ b/cms/src/builder.rs
@@ -26,10 +26,8 @@ use alloc::{
     vec::Vec,
 };
 use cipher::{
-    BlockModeEncrypt, Iv, Key, KeyIvInit,
-    block_padding::Pkcs7,
-    crypto_common::Generate,
-    rand_core::{CryptoRng, RngCore},
+    BlockModeEncrypt, Iv, Key, KeyIvInit, block_padding::Pkcs7, crypto_common::Generate,
+    rand_core::CryptoRng,
 };
 use const_oid::ObjectIdentifier;
 use core::{cmp::Ordering, fmt, marker::PhantomData};
@@ -439,7 +437,7 @@ impl<'s> SignedDataBuilder<'s> {
         S: RandomizedSigner<Signature>,
         S::VerifyingKey: EncodePublicKey,
         Signature: SignatureBitStringEncoding,
-        R: CryptoRng + RngCore + ?Sized,
+        R: CryptoRng + ?Sized,
     {
         let signer_info = signer_info_builder
             .build_with_rng::<S, Signature, R>(signer, rng)
@@ -484,7 +482,7 @@ impl<'s> SignedDataBuilder<'s> {
         S: AsyncRandomizedSigner<Signature>,
         S::VerifyingKey: EncodePublicKey,
         Signature: SignatureBitStringEncoding,
-        R: CryptoRng + RngCore + ?Sized,
+        R: CryptoRng + ?Sized,
     {
         let signer_info = signer_info_builder
             .build_with_rng_async::<S, Signature, R>(signer, rng)
@@ -608,7 +606,7 @@ impl<'s> SignedDataBuilder<'s> {
 /// formats. All implementations must implement this trait.
 pub trait RecipientInfoBuilder {
     /// Associated Rng type
-    type Rng: CryptoRng + RngCore + ?Sized;
+    type Rng: CryptoRng + ?Sized;
 
     /// Return the recipient info type
     fn recipient_info_type(&self) -> RecipientInfoType;
@@ -670,9 +668,9 @@ impl<R> KeyTransRecipientInfoBuilder<R> {
     }
 }
 
-impl<R> RecipientInfoBuilder for KeyTransRecipientInfoBuilder<R>
+impl<R: ?Sized> RecipientInfoBuilder for KeyTransRecipientInfoBuilder<R>
 where
-    R: CryptoRng + RngCore + ?Sized,
+    R: CryptoRng,
 {
     type Rng = R;
 
@@ -741,9 +739,9 @@ impl<R> KekRecipientInfoBuilder<R> {
     }
 }
 
-impl<R> RecipientInfoBuilder for KekRecipientInfoBuilder<R>
+impl<R: ?Sized> RecipientInfoBuilder for KekRecipientInfoBuilder<R>
 where
-    R: CryptoRng + RngCore + ?Sized,
+    R: CryptoRng,
 {
     type Rng = R;
 
@@ -784,7 +782,7 @@ pub trait PwriEncryptor {
     /// including eventual parameters (e.g. the used iv).
     fn key_encryption_algorithm(&self) -> Result<AlgorithmIdentifierOwned>;
     /// Encrypt the padded content-encryption key twice following RFC 3211, § 2.3.1
-    fn encrypt_rfc3211<R: CryptoRng + RngCore + ?Sized>(
+    fn encrypt_rfc3211<R: CryptoRng + ?Sized>(
         &mut self,
         padded_content_encryption_key: &[u8],
         rng: &mut R,
@@ -832,10 +830,10 @@ where
     }
 }
 
-impl<P, R> PasswordRecipientInfoBuilder<P, R>
+impl<P, R: ?Sized> PasswordRecipientInfoBuilder<P, R>
 where
     P: PwriEncryptor,
-    R: CryptoRng + RngCore + ?Sized,
+    R: CryptoRng,
 {
     /// Wrap the content-encryption key according to [RFC 3211, §2.3.1]:
     ///     ....
@@ -876,7 +874,7 @@ where
 impl<P, R> RecipientInfoBuilder for PasswordRecipientInfoBuilder<P, R>
 where
     P: PwriEncryptor,
-    R: CryptoRng + RngCore + ?Sized,
+    R: CryptoRng + ?Sized,
 {
     type Rng = R;
 
@@ -935,7 +933,7 @@ impl<R> OtherRecipientInfoBuilder<R> {
 
 impl<R> RecipientInfoBuilder for OtherRecipientInfoBuilder<R>
 where
-    R: CryptoRng + RngCore + ?Sized,
+    R: CryptoRng + ?Sized,
 {
     type Rng = R;
 
@@ -1019,7 +1017,7 @@ impl<'c, R> EnvelopedDataBuilder<'c, R> {
 
 impl<'c, R> EnvelopedDataBuilder<'c, R>
 where
-    R: CryptoRng + RngCore + ?Sized,
+    R: CryptoRng + ?Sized,
 {
     /// Add recipient info. A builder is used, which generates a `RecipientInfo` according to
     /// RFC 5652 § 6.2, when `EnvelopedData` is built.
@@ -1216,7 +1214,7 @@ fn encrypt_data<R>(
     rng: &mut R,
 ) -> Result<(Vec<u8>, Vec<u8>, AlgorithmIdentifierOwned)>
 where
-    R: CryptoRng + RngCore + ?Sized,
+    R: CryptoRng + ?Sized,
 {
     match encryption_algorithm_identifier {
         ContentEncryptionAlgorithm::Aes128Cbc => encrypt_block_mode!(

--- a/cms/src/builder/kari.rs
+++ b/cms/src/builder/kari.rs
@@ -8,7 +8,7 @@
 
 // Super imports
 use super::{
-    AlgorithmIdentifierOwned, CryptoRng, RecipientInfoBuilder, RecipientInfoType, Result, RngCore,
+    AlgorithmIdentifierOwned, CryptoRng, RecipientInfoBuilder, RecipientInfoType, Result,
     UserKeyingMaterial,
     utils::kw::{KeyWrapAlgorithm, WrappedKey},
 };
@@ -250,9 +250,10 @@ where
         })
     }
 }
-impl<R, C, KA, KW, Enc> RecipientInfoBuilder for KeyAgreeRecipientInfoBuilder<R, C, KA, KW, Enc>
+impl<R: ?Sized, C, KA, KW, Enc> RecipientInfoBuilder
+    for KeyAgreeRecipientInfoBuilder<R, C, KA, KW, Enc>
 where
-    R: CryptoRng + RngCore + ?Sized,
+    R: CryptoRng,
     KA: KeyAgreementAlgorithm + AssociatedOid,
     C: CurveArithmetic + AssociatedOid + PointCompression,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,

--- a/cms/tests/builder.rs
+++ b/cms/tests/builder.rs
@@ -23,7 +23,7 @@ use pem_rfc7468::LineEnding;
 use pkcs5::pbes2::Pbkdf2Params;
 use rand::rngs::SysRng;
 use rsa::pkcs1::DecodeRsaPrivateKey;
-use rsa::rand_core::{CryptoRng, RngCore, TryRngCore};
+use rsa::rand_core::{CryptoRng, TryRngCore};
 use rsa::{Pkcs1v15Encrypt, RsaPrivateKey, RsaPublicKey};
 use rsa::{pkcs1v15, pss};
 use sha2::Sha256;
@@ -690,10 +690,7 @@ fn test_create_password_recipient_info() {
         key_derivation_params: pkcs5::pbes2::Pbkdf2Params,
     }
     impl<'a> Aes128CbcPwriEncryptor<'a> {
-        pub fn new<R: CryptoRng + RngCore + ?Sized>(
-            challenge_password: &'a [u8],
-            rng: &mut R,
-        ) -> Self {
+        pub fn new<R: CryptoRng + ?Sized>(challenge_password: &'a [u8], rng: &mut R) -> Self {
             let mut key_encryption_iv = [0u8; 16];
             rng.fill_bytes(key_encryption_iv.as_mut_slice());
             let key_encryption_iv = key_encryption_iv.into();
@@ -711,7 +708,7 @@ fn test_create_password_recipient_info() {
     }
     impl PwriEncryptor for Aes128CbcPwriEncryptor<'_> {
         const BLOCK_LENGTH_BITS: usize = 128; // AES block length
-        fn encrypt_rfc3211<R: CryptoRng + RngCore + ?Sized>(
+        fn encrypt_rfc3211<R: CryptoRng + ?Sized>(
             &mut self,
             padded_content_encryption_key: &[u8],
             _rng: &mut R,
@@ -921,7 +918,7 @@ fn test_create_password_recipient_info() {
     let enveloped_data = builder
         .add_recipient_info(recipient_info_builder)
         .expect("Could not add a recipient info")
-        .build_with_rng(&mut the_one_and_only_rng.unwrap_mut())
+        .build_with_rng(&mut the_one_and_only_rng)
         .expect("Building EnvelopedData failed");
     let enveloped_data_der = enveloped_data
         .to_der()

--- a/phc/Cargo.toml
+++ b/phc/Cargo.toml
@@ -20,7 +20,7 @@ subtle = { version = "2", default-features = false }
 
 # optional dependencies
 getrandom = { version = "0.4.0-rc.0", optional = true, default-features = false }
-rand_core = { version = "0.10.0-rc-3", optional = true, default-features = false }
+rand_core = { version = "0.10.0-rc-5", optional = true, default-features = false }
 
 [features]
 default = ["rand_core"]

--- a/phc/src/salt.rs
+++ b/phc/src/salt.rs
@@ -8,7 +8,7 @@ use core::{
     str::{self, FromStr},
 };
 #[cfg(feature = "rand_core")]
-use rand_core::{CryptoRng, RngCore, TryCryptoRng, TryRngCore};
+use rand_core::{CryptoRng, TryCryptoRng};
 
 /// Error message used with `expect` for when internal invariants are violated
 /// (i.e. the contents of a [`Salt`] should always be valid)
@@ -117,14 +117,14 @@ impl Salt {
 
     /// Generate a random [`Salt`] from the given [`CryptoRng`].
     #[cfg(feature = "rand_core")]
-    pub fn from_rng<R: CryptoRng + RngCore + ?Sized>(rng: &mut R) -> Self {
+    pub fn from_rng<R: CryptoRng + ?Sized>(rng: &mut R) -> Self {
         let Ok(out) = Self::try_from_rng(rng);
         out
     }
 
     /// Generate a random [`Salt`] from the given [`TryCryptoRng`].
     #[cfg(feature = "rand_core")]
-    pub fn try_from_rng<R: TryCryptoRng + TryRngCore + ?Sized>(
+    pub fn try_from_rng<R: TryCryptoRng + ?Sized>(
         rng: &mut R,
     ) -> core::result::Result<Self, R::Error> {
         let mut bytes = [0u8; Self::RECOMMENDED_LENGTH];
@@ -256,14 +256,14 @@ impl SaltString {
 
     /// Generate a random B64-encoded [`SaltString`] from [`CryptoRng`].
     #[cfg(feature = "rand_core")]
-    pub fn from_rng<R: CryptoRng + RngCore + ?Sized>(rng: &mut R) -> Self {
+    pub fn from_rng<R: CryptoRng + ?Sized>(rng: &mut R) -> Self {
         let Ok(out) = Self::try_from_rng(rng);
         out
     }
 
     /// Generate a random B64-encoded [`SaltString`] from [`TryCryptoRng`].
     #[cfg(feature = "rand_core")]
-    pub fn try_from_rng<R: TryCryptoRng + TryRngCore + ?Sized>(
+    pub fn try_from_rng<R: TryCryptoRng + ?Sized>(
         rng: &mut R,
     ) -> core::result::Result<Self, R::Error> {
         Ok(Salt::try_from_rng(rng)?.to_salt_string())

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -25,7 +25,7 @@ aes = { version = "0.9.0-rc.2", optional = true, default-features = false }
 aes-gcm = { version = "0.11.0-rc.2", optional = true, default-features = false, features = ["aes"] }
 des = { version = "0.9.0-rc.2", optional = true, default-features = false }
 pbkdf2 = { version = "0.13.0-rc.6", optional = true, default-features = false, features = ["hmac"] }
-rand_core = { version = "0.10.0-rc-3", optional = true, default-features = false }
+rand_core = { version = "0.10.0-rc-5", optional = true, default-features = false }
 scrypt = { version = "0.12.0-rc.8", optional = true, default-features = false }
 sha1 = { version = "0.11.0-rc.3", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }

--- a/pkcs5/src/pbes2.rs
+++ b/pkcs5/src/pbes2.rs
@@ -19,7 +19,7 @@ use der::{
 };
 
 #[cfg(feature = "rand_core")]
-use rand_core::{CryptoRng, RngCore};
+use rand_core::CryptoRng;
 
 #[cfg(all(feature = "alloc", feature = "pbes2"))]
 use alloc::vec::Vec;
@@ -106,7 +106,7 @@ impl Parameters {
     /// This is currently an alias for [`Parameters::scrypt`]. See that method
     /// for more information.
     #[cfg(all(feature = "pbes2", feature = "rand_core"))]
-    pub fn recommended<R: CryptoRng + RngCore + ?Sized>(rng: &mut R) -> Self {
+    pub fn recommended<R: CryptoRng>(rng: &mut R) -> Self {
         Self::scrypt(rng)
     }
 
@@ -118,7 +118,7 @@ impl Parameters {
     /// This will use AES-256-CBC as the encryption algorithm and SHA-256 as
     /// the hash function for PBKDF2.
     #[cfg(feature = "rand_core")]
-    pub fn pbkdf2<R: CryptoRng + RngCore + ?Sized>(rng: &mut R) -> Self {
+    pub fn pbkdf2<R: CryptoRng>(rng: &mut R) -> Self {
         let mut iv = [0u8; Self::DEFAULT_IV_LEN];
         rng.fill_bytes(&mut iv);
 
@@ -169,7 +169,7 @@ impl Parameters {
     ///
     /// [RustCrypto/formats#1205]: https://github.com/RustCrypto/formats/issues/1205
     #[cfg(all(feature = "pbes2", feature = "rand_core"))]
-    pub fn scrypt<R: CryptoRng + RngCore + ?Sized>(rng: &mut R) -> Self {
+    pub fn scrypt<R: CryptoRng>(rng: &mut R) -> Self {
         let mut iv = [0u8; Self::DEFAULT_IV_LEN];
         rng.fill_bytes(&mut iv);
 

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -21,7 +21,7 @@ der = { version = "0.8.0-rc.10", features = ["oid"] }
 spki = "0.8.0-rc.4"
 
 # optional dependencies
-rand_core = { version = "0.10.0-rc-3", optional = true, default-features = false }
+rand_core = { version = "0.10.0-rc-5", optional = true, default-features = false }
 pkcs5 = { version = "0.8.0-rc.12", optional = true, features = ["rand_core"] }
 subtle = { version = "2", optional = true, default-features = false }
 

--- a/pkcs8/src/encrypted_private_key_info.rs
+++ b/pkcs8/src/encrypted_private_key_info.rs
@@ -12,10 +12,7 @@ use pkcs5::EncryptionScheme;
 use der::{SecretDocument, asn1::OctetString};
 
 #[cfg(feature = "encryption")]
-use {
-    pkcs5::pbes2,
-    rand_core::{CryptoRng, RngCore},
-};
+use {pkcs5::pbes2, rand_core::CryptoRng};
 
 #[cfg(feature = "pem")]
 use der::pem::PemLabel;
@@ -67,7 +64,7 @@ where
     /// Encrypt the given ASN.1 DER document using a symmetric encryption key
     /// derived from the provided password.
     #[cfg(feature = "encryption")]
-    pub(crate) fn encrypt<R: CryptoRng + RngCore + ?Sized>(
+    pub(crate) fn encrypt<R: CryptoRng>(
         rng: &mut R,
         password: impl AsRef<[u8]>,
         doc: &[u8],

--- a/pkcs8/src/private_key_info.rs
+++ b/pkcs8/src/private_key_info.rs
@@ -17,10 +17,7 @@ use der::{
 
 #[cfg(feature = "encryption")]
 use {
-    crate::EncryptedPrivateKeyInfoRef,
-    der::zeroize::Zeroizing,
-    pkcs5::pbes2,
-    rand_core::{CryptoRng, RngCore},
+    crate::EncryptedPrivateKeyInfoRef, der::zeroize::Zeroizing, pkcs5::pbes2, rand_core::CryptoRng,
 };
 
 #[cfg(feature = "pem")]
@@ -151,7 +148,7 @@ where
     ///   - p: 1
     /// - Cipher: AES-256-CBC (best available option for PKCS#5 encryption)
     #[cfg(feature = "encryption")]
-    pub fn encrypt<R: CryptoRng + RngCore + ?Sized>(
+    pub fn encrypt<R: CryptoRng>(
         &self,
         rng: &mut R,
         password: impl AsRef<[u8]>,

--- a/pkcs8/src/traits.rs
+++ b/pkcs8/src/traits.rs
@@ -6,10 +6,7 @@ use crate::{Error, PrivateKeyInfoRef, Result};
 use der::SecretDocument;
 
 #[cfg(feature = "encryption")]
-use {
-    crate::EncryptedPrivateKeyInfoRef,
-    rand_core::{CryptoRng, RngCore},
-};
+use {crate::EncryptedPrivateKeyInfoRef, rand_core::CryptoRng};
 
 #[cfg(feature = "pem")]
 use {
@@ -104,7 +101,7 @@ pub trait EncodePrivateKey {
     /// Create an [`SecretDocument`] containing the ciphertext of
     /// a PKCS#8 encoded private key encrypted under the given `password`.
     #[cfg(feature = "encryption")]
-    fn to_pkcs8_encrypted_der<R: CryptoRng + RngCore + ?Sized>(
+    fn to_pkcs8_encrypted_der<R: CryptoRng>(
         &self,
         rng: &mut R,
         password: impl AsRef<[u8]>,
@@ -122,7 +119,7 @@ pub trait EncodePrivateKey {
     /// Serialize this private key as an encrypted PEM-encoded PKCS#8 private
     /// key using the `provided` to derive an encryption key.
     #[cfg(all(feature = "encryption", feature = "pem"))]
-    fn to_pkcs8_encrypted_pem<R: CryptoRng + RngCore + ?Sized>(
+    fn to_pkcs8_encrypted_pem<R: CryptoRng>(
         &self,
         rng: &mut R,
         password: impl AsRef<[u8]>,

--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -24,15 +24,15 @@ spki = { version = "0.8.0-rc.4", features = ["alloc"] }
 arbitrary = { version = "1.4", features = ["derive"], optional = true }
 digest = { version = "0.11.0-rc.4", optional = true, default-features = false }
 sha1 = { version = "0.11.0-rc.3", default-features = false, optional = true }
-signature = { version = "3.0.0-rc.5", features = ["rand_core"], optional = true }
+signature = { version = "3.0.0-rc.8", features = ["rand_core"], optional = true }
 tls_codec = { version = "0.4", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
 hex-literal = "1"
-rand = "0.10.0-rc.6"
-rsa = { version = "0.10.0-rc.11", features = ["sha2"] }
-ecdsa = { version = "0.17.0-rc.9", features = ["digest", "pem"] }
-p256 = "0.14.0-rc.4"
+rand = "0.10.0-rc.7"
+rsa = { version = "0.10.0-rc.13", features = ["sha2"] }
+ecdsa = { version = "0.17.0-rc.13", features = ["digest", "pem"] }
+p256 = "0.14.0-rc.5"
 rstest = "0.26"
 sha2 = { version = "0.11.0-rc.3", features = ["oid"] }
 tempfile = "3.5"

--- a/x509-cert/src/builder.rs
+++ b/x509-cert/src/builder.rs
@@ -4,8 +4,7 @@ use alloc::vec;
 use core::fmt;
 use der::{Encode, asn1::BitString, referenced::OwnedToRef};
 use signature::{
-    AsyncRandomizedSigner, AsyncSigner, Keypair, RandomizedSigner, Signer,
-    rand_core::{CryptoRng, RngCore},
+    AsyncRandomizedSigner, AsyncSigner, Keypair, RandomizedSigner, Signer, rand_core::CryptoRng,
 };
 use spki::{
     DynSignatureAlgorithmIdentifier, EncodePublicKey, ObjectIdentifier, SignatureBitStringEncoding,
@@ -348,7 +347,7 @@ pub trait Builder: Sized {
         S: Keypair + DynSignatureAlgorithmIdentifier,
         S::VerifyingKey: EncodePublicKey,
         Signature: SignatureBitStringEncoding,
-        R: CryptoRng + RngCore + ?Sized,
+        R: CryptoRng + ?Sized,
     {
         let blob = self.finalize(signer)?;
 
@@ -540,7 +539,7 @@ pub trait AsyncBuilder: Sized {
         S: Keypair + DynSignatureAlgorithmIdentifier,
         S::VerifyingKey: EncodePublicKey,
         Signature: SignatureBitStringEncoding,
-        R: CryptoRng + RngCore + ?Sized,
+        R: CryptoRng + ?Sized,
     {
         let blob = self.finalize(signer)?;
 

--- a/x509-cert/src/serial_number.rs
+++ b/x509-cert/src/serial_number.rs
@@ -8,10 +8,7 @@ use der::{
     asn1::{self, Int},
 };
 #[cfg(feature = "builder")]
-use {
-    alloc::vec,
-    signature::rand_core::{CryptoRng, RngCore},
-};
+use {alloc::vec, signature::rand_core::CryptoRng};
 
 use crate::certificate::{Profile, Rfc5280};
 
@@ -80,7 +77,7 @@ impl<P: Profile> SerialNumber<P> {
     /// of output from the CSPRNG. This currently defaults to a 17-bytes long serial number.
     ///
     /// [ballot 164]: https://cabforum.org/2016/03/31/ballot-164/
-    pub fn generate<R: CryptoRng + RngCore + ?Sized>(rng: &mut R) -> Self {
+    pub fn generate<R: CryptoRng + ?Sized>(rng: &mut R) -> Self {
         Self::generate_with_prefix(&[], 17, rng)
             .expect("a random of 17 is acceptable, and rng may not fail")
     }
@@ -94,7 +91,7 @@ impl<P: Profile> SerialNumber<P> {
     /// equal or below 19 (to account for leading sign disambiguation, and the maximum length of 20).
     ///
     /// [ballot 164]: https://cabforum.org/2016/03/31/ballot-164/
-    pub fn generate_with_prefix<R: CryptoRng + RngCore + ?Sized>(
+    pub fn generate_with_prefix<R: CryptoRng + ?Sized>(
         prefix: &[u8],
         rand_len: usize,
         rng: &mut R,

--- a/x509-ocsp/Cargo.toml
+++ b/x509-ocsp/Cargo.toml
@@ -23,14 +23,14 @@ x509-cert = { version = "0.3.0-rc.3", default-features = false }
 
 # Optional
 digest = { version = "0.11.0-rc.4", optional = true, default-features = false, features = ["oid"] }
-rand_core = { version = "0.10.0-rc-3", optional = true, default-features = false }
+rand_core = { version = "0.10.0-rc-5", optional = true, default-features = false }
 signature = { version = "3.0.0-rc.5", optional = true, default-features = false, features = ["digest", "rand_core"] }
 
 [dev-dependencies]
 hex-literal = "1"
 lazy_static = "1.5.0"
-rand = "0.10.0-rc.6"
-rsa = { version = "0.10.0-rc.11", default-features = false, features = ["encoding", "sha2"] }
+rand = "0.10.0-rc.7"
+rsa = { version = "0.10.0-rc.13", default-features = false, features = ["encoding", "sha2"] }
 sha1 = { version = "0.11.0-rc.3", default-features = false, features = ["oid"] }
 sha2 = { version = "0.11.0-rc.3", default-features = false, features = ["oid"] }
 

--- a/x509-ocsp/src/builder/request.rs
+++ b/x509-ocsp/src/builder/request.rs
@@ -3,7 +3,7 @@
 use crate::{OcspRequest, Request, Signature, TbsRequest, Version, builder::Error};
 use alloc::vec::Vec;
 use der::Encode;
-use rand_core::{CryptoRng, RngCore};
+use rand_core::CryptoRng;
 use signature::{RandomizedSigner, Signer};
 use spki::{DynSignatureAlgorithmIdentifier, SignatureBitStringEncoding};
 use x509_cert::{
@@ -148,7 +148,7 @@ impl OcspRequestBuilder {
     where
         S: RandomizedSigner<Sig> + DynSignatureAlgorithmIdentifier,
         Sig: SignatureBitStringEncoding,
-        R: CryptoRng + RngCore + ?Sized,
+        R: CryptoRng + ?Sized,
     {
         let signature_algorithm = signer.signature_algorithm_identifier()?;
         let signature = signer

--- a/x509-ocsp/src/builder/response.rs
+++ b/x509-ocsp/src/builder/response.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use alloc::vec::Vec;
 use der::Encode;
-use rand_core::{CryptoRng, RngCore};
+use rand_core::CryptoRng;
 use signature::{RandomizedSigner, Signer};
 use spki::{DynSignatureAlgorithmIdentifier, SignatureBitStringEncoding};
 use x509_cert::{
@@ -168,7 +168,7 @@ impl OcspResponseBuilder {
     where
         S: RandomizedSigner<Sig> + DynSignatureAlgorithmIdentifier,
         Sig: SignatureBitStringEncoding,
-        R: CryptoRng + RngCore + ?Sized,
+        R: CryptoRng + ?Sized,
     {
         let tbs_response_data = self.into_response_data(produced_at);
         let signature_algorithm = signer.signature_algorithm_identifier()?;

--- a/x509-ocsp/src/ext.rs
+++ b/x509-ocsp/src/ext.rs
@@ -21,7 +21,7 @@ use x509_cert::{
 };
 
 #[cfg(feature = "rand")]
-use rand_core::{CryptoRng, RngCore};
+use rand_core::CryptoRng;
 
 // x509-cert's is not exported
 macro_rules! impl_extension {
@@ -64,7 +64,7 @@ impl Nonce {
     #[cfg(feature = "rand")]
     pub fn generate<R>(rng: &mut R, length: usize) -> Result<Self, der::Error>
     where
-        R: CryptoRng + RngCore + ?Sized,
+        R: CryptoRng + ?Sized,
     {
         let mut bytes = alloc::vec![0; length];
         rng.fill_bytes(&mut bytes);


### PR DESCRIPTION
This also puts back `sec1` into the workspace.