### PR TITLE
phc v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1035,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "phc"
-version = "0.6.0-rc.2"
+version = "0.6.0"
 dependencies = [
  "base64ct",
  "ctutils",

--- a/phc/CHANGELOG.md
+++ b/phc/CHANGELOG.md
@@ -3,3 +3,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.6.0 (2026-03-09)
+Initial RustCrypto release with version numbers skipped to match `password-hash`.
+
+There was previously a crate named `phc`, however this release is an extraction from
+the `password-hash` crate which is effectively a new crate.

--- a/phc/Cargo.toml
+++ b/phc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phc"
-version = "0.6.0-rc.2"
+version = "0.6.0"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"


### PR DESCRIPTION
Initial RustCrypto release with version numbers skipped to match `password-hash`.

There was previously a crate named `phc`, however this release is an extraction from
the `password-hash` crate which is effectively a new crate.