### PR TITLE
chore(deps): bump dependencies to release versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,9 +39,9 @@ dependencies = [
 
 [[package]]
 name = "aes-kw"
-version = "0.3.0-rc.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d3f56c4f20065fe12a323918242aefbbd7d85f8ce81dabfdb4b61726d0fe642"
+checksum = "40e4645e6ea320665abf87e13821f9a37ab204b34bcb18e34e7d1dcf2366516e"
 dependencies = [
  "aes",
  "const-oid",
@@ -198,9 +198,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cbc"
-version = "0.2.0-rc.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab1412b9ae2463ede01f1e591412dfbcfeacecf40e8c4c3e0655814c19065c38"
+checksum = "98db6aeaef0eeef2c1e3ce9a27b739218825dae116076352ac3777076aa22225"
 dependencies = [
  "cipher",
 ]
@@ -465,9 +465,9 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.10.0-rc.4"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fee683dd898fbd052617b4514bc31f98bc32081a83b69ec46adef3b1ef4ae36f"
+checksum = "17469f8eb9bdbfad10f71f4cfddfd38b01143520c0e717d8796ccb4d44d44e42"
 dependencies = [
  "cipher",
 ]
@@ -530,9 +530,9 @@ dependencies = [
 
 [[package]]
 name = "des"
-version = "0.9.0-rc.3"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3214053e68a813b9c06ef61075c844f3a1cdeb307d8998ea8555c063caa52fa9"
+checksum = "916a94e407b54f9034d71dd748234cd1e516ced6284009906ae246f177eafe5a"
 dependencies = [
  "cipher",
 ]
@@ -572,9 +572,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.29"
+version = "0.14.0-rc.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e84043d573efd4ac9d2d125817979a379204bf7e328b25a4a30487e8d100e618"
+checksum = "7d7a0bfd012613a7bcfe02cbfccf2b846e9ef9e1bccb641c48d461253cfb034d"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -1359,7 +1359,8 @@ dependencies = [
 [[package]]
 name = "rsa"
 version = "0.10.0-rc.17"
-source = "git+https://github.com/RustCrypto/RSA#30560f59e9da8e3be458adfd1a1fd8a19e8ad125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ed3e93fc7e473e464b9726f4759659e72bc8665e4b8ea227547024f416d905"
 dependencies = [
  "const-oid",
  "crypto-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,8 +61,6 @@ x509-tsp = { path = "./x509-tsp" }
 x509-cert = { path = "./x509-cert" }
 x509-ocsp = { path = "./x509-ocsp" }
 
-rsa = { git = "https://github.com/RustCrypto/RSA" }
-
 [workspace.lints.clippy]
 borrow_as_ptr = "warn"
 cast_lossless = "warn"

--- a/cms/Cargo.toml
+++ b/cms/Cargo.toml
@@ -22,16 +22,16 @@ x509-cert = { version = "0.3.0-rc.4", default-features = false }
 
 # optional dependencies
 aes = { version = "0.9", optional = true }
-aes-kw = { version = "0.3.0-rc.2", optional = true }
+aes-kw = { version = "0.3", optional = true }
 ansi-x963-kdf = { version = "0.1.0-rc.2", optional = true }
-cbc = { version = "0.2.0-rc.4", optional = true }
+cbc = { version = "0.2", optional = true }
 cipher = { version = "0.5", features = ["alloc", "block-padding", "rand_core"], optional = true }
 digest = { version = "0.11", optional = true }
-elliptic-curve = { version = "0.14.0-rc.28", optional = true }
-rsa = { version = "0.10.0-rc.15", optional = true }
+elliptic-curve = { version = "0.14.0-rc.30", optional = true }
+rsa = { version = "0.10.0-rc.17", optional = true }
 sha1 = { version = "0.11", optional = true }
 sha2 = { version = "0.11", optional = true }
-sha3 = { version = "0.11.0-rc.7", optional = true }
+sha3 = { version = "0.11", optional = true }
 signature = { version = "3.0.0-rc.10", features = ["digest", "alloc"], optional = true }
 zeroize = { version = "1.8.1", optional = true }
 
@@ -43,7 +43,7 @@ pem-rfc7468 = "1"
 pkcs5 = "0.8.0-rc.13"
 pbkdf2 = "0.13.0-rc.9"
 rand = "0.10"
-rsa = { version = "0.10.0-rc.15", features = ["sha2"] }
+rsa = { version = "0.10.0-rc.17", features = ["sha2"] }
 ecdsa = { version = "0.17.0-rc.16", features = ["digest", "pem"] }
 p256 = "0.14.0-rc.7"
 tokio = { version = "1.45.1", features = ["macros", "rt"] }

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -20,10 +20,10 @@ der = { version = "0.8", features = ["oid"] }
 spki = "0.8"
 
 # optional dependencies
-cbc = { version = "0.2.0-rc.4", optional = true }
+cbc = { version = "0.2", optional = true }
 aes = { version = "0.9", optional = true, default-features = false }
 aes-gcm = { version = "0.11.0-rc.3", optional = true, default-features = false, features = ["aes"] }
-des = { version = "0.9.0-rc.3", optional = true, default-features = false }
+des = { version = "0.9", optional = true, default-features = false }
 pbkdf2 = { version = "0.13.0-rc.9", optional = true, default-features = false, features = ["hmac"] }
 rand_core = { version = "0.10", optional = true, default-features = false }
 scrypt = { version = "0.12.0-rc.10", optional = true, default-features = false }

--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -30,7 +30,7 @@ tls_codec = { version = "0.4", default-features = false, features = ["derive"], 
 [dev-dependencies]
 hex-literal = "1"
 rand = "0.10"
-rsa = { version = "0.10.0-rc.15", features = ["sha2"] }
+rsa = { version = "0.10.0-rc.17", features = ["sha2"] }
 ecdsa = { version = "0.17.0-rc.16", features = ["digest", "pem"] }
 p256 = "0.14.0-rc.7"
 rstest = "0.26"

--- a/x509-ocsp/Cargo.toml
+++ b/x509-ocsp/Cargo.toml
@@ -30,7 +30,7 @@ signature = { version = "3.0.0-rc.10", optional = true, default-features = false
 hex-literal = "1"
 lazy_static = "1.5.0"
 rand = "0.10"
-rsa = { version = "0.10.0-rc.15", default-features = false, features = ["encoding", "sha2"] }
+rsa = { version = "0.10.0-rc.17", default-features = false, features = ["encoding", "sha2"] }
 sha1 = { version = "0.11", default-features = false, features = ["oid"] }
 sha2 = { version = "0.11", default-features = false, features = ["oid"] }
 


### PR DESCRIPTION
This bumps:
 - `aes-kw` to `0.3.0`
 - `cbc` to `0.2.0`
 - `ctr` to `0.10.0`
 - `des` to `0.9.0`

This also bumps the following crates to latest pre-release versions:
 - `elliptic-curve` to `0.14.0-rc.30`
 - `rsa` to `0.10.0-rc.17`