### PR TITLE
sec1 v0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1512,7 +1512,7 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "base16ct",
  "ctutils",

--- a/sec1/CHANGELOG.md
+++ b/sec1/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.1 (2026-03-31)
+### Added
+- Impl `CtAssign(Slice)`/`CtEq(Slice)` for `EncodedPoint` ([#2269])
+
+[#2269]: https://github.com/RustCrypto/formats/pull/2269
+
 ## 0.8.0 (2026-03-10)
 ### Added
 - `ctutils` feature ([#2150])

--- a/sec1/Cargo.toml
+++ b/sec1/Cargo.toml
@@ -1,10 +1,9 @@
 [package]
 name = "sec1"
-version = "0.8.0"
+version = "0.8.1"
 description = """
-Pure Rust implementation of SEC1: Elliptic Curve Cryptography encoding formats
-including ASN.1 DER-serialized private keys as well as the
-Elliptic-Curve-Point-to-Octet-String encoding
+Pure Rust implementation of SEC1: Elliptic Curve Cryptography encoding formats including ASN.1 DER
+encoded private keys as well as the Elliptic-Curve-Point-to-Octet-String encoding
 """
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
@@ -42,4 +41,3 @@ zeroize = ["dep:zeroize", "der?/zeroize"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
## Added
- Impl `CtAssign(Slice)`/`CtEq(Slice)` for `EncodedPoint` ([#2269])

[#2269]: https://github.com/RustCrypto/formats/pull/2269