### PR TITLE
sec1 v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1505,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.8.0-rc.13"
+version = "0.8.0"
 dependencies = [
  "base16ct",
  "ctutils",
@@ -1727,7 +1727,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix",
  "windows-sys",

--- a/sec1/CHANGELOG.md
+++ b/sec1/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.0 (2026-03-10)
+### Added
+- `ctutils` feature ([#2150])
+
+### Changed
+- Migrate from `generic-array` to `hybrid-array` ([#1298])
+- Use `core::error::Error` ([#1573])
+- Blanket impl `ModulusSize` for all typenums ([#1650])
+- Upgrade to edition 2024; bump MSRV to 1.85 ([#1666])
+- Bump `serdect` to v0.4 ([#2008])
+- Bump `base16ct` to v1 ([#2145])
+- Bump `der` to v0.8 ([#2234])
+
+### Removed
+- Integration with `pkcs8` crate ([#1927])
+
+[#1298]: https://github.com/RustCrypto/formats/pull/1298
+[#1573]: https://github.com/RustCrypto/formats/pull/1573
+[#1650]: https://github.com/RustCrypto/formats/pull/1650
+[#1666]: https://github.com/RustCrypto/formats/pull/1666
+[#1927]: https://github.com/RustCrypto/formats/pull/1927
+[#2008]: https://github.com/RustCrypto/formats/pull/2008
+[#2145]: https://github.com/RustCrypto/formats/pull/2145
+[#2150]: https://github.com/RustCrypto/formats/pull/2150
+[#2234]: https://github.com/RustCrypto/formats/pull/2234
+
 ## 0.7.3 (2023-07-16)
 ### Added
 - Impl `Hash` for `EncodedPoint` ([#1102])

--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sec1"
-version = "0.8.0-rc.13"
+version = "0.8.0"
 description = """
 Pure Rust implementation of SEC1: Elliptic Curve Cryptography encoding formats
 including ASN.1 DER-serialized private keys as well as the

--- a/sec1/LICENSE-MIT
+++ b/sec1/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2021-2025 The RustCrypto Project Developers
+Copyright (c) 2021-2026 The RustCrypto Project Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated


### PR DESCRIPTION
## Added
- `ctutils` feature ([#2150])

## Changed
- Migrate from `generic-array` to `hybrid-array` ([#1298])
- Use `core::error::Error` ([#1573])
- Blanket impl `ModulusSize` for all typenums ([#1650])
- Upgrade to edition 2024; bump MSRV to 1.85 ([#1666])
- Bump `serdect` to v0.4 ([#2008])
- Bump `base16ct` to v1 ([#2145])
- Bump `der` to v0.8 ([#2234])

## Removed
- Integration with `pkcs8` crate ([#1927])

[#1298]: https://github.com/RustCrypto/formats/pull/1298
[#1573]: https://github.com/RustCrypto/formats/pull/1573
[#1650]: https://github.com/RustCrypto/formats/pull/1650
[#1666]: https://github.com/RustCrypto/formats/pull/1666
[#1927]: https://github.com/RustCrypto/formats/pull/1927
[#2008]: https://github.com/RustCrypto/formats/pull/2008
[#2145]: https://github.com/RustCrypto/formats/pull/2145
[#2150]: https://github.com/RustCrypto/formats/pull/2150
[#2234]: https://github.com/RustCrypto/formats/pull/2234