### PR TITLE
base32ct v0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "022dfe9eb35f19ebbcb51e0b40a5ab759f46ad60cadf7297e0bd085afb50e076"
 
 [[package]]
 name = "base32ct"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "base32",
  "proptest",

--- a/base32ct/CHANGELOG.md
+++ b/base32ct/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.1 (2026-02-26)
+### Fixed
+- Avoid panics when decoding inputs; enforce lengths ([#2084])
+
+[#2084]: https://github.com/RustCrypto/formats/pull/2084
+
 ## 0.3.0 (2025-08-20)
 ### Changed
 - Upgrade to 2024 edition; MSRV 1.85 ([#1670])

--- a/base32ct/Cargo.toml
+++ b/base32ct/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base32ct"
-version = "0.3.0"
+version = "0.3.1"
 description = """
 Pure Rust implementation of Base32 (RFC 4648) which avoids any usages of
 data-dependent branches/LUTs and thereby provides portable "best effort"

--- a/base32ct/LICENSE-MIT
+++ b/base32ct/LICENSE-MIT
@@ -1,6 +1,6 @@
 Copyright (c) 2014 Steve "Sc00bz" Thomas (steve at tobtu dot com)
 Copyright (c) 2016-2018 Paragon Initiative Enterprises.
-Copyright (c) 2022-2025 The RustCrypto Project Developers
+Copyright (c) 2022-2026 The RustCrypto Project Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated


### PR DESCRIPTION
### Fixed
- Avoid panics when decoding inputs; enforce lengths ([#2084])

[#2084]: https://github.com/RustCrypto/formats/pull/2084