### PR TITLE
sec1: simplify `ModulusSize` bounds

### DIFF
--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -20,7 +20,7 @@ rust-version = "1.85"
 base16ct = { version = "1", optional = true, default-features = false }
 ctutils = { version = "0.4", optional = true }
 der = { version = "0.8.0-rc.10", optional = true, features = ["oid"] }
-hybrid-array = { version = "0.4", optional = true, default-features = false }
+hybrid-array = { version = "0.4.6", optional = true, default-features = false }
 serdect = { version = "0.4", optional = true, default-features = false, features = ["alloc"] }
 subtle = { version = "2", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }

--- a/sec1/src/point.rs
+++ b/sec1/src/point.rs
@@ -31,33 +31,27 @@ use zeroize::Zeroize;
 /// Trait for supported modulus sizes which precomputes the typenums for various point encodings so
 /// they don't need to be included as bounds.
 // TODO(tarcieri): replace this all with const generic expressions.
-pub trait ModulusSize:
-    'static + ArraySize + Copy + Debug + Add<U1, Output = Self::CompressedPointSize>
-{
+pub trait ModulusSize: ArraySize + Add<U1, Output = Self::CompressedPointSize> {
     /// Size of a compressed point for the given elliptic curve when encoded using the SEC1
     /// `Elliptic-Curve-Point-to-Octet-String` algorithm (including leading `0x02` or `0x03`
     /// tag byte).
-    type CompressedPointSize: 'static
-        + ArraySize
-        + Copy
-        + Debug
-        + Add<Self, Output = Self::UncompressedPointSize>;
+    type CompressedPointSize: ArraySize + Add<Self, Output = Self::UncompressedPointSize>;
 
     /// Size of an uncompressed point for the given elliptic curve when encoded using the SEC1
     /// `Elliptic-Curve-Point-to-Octet-String` algorithm (including leading `0x04` tag byte).
-    type UncompressedPointSize: 'static + ArraySize + Copy + Debug;
+    type UncompressedPointSize: ArraySize;
 
     /// Size of an untagged point for given elliptic curve, i.e. size of two serialized base field
     /// elements when concatenated.
-    type UntaggedPointSize: 'static + ArraySize + Copy + Debug + Sub<Self, Output = Self>;
+    type UntaggedPointSize: ArraySize + Sub<Self, Output = Self>;
 }
 
 impl<T> ModulusSize for T
 where
-    T: 'static + ArraySize + Copy + Debug,
-    T: Add<U1, Output: 'static + ArraySize + Copy + Debug>,
-    T: Add<T, Output: 'static + ArraySize + Copy + Debug + Sub<T, Output = T>>,
-    <T as Add<U1>>::Output: Add<T, Output: 'static + ArraySize + Copy + Debug>,
+    T: ArraySize,
+    T: Add<U1, Output: ArraySize>,
+    T: Add<T, Output: ArraySize + Sub<T, Output = T>>,
+    <T as Add<U1>>::Output: Add<T, Output: 'static + ArraySize>,
 {
     type CompressedPointSize = <T as Add<U1>>::Output;
     type UncompressedPointSize = <Self::CompressedPointSize as Add<T>>::Output;


### PR DESCRIPTION
- Removes explicit `'static + Copy` bounds: a `'static` bound to `Unsigned`, a supertrait of `ArraySize`, was added in [paholg/typenum#171](https://github.com/paholg/typenum/pull/171) which was released in `typenum` v1.16, where `hybrid-array` requires at least `typenum` v1.17. In the same PR you can see that `Unsigned` was already bounded on `Copy`, so both these bounds are redundant
- Removes explicit `Debug` bounds: this also upgrades to `hybrid-array` v0.4.6 (as a new requirement in Cargo.toml) which added a `Debug` bound to `ArraySize`, so one is no longer required here.