### PR TITLE
phc: render `--all-features` on docs.rs

### DIFF
--- a/phc/Cargo.toml
+++ b/phc/Cargo.toml
@@ -27,3 +27,6 @@ default = ["rand_core"]
 alloc = ["base64ct/alloc"]
 getrandom = ["dep:getrandom"]
 rand_core = ["dep:rand_core"]
+
+[package.metadata.docs.rs]
+all-features = true


### PR DESCRIPTION
The docs for the `getrandom` feature aren't showing up