### PR TITLE
fix(pkcs12): validate kdf iteration count >= 1

### DIFF
--- a/pkcs12/src/kdf.rs
+++ b/pkcs12/src/kdf.rs
@@ -15,7 +15,7 @@
 //! [`argon2`](https://docs.rs/argon2) crate for a state-of-the-art password-based KDF.
 
 use alloc::{vec, vec::Vec};
-use der::asn1::BmpString;
+use der::{Tag, asn1::BmpString};
 use digest::{Digest, FixedOutputReset, OutputSizeUser, Update, block_api::BlockSizeUser};
 use zeroize::{Zeroize, Zeroizing};
 
@@ -32,8 +32,14 @@ pub enum Pkcs12KeyType {
 }
 
 /// Derives `key` of type `id` from `pass` and `salt` with length `key_len` using `rounds`
-/// iterations of the algorithm
-/// `pass` must be a utf8 string.
+/// iterations of the algorithm.
+///
+/// `pass` must be a UTF-8 string.  Characters outside the Unicode Basic Multilingual Plane
+/// (U+0000–U+FFFF) are rejected; BMP encoding is required by the PKCS#12 §B.2 KDF.
+///
+/// `rounds` must be ≥ 1 (RFC 7292 Appendix C defines `iterations INTEGER (1..MAX)`).
+/// An error is returned if `rounds < 1`.
+///
 /// ```rust
 /// let key = pkcs12::kdf::derive_key_utf8::<sha2::Sha256>("top-secret", &[0x1, 0x2, 0x3, 0x4],
 ///     pkcs12::kdf::Pkcs12KeyType::EncryptionKey, 1000, 32);
@@ -49,17 +55,21 @@ where
     D: Digest + FixedOutputReset + BlockSizeUser,
 {
     let password_bmp = BmpString::from_utf8(password)?;
-    Ok(derive_key_bmp::<D>(password_bmp, salt, id, rounds, key_len))
+    derive_key_bmp::<D>(password_bmp, salt, id, rounds, key_len)
 }
 
-/// Derive
+/// Derives `key` of type `id` from `pass` (as a [`BmpString`]) and `salt` with length `key_len`
+/// using `rounds` iterations of the algorithm.
+///
+/// `rounds` must be ≥ 1 (RFC 7292 Appendix C defines `iterations INTEGER (1..MAX)`).
+/// An error is returned if `rounds < 1`.
 pub fn derive_key_bmp<D>(
     password: BmpString,
     salt: &[u8],
     id: Pkcs12KeyType,
     rounds: i32,
     key_len: usize,
-) -> Vec<u8>
+) -> der::Result<Vec<u8>>
 where
     D: Digest + FixedOutputReset + BlockSizeUser,
 {
@@ -72,9 +82,14 @@ where
 }
 
 /// Derives `key` of type `id` from `pass` and `salt` with length `key_len` using `rounds`
-/// iterations of the algorithm
-/// `pass` must be a unicode (utf16) byte array in big endian order without order mark and with two
-/// terminating zero bytes.
+/// iterations of the algorithm.
+///
+/// `pass` must be a Unicode (UTF-16BE) byte array in big-endian order without a byte-order mark
+/// and with two terminating zero bytes.
+///
+/// `rounds` must be ≥ 1 (RFC 7292 Appendix C defines `iterations INTEGER (1..MAX)`).
+/// An error is returned if `rounds < 1`.
+///
 /// ```rust
 /// let key = pkcs12::kdf::derive_key_utf8::<sha2::Sha256>("top-secret", &[0x1, 0x2, 0x3, 0x4],
 ///     pkcs12::kdf::Pkcs12KeyType::EncryptionKey, 1000, 32);
@@ -85,10 +100,19 @@ pub fn derive_key<D>(
     id: Pkcs12KeyType,
     rounds: i32,
     key_len: usize,
-) -> Vec<u8>
+) -> der::Result<Vec<u8>>
 where
     D: Digest + FixedOutputReset + BlockSizeUser,
 {
+    // RFC 7292 Appendix C: `iterations INTEGER (1..MAX)`.  The iteration loop
+    // `for _ in 1..rounds` silently degenerates to a single hash application
+    // when rounds <= 0, producing wrong output without signalling failure.
+    if rounds < 1 {
+        return Err(der::Error::from(der::ErrorKind::Value {
+            tag: Tag::Integer,
+        }));
+    }
+
     let mut digest = D::new();
     let output_size = <D as OutputSizeUser>::output_size();
     let block_size = D::block_size();
@@ -183,5 +207,5 @@ where
     }
     init_key.zeroize();
     // 8. Use the first n bits of A as the output of this entire process.
