### PR TITLE
mcf v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,7 +964,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "mcf"
-version = "0.6.0-rc.3"
+version = "0.6.0"
 dependencies = [
  "base64ct",
  "hex-literal",

--- a/mcf/CHANGELOG.md
+++ b/mcf/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2026-03-08)
+NOTE: v0.3 - v0.5 skipped to sync version numbers with the `password-hash` crate.
+
+### Added
+- `Display` impl for `PasswordHashRef` ([#2114])
+- `PasswordHash::push_displayable` ([#2115])
+- `PasswordHash::as_password_hash_ref` method ([#2117])
+- `Base64::B64` alphabet ([#2152])
+- `Base64::Pbkdf2` alphabet ([#2168])
+
+### Changed
+- `Error` enum ([#2119])
+- Rename `Base64::ShaCrypt` to `Base64::Crypt` replacing old alphabet ([#2134])
+
+### Removed
+- `PasswordHashRef` lifetime ([#2116])
+
+[#2114]: https://github.com/RustCrypto/formats/pull/2114
+[#2115]: https://github.com/RustCrypto/formats/pull/2115
+[#2116]: https://github.com/RustCrypto/formats/pull/2116
+[#2117]: https://github.com/RustCrypto/formats/pull/2117
+[#2119]: https://github.com/RustCrypto/formats/pull/2119
+[#2134]: https://github.com/RustCrypto/formats/pull/2134
+[#2152]: https://github.com/RustCrypto/formats/pull/2152
+[#2168]: https://github.com/RustCrypto/formats/pull/2168
+
 ## 0.2.0 (2025-09-07)
 ### Added
 - `(Try)From` impls for `PasswordHash` <=> `String` ([#2027])

--- a/mcf/Cargo.toml
+++ b/mcf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcf"
-version = "0.6.0-rc.3"
+version = "0.6.0"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/mcf/LICENSE-MIT
+++ b/mcf/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2025 The RustCrypto Project Developers
+Copyright (c) 2025-2026 The RustCrypto Project Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated


### PR DESCRIPTION
## Added
- `Display` impl for `PasswordHashRef` ([#2114])
- `PasswordHash::push_displayable` ([#2115])
- `PasswordHash::as_password_hash_ref` method ([#2117])
- `Base64::B64` alphabet ([#2152])
- `Base64::Pbkdf2` alphabet ([#2168])

## Changed
- `Error` enum ([#2119])
- Rename `Base64::ShaCrypt` to `Base64::Crypt` replacing old alphabet ([#2134])

## Removed
- `PasswordHashRef` lifetime ([#2116])

[#2114]: https://github.com/RustCrypto/formats/pull/2114
[#2115]: https://github.com/RustCrypto/formats/pull/2115
[#2116]: https://github.com/RustCrypto/formats/pull/2116
[#2117]: https://github.com/RustCrypto/formats/pull/2117
[#2119]: https://github.com/RustCrypto/formats/pull/2119
[#2134]: https://github.com/RustCrypto/formats/pull/2134
[#2152]: https://github.com/RustCrypto/formats/pull/2152
[#2168]: https://github.com/RustCrypto/formats/pull/2168