### PR TITLE
der_derive v0.8.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,7 @@ on:
       "const-oid/v**",
       "crmf/v**",
       "der/v**",
+      "der_derive/v**"
       "gss-api/v**",
       "mcf/v**",
       "pem-rfc7468/v**",

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -20,7 +20,7 @@ rust-version = "1.85"
 arbitrary = { version = "1.4", features = ["derive"], optional = true }
 bytes = { version = "1", optional = true, default-features = false }
 const-oid = { version = "0.10", optional = true }
-der_derive = { version = "0.8.0-rc.6", optional = true }
+der_derive = { version = "0.8", optional = true }
 flagset = { version = "0.4.7", optional = true }
 pem-rfc7468 = { version = "1", optional = true, features = ["alloc"] }
 time = { version = "0.3.4", optional = true, default-features = false }

--- a/der_derive/CHANGELOG.md
+++ b/der_derive/CHANGELOG.md
@@ -5,20 +5,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## 0.8.0 (UNRELEASED)
-
+## 0.8.0 (2026-02-11)
 ### Added
-- `Sequence`, `Enumerated` and `Choice` macros now support `#[asn1(error = Ty)]` attribute that provides a custom error type for `Decode`/`DecodeValue` implementations ([#1560])
-- `BitString` macro ([#1720]) ([#1733])
+- `Sequence`, `Enumerated` and `Choice` macros now support `#[asn1(error = Ty)]` attribute that provides a custom error
+  type for `Decode`/`DecodeValue` implementations ([#1560])
+- `BitString` macro ([#1720], [#1733])
 - `DecodeValue`, `EncodeValue` macros ([#1722])
-- impl DecodeValue for Choice ([#1986])
-- derive support for `APPLICATION` and `PRIVATE` tags ([#1825])
+- Derive support for `APPLICATION` and `PRIVATE` tags ([#1825])
+- Impl `DecodeValue` for `Choice` ([#1986])
 
 ### Changed
-- move `der/derive` => `der_derive` ([#1457])
-- use `TryFrom` conversions for `asn1(type = ...)` ([#1562])
-- rewrite `EncodeValue::value_len` as simple addition ([#1810])
-- change OctetStringRef `&` handling due to der type changes ([#2043]) ([#2040]) ([#1998])
+- Use `TryFrom` conversions for `asn1(type = ...)` ([#1562])
+- Rewrite `EncodeValue::value_len` as simple addition ([#1810])
+- Change OctetStringRef `&` handling due to `der` type changes ([#1998], [#2040], [#2043])
 
 [#1457]: https://github.com/RustCrypto/formats/pull/1457
 [#1560]: https://github.com/RustCrypto/formats/pull/1560

--- a/der_derive/Cargo.toml
+++ b/der_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der_derive"
-version = "0.8.0-rc.6   "
+version = "0.8.0"
 description = "Custom derive support for the `der` crate's `Choice` and `Sequence` traits"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
## Added
- `Sequence`, `Enumerated` and `Choice` macros now support `#[asn1(error = Ty)]` attribute that provides a custom error
  type for `Decode`/`DecodeValue` implementations ([#1560])
- `BitString` macro ([#1720], [#1733])
- `DecodeValue`, `EncodeValue` macros ([#1722])
- Derive support for `APPLICATION` and `PRIVATE` tags ([#1825])
- Impl `DecodeValue` for `Choice` ([#1986])

## Changed
- Use `TryFrom` conversions for `asn1(type = ...)` ([#1562])
- Rewrite `EncodeValue::value_len` as simple addition ([#1810])
- Change OctetStringRef `&` handling due to `der` type changes ([#1998], [#2040], [#2043])

[#1457]: https://github.com/RustCrypto/formats/pull/1457
[#1560]: https://github.com/RustCrypto/formats/pull/1560
[#1562]: https://github.com/RustCrypto/formats/pull/1562
[#1720]: https://github.com/RustCrypto/formats/pull/1720
[#1722]: https://github.com/RustCrypto/formats/pull/1722
[#1733]: https://github.com/RustCrypto/formats/pull/1733
[#1825]: https://github.com/RustCrypto/formats/pull/1825
[#1810]: https://github.com/RustCrypto/formats/pull/1810
[#1986]: https://github.com/RustCrypto/formats/pull/1986
[#1998]: https://github.com/RustCrypto/formats/pull/1998
[#2040]: https://github.com/RustCrypto/formats/pull/2040
[#2043]: https://github.com/RustCrypto/formats/pull/2043