-    out
+    Ok(out)
 }

--- a/pkcs12/tests/kdf.rs
+++ b/pkcs12/tests/kdf.rs
@@ -6,6 +6,49 @@
 use hex_literal::hex;
 use pkcs12::kdf::{Pkcs12KeyType, derive_key_utf8};
 
+/// rounds=1 is the minimum valid value per RFC 7292 Appendix C (`iterations INTEGER (1..MAX)`).
+/// Vectors generated with:
+///   openssl kdf -keylen 32 -kdfopt digest:SHA256 \
+///     -kdfopt hexpass:00670065004000e4006800650069006d0000 \
+///     -kdfopt hexsalt:0102030405060708 -kdfopt iter:1 -kdfopt id:<N> PKCS12KDF
+/// where hexpass is "ge@äheim" encoded as UTF-16BE with a 2-byte null terminator.
+#[test]
+fn pkcs12_key_derive_rounds_one_boundary() {
+    const PASS: &str = "ge@äheim";
+    const SALT: [u8; 8] = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+
+    assert_eq!(
+        derive_key_utf8::<sha2::Sha256>(PASS, &SALT, Pkcs12KeyType::Mac, 1, 32).unwrap(),
+        hex!("6490c5afd22f24a9346308c25babe8446c632c5937685bebc88feda260bad102")
+    );
+
+    assert_eq!(
+        derive_key_utf8::<sha2::Sha256>(PASS, &SALT, Pkcs12KeyType::EncryptionKey, 1, 32).unwrap(),
+        hex!("637bbe1fe81bfc5abb031f335548d5dced0f0051c69cc2b9c28b2c66935085e5")
+    );
+}
+
+/// rounds <= 0 must return an error; silently producing wrong output (one hash application
+/// instead of the requested count) is a correctness failure.
+#[test]
+fn pkcs12_key_derive_zero_rounds_errors() {
+    const PASS: &str = "ge@äheim";
+    const SALT: [u8; 8] = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+
+    assert!(
+        derive_key_utf8::<sha2::Sha256>(PASS, &SALT, Pkcs12KeyType::Mac, 0, 32).is_err(),
+        "rounds=0 must be rejected"
+    );
+    assert!(
+        derive_key_utf8::<sha2::Sha256>(PASS, &SALT, Pkcs12KeyType::Mac, -1, 32).is_err(),
+        "rounds=-1 must be rejected"
+    );
+    assert!(
+        derive_key_utf8::<sha2::Sha256>(PASS, &SALT, Pkcs12KeyType::Mac, i32::MIN, 32).is_err(),
+        "rounds=i32::MIN must be rejected"
+    );
+}
+
 #[test]
 fn pkcs12_key_derive_sha256() {
     const PASS_SHORT: &str = "ge@äheim";


### PR DESCRIPTION
## Summary

- `derive_key`, `derive_key_bmp`, and `derive_key_utf8` all accept `rounds: i32` with no validation
- The iteration loop `for _ in 1..rounds` silently degenerates to a **single hash application** when `rounds <= 0`, producing wrong output with no error
- RFC 7292 Appendix C defines `iterations INTEGER (1..MAX)` — zero and negative values are out-of-spec

### Fix

Add a `rounds < 1` guard at the top of each function returning `Err(ErrorKind::Value { tag: Tag::Integer })`. `derive_key` and `derive_key_bmp` return types change from `Vec<u8>` to `der::Result<Vec<u8>>` to carry the error.

### Tests

- **`pkcs12_key_derive_rounds_one_boundary`** — verifies `rounds=1` produces the correct output for `EncryptionKey` and `Mac` key types (SHA-256, vectors generated with `openssl kdf … -kdfopt iter:1 … PKCS12KDF` and hardcoded)
- **`pkcs12_key_derive_zero_rounds_errors`** — asserts that `rounds=0`, `rounds=-1`, and `rounds=i32::MIN` all return `Err`

### Breaking change note

`derive_key` and `derive_key_bmp` are public API. Changing their return type from `Vec<u8>` to `der::Result<Vec<u8>>` is a breaking change. Given that the previous behaviour was silently incorrect for `rounds <= 0`, and `pkcs12` is still pre-release (`0.2.0-pre.0`), this seems justified. Happy to discuss alternatives (e.g. `u32` parameter, or a separate validated wrapper).