### PR TITLE
der: expand CI coverage

### DIFF
--- a/.github/workflows/der.yml
+++ b/.github/workflows/der.yml
@@ -25,24 +25,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  build-no-std:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - 1.85.0 # MSRV
-          - stable
-        target:
-          - thumbv7em-none-eabi
-          - wasm32-unknown-unknown
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ matrix.rust }}
-          targets: ${{ matrix.target }}
+          toolchain: stable
+          targets: thumbv7em-none-eabi
       - uses: RustCrypto/actions/cargo-hack-install@master
-      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features arbitrary,std,heapless
+      - run: cargo hack build --target thumbv7em-none-eabi --feature-powerset --exclude-features arbitrary,std
 
   minimal-versions:
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
@@ -53,33 +45,44 @@ jobs:
     strategy:
       matrix:
         include:
-          # 32-bit Linux
-          - targets: i686-unknown-linux-gnu
-            platform: ubuntu-latest
+          # `aarch64` Linux
+          - target: aarch64-unknown-linux-gnu
+            rust: 1.85.0
+            runner: ubuntu-24.04-arm
+          - target: aarch64-unknown-linux-gnu
+            rust: stable
+            runner: ubuntu-24.04-arm
+
+          # `aarch64` macOS
+          - target: aarch64-apple-darwin
+            rust: 1.85.0
+            runner: macos-latest
+          - target: aarch64-apple-darwin
+            rust: stable
+            runner: macos-latest
+
+          # `x86` Linux (32-bit)
+          - target: i686-unknown-linux-gnu
             rust: 1.85.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
-          - targets: i686-unknown-linux-gnu
-            platform: ubuntu-latest
+          - target: i686-unknown-linux-gnu
             rust: stable
             deps: sudo apt update && sudo apt install gcc-multilib
 
-          # 64-bit Linux
-          - targets: x86_64-unknown-linux-gnu
-            platform: ubuntu-latest
+          # `x86_64` Linux
+          - target: x86_64-unknown-linux-gnu
             rust: 1.85.0 # MSRV
-          - targets: x86_64-unknown-linux-gnu
-            platform: ubuntu-latest
+          - target: x86_64-unknown-linux-gnu
             rust: stable
 
