### PR TITLE
Add `heapless::Vec`-backed `SequenceOf` and `SetOf`

### DIFF
--- a/.github/workflows/der.yml
+++ b/.github/workflows/der.yml
@@ -91,7 +91,16 @@ jobs:
       - run: cargo hack test --feature-powerset --exclude-features arbitrary,std,heapless
       - run: cargo test --features arbitrary
       - run: cargo test --features std
-      #- run: cargo test --all-features # TODO(tarcieri): test heapless
+
+  # Test `heapless` feature (requires MSRV 1.87)
+  test-heapless:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.87
+      - run: cargo test --features heapless
 
   derive:
     runs-on: ubuntu-latest

--- a/der/src/asn1.rs
+++ b/der/src/asn1.rs
@@ -26,9 +26,7 @@ mod private;
 #[cfg(feature = "real")]
 mod real;
 mod sequence;
-#[cfg(feature = "alloc")]
 mod sequence_of;
-#[cfg(feature = "alloc")]
 mod set_of;
 mod teletex_string;
 mod utc_time;
@@ -68,6 +66,15 @@ pub use self::{
     set_of::SetOfVec,
     teletex_string::TeletexString,
 };
+
+#[cfg(feature = "heapless")]
+pub use self::{
+    sequence_of::{SequenceOf, SequenceOfIter},
+    set_of::SetOf,
+};
+
+#[cfg(any(feature = "alloc", feature = "heapless"))]
+pub use set_of::SetOfIter;
 
 #[cfg(feature = "oid")]
 pub use const_oid::ObjectIdentifier;

--- a/der/src/asn1/context_specific.rs
+++ b/der/src/asn1/context_specific.rs
@@ -30,8 +30,8 @@ mod tests {
     use crate::{Decode, Encode, SliceReader, TagMode, TagNumber, asn1::BitStringRef};
     use hex_literal::hex;
 
-    #[cfg(feature = "alloc")]
-    use crate::asn1::{ContextSpecificRef, SetOfVec, Utf8StringRef};
+    #[cfg(feature = "heapless")]
+    use crate::asn1::{ContextSpecificRef, SetOf, Utf8StringRef};
 
     // Public key data from `pkcs8` crate's `ed25519-pkcs8-v2.der`
     const EXAMPLE_BYTES: &[u8] =
@@ -125,13 +125,13 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "alloc")]
+    #[cfg(feature = "heapless")]
     fn context_specific_explicit_ref() {
-        let mut set = SetOfVec::new();
+        let mut set = SetOf::new();
         set.insert(8u16).unwrap();
         set.insert(7u16).unwrap();
 
-        let field = ContextSpecificRef::<SetOfVec<u16>> {
+        let field = ContextSpecificRef::<SetOf<u16, 2>> {
             value: &set,
             tag_number: TagNumber(2),
             tag_mode: TagMode::Explicit,
@@ -148,7 +148,7 @@ mod tests {
         );
 
         let mut reader = SliceReader::new(encoded).unwrap();
-        let field = ContextSpecific::<SetOfVec<u16>>::decode_explicit(&mut reader, TagNumber(2))
+        let field = ContextSpecific::<SetOf<u16, 2>>::decode_explicit(&mut reader, TagNumber(2))
             .unwrap()
             .unwrap();
 
@@ -158,16 +158,16 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "alloc")]
+    #[cfg(feature = "heapless")]
     fn context_specific_implicit_ref() {
         let hello = Utf8StringRef::new("Hello").unwrap();
         let world = Utf8StringRef::new("world").unwrap();
 
-        let mut set = SetOfVec::new();
+        let mut set = SetOf::new();
         set.insert(hello).unwrap();
         set.insert(world).unwrap();
 
-        let field = ContextSpecificRef::<SetOfVec<Utf8StringRef<'_>>> {
+        let field = ContextSpecificRef::<SetOf<Utf8StringRef<'_>, 2>> {
             value: &set,
             tag_number: TagNumber(2),
             tag_mode: TagMode::Implicit,
@@ -185,7 +185,7 @@ mod tests {
         );
 
         let mut reader = SliceReader::new(encoded).unwrap();
-        let field = ContextSpecific::<SetOfVec<Utf8StringRef<'_>>>::decode_implicit(
+        let field = ContextSpecific::<SetOf<Utf8StringRef<'_>, 2>>::decode_implicit(
             &mut reader,
             TagNumber(2),
         )

--- a/der/src/asn1/sequence_of.rs
+++ b/der/src/asn1/sequence_of.rs
@@ -1,13 +1,178 @@
 //! ASN.1 `SEQUENCE OF` support.
 
 use crate::{
-    Decode, DecodeValue, DerOrd, Encode, EncodeValue, Error, FixedTag, Header, Length, Reader, Tag,
-    ValueOrd, Writer, ord::iter_cmp,
+    DerOrd, Encode, EncodeValue, Error, FixedTag, Length, Tag, ValueOrd, Writer, ord::iter_cmp,
 };
 use core::cmp::Ordering;
 
+#[cfg(any(feature = "alloc", feature = "heapless"))]
+use crate::{Decode, DecodeValue, Header, Reader};
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
+#[cfg(feature = "heapless")]
+use {crate::ErrorKind, core::slice};
+
+/// ASN.1 `SEQUENCE OF` backed by an array.
+///
+/// This type implements an append-only `SEQUENCE OF` type which is stack-based
+/// and does not depend on `alloc` support.
+// TODO(tarcieri): use `ArrayVec` when/if it's merged into `core` (rust-lang/rfcs#3316)
+#[cfg(feature = "heapless")]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SequenceOf<T, const N: usize> {
+    inner: heapless::Vec<T, N>,
+}
+
+#[cfg(feature = "heapless")]
+impl<T, const N: usize> SequenceOf<T, N> {
+    /// Create a new [`SequenceOf`].
+    pub fn new() -> Self {
+        Self {
+            inner: heapless::Vec::new(),
+        }
+    }
+
+    /// Add an element to this [`SequenceOf`].
+    pub fn add(&mut self, element: T) -> Result<(), Error> {
+        self.inner
+            .push(element)
+            .map_err(|_| ErrorKind::Overlength.into())
+    }
+
+    /// Borrow the elements of this [`SequenceOf`] as a slice.
+    pub fn as_slice(&self) -> &[T] {
+        self.inner.as_slice()
+    }
+
+    /// Borrow the elements of this [`SequenceOf`] mutably as a slice.
+    pub fn as_mut_slice(&mut self) -> &mut [T] {
+        self.inner.as_mut_slice()
+    }
+
+    /// Get an element of this [`SequenceOf`].
+    pub fn get(&self, index: usize) -> Option<&T> {
+        self.inner.get(index)
+    }
+
+    /// Extract the inner `heapless::Vec`.
+    pub fn into_inner(self) -> heapless::Vec<T, N> {
+        self.inner
+    }
+
+    /// Iterate over the elements in this [`SequenceOf`].
+    pub fn iter(&self) -> SequenceOfIter<'_, T> {
+        SequenceOfIter {
+            inner: self.inner.iter(),
+        }
+    }
+
+    /// Is this [`SequenceOf`] empty?
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Number of elements in this [`SequenceOf`].
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+}
+
+#[cfg(feature = "heapless")]
+impl<T, const N: usize> AsRef<[T]> for SequenceOf<T, N> {
+    fn as_ref(&self) -> &[T] {
+        self.as_slice()
+    }
+}
+
+#[cfg(feature = "heapless")]
+impl<T, const N: usize> AsMut<[T]> for SequenceOf<T, N> {
+    fn as_mut(&mut self) -> &mut [T] {
+        self.as_mut_slice()
+    }
+}
+
+#[cfg(feature = "heapless")]
+impl<T, const N: usize> Default for SequenceOf<T, N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(feature = "heapless")]
+impl<'a, T, const N: usize> DecodeValue<'a> for SequenceOf<T, N>
+where
+    T: Decode<'a>,
+{
+    type Error = T::Error;
+
+    fn decode_value<R: Reader<'a>>(reader: &mut R, _header: Header) -> Result<Self, Self::Error> {
+        let mut sequence_of = Self::new();
+
+        while !reader.is_finished() {
+            sequence_of.add(T::decode(reader)?)?;
+        }
+
+        Ok(sequence_of)
+    }
+}
+
+#[cfg(feature = "heapless")]
+impl<T, const N: usize> EncodeValue for SequenceOf<T, N>
+where
+    T: Encode,
+{
+    fn value_len(&self) -> Result<Length, Error> {
+        self.iter()
+            .try_fold(Length::ZERO, |len, elem| len + elem.encoded_len()?)
+    }
+
+    fn encode_value(&self, writer: &mut impl Writer) -> Result<(), Error> {
+        for elem in self.iter() {
+            elem.encode(writer)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(feature = "heapless")]
+impl<T, const N: usize> FixedTag for SequenceOf<T, N> {
+    const TAG: Tag = Tag::Sequence;
+}
+
+#[cfg(feature = "heapless")]
+impl<T, const N: usize> ValueOrd for SequenceOf<T, N>
+where
+    T: DerOrd,
+{
+    fn value_cmp(&self, other: &Self) -> Result<Ordering, Error> {
+        iter_cmp(self.iter(), other.iter())
+    }
+}
+
+/// Iterator over the elements of an [`SequenceOf`].
+#[cfg(feature = "heapless")]
+#[derive(Clone, Debug)]
+pub struct SequenceOfIter<'a, T> {
+    /// Inner iterator.
+    inner: slice::Iter<'a, T>,
+}
+
+#[cfg(feature = "heapless")]
+impl<'a, T: 'a> Iterator for SequenceOfIter<'a, T> {
+    type Item = &'a T;
+
+    fn next(&mut self) -> Option<&'a T> {
+        self.inner.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+#[cfg(feature = "heapless")]
+impl<'a, T: 'a> ExactSizeIterator for SequenceOfIter<'a, T> {}
 
 impl<T: Encode> EncodeValue for [T] {
     fn value_len(&self) -> Result<Length, Error> {
@@ -21,6 +186,49 @@ impl<T: Encode> EncodeValue for [T] {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(feature = "heapless")]
+impl<'a, T, const N: usize> DecodeValue<'a> for [T; N]
+where
+    T: Decode<'a>,
+{
+    type Error = T::Error;
+
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self, Self::Error> {
+        let sequence_of = SequenceOf::<T, N>::decode_value(reader, header)?;
+        sequence_of
+            .inner
+            .into_array()
+            .map_err(|_| reader.error(Self::TAG.length_error()).into())
+    }
+}
+
+impl<T, const N: usize> EncodeValue for [T; N]
+where
+    T: Encode,
+{
+    fn value_len(&self) -> Result<Length, Error> {
+        self.iter()
+            .try_fold(Length::ZERO, |len, elem| len + elem.encoded_len()?)
+    }
+
+    fn encode_value(&self, writer: &mut impl Writer) -> Result<(), Error> {
+        self.as_slice().encode_value(writer)
+    }
+}
+
+impl<T, const N: usize> FixedTag for [T; N] {
+    const TAG: Tag = Tag::Sequence;
+}
+
+impl<T, const N: usize> ValueOrd for [T; N]
+where
+    T: DerOrd,
+{
+    fn value_cmp(&self, other: &Self) -> Result<Ordering, Error> {
+        iter_cmp(self.iter(), other.iter())
     }
 }
 
@@ -69,5 +277,30 @@ where
 {
     fn value_cmp(&self, other: &Self) -> Result<Ordering, Error> {
         iter_cmp(self.iter(), other.iter())
+    }
+}
+
+#[cfg(all(test, feature = "heapless"))]
+mod tests {
+    use super::SequenceOf;
+    use crate::ord::DerOrd;
+
+    #[test]
+    fn sequenceof_valueord_value_cmp() {
+        use core::cmp::Ordering;
+
+        let arr1 = {
+            let mut arr: SequenceOf<u16, 2> = SequenceOf::new();
+            arr.add(0u16).expect("element to be added");
+            arr.add(2u16).expect("element to be added");
+            arr
+        };
+        let arr2 = {
+            let mut arr: SequenceOf<u16, 2> = SequenceOf::new();
+            arr.add(0u16).expect("element to be added");
+            arr.add(1u16).expect("element to be added");
+            arr
+        };
+        assert_eq!(arr1.der_cmp(&arr2), Ok(Ordering::Greater));
     }
 }

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -37,16 +37,16 @@
 //! - [`bool`]: ASN.1 `BOOLEAN`.
 //! - [`i8`], [`i16`], [`i32`], [`i64`], [`i128`]: ASN.1 `INTEGER`.
 //! - [`u8`], [`u16`], [`u32`], [`u64`], [`u128`]: ASN.1 `INTEGER`.
-//! - [`f64`]: ASN.1 `REAL` (requires `real` crate feature).
+//! - [`f64`]: ASN.1 `REAL` (gated on `real` crate feature)
 //! - [`str`], [`String`][`alloc::string::String`]: ASN.1 `UTF8String`. See also [`Utf8StringRef`].
-//!   (note: `String` requires `alloc` feature).
 //! - [`Option`]: ASN.1 `OPTIONAL`.
-//! - [`SystemTime`][`std::time::SystemTime`]: ASN.1 `GeneralizedTime` (requires `std` feature).
-//! - [`Vec`][`alloc::vec::Vec`]: ASN.1 `SEQUENCE OF` (requires `alloc` feature).
+//! - [`SystemTime`][`std::time::SystemTime`]: ASN.1 `GeneralizedTime`. Requires `std` feature.
+//! - [`Vec`][`alloc::vec::Vec`]: ASN.1 `SEQUENCE OF` (requires `alloc` feature)
+//! - `[T; N]`: ASN.1 `SEQUENCE OF`. See also [`SequenceOf`].
 //!
 //! The following ASN.1 types provided by this crate also impl these traits:
 //! - [`Any`], [`AnyRef`]: ASN.1 `ANY`.
-//! - [`BitString`], [`BitStringRef`]: ASN.1 `BIT STRING`.
+//! - [`BitString`], [`BitStringRef`]: ASN.1 `BIT STRING`
 //! - [`GeneralizedTime`]: ASN.1 `GeneralizedTime`.
 //! - [`Ia5StringRef`]: ASN.1 `IA5String`.
 //! - [`Null`]: ASN.1 `NULL`.
@@ -55,7 +55,8 @@
 //! - [`PrintableStringRef`]: ASN.1 `PrintableString` (ASCII subset).
 //! - [`TeletexStringRef`]: ASN.1 `TeletexString`.
 //! - [`VideotexStringRef`]: ASN.1 `VideotexString`.
-//! - [`SetOfVec`]: ASN.1 `SET OF`.
+//! - [`SequenceOf`]: ASN.1 `SEQUENCE OF`.
+//! - [`SetOf`] (requires `heapless` feature), [`SetOfVec`] (requires `alloc`): ASN.1 `SET OF`.
 //! - [`UintRef`]: ASN.1 unsigned `INTEGER` with raw access to encoded bytes.
 //! - [`UtcTime`]: ASN.1 `UTCTime`.
 //! - [`Utf8StringRef`]: ASN.1 `UTF8String`.
@@ -313,6 +314,8 @@
 //! [`PrintableStringRef`]: asn1::PrintableStringRef
 //! [`TeletexStringRef`]: asn1::TeletexStringRef
 //! [`VideotexStringRef`]: asn1::VideotexStringRef
+//! [`SequenceOf`]: asn1::SequenceOf
+//! [`SetOf`]: asn1::SetOf
 //! [`SetOfVec`]: asn1::SetOfVec
 //! [`UintRef`]: asn1::UintRef
 //! [`UtcTime`]: asn1::UtcTime

--- a/der/src/ord.rs
+++ b/der/src/ord.rs
@@ -62,7 +62,6 @@ where
 }
 
 /// Compare the order of two iterators using [`DerCmp`] on the values.
-#[cfg(feature = "alloc")]
 pub(crate) fn iter_cmp<'a, I, T>(a: I, b: I) -> Result<Ordering>
 where
     I: Iterator<Item = &'a T> + ExactSizeIterator,

--- a/der/tests/derive.rs
+++ b/der/tests/derive.rs
@@ -118,10 +118,12 @@ mod choice {
     }
 
     /// `Choice` with `IMPLICIT` tagging.
+    #[cfg(feature = "heapless")]
     mod implicit {
+        use der::asn1::Null;
         use der::{
             Choice, Decode, Encode, Sequence, SliceWriter,
-            asn1::{BitStringRef, GeneralizedTime},
+            asn1::{BitStringRef, GeneralizedTime, SequenceOf},
         };
         use hex_literal::hex;
 
@@ -137,6 +139,9 @@ mod choice {
 
             #[asn1(context_specific = "2", type = "UTF8String")]
             Utf8String(String),
+
+            #[asn1(context_specific = "3", constructed = "true")]
+            SequenceOfNulls(SequenceOf<Null, 1>),
         }
 
         impl<'a> ImplicitChoice<'a> {
@@ -186,6 +191,24 @@ mod choice {
             let mut writer = SliceWriter::new(&mut buf);
             cs_time.encode(&mut writer).unwrap();
             assert_eq!(TIME_DER, writer.finish().unwrap());
+        }
+
+        #[test]
+        fn roundtrip_implicit_constructed_variant() {
+            let mut seq = SequenceOf::new();
+            seq.add(Null).unwrap();
+            let obj = ImplicitChoice::SequenceOfNulls(seq);
+            let mut buf = [0u8; 128];
+
+            let mut writer = SliceWriter::new(&mut buf);
+            obj.encode(&mut writer).unwrap();
+
+            let encoded = writer.finish().unwrap();
+            println!("encoded: {encoded:02X?}");
+
+            let decoded = ImplicitChoice::from_der(encoded).unwrap();
+
+            assert_eq!(decoded, obj);
         }
 
         /// Test case for `CHOICE` inside `[0]` `EXPLICIT` tag in `SEQUENCE`.
@@ -258,13 +281,13 @@ mod enumerated {
 }
 
 /// Custom derive test cases for the `Sequence` macro.
-#[cfg(feature = "oid")]
+#[cfg(all(feature = "heapless", feature = "oid"))]
 mod sequence {
     use super::CustomError;
     use core::marker::PhantomData;
     use der::{
         Decode, Encode, Sequence, ValueOrd,
-        asn1::{AnyRef, ObjectIdentifier},
+        asn1::{AnyRef, ObjectIdentifier, SetOf},
     };
     use hex_literal::hex;
 
@@ -407,23 +430,24 @@ mod sequence {
         assert_eq!(spki.subject_public_key, hex!("B0 B1 B2 B3 B4 B5 B6 B7"));
     }
 
-    // /// PKCS#8v2 `OneAsymmetricKey`
-    // #[derive(Sequence)]
-    // pub struct OneAsymmetricKey<'a> {
-    //     pub version: u8,
-    //     pub private_key_algorithm: AlgorithmIdentifier<'a>,
-    //     #[asn1(type = "OCTET STRING")]
-    //     pub private_key: &'a [u8],
-    //     #[asn1(context_specific = "0", extensible = "true", optional = "true")]
-    //     pub attributes: Option<SetOf<AnyRef<'a>, 1>>,
-    //     #[asn1(
-    //         context_specific = "1",
-    //         extensible = "true",
-    //         optional = "true",
-    //         type = "BIT STRING"
-    //     )]
-    //     pub public_key: Option<&'a [u8]>,
-    // }
+    /// PKCS#8v2 `OneAsymmetricKey`
+    #[derive(Sequence)]
+    #[allow(dead_code)]
+    pub struct OneAsymmetricKey<'a> {
+        pub version: u8,
+        pub private_key_algorithm: AlgorithmIdentifier<'a>,
+        #[asn1(type = "OCTET STRING")]
+        pub private_key: &'a [u8],
+        #[asn1(context_specific = "0", extensible = "true", optional = "true")]
+        pub attributes: Option<SetOf<AnyRef<'a>, 1>>,
+        #[asn1(
+            context_specific = "1",
+            extensible = "true",
+            optional = "true",
+            type = "BIT STRING"
+        )]
+        pub public_key: Option<&'a [u8]>,
+    }
 
     /// X.509 extension
     // TODO(tarcieri): tests for code derived with the `default` attribute

--- a/der/tests/set_of.rs
+++ b/der/tests/set_of.rs
@@ -1,6 +1,6 @@
 //! `SetOf` tests.
 
-#![cfg(feature = "alloc")]
+#![cfg(all(feature = "alloc", feature = "heapless"))]
 
 use der::{DerOrd, asn1::SetOfVec};
 use proptest::{prelude::*, string::*};
@@ -27,7 +27,7 @@ proptest! {
 mod ordering {
     use der::{
         Decode, Sequence, ValueOrd,
-        asn1::{AnyRef, ObjectIdentifier, SetOfVec},
+        asn1::{AnyRef, ObjectIdentifier, SetOf, SetOfVec},
     };
     use hex_literal::hex;
 
@@ -41,9 +41,27 @@ mod ordering {
     const OUT_OF_ORDER_RDN_EXAMPLE: &[u8] =
         &hex!("311F301106035504030C0A4A4F484E20534D495448300A060355040A0C03313233");
 
+    /// For compatibility reasons, we allow non-canonical DER with out-of-order
+    /// sets in order to match the behavior of other implementations.
+    #[test]
+    fn allow_out_of_order_setof() {
+        assert!(SetOf::<AttributeTypeAndValue<'_>, 2>::from_der(OUT_OF_ORDER_RDN_EXAMPLE).is_ok());
+    }
+
     /// Same as above, with `SetOfVec` instead of `SetOf`.
     #[test]
     fn allow_out_of_order_setofvec() {
         assert!(SetOfVec::<AttributeTypeAndValue<'_>>::from_der(OUT_OF_ORDER_RDN_EXAMPLE).is_ok());
+    }
+
+    /// Test to ensure ordering is handled correctly.
+    #[test]
+    fn ordering_regression() {
+        let der_bytes = hex!(
+            "3139301906035504030C12546573742055736572393031353734333830301C060A0992268993F22C640101130E3437303031303030303134373333"
+        );
+        let set = SetOf::<AttributeTypeAndValue<'_>, 3>::from_der(&der_bytes).unwrap();
+        let attr1 = set.get(0).unwrap();
+        assert_eq!(ObjectIdentifier::new("2.5.4.3").unwrap(), attr1.oid);
     }
 }


### PR DESCRIPTION
This reverts commit 48cb7303ed7f163c4abff23a4ae2ee498cc48e80 (#2220)

We already have a `heapless` feature, so might as well use it as the backing implementation for these types.

This restores the previously removed `SequenceOf` and `SetOf` types, using `heapless::Vec` as their internal data structure.

Closes #2218