### PR TITLE
der: add `SetOfRef` struct

### DIFF
--- a/der/src/asn1.rs
+++ b/der/src/asn1.rs
@@ -74,7 +74,7 @@ pub use self::{
 };
 
 #[cfg(any(feature = "alloc", feature = "heapless"))]
-pub use set_of::SetOfIter;
+pub use set_of::{SetOfIter, SetOfRef};
 
 #[cfg(feature = "oid")]
 pub use const_oid::ObjectIdentifier;

--- a/der/src/asn1/set_of.rs
+++ b/der/src/asn1/set_of.rs
@@ -11,8 +11,8 @@
 #![cfg(any(feature = "alloc", feature = "heapless"))]
 
 use crate::{
-    Decode, DecodeValue, DerOrd, Encode, EncodeValue, Error, ErrorKind, FixedTag, Header, Length,
-    Reader, Tag, ValueOrd, Writer, ord::iter_cmp,
+    AnyRef, Decode, DecodeValue, DerOrd, Encode, EncodeValue, Error, ErrorKind, FixedTag, Header,
+    Length, Reader, SliceReader, Tag, ValueOrd, Writer, ord::iter_cmp, ord::iter_cmp_owned,
 };
 use core::cmp::Ordering;
 
@@ -33,6 +33,28 @@ where
     T: DerOrd,
 {
     inner: heapless::Vec<T, N>,
+}
+
+// Inner reference of a SetOfRef
+//
+// An internal reference can either be bytes when constructed during decoding
+// or a slice of items of the generic type T.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+enum InnerRef<'a, T> {
+    BytesRef(&'a [u8], usize),
+    ObjectsRef(&'a [T]),
+}
+
+/// ASN.1 `SET OF` with a reference to an array.
+///
+/// This type implements a viewer in a `SET OF` type
+/// and does not depend on `alloc` support.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct SetOfRef<'a, T>
+where
+    T: DerOrd,
+{
+    inner: InnerRef<'a, T>,
 }
 
 #[cfg(feature = "heapless")]
@@ -124,6 +146,91 @@ where
     }
 }
 
+impl<'a, T> SetOfRef<'a, T>
+where
+    T: Decode<'a> + 'a,
+    T: Clone + DerOrd,
+{
+    /// Creates a [`SetOfRef`] by parsing the *contents* of a DER-encoded `SET OF` —
+    /// that is, the raw bytes after the tag and length bytes have been stripped.
+    fn from_bytes(v: &'a [u8]) -> Result<Self, Error> {
+        // Make sure we can decode valid objects from the bytes
+        let mut reader = SliceReader::new(v)?;
+
+        let mut iter_len = 0;
+        while !reader.is_finished() {
+            AnyRef::decode(&mut reader).map_err(|_| Error::from_kind(ErrorKind::Failed))?;
+            iter_len += 1;
+        }
+
+        // Generate the set as a byte reference
+        let new_set = Self {
+            inner: InnerRef::BytesRef(v, iter_len),
+        };
+
+        // Assert the constructed set obeys ordering rules
+        new_set
+            .iter()
+            .is_sorted_by(|a, b| !matches!(a.der_cmp(b), Ok(Ordering::Greater)))
+            .then_some(new_set)
+            .ok_or_else(|| Error::from_kind(ErrorKind::SetOrdering))
+    }
+
+    /// Get the nth element from this [`SetOfRef`].
+    #[must_use]
+    pub fn get(&self, index: usize) -> Option<T>
+    where
+        T: Decode<'a> + 'a,
+        T: Clone,
+    {
+        self.iter().nth(index)
+    }
+
+    /// Iterate over the elements of this [`SetOfRef`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if the inner byte slice contains invalid data that cannot be
+    /// parsed by [`SliceReader`].
+    #[must_use]
+    pub fn iter(&self) -> SetOfRefIter<'a, T>
+    where
+        T: Decode<'a> + 'a,
+    {
+        match self.inner {
+            InnerRef::BytesRef(inner, length) => SetOfRefIter {
+                inner: InnerIterRef::<'a, T>::BytesRef(
+                    SliceReader::new(inner).expect("Invalid data"),
+                ),
+                length,
+            },
+            InnerRef::ObjectsRef(inner) => SetOfRefIter {
+                inner: InnerIterRef::<'a, T>::ObjectsRef(inner),
+                length: inner.len(),
+            },
+        }
+    }
+
+    /// Is this [`SetOfRef`] empty?
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        match self.inner {
+            InnerRef::BytesRef(inner, _) => inner.is_empty(),
+            InnerRef::ObjectsRef(inner) => inner.is_empty(),
+        }
+    }
+
+    /// Number of elements in this [`SetOfRef`].
+    #[must_use]
+    pub fn len(&self) -> usize
+    where
+        T: Decode<'a> + 'a,
+        T: Clone,
+    {
+        self.iter().len()
+    }
+}
+
 #[cfg(feature = "heapless")]
 impl<T, const N: usize> Default for SetOf<T, N>
 where
@@ -157,6 +264,19 @@ where
     }
 }
 
+impl<'a, T> DecodeValue<'a> for SetOfRef<'a, T>
+where
+    T: Clone,
+    T: Decode<'a> + DerOrd,
+{
+    type Error = Error;
+
+    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> Result<Self, Self::Error> {
+        let inner_slice: &'a [u8] = reader.read_slice(header.length())?;
+        SetOfRef::<'a, T>::from_bytes(inner_slice)
+    }
+}
+
 #[cfg(feature = "heapless")]
 impl<T, const N: usize> EncodeValue for SetOf<T, N>
 where
@@ -176,8 +296,34 @@ where
     }
 }
 
+impl<'a, T> EncodeValue for SetOfRef<'a, T>
+where
+    T: Decode<'a> + Encode + DerOrd,
+    T: Clone,
+{
+    fn value_len(&self) -> Result<Length, Error> {
+        self.iter()
+            .try_fold(Length::ZERO, |len, elem| len + elem.encoded_len()?)
+    }
+
+    fn encode_value(&self, writer: &mut impl Writer) -> Result<(), Error> {
+        for elem in self.iter() {
+            elem.encode(writer)?;
+        }
+
+        Ok(())
+    }
+}
+
 #[cfg(feature = "heapless")]
 impl<T, const N: usize> FixedTag for SetOf<T, N>
+where
+    T: DerOrd,
+{
+    const TAG: Tag = Tag::Set;
+}
+
+impl<'a, T> FixedTag for SetOfRef<'a, T>
 where
     T: DerOrd,
 {
@@ -204,6 +350,31 @@ where
     }
 }
 
+impl<'a, T> TryFrom<&'a [T]> for SetOfRef<'a, T>
+where
+    T: DerOrd,
+{
+    type Error = Error;
+
+    fn try_from(arr: &'a [T]) -> Result<SetOfRef<'a, T>, Error> {
+        arr.iter()
+            .is_sorted_by(|a, b| !matches!(a.der_cmp(b), Ok(Ordering::Greater)))
+            .then_some(SetOfRef {
+                inner: InnerRef::ObjectsRef(arr),
+            })
+            .ok_or_else(|| Error::from_kind(ErrorKind::SetOrdering))
+    }
+}
+
+impl<'a, T> From<&SetOfRef<'a, T>> for SetOfRef<'a, T>
+where
+    T: Clone + DerOrd,
+{
+    fn from(value: &SetOfRef<'a, T>) -> SetOfRef<'a, T> {
+        value.clone()
+    }
+}
+
 #[cfg(feature = "heapless")]
 impl<T, const N: usize> ValueOrd for SetOf<T, N>
 where
@@ -211,6 +382,16 @@ where
 {
     fn value_cmp(&self, other: &Self) -> Result<Ordering, Error> {
         iter_cmp(self.iter(), other.iter())
+    }
+}
+
+impl<'a, T> ValueOrd for SetOfRef<'a, T>
+where
+    T: Decode<'a> + DerOrd + 'a,
+    T: Clone,
+{
+    fn value_cmp(&self, other: &Self) -> Result<Ordering, Error> {
+        iter_cmp_owned(self.iter(), other.iter())
     }
 }
 
@@ -234,6 +415,67 @@ impl<'a, T: 'a> Iterator for SetOfIter<'a, T> {
 }
 
 impl<'a, T: 'a> ExactSizeIterator for SetOfIter<'a, T> {}
+
+// Inner reference of a SetOfRefIter
+//
+// An internal reference can either be a slice reader when constructed during decoding
+// or a slice of items of the generic type T.
+#[derive(Clone, Debug)]
+enum InnerIterRef<'a, T> {
+    BytesRef(SliceReader<'a>),
+    ObjectsRef(&'a [T]),
+}
+
+/// Iterator over the elements of an [`SetOfRef`].
+#[derive(Clone, Debug)]
+pub struct SetOfRefIter<'a, T>
+where
+    T: Decode<'a>,
+{
+    /// Inner iterator.
+    inner: InnerIterRef<'a, T>,
+    length: usize,
+}
+
+impl<'a, T> Iterator for SetOfRefIter<'a, T>
+where
+    T: Decode<'a> + 'a,
+    T: Clone,
+{
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        match &mut self.inner {
+            InnerIterRef::BytesRef(inner_reader) => {
+                if inner_reader.is_finished() {
+                    return None;
+                }
+
+                let next_val = T::decode(inner_reader).ok()?;
+                self.length -= 1;
+                Some(next_val)
+            }
+            InnerIterRef::ObjectsRef(inner_slice) => {
+                let next_val = inner_slice.first()?;
+                self.inner = InnerIterRef::ObjectsRef(&inner_slice[1..]);
+                self.length -= 1;
+
+                Some(next_val.clone())
+            }
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.length, Some(self.length))
+    }
+}
+
+impl<'a, T> ExactSizeIterator for SetOfRefIter<'a, T>
+where
+    T: Decode<'a> + 'a,
+    T: Clone,
+{
+}
 
 /// ASN.1 `SET OF` backed by a [`Vec`].
 ///
@@ -522,13 +764,55 @@ fn der_sort<T: DerOrd>(slice: &mut [T]) -> Result<(), Error> {
     Ok(())
 }
 
+#[cfg(feature = "alloc")]
+mod allocating {
+    use super::*;
+    use crate::referenced::*;
+
+    impl<'a, T> RefToOwned<'a> for SetOfRef<'a, T>
+    where
+        T: Decode<'a> + EncodeValue + 'a,
+        T: DerOrd + FixedTag,
+        T: Clone,
+    {
+        type Owned = SetOfVec<T>;
+        fn ref_to_owned(&self) -> Self::Owned {
+            SetOfVec::from_iter(self.iter()).expect("SetOfVec: Could not sort inner slice")
+        }
+    }
+
+    impl<T> OwnedToRef for SetOfVec<T>
+    where
+        T: Encode,
+        T: DerOrd,
+    {
+        type Borrowed<'a>
+            = SetOfRef<'a, T>
+        where
+            T: 'a;
+
+        fn owned_to_ref(&self) -> Self::Borrowed<'_> {
+            SetOfRef::<T>::try_from(self.inner.as_slice()).expect("Unsorted slice")
+        }
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
+
+    use crate::ErrorKind;
     #[cfg(feature = "alloc")]
-    use super::SetOfVec;
+    use {
+        super::SetOfVec,
+        crate::{Decode, Encode, EncodeValue, SliceWriter},
+        alloc::vec,
+    };
+
     #[cfg(feature = "heapless")]
-    use {super::SetOf, crate::DerOrd};
+    use super::SetOf;
+    #[cfg(any(feature = "alloc", feature = "heapless"))]
+    use {super::SetOfRef, crate::DerOrd};
 
     #[cfg(feature = "heapless")]
     #[test]
@@ -572,6 +856,63 @@ mod tests {
         let arr2 = [3u16, 2, 1, 4, 0];
         let set1 = SetOf::try_from(arr1).unwrap();
         let set2 = SetOf::try_from(arr2).unwrap();
+        assert_eq!(set1.der_cmp(&set2), Ok(Ordering::Greater));
+    }
+
+    #[test]
+    fn setofref_tryfrom_array() {
+        let arr = [0u16, 1, 2, 3, 65535];
+        let set = SetOfRef::try_from(arr.as_ref()).unwrap();
+        assert!(set.iter().eq([0, 1, 2, 3, 65535]));
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn setofref_tryfrom_der() {
+        let arr = SetOfVec::try_from([0u16, 1, 2, 3, 65535])
+            .unwrap()
+            .to_der()
+            .unwrap();
+        let set = SetOfRef::<u16>::from_der(arr.as_ref()).unwrap();
+        assert!(set.iter().eq([0, 1, 2, 3, 65535]));
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn setofref_tryfrom_bytes() {
+        let arr = SetOfVec::try_from([0u16, 1, 2, 3, 65535]).unwrap();
+
+        let mut encoded = vec![0u8; arr.value_len().unwrap().try_into().unwrap()];
+        let mut writer = SliceWriter::new(&mut encoded);
+        arr.encode_value(&mut writer).unwrap();
+
+        let decoded = SetOfRef::<u16>::from_bytes(writer.finish().unwrap()).unwrap();
+
+        assert!(decoded.iter().eq([0, 1, 2, 3, 65535]));
+    }
+
+    #[test]
+    fn setofref_tryfrom_array_reject_unsorted() {
+        let arr = [3u16, 2, 1, 65535, 0];
+        let err = SetOfRef::try_from(arr.as_ref()).err().unwrap();
+        assert_eq!(err.kind(), ErrorKind::SetOrdering);
+    }
+
+    #[test]
+    fn setofref_tryfrom_array_allow_duplicates() {
+        let arr = [1u16, 1];
+        let set = SetOfRef::try_from(arr.as_ref()).unwrap();
+        assert!(set.iter().eq([1, 1]));
+    }
+
+    #[test]
+    fn setofref_valueord_value_cmp() {
+        use core::cmp::Ordering;
+
+        let arr1 = [0u16, 1, 2, 3, 5];
+        let arr2 = [0u16, 1, 2, 3, 4];
+        let set1 = SetOfRef::try_from(arr1.as_ref()).unwrap();
+        let set2 = SetOfRef::try_from(arr2.as_ref()).unwrap();
         assert_eq!(set1.der_cmp(&set2), Ok(Ordering::Greater));
     }
 

--- a/der/src/ord.rs
+++ b/der/src/ord.rs
@@ -85,6 +85,25 @@ where
     Ok(length_ord)
 }
 
+#[cfg(any(feature = "alloc", feature = "heapless"))]
+/// Compare the order of two iterators using [`DerCmp`] on the values.
+pub(crate) fn iter_cmp_owned<'a, I, T>(a: I, b: I) -> Result<Ordering>
+where
+    I: Iterator<Item = T> + ExactSizeIterator,
+    T: 'a + DerOrd,
+{
+    let length_ord = a.len().cmp(&b.len());
+
+    for (value1, value2) in a.zip(b) {
+        match value1.der_cmp(&value2)? {
+            Ordering::Equal => (),
+            other => return Ok(other),
+        }
+    }
+
+    Ok(length_ord)
+}
+
 /// Provide a no-op implementation for `PhantomData`
 impl<T> ValueOrd for PhantomData<T> {
     fn value_cmp(&self, _other: &Self) -> Result<Ordering> {


### PR DESCRIPTION
Hello everyone,
in this PR I add a referenced version to the SetOf struct. This can be useful to implement referenced versions of structs containing SetOfs.

In order to allow both decoding from DER bytes and creating references from existing SetOfs, the SetOfRef contains an internal reference that can be both. The inner reference to raw bytes is not pretty, but I do not see another way to implement this with no_std requirements. Most functions like get are then implemented over iterators, that hide the inner reference type. I check sorting on all constructors.

In order for CI to go through, we need a MSRV of 1.87 for the heapless crate.

I am happy to receive feedback on this PR!