-          # temporary disable, since cargo-hack installation does not work yet
-          # 64-bit Windows
-          #- targets: x86_64-pc-windows-msvc
-          #  platform: windows-latest
-          #  rust: 1.85.0 # MSRV
-          #- targets: x86_64-pc-windows-msvc
-          #  platform: windows-latest
-          #  rust: stable
-    runs-on: ${{ matrix.platform }}
+          # `x86_64` Windows
+          - target: x86_64-pc-windows-msvc
+            rust: 1.85.0
+            runner: windows-latest
+          - target: x86_64-pc-windows-msvc
+            rust: stable
+            runner: windows-latest
+    runs-on: ${{ matrix.runner != '' && matrix.runner || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
@@ -87,22 +90,44 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
       - run: ${{ matrix.deps }}
-      - uses: RustCrypto/actions/cargo-hack-install@master
-      - run: cargo hack test --feature-powerset --exclude-features arbitrary,std,heapless
-      - run: cargo test --features arbitrary
-      - run: cargo test --features std
+      - uses: taiki-e/install-action@cargo-hack
+      - run: cargo hack test --target ${{ matrix.target }} --feature-powerset --exclude-features arbitrary,std,heapless
+      - run: cargo test --target ${{ matrix.target }} --features arbitrary
+      - run: cargo test --target ${{ matrix.target }} --features std
+      - run: cargo test --target ${{ matrix.target }} --features arbitrary,ber,bytes,derive,oid,pem,real,std
+      - run: cargo test --target ${{ matrix.target }} --features arbitrary,ber,bytes,derive,oid,pem,real,std --release
 
-  # Test `heapless` feature (requires MSRV 1.87)
-  test-heapless:
+  # Test using `cargo careful`
+  test-careful:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@nightly
+      - run: cargo install cargo-careful
+      - run: cargo careful test --all-features
+
+  # Test on foreign architectures using `cross test`
+  test-cross:
+    strategy:
+      matrix:
+        include:
+          - target: armv7-unknown-linux-gnueabi # ARM32
+          - target: powerpc-unknown-linux-gnu   # PPC32 (big endian)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.87
-      - run: cargo test --features heapless
+          toolchain: stable
+          targets: ${{ matrix.target }}
+      - run: cargo install cross
+      - run: cross test --target ${{ matrix.target }} --no-default-features
+      - run: cross test --target ${{ matrix.target }}
+      - run: cross test --target ${{ matrix.target }} --all-features
+      - run: cross test --target ${{ matrix.target }} --all-features --release
 
-  derive:
+  # Test `der_derive`
+  test-derive:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -117,3 +142,48 @@ jobs:
       - uses: RustCrypto/actions/cargo-hack-install@master
       - run: cargo hack test --feature-powerset
         working-directory: der_derive
+
+  # Test `heapless` feature (requires MSRV 1.87)
+  test-heapless:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.87
+      - run: cargo test --features heapless
+
+  # Test using `cargo miri`
+  test-miri:
+    runs-on: ubuntu-latest
+    env:
+      MIRIFLAGS: "-Zmiri-symbolic-alignment-check -Zmiri-strict-provenance"
+    strategy:
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - s390x-unknown-linux-gnu
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: nightly-2026-02-11 # pinned due to rust-lang/miri#4855
+      - run: rustup component add miri && cargo miri setup
+      - run: cargo miri test --target ${{ matrix.target }} --no-default-features --lib
+
+  # Test WASM using `wasmtime`
+  test-wasm:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TARGET_WASM32_WASIP1_RUNNER: "wasmtime"
+    steps:
+      - uses: actions/checkout@v6
+      - uses: bytecodealliance/actions/wasmtime/setup@v1
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          targets: wasm32-wasip1
+      - run: cargo test --target wasm32-wasip1 --no-default-features
+      - run: cargo test --target wasm32-wasip1
+      - run: cargo test --target wasm32-wasip1 --all-features
+      - run: cargo test --target wasm32-wasip1 --all-features --release

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -29,7 +29,8 @@ zeroize = { version = "1.8", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "1"
-proptest = "1"
+[target.'cfg(any(unix, windows))'.dev-dependencies]
+proptest = "1.10"
 
 [features]
 alloc = ["zeroize?/alloc"]

--- a/der/tests/datetime.rs
+++ b/der/tests/datetime.rs
@@ -1,5 +1,7 @@
 //! Tests for the [`DateTime`] type.
 
+#![cfg(any(unix, windows))]
+
 use der::{DateTime, Decode, Encode, asn1::UtcTime};
 use proptest::prelude::*;
 

--- a/der/tests/pem.rs
+++ b/der/tests/pem.rs
@@ -62,7 +62,7 @@ fn from_pem() {
 #[test]
 fn to_pem() {
     let spki = SpkiBorrowed::from_der(SPKI_DER).unwrap();
-    let pem = spki.to_pem(LineEnding::LF).unwrap();
+    let pem = spki.to_pem(LineEnding::default()).unwrap();
     assert_eq!(&pem, SPKI_PEM);
 }
 

--- a/der/tests/set_of.rs
+++ b/der/tests/set_of.rs
@@ -1,6 +1,6 @@
 //! `SetOf` tests.
 
-#![cfg(all(feature = "alloc", feature = "heapless"))]
+#![cfg(all(any(unix, windows), feature = "alloc", feature = "heapless"))]
 
 use der::{DerOrd, asn1::SetOfVec};
 use proptest::{prelude::*, string::*};


### PR DESCRIPTION
Adopts some additional testing and changes inspired by configs in other git repos we maintain:

- `build-no-std`: only test build on `thumbv7em-none-eabi` to ensure we're avoiding `std` linkage, removing `wasm32-unknown-unknown` because we now actually run tests on WASM with wasmtime
- `test`: checks `aarch64` Linux/macOS targets and `x86_64` Windows targets (more OS coverage is good because `der` has `std`-based features that interact with e.g. filesystems)
- `test-careful`: because we have some `unsafe` code
- `test-cross`: test on 32-bit and big endian architectures
- `test-miri`: because we have some `unsafe` code
- `test-wasm`: we can actually test directly on WASM using wasmtime, rather than just ensuring our code compiles