### PR TITLE
Bump dependency requirements in `Cargo.toml`s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "aead"
-version = "0.6.0-rc.8"
+version = "0.6.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b86f658b0f536411ee61c10cec8376f83375b0c98bdc6a640e249f01549d0"
+checksum = "6b657e772794c6b04730ea897b66a058ccd866c16d1967da05eeeecec39043fe"
 dependencies = [
  "crypto-common",
  "inout",
@@ -14,20 +14,20 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.9.0-rc.2"
+version = "0.9.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9e1c818b25efb32214df89b0ec22f01aa397aaeb718d1022bf0635a3bfd1a8"
+checksum = "04097e08a47d9ad181c2e1f4a5fabc9ae06ce8839a333ba9a949bcb0d31fd2a3"
 dependencies = [
- "cfg-if",
  "cipher",
+ "cpubits",
  "cpufeatures",
 ]
 
 [[package]]
 name = "aes-gcm"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f5c07f414d7dc0755870f84c7900425360288d24e0eae4836f9dee19a30fa5f"
+checksum = "e22c0c90bbe8d4f77c3ca9ddabe41a1f8382d6fc1f7cea89459d0f320371f972"
 dependencies = [
  "aead",
  "aes",
@@ -39,9 +39,9 @@ dependencies = [
 
 [[package]]
 name = "aes-kw"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02eaa2d54d0fad0116e4b1efb65803ea0bf059ce970a67cd49718d87e807cb51"
+checksum = "9d3f56c4f20065fe12a323918242aefbbd7d85f8ce81dabfdb4b61726d0fe642"
 dependencies = [
  "aes",
  "const-oid",
@@ -64,9 +64,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "ansi-x963-kdf"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092f613e595bafbe1cfbed4affec29003c3d4ed08aebcaeb5c7529563330c8ca"
+checksum = "f52e4ce522e484c3a0e6723a7fe3ba130b2075ef37cdb06d4c0c976d62d4b746"
 dependencies = [
  "digest",
 ]
@@ -198,9 +198,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cbc"
-version = "0.2.0-rc.2"
+version = "0.2.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c34a745c272d1f6124df3006881364190a8f033ff3857ce196a17aa4a753096"
+checksum = "85742c5f1d0dda799d2e582c76b82b817d3e4d6434dd285e48e90ed0c963b667"
 dependencies = [
  "cipher",
 ]
@@ -251,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.5.0-rc.6"
+version = "0.5.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba4d87abf4032a6d927f84b71af5086128a3349b929b4501c51a0fe0981a937"
+checksum = "9002c8edb9b1e21938663da3489c9c4403bba2393997fb2ecbd401386c0e71dc"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -357,9 +357,9 @@ dependencies = [
 
 [[package]]
 name = "cpubits"
-version = "0.1.0-rc.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "251aaca52dbc19119279d9364222e188ffdf48006791040bfd002617ab0ebc41"
+checksum = "5ef0c543070d296ea414df2dd7625d1b24866ce206709d8a4a424f28377f5861"
 
 [[package]]
 name = "cpufeatures"
@@ -426,10 +426,11 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.22"
+version = "0.7.0-rc.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c3561863ce55e3226ecc48b08679f4b66cb1b92b9afb42c2c402dfe8b9b51"
+checksum = "cba9eeeb213f7fd29353032f71f7c173e5f6d95d85151cb3a47197b0ea7e8be7"
 dependencies = [
+ "cpubits",
  "ctutils",
  "getrandom 0.4.0",
  "hybrid-array",
@@ -442,9 +443,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.13"
+version = "0.2.0-rc.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7722afd27468475c9b6063dc03a57ef2ca833816981619f8ebe64d38d207eef"
+checksum = "6f8441110cea75afde0b89a8d796e2bc67b23432f5a9566cb15d9d365d91a2b0"
 dependencies = [
  "getrandom 0.4.0",
  "hybrid-array",
@@ -464,9 +465,9 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.10.0-rc.2"
+version = "0.10.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0ec605a95e78815a4c4b8040217d56d5a1ab37043851ee9e7e65b89afa00e3"
+checksum = "65ea71550d18331d179854662ab330bb54306b9b56020d0466aae2a58f4e17c1"
 dependencies = [
  "cipher",
 ]
@@ -529,18 +530,18 @@ dependencies = [
 
 [[package]]
 name = "des"
-version = "0.9.0-rc.2"
+version = "0.9.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512ca722eff02fa73c43e5136f440c46f861d41f9dd7761c1f2817a5ca5d9ad7"
+checksum = "3214053e68a813b9c06ef61075c844f3a1cdeb307d8998ea8555c063caa52fa9"
 dependencies = [
  "cipher",
 ]
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.9"
+version = "0.11.0-rc.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff8de092798697546237a3a701e4174fe021579faec9b854379af9bf1e31962"
+checksum = "02b42f1d9edf5207c137646b568a0168ca0ec25b7f9eaf7f9961da51a3d91cea"
 dependencies = [
  "block-buffer",
  "const-oid",
@@ -550,9 +551,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.14"
+version = "0.17.0-rc.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e5676a9322ce14a73b65930ef95139fb8c41df02dfa610a3a5928a52f9ae4ee"
+checksum = "91bbdd377139884fafcad8dc43a760a3e1e681aa26db910257fa6535b70e1829"
 dependencies = [
  "der",
  "digest",
@@ -571,15 +572,14 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.24"
+version = "0.14.0-rc.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0f6cc67cc39a00bce2c6f8f8aced0e8c0a06eb1a30f9dd2a9c9f4618bdf3b4"
+checksum = "bde7860544606d222fd6bd6d9f9a0773321bf78072a637e1d560a058c0031978"
 dependencies = [
  "base16ct",
  "crypto-bigint",
  "crypto-common",
  "digest",
- "getrandom 0.4.0",
  "hkdf",
  "hybrid-array",
  "once_cell",
@@ -716,9 +716,9 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.6.0-rc.3"
+version = "0.6.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "333de57ed9494a40df4bbb866752b100819dde0d18f2264c48f5a08a85fe673d"
+checksum = "f484be0236661c5ba22d445ed75d3624ba5544541c647549f867fb576e55b2a2"
 dependencies = [
  "polyval",
 ]
@@ -821,18 +821,18 @@ checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 
 [[package]]
 name = "hkdf"
-version = "0.13.0-rc.4"
+version = "0.13.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1493605868fc7d216afa78a26956d56f5c0a12dbdb8ee4fe9e0b70a28ec7d57"
+checksum = "cbb55385998ae66b8d2d5143c05c94b9025ab863966f0c94ce7a5fde30105092"
 dependencies = [
  "hmac",
 ]
 
 [[package]]
 name = "hmac"
-version = "0.13.0-rc.4"
+version = "0.13.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9956e202a691c5c86c60303a421f66f93f44b29433407b7c43cf2bebadc750e"
+checksum = "ef451d73f36d8a3f93ad32c332ea01146c9650e1ec821a9b0e46c01277d544f8"
 dependencies = [
  "digest",
 ]
@@ -997,9 +997,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "p256"
-version = "0.14.0-rc.6"
+version = "0.14.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de1286c2d38465adf5a7d970766796c1fb343172c58fd70f69e8d96e7d9dcbe4"
+checksum = "018bfbb86e05fd70a83e985921241035ee09fcd369c4a2c3680b389a01d2ad28"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -1010,9 +1010,9 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.13.0-rc.8"
+version = "0.13.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626220f48328b90cad8393e99e9ef80503970e6e86e77f32f7e42227972e7c2c"
+checksum = "c8dfa4e14084d963d35bfb4cdb38712cde78dcf83054c0e8b9b8e899150f374e"
 dependencies = [
  "digest",
  "hmac",
@@ -1109,9 +1109,9 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.7.0-rc.4"
+version = "0.7.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d5104542958eebb462a4d4b5acbf7756da05448b72fb7d222199bd1eda42a46"
+checksum = "63641a86fddf4b5274f31c43734458ec7acd3133016dbaa37e4e247e1e9acd46"
 dependencies = [
  "cpubits",
  "cpufeatures",
@@ -1158,9 +1158,9 @@ dependencies = [
 
 [[package]]
 name = "primefield"
-version = "0.14.0-rc.6"
+version = "0.14.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40d00b69a9bd66d09004e2db633068d5af00435f6e673838e50f2944b8033ec8"
+checksum = "93401c13cc7ff24684571cfca9d3cf9ebabfaf3d4b7b9963ade41ec54da196b5"
 dependencies = [
  "crypto-bigint",
  "crypto-common",
@@ -1172,9 +1172,9 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-rc.6"
+version = "0.14.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "156aeda78c4a7e86701563514573bc28f127eec880bfa6a22efc4b8139b1c049"
+checksum = "a0c5c8a39bcd764bfedf456e8d55e115fe86dda3e0f555371849f2a41cbc9706"
 dependencies = [
  "elliptic-curve",
 ]
@@ -1328,9 +1328,9 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "rfc6979"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b8e2323084c987a72875b2fd682b7307d5cf14d47e3875bb5e89948e8809d4"
+checksum = "23a3127ee32baec36af75b4107082d9bd823501ec14a4e016be4b6b37faa74ae"
 dependencies = [
  "hmac",
  "subtle",
@@ -1357,9 +1357,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.10.0-rc.14"
+version = "0.10.0-rc.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef381dd6f207f81aff2ee3a8264eddd68ba475bbfcdb44ca445e5906bce381b"
+checksum = "1b342b99544549f37509ed7fd42b0cea04bfd9ce07c16ca56094cf0fbeefbbcd"
 dependencies = [
  "const-oid",
  "crypto-bigint",
@@ -1414,9 +1414,9 @@ dependencies = [
 
 [[package]]
 name = "rustcrypto-ff"
-version = "0.14.0-pre.1"
+version = "0.14.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36fdf8f956089df8343b9479045c026932f9eb004d0f32d8497b4d133b316a66"
+checksum = "c5db129183b2c139d7d87d08be57cba626c715789db17aec65c8866bfd767d1f"
 dependencies = [
  "rand_core 0.10.0",
  "subtle",
@@ -1424,9 +1424,9 @@ dependencies = [
 
 [[package]]
 name = "rustcrypto-group"
-version = "0.14.0-pre.1"
+version = "0.14.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df76d08c12814c794ffe95ac788b48081cccb607fade4ed746825d29791ce538"
+checksum = "57c4b1463f274a3ff6fb2f44da43e576cb9424367bd96f185ead87b52fe00523"
 dependencies = [
  "rand_core 0.10.0",
  "rustcrypto-ff",
@@ -1491,9 +1491,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scrypt"
-version = "0.12.0-rc.9"
+version = "0.12.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f847dca682a96ca7c9a3683e155cc91f3acd57b6ff8fc19dcf4f5190bf732b3"
+checksum = "e03ed5b54ed5fcc8e016cd94301416bc2c01c05c87a6742b97468337c8804598"
 dependencies = [
  "cfg-if",
  "pbkdf2",
@@ -1613,9 +1613,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.11.0-rc.4"
+version = "0.11.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c777f0a122a53fddb0beb6e706771197000b8eb5c9f42b5b850f450ef48c788"
+checksum = "3b167252f3c126be0d8926639c4c4706950f01445900c4b3db0fd7e89fcb750a"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1624,9 +1624,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-rc.4"
+version = "0.11.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7535f94fa3339fe9e5e9be6260a909e62af97f6e14b32345ccf79b92b8b81233"
+checksum = "7c5f3b1e2dc8aad28310d8410bd4d7e180eca65fca176c52ab00d364475d0024"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1635,9 +1635,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.11.0-rc.6"
+version = "0.11.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1deee7fbcdd62fbcffc9dc2f5f17f96adac881ec7e1506e1eedee1644d0cc535"
+checksum = "c5bfe7820113e633d8886e839aae78c1184b8d7011000db6bc7eb61e34f28350"
 dependencies = [
  "digest",
  "keccak",
@@ -1645,9 +1645,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "3.0.0-rc.9"
+version = "3.0.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad0ce3b3f8efd7406f22e2ca5d02be21cdf3b3d1d53ab141f784de8965c7c7e"
+checksum = "7f1880df446116126965eeec169136b2e0251dba37c6223bcc819569550edea3"
 dependencies = [
  "digest",
  "rand_core 0.10.0",
@@ -1925,9 +1925,9 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"
-version = "0.6.0-rc.8"
+version = "0.6.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82084f2919885ea910502c74f0a362827aaad3d28d142ca97448bfb39c7e271a"
+checksum = "058482a494bb3c9c39447d8b40a3a0f38ebb3dccaf02c5a2d681e69035f8da11"
 dependencies = [
  "crypto-common",
  "subtle",
@@ -2006,9 +2006,9 @@ dependencies = [
 
 [[package]]
 name = "whirlpool"
-version = "0.11.0-rc.4"
+version = "0.11.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f6d04322f1a81f486a4cde9936268d738f2114753225b52a76903675c02bd3f"
+checksum = "5a9c5a8352e7ed80906a5d00ef4be5feb1b85eab9a37f13543129be1c70b93cf"
 dependencies = [
  "digest",
 ]

--- a/cms/Cargo.toml
+++ b/cms/Cargo.toml
@@ -21,18 +21,18 @@ spki = "0.8.0-rc.4"
 x509-cert = { version = "0.3.0-rc.4", default-features = false }
 
 # optional dependencies
-aes = { version = "0.9.0-rc.2", optional = true }
-aes-kw = { version = "0.3.0-rc.1", optional = true }
-ansi-x963-kdf = { version = "0.1.0-rc.1", optional = true }
-cbc = { version = "0.2.0-rc.2", optional = true }
-cipher = { version = "0.5.0-rc.6", features = ["alloc", "block-padding", "rand_core"], optional = true }
-digest = { version = "0.11.0-rc.9", optional = true }
-elliptic-curve = { version = "0.14.0-rc.24", optional = true }
-rsa = { version = "0.10.0-rc.14", optional = true }
-sha1 = { version = "0.11.0-rc.4", optional = true }
-sha2 = { version = "0.11.0-rc.4", optional = true }
-sha3 = { version = "0.11.0-rc.4", optional = true }
-signature = { version = "3.0.0-rc.9", features = ["digest", "alloc"], optional = true }
+aes = { version = "0.9.0-rc.4", optional = true }
+aes-kw = { version = "0.3.0-rc.2", optional = true }
+ansi-x963-kdf = { version = "0.1.0-rc.2", optional = true }
+cbc = { version = "0.2.0-rc.3", optional = true }
+cipher = { version = "0.5.0-rc.8", features = ["alloc", "block-padding", "rand_core"], optional = true }
+digest = { version = "0.11.0-rc.11", optional = true }
+elliptic-curve = { version = "0.14.0-rc.28", optional = true }
+rsa = { version = "0.10.0-rc.15", optional = true }
+sha1 = { version = "0.11.0-rc.5", optional = true }
+sha2 = { version = "0.11.0-rc.5", optional = true }
+sha3 = { version = "0.11.0-rc.7", optional = true }
+signature = { version = "3.0.0-rc.10", features = ["digest", "alloc"], optional = true }
 zeroize = { version = "1.8.1", optional = true }
 
 [dev-dependencies]
@@ -41,11 +41,11 @@ getrandom = "0.4"
 hex-literal = "1"
 pem-rfc7468 = "1"
 pkcs5 = "0.8.0-rc.13"
-pbkdf2 = "0.13.0-rc.6"
+pbkdf2 = "0.13.0-rc.9"
 rand = "0.10.0-rc.8"
-rsa = { version = "0.10.0-rc.14", features = ["sha2"] }
-ecdsa = { version = "0.17.0-rc.14", features = ["digest", "pem"] }
-p256 = "0.14.0-rc.6"
+rsa = { version = "0.10.0-rc.15", features = ["sha2"] }
+ecdsa = { version = "0.17.0-rc.16", features = ["digest", "pem"] }
+p256 = "0.14.0-rc.7"
 tokio = { version = "1.45.1", features = ["macros", "rt"] }
 x509-cert = { version = "0.3.0-rc.4", features = ["pem"] }
 

--- a/cms/src/builder.rs
+++ b/cms/src/builder.rs
@@ -26,7 +26,7 @@ use alloc::{
     vec::Vec,
 };
 use cipher::{
-    BlockModeEncrypt, Iv, Key, KeyIvInit, block_padding::Pkcs7, crypto_common::Generate,
+    BlockModeEncrypt, Iv, Key, KeyIvInit, block_padding::Pkcs7, common::Generate,
     rand_core::CryptoRng,
 };
 use const_oid::ObjectIdentifier;

--- a/cms/src/builder/kari.rs
+++ b/cms/src/builder/kari.rs
@@ -48,7 +48,7 @@ use elliptic_curve::{
     AffinePoint, Curve, CurveArithmetic, FieldBytesSize, Generate, PublicKey,
     ecdh::{EphemeralSecret, SharedSecret},
     point::PointCompression,
-    sec1::{FromEncodedPoint, ModulusSize, ToEncodedPoint},
+    sec1::{FromSec1Point, ModulusSize, ToSec1Point},
 };
 
 /// The `EccCmsSharedInfo` type is defined in [RFC 5753 Section 7.2].
@@ -256,7 +256,7 @@ where
     R: CryptoRng,
     KA: KeyAgreementAlgorithm + AssociatedOid,
     C: CurveArithmetic + AssociatedOid + PointCompression,
-    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
+    AffinePoint<C>: FromSec1Point<C> + ToSec1Point<C>,
     FieldBytesSize<C>: ModulusSize,
     KW: KeyWrapAlgorithm,
     Enc: KeySizeUser,
@@ -307,7 +307,7 @@ where
                 // Generate ephemeral key using ecdh
                 let ephemeral_secret = EphemeralSecret::generate_from_rng(rng);
                 let ephemeral_public_key_encoded_point =
-                    ephemeral_secret.public_key().to_encoded_point(false);
+                    ephemeral_secret.public_key().to_sec1_point(false);
 
                 // Compute a shared secret with recipient public key. Non-uniformly random, but will be used as input for KDF later.
                 let non_uniformly_random_shared_secret =

--- a/pkcs12/Cargo.toml
+++ b/pkcs12/Cargo.toml
@@ -30,8 +30,8 @@ zeroize = { version = "1.8.1", optional = true, default-features = false }
 hex-literal = "1"
 pkcs8 = { version = "0.11.0-rc.10", features = ["pkcs5"] }
 pkcs5 = { version = "0.8.0-rc.13", features = ["pbes2", "3des"] }
-sha2 = "0.11.0-rc.4"
-whirlpool = "0.11.0-rc.4"
+sha2 = "0.11.0-rc.5"
+whirlpool = "0.11.0-rc.5"
 
 [features]
 default = ["pem"]

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -20,15 +20,15 @@ der = { version = "0.8.0-rc.10", features = ["oid"] }
 spki = "0.8.0-rc.4"
 
 # optional dependencies
-cbc = { version = "0.2.0-rc.2", optional = true }
-aes = { version = "0.9.0-rc.2", optional = true, default-features = false }
-aes-gcm = { version = "0.11.0-rc.2", optional = true, default-features = false, features = ["aes"] }
-des = { version = "0.9.0-rc.2", optional = true, default-features = false }
-pbkdf2 = { version = "0.13.0-rc.8", optional = true, default-features = false, features = ["hmac"] }
+cbc = { version = "0.2.0-rc.3", optional = true }
+aes = { version = "0.9.0-rc.4", optional = true, default-features = false }
+aes-gcm = { version = "0.11.0-rc.3", optional = true, default-features = false, features = ["aes"] }
+des = { version = "0.9.0-rc.3", optional = true, default-features = false }
+pbkdf2 = { version = "0.13.0-rc.9", optional = true, default-features = false, features = ["hmac"] }
 rand_core = { version = "0.10", optional = true, default-features = false }
-scrypt = { version = "0.12.0-rc.9", optional = true, default-features = false }
-sha1 = { version = "0.11.0-rc.4", optional = true, default-features = false }
-sha2 = { version = "0.11.0-rc.4", optional = true, default-features = false }
+scrypt = { version = "0.12.0-rc.10", optional = true, default-features = false }
+sha1 = { version = "0.11.0-rc.5", optional = true, default-features = false }
+sha2 = { version = "0.11.0-rc.5", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "1"

--- a/spki/Cargo.toml
+++ b/spki/Cargo.toml
@@ -21,7 +21,7 @@ der = { version = "0.8.0-rc.10", features = ["oid"] }
 # Optional dependencies
 arbitrary = { version = "1.4", features = ["derive"], optional = true }
 base64ct = { version = "1", optional = true, default-features = false }
-digest = { version = "0.11.0-rc.4", optional = true, default-features = false }
+digest = { version = "0.11.0-rc.5", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.2", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -22,19 +22,19 @@ spki = { version = "0.8.0-rc.4", features = ["alloc"] }
 
 # optional dependencies
 arbitrary = { version = "1.4", features = ["derive"], optional = true }
-digest = { version = "0.11.0-rc.9", optional = true, default-features = false }
-sha1 = { version = "0.11.0-rc.4", default-features = false, optional = true }
-signature = { version = "3.0.0-rc.9", features = ["rand_core"], optional = true }
+digest = { version = "0.11.0-rc.11", optional = true, default-features = false }
+sha1 = { version = "0.11.0-rc.5", default-features = false, optional = true }
+signature = { version = "3.0.0-rc.10", features = ["rand_core"], optional = true }
 tls_codec = { version = "0.4", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
 hex-literal = "1"
 rand = "0.10.0-rc.8"
-rsa = { version = "0.10.0-rc.14", features = ["sha2"] }
-ecdsa = { version = "0.17.0-rc.14", features = ["digest", "pem"] }
-p256 = "0.14.0-rc.6"
+rsa = { version = "0.10.0-rc.15", features = ["sha2"] }
+ecdsa = { version = "0.17.0-rc.16", features = ["digest", "pem"] }
+p256 = "0.14.0-rc.7"
 rstest = "0.26"
-sha2 = { version = "0.11.0-rc.4", features = ["oid"] }
+sha2 = { version = "0.11.0-rc.5", features = ["oid"] }
 tempfile = "3.5"
 tokio = { version = "1.45", features = ["macros", "rt"] }
 x509-cert-test-support = { path = "./test-support" }

--- a/x509-ocsp/Cargo.toml
+++ b/x509-ocsp/Cargo.toml
@@ -22,17 +22,17 @@ spki = { version = "0.8.0-rc.4", features = ["alloc"] }
 x509-cert = { version = "0.3.0-rc.4", default-features = false }
 
 # Optional
-digest = { version = "0.11.0-rc.9", optional = true, default-features = false, features = ["oid"] }
+digest = { version = "0.11.0-rc.11", optional = true, default-features = false, features = ["oid"] }
 rand_core = { version = "0.10", optional = true, default-features = false }
-signature = { version = "3.0.0-rc.9", optional = true, default-features = false, features = ["digest", "rand_core"] }
+signature = { version = "3.0.0-rc.10", optional = true, default-features = false, features = ["digest", "rand_core"] }
 
 [dev-dependencies]
 hex-literal = "1"
 lazy_static = "1.5.0"
 rand = "0.10.0-rc.8"
-rsa = { version = "0.10.0-rc.14", default-features = false, features = ["encoding", "sha2"] }
-sha1 = { version = "0.11.0-rc.4", default-features = false, features = ["oid"] }
-sha2 = { version = "0.11.0-rc.4", default-features = false, features = ["oid"] }
+rsa = { version = "0.10.0-rc.15", default-features = false, features = ["encoding", "sha2"] }
+sha1 = { version = "0.11.0-rc.5", default-features = false, features = ["oid"] }
+sha2 = { version = "0.11.0-rc.5", default-features = false, features = ["oid"] }
 
 [features]
 rand = ["rand_core"]


### PR DESCRIPTION
Updates the following dependency requirements which gets us onto releases which are all `rand_core` v0.10 / `getrandom` v0.4 compatible:

- `aes` v0.9.0-rc.4
- `aes-kw` v0.3.0-rc.2
- `ansi-x963-kdf` v0.1.0-rc.2
- `cbc` v0.2.0-rc.3
- `cipher` v0.5.0-rc.8
- `digest` v0.11.0-rc.11
- `elliptic-curve` v0.14.0-rc.28
- `p256` v0.14.0-rc.7
- `pbkdf2` v0.13.0-rc.9
- `rsa` v0.10.0-rc.15
- `sha1` v0.11.0-rc.5
- `sha2` v0.11.0-rc.5
- `sha3` v0.11.0-rc.7