### PR TITLE
tls_codec: manually implement `zeroize`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2254,20 +2254,6 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "zmij"

--- a/tls_codec/Cargo.toml
+++ b/tls_codec/Cargo.toml
@@ -12,10 +12,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-zeroize = { version = "1.8", default-features = false, features = [
-    "alloc",
-    "zeroize_derive",
-] }
+zeroize = { version = "1.8", default-features = false, features = ["alloc"] }
 
 # optional dependencies
 arbitrary = { version = "1.4", features = ["derive"], optional = true }

--- a/tls_codec/src/quic_vec.rs
+++ b/tls_codec/src/quic_vec.rs
@@ -232,7 +232,6 @@ macro_rules! impl_vl_bytes_generic {
 /// Use this struct if bytes are encoded.
 /// This is faster than the generic version.
 #[cfg_attr(feature = "serde", derive(SerdeSerialize, SerdeDeserialize))]
-#[cfg_attr(feature = "std", derive(Zeroize))]
 #[derive(Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct VLBytes {
     #[cfg_attr(feature = "serde", serde(serialize_with = "serde_bytes::serialize"))]
@@ -259,6 +258,13 @@ impl VLBytes {
 }
 
 impl_vl_bytes_generic!(VLBytes);
+
+#[cfg(feature = "std")]
+impl Zeroize for VLBytes {
+    fn zeroize(&mut self) {
+        self.vec.zeroize();
+    }
+}
 
 impl From<VLBytes> for Vec<u8> {
     fn from(b: VLBytes) -> Self {
@@ -578,7 +584,7 @@ mod secret_bytes {
     /// behaves just like [`VLBytes`], except that it doesn't allow conversion into
     /// a [`Vec<u8>`].
     #[cfg_attr(feature = "serde", derive(SerdeSerialize, SerdeDeserialize))]
-    #[derive(Clone, PartialEq, Eq, Hash, Ord, PartialOrd, Zeroize, ZeroizeOnDrop)]
+    #[derive(Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
     pub struct SecretVLBytes(VLBytes);
 
     impl SecretVLBytes {
@@ -598,6 +604,20 @@ mod secret_bytes {
     }
 
     impl_vl_bytes_generic!(SecretVLBytes);
+
+    impl Zeroize for SecretVLBytes {
+        fn zeroize(&mut self) {
+            self.0.zeroize();
+        }
+    }
+
+    impl Drop for SecretVLBytes {
+        fn drop(&mut self) {
+            self.zeroize();
+        }
+    }
+
+    impl ZeroizeOnDrop for SecretVLBytes {}
 
     impl Size for SecretVLBytes {
         fn tls_serialized_len(&self) -> usize {


### PR DESCRIPTION
Fairly trivial implementation, avoids pulling in the proc-macro machinery by default.
