### PR TITLE
Bump `rand_core` to v0.10.0-rc-6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,13 +213,13 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0-rc.8"
+version = "0.10.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31cd65b2ca03198c223cd9a8fa1152c4ec251cd79049f6dc584152ad3fb5ba9d"
+checksum = "c81d916c6ae06736ec667b51f95ee5ff660a75f4ea6ce1bd932c942365c0ea43"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "rand_core 0.10.0-rc-5",
+ "rand_core 0.10.0-rc-6",
 ]
 
 [[package]]
@@ -312,7 +318,7 @@ dependencies = [
  "digest",
  "ecdsa",
  "elliptic-curve",
- "getrandom 0.4.0-rc.0",
+ "getrandom 0.4.0-rc.1",
  "hex-literal",
  "p256",
  "pbkdf2",
@@ -414,15 +420,15 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.21"
+version = "0.7.0-rc.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f9a78b88bb8255ec59a81423aa92ada22f96883f9ae59dcb68613907636ae5"
+checksum = "053c3561863ce55e3226ecc48b08679f4b66cb1b92b9afb42c2c402dfe8b9b51"
 dependencies = [
  "ctutils",
- "getrandom 0.4.0-rc.0",
+ "getrandom 0.4.0-rc.1",
  "hybrid-array",
  "num-traits",
- "rand_core 0.10.0-rc-5",
+ "rand_core 0.10.0-rc-6",
  "serdect",
  "subtle",
  "zeroize",
@@ -430,24 +436,23 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.11"
+version = "0.2.0-rc.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d2bcc93d5cde6659e8649fc412894417ebc14dee54cfc6ee439c683a4a58342"
+checksum = "c7722afd27468475c9b6063dc03a57ef2ca833816981619f8ebe64d38d207eef"
 dependencies = [
- "getrandom 0.4.0-rc.0",
+ "getrandom 0.4.0-rc.1",
  "hybrid-array",
- "rand_core 0.10.0-rc-5",
+ "rand_core 0.10.0-rc-6",
 ]
 
 [[package]]
 name = "crypto-primes"
 version = "0.7.0-pre.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6372ba15f988d7cd77e9cfbc42b269601c006f2f16a21a72b886136caf04bfb"
+source = "git+https://github.com/entropyxyz/crypto-primes#ba1024f4985d351d83dc588ee2607604ad19dba6"
 dependencies = [
  "crypto-bigint",
  "libm",
- "rand_core 0.10.0-rc-5",
+ "rand_core 0.10.0-rc-6",
 ]
 
 [[package]]
@@ -526,9 +531,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.7"
+version = "0.11.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca14c221bd9052fd2da7c34a2eeb5ae54732db28be47c35937be71793d675422"
+checksum = "2fc1408b7a9f59a7b933faff3e9e7fc15a05a524effd3b3d1601156944c8077f"
 dependencies = [
  "block-buffer",
  "const-oid",
@@ -538,9 +543,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.13"
+version = "0.17.0-rc.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b41c78c24288ec2644aeb00ebc58bf8cd5ff7e9a6e2a2081ed80fa7e1262dc7"
+checksum = "1e5676a9322ce14a73b65930ef95139fb8c41df02dfa610a3a5928a52f9ae4ee"
 dependencies = [
  "der",
  "digest",
@@ -559,21 +564,21 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.23"
+version = "0.14.0-rc.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "660a2eb4d46d49d4c0b122a8cad1fa7926b0e3e99913796243a7dc280021eadc"
+checksum = "5b0f6cc67cc39a00bce2c6f8f8aced0e8c0a06eb1a30f9dd2a9c9f4618bdf3b4"
 dependencies = [
  "base16ct",
  "crypto-bigint",
  "crypto-common",
  "digest",
- "getrandom 0.4.0-rc.0",
+ "getrandom 0.4.0-rc.1",
  "hkdf",
  "hybrid-array",
  "once_cell",
  "pem-rfc7468",
  "pkcs8",
- "rand_core 0.10.0-rc-5",
+ "rand_core 0.10.0-rc-6",
  "rustcrypto-ff",
  "rustcrypto-group",
  "sec1",
@@ -626,6 +631,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "futures-core"
@@ -684,15 +695,16 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.0-rc.0"
+version = "0.4.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b99f0d993a2b9b97b9a201193aa8ad21305cde06a3be9a7e1f8f4201e5cc27e"
+checksum = "74f70a332ddf75e5e5e43284304179ba02f391f82f692f030b08a8378adf3c99"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "rand_core 0.10.0-rc-5",
+ "rand_core 0.10.0-rc-6",
  "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -751,6 +763,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
@@ -778,6 +799,12 @@ dependencies = [
  "hash32 0.3.1",
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex-literal"
@@ -815,13 +842,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -860,9 +895,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "keccak"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d546793a04a1d3049bd192856f804cfe96356e2cf36b54b4e575155babe9f41"
+checksum = "5a412fe37705d515cba9dbf1448291a717e187e2351df908cfc0137cbec3d480"
 dependencies = [
  "cpufeatures",
 ]
@@ -872,6 +907,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -899,6 +940,12 @@ checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
  "scopeguard",
 ]
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "mcf"
@@ -943,9 +990,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "p256"
-version = "0.14.0-rc.5"
+version = "0.14.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23920bdbd723052dc68186e64d2c8c2a3b2998b42d61df716f67ef771ce358b"
+checksum = "de1286c2d38465adf5a7d970766796c1fb343172c58fd70f69e8d96e7d9dcbe4"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -976,8 +1023,8 @@ name = "phc"
 version = "0.6.0-rc.1"
 dependencies = [
  "base64ct",
- "getrandom 0.4.0-rc.0",
- "rand_core 0.10.0-rc-5",
+ "getrandom 0.4.0-rc.1",
+ "rand_core 0.10.0-rc-6",
  "subtle",
 ]
 
@@ -1033,7 +1080,7 @@ dependencies = [
  "des",
  "hex-literal",
  "pbkdf2",
- "rand_core 0.10.0-rc-5",
+ "rand_core 0.10.0-rc-6",
  "scrypt",
  "sha1",
  "sha2",
@@ -1047,7 +1094,7 @@ dependencies = [
  "der",
  "hex-literal",
  "pkcs5",
- "rand_core 0.10.0-rc-5",
+ "rand_core 0.10.0-rc-6",
  "spki",
  "subtle",
  "tempfile",
@@ -1093,14 +1140,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "primefield"
-version = "0.14.0-rc.5"
+name = "prettyplease"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90de6476b10bedc43e91337d44440bec88d9c253a1676a046438ba3f5b1d81e"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "primefield"
+version = "0.14.0-rc.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d00b69a9bd66d09004e2db633068d5af00435f6e673838e50f2944b8033ec8"
 dependencies = [
  "crypto-bigint",
  "crypto-common",
- "rand_core 0.10.0-rc-5",
+ "rand_core 0.10.0-rc-6",
  "rustcrypto-ff",
  "subtle",
  "zeroize",
@@ -1108,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-rc.5"
+version = "0.14.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e77e56adc743d5601fe3a8534fc7c25a28fbbb7470a4f13700e8fdc6817d3a0a"
+checksum = "156aeda78c4a7e86701563514573bc28f127eec880bfa6a22efc4b8139b1c049"
 dependencies = [
  "elliptic-curve",
 ]
@@ -1186,12 +1243,11 @@ dependencies = [
 [[package]]
 name = "rand"
 version = "0.10.0-rc.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d3e6a909ceda8ceb12ef039b675ecf4bbe6def127e773cac109ab8347633766"
+source = "git+https://github.com/rust-random/rand?branch=rand_core%2Fv0.10.0-rc-6#b7eeedd572862491e57fdb912b7bc6fbd78f6bc1"
 dependencies = [
  "chacha20",
- "getrandom 0.4.0-rc.0",
- "rand_core 0.10.0-rc-5",
+ "getrandom 0.4.0-rc.1",
+ "rand_core 0.10.0-rc-6",
 ]
 
 [[package]]
@@ -1215,9 +1271,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0-rc-5"
+version = "0.10.0-rc-6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05a06e03bd1f2ae861ab9e7498b6c64ed3dadb9ce175c0464a2522a5f23c0045"
+checksum = "70765ff7112b0fb2d272d24d9a2f907fc206211304328fe58b2db15a5649ef28"
 
 [[package]]
 name = "rand_xorshift"
@@ -1295,8 +1351,7 @@ dependencies = [
 [[package]]
 name = "rsa"
 version = "0.10.0-rc.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ff85dd219e338d42a2eada54ad71fe515717e08d53f728a8803de33b83f80b8"
+source = "git+https://github.com/RustCrypto/RSA#aceaef909cd70dd83a60298d3f2a12d5258d8496"
 dependencies = [
  "const-oid",
  "crypto-bigint",
@@ -1304,7 +1359,7 @@ dependencies = [
  "digest",
  "pkcs1",
  "pkcs8",
- "rand_core 0.10.0-rc-5",
+ "rand_core 0.10.0-rc-6",
  "sha2",
  "signature",
  "spki",
@@ -1351,21 +1406,21 @@ dependencies = [
 
 [[package]]
 name = "rustcrypto-ff"
-version = "0.14.0-pre.0"
+version = "0.14.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9cd37111549306f79b09aa2618e15b1e8241b7178c286821e3dd71579db4db"
+checksum = "36fdf8f956089df8343b9479045c026932f9eb004d0f32d8497b4d133b316a66"
 dependencies = [
- "rand_core 0.10.0-rc-5",
+ "rand_core 0.10.0-rc-6",
  "subtle",
 ]
 
 [[package]]
 name = "rustcrypto-group"
-version = "0.14.0-pre.0"
+version = "0.14.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e394cd734b5f97dfc3484fa42aad7acd912961c2bcd96c99aa05b3d6cab7cafd"
+checksum = "df76d08c12814c794ffe95ac788b48081cccb607fade4ed746825d29791ce538"
 dependencies = [
- "rand_core 0.10.0-rc-5",
+ "rand_core 0.10.0-rc-6",
  "rustcrypto-ff",
  "subtle",
 ]
@@ -1550,9 +1605,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.11.0-rc.3"
+version = "0.11.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa1ae819b9870cadc959a052363de870944a1646932d274a4e270f64bf79e5ef"
+checksum = "9c777f0a122a53fddb0beb6e706771197000b8eb5c9f42b5b850f450ef48c788"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1561,9 +1616,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-rc.3"
+version = "0.11.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d43dc0354d88b791216bb5c1bfbb60c0814460cc653ae0ebd71f286d0bd927"
+checksum = "7535f94fa3339fe9e5e9be6260a909e62af97f6e14b32345ccf79b92b8b81233"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1572,9 +1627,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.11.0-rc.3"
+version = "0.11.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2103ca0e6f4e9505eae906de5e5883e06fc3b2232fb5d6914890c7bbcb62f478"
+checksum = "1deee7fbcdd62fbcffc9dc2f5f17f96adac881ec7e1506e1eedee1644d0cc535"
 dependencies = [
  "digest",
  "keccak",
@@ -1582,12 +1637,12 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "3.0.0-rc.8"
+version = "3.0.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c04b70a14ee5f15e2e0c785a5fdb2e9a51138dfe13ba3cf8eab037a9e60b1879"
+checksum = "0ad0ce3b3f8efd7406f22e2ca5d02be21cdf3b3d1d53ab141f784de8965c7c7e"
 dependencies = [
  "digest",
- "rand_core 0.10.0-rc-5",
+ "rand_core 0.10.0-rc-6",
 ]
 
 [[package]]
@@ -1855,6 +1910,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "universal-hash"
 version = "0.6.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1889,14 +1950,57 @@ version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.3.1+wasi-0.3.0-rc-2025-09-16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba4be47b1d11244670d11857eee0758a8f2c39aea64d80b78c1ce29b4642cd"
+dependencies = [
+ "wit-bindgen 0.48.1",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.241.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01164c9dda68301e34fdae536c23ed6fe90ce6d97213ccc171eebbd3d02d6b8"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.241.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876fe286f2fa416386deedebe8407e6f19e0b5aeaef3d03161e77a15fa80f167"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.241.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46d90019b1afd4b808c263e428de644f3003691f243387d30d673211ee0cb8e8"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
 name = "whirlpool"
-version = "0.11.0-rc.3"
+version = "0.11.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc9c11a2ebed7575871cb4d0ffd752b98d91d008445fbb354e26bf6b193a6208"
+checksum = "4f6d04322f1a81f486a4cde9936268d738f2114753225b52a76903675c02bd3f"
 dependencies = [
  "digest",
 ]
@@ -1936,9 +2040,97 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f8c2adb5f74ac9395bc3121c99a1254bf9310482c27b13f97167aedb5887138"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b881a098cae03686d7a0587f8f306f8a58102ad8da8b5599100fbe0e7f5800b"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69667efa439a453e1d50dac939c6cab6d2c3ac724a9d232b6631dad2472a5b70"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae2e22cceb5d105d52326c07e3e67603a861cc7add70fc467f7cc7ec5265017"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.241.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0c57df25e7ee612d946d3b7646c1ddb2310f8280aa2c17e543b66e0812241"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.241.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ef1c6ad67f35c831abd4039c02894de97034100899614d1c44e2268ad01c91"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "x509-cert"
@@ -1983,7 +2175,7 @@ dependencies = [
  "hex-literal",
  "lazy_static",
  "rand 0.10.0-rc.7",
- "rand_core 0.10.0-rc-5",
+ "rand_core 0.10.0-rc-6",
  "rsa",
  "sha1",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,3 +60,7 @@ tls_codec_derive = { path = "./tls_codec/derive" }
 x509-tsp = { path = "./x509-tsp" }
 x509-cert = { path = "./x509-cert" }
 x509-ocsp = { path = "./x509-ocsp" }
+
+crypto-primes = { git = "https://github.com/entropyxyz/crypto-primes" }
+rand = { git = "https://github.com/rust-random/rand", branch = "rand_core/v0.10.0-rc-6" }
+rsa = { git = "https://github.com/RustCrypto/RSA" }

--- a/cmpv2/Cargo.toml
+++ b/cmpv2/Cargo.toml
@@ -22,7 +22,7 @@ spki = "0.8.0-rc.4"
 x509-cert = { version = "0.3.0-rc.3", default-features = false }
 
 # optional features
-digest = { version = "0.11.0-rc.5", optional = true, default-features = false }
+digest = { version = "0.11.0-rc.8", optional = true, default-features = false }
 
 [dev-dependencies]
 const-oid = { version = "0.10", features = ["db"] }

--- a/cms/Cargo.toml
+++ b/cms/Cargo.toml
@@ -26,12 +26,12 @@ aes-kw = { version = "0.3.0-rc.1", optional = true }
 ansi-x963-kdf = { version = "0.1.0-rc.1", optional = true }
 cbc = { version = "0.2.0-rc.2", optional = true }
 cipher = { version = "0.5.0-rc.3", features = ["alloc", "block-padding", "rand_core"], optional = true }
-digest = { version = "0.11.0-rc.5", optional = true }
+digest = { version = "0.11.0-rc.8", optional = true }
 elliptic-curve = { version = "0.14.0-rc.21", optional = true }
 rsa = { version = "0.10.0-rc.13", optional = true }
-sha1 = { version = "0.11.0-rc.3", optional = true }
-sha2 = { version = "0.11.0-rc.3", optional = true }
-sha3 = { version = "0.11.0-rc.3", optional = true }
+sha1 = { version = "0.11.0-rc.4", optional = true }
+sha2 = { version = "0.11.0-rc.4", optional = true }
+sha3 = { version = "0.11.0-rc.4", optional = true }
 signature = { version = "3.0.0-rc.6", features = ["digest", "alloc"], optional = true }
 zeroize = { version = "1.8.1", optional = true }
 
@@ -45,7 +45,7 @@ pbkdf2 = "0.13.0-rc.6"
 rand = "0.10.0-rc.7"
 rsa = { version = "0.10.0-rc.13", features = ["sha2"] }
 ecdsa = { version = "0.17.0-rc.13", features = ["digest", "pem"] }
-p256 = "0.14.0-rc.5"
+p256 = "0.14.0-rc.6"
 tokio = { version = "1.45.1", features = ["macros", "rt"] }
 x509-cert = { version = "0.3.0-rc.3", features = ["pem"] }
 

--- a/cms/tests/builder.rs
+++ b/cms/tests/builder.rs
@@ -21,9 +21,8 @@ use der::{Any, AnyRef, Decode, DecodePem, Encode, Tag, Tagged};
 use p256::{NistP256, pkcs8::DecodePrivateKey};
 use pem_rfc7468::LineEnding;
 use pkcs5::pbes2::Pbkdf2Params;
-use rand::rngs::SysRng;
 use rsa::pkcs1::DecodeRsaPrivateKey;
-use rsa::rand_core::{CryptoRng, TryRngCore};
+use rsa::rand_core::CryptoRng;
 use rsa::{Pkcs1v15Encrypt, RsaPrivateKey, RsaPublicKey};
 use rsa::{pkcs1v15, pss};
 use sha2::Sha256;
@@ -159,7 +158,7 @@ fn test_build_signed_data() {
         .add_signer_info_with_rng::<pss::SigningKey<Sha256>, pss::Signature, _>(
             signer_info_builder_3,
             &signer_3,
-            &mut SysRng.unwrap_err(),
+            &mut rand::rng(),
         )
         .expect("error adding PKCS1v15 RSA signer info")
         .build()
@@ -183,7 +182,7 @@ fn test_build_signed_data() {
 #[test]
 fn test_build_enveloped_data() {
     let recipient_identifier = recipient_identifier(1);
-    let mut rng = SysRng.unwrap_err();
+    let mut rng = rand::rng();
     let bits = 2048;
     let recipient_private_key =
         RsaPrivateKey::new(&mut rng, bits).expect("failed to generate a key");
@@ -195,7 +194,7 @@ fn test_build_enveloped_data() {
     )
     .expect("Could not create a KeyTransRecipientInfoBuilder");
 
-    let mut rng = SysRng.unwrap_err();
+    let mut rng = rand::rng();
     let mut builder = EnvelopedDataBuilder::new(
         None,
         "Arbitrary unencrypted content".as_bytes(),
@@ -657,7 +656,7 @@ async fn async_builder() {
         .add_signer_info_with_rng_async::<pss::SigningKey<Sha256>, pss::Signature, _>(
             signer_info_builder_3,
             &signer_3,
-            &mut SysRng.unwrap_err(),
+            &mut rand::rng(),
         )
         .await
         .expect("error adding PKCS1v15 RSA signer info")
@@ -897,7 +896,7 @@ fn test_create_password_recipient_info() {
         content_encryption_key
     }
 
-    let mut the_one_and_only_rng = SysRng.unwrap_err();
+    let mut the_one_and_only_rng = rand::rng();
 
     // Encrypt the content-encryption key (CEK) using custom encryptor
     // of type `Aes128CbcPwriEncryptor`:

--- a/cms/tests/builder/kari.rs
+++ b/cms/tests/builder/kari.rs
@@ -11,7 +11,6 @@ use cms::{
 use der::{Any, AnyRef, Encode};
 use p256::{SecretKey, pkcs8::DecodePrivateKey};
 use pem_rfc7468::LineEnding;
-use rand::{TryRngCore, rngs::SysRng};
 use x509_cert::serial_number::SerialNumber;
 
 fn key_agreement_recipient_identifier(id: i32) -> KeyAgreeRecipientIdentifier {
@@ -55,7 +54,7 @@ fn test_build_enveloped_data_ec() {
     .expect("Could not create a KeyAgreeRecipientInfoBuilder");
 
     // Enveloped data builder
-    let mut rng = SysRng.unwrap_err();
+    let mut rng = rand::rng();
     let mut builder = EnvelopedDataBuilder::new(
         None,
         "Arbitrary unencrypted content, encrypted using ECC".as_bytes(),

--- a/phc/Cargo.toml
+++ b/phc/Cargo.toml
@@ -20,7 +20,7 @@ subtle = { version = "2", default-features = false }
 
 # optional dependencies
 getrandom = { version = "0.4.0-rc.0", optional = true, default-features = false }
-rand_core = { version = "0.10.0-rc-5", optional = true, default-features = false }
+rand_core = { version = "0.10.0-rc-6", optional = true, default-features = false }
 
 [features]
 default = ["rand_core"]

--- a/pkcs12/Cargo.toml
+++ b/pkcs12/Cargo.toml
@@ -23,15 +23,15 @@ const-oid = { version = "0.10", features = ["db"], default-features = false }
 cms = { version = "=0.3.0-pre.1", default-features = false }
 
 # optional dependencies
-digest = { version = "0.11.0-rc.5", features = ["alloc"], optional = true }
+digest = { version = "0.11.0-rc.8", features = ["alloc"], optional = true }
 zeroize = { version = "1.8.1", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "1"
 pkcs8 = { version = "0.11.0-rc.9", features = ["pkcs5"] }
 pkcs5 = { version = "0.8.0-rc.12", features = ["pbes2", "3des"] }
-sha2 = "0.11.0-rc.3"
-whirlpool = "0.11.0-rc.3"
+sha2 = "0.11.0-rc.4"
+whirlpool = "0.11.0-rc.4"
 
 [features]
 default = ["pem"]

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -25,10 +25,10 @@ aes = { version = "0.9.0-rc.2", optional = true, default-features = false }
 aes-gcm = { version = "0.11.0-rc.2", optional = true, default-features = false, features = ["aes"] }
 des = { version = "0.9.0-rc.2", optional = true, default-features = false }
 pbkdf2 = { version = "0.13.0-rc.6", optional = true, default-features = false, features = ["hmac"] }
-rand_core = { version = "0.10.0-rc-5", optional = true, default-features = false }
+rand_core = { version = "0.10.0-rc-6", optional = true, default-features = false }
 scrypt = { version = "0.12.0-rc.8", optional = true, default-features = false }
-sha1 = { version = "0.11.0-rc.3", optional = true, default-features = false }
-sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false }
+sha1 = { version = "0.11.0-rc.4", optional = true, default-features = false }
+sha2 = { version = "0.11.0-rc.4", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "1"

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -21,7 +21,7 @@ der = { version = "0.8.0-rc.10", features = ["oid"] }
 spki = "0.8.0-rc.4"
 
 # optional dependencies
-rand_core = { version = "0.10.0-rc-5", optional = true, default-features = false }
+rand_core = { version = "0.10.0-rc-6", optional = true, default-features = false }
 pkcs5 = { version = "0.8.0-rc.12", optional = true, features = ["rand_core"] }
 subtle = { version = "2", optional = true, default-features = false }
 

--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -23,7 +23,7 @@ spki = { version = "0.8.0-rc.4", features = ["alloc"] }
 # optional dependencies
 arbitrary = { version = "1.4", features = ["derive"], optional = true }
 digest = { version = "0.11.0-rc.4", optional = true, default-features = false }
-sha1 = { version = "0.11.0-rc.3", default-features = false, optional = true }
+sha1 = { version = "0.11.0-rc.4", default-features = false, optional = true }
 signature = { version = "3.0.0-rc.8", features = ["rand_core"], optional = true }
 tls_codec = { version = "0.4", default-features = false, features = ["derive"], optional = true }
 
@@ -32,9 +32,9 @@ hex-literal = "1"
 rand = "0.10.0-rc.7"
 rsa = { version = "0.10.0-rc.13", features = ["sha2"] }
 ecdsa = { version = "0.17.0-rc.13", features = ["digest", "pem"] }
-p256 = "0.14.0-rc.5"
+p256 = "0.14.0-rc.6"
 rstest = "0.26"
-sha2 = { version = "0.11.0-rc.3", features = ["oid"] }
+sha2 = { version = "0.11.0-rc.4", features = ["oid"] }
 tempfile = "3.5"
 tokio = { version = "1.45", features = ["macros", "rt"] }
 x509-cert-test-support = { path = "./test-support" }

--- a/x509-ocsp/Cargo.toml
+++ b/x509-ocsp/Cargo.toml
@@ -23,7 +23,7 @@ x509-cert = { version = "0.3.0-rc.3", default-features = false }
 
 # Optional
 digest = { version = "0.11.0-rc.4", optional = true, default-features = false, features = ["oid"] }
-rand_core = { version = "0.10.0-rc-5", optional = true, default-features = false }
+rand_core = { version = "0.10.0-rc-6", optional = true, default-features = false }
 signature = { version = "3.0.0-rc.5", optional = true, default-features = false, features = ["digest", "rand_core"] }
 
 [dev-dependencies]
@@ -31,8 +31,8 @@ hex-literal = "1"
 lazy_static = "1.5.0"
 rand = "0.10.0-rc.7"
 rsa = { version = "0.10.0-rc.13", default-features = false, features = ["encoding", "sha2"] }
-sha1 = { version = "0.11.0-rc.3", default-features = false, features = ["oid"] }
-sha2 = { version = "0.11.0-rc.3", default-features = false, features = ["oid"] }
+sha1 = { version = "0.11.0-rc.4", default-features = false, features = ["oid"] }
+sha2 = { version = "0.11.0-rc.4", default-features = false, features = ["oid"] }
 
 [features]
 rand = ["rand_core"]


### PR DESCRIPTION
Also bumps all necessary dependencies to complete the upgrade.

This release renames `(Try)RngCore` => `(Try)Rng`