### PR TITLE
pkcs5: bump `pbkdf2` to v0.13; `scrypt` to v0.12

### DIFF
--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -24,9 +24,9 @@ cbc = { version = "0.2", optional = true }
 aes = { version = "0.9", optional = true, default-features = false }
 aes-gcm = { version = "0.11.0-rc.3", optional = true, default-features = false, features = ["aes"] }
 des = { version = "0.9", optional = true, default-features = false }
-pbkdf2 = { version = "0.13.0-rc.9", optional = true, default-features = false, features = ["hmac"] }
+pbkdf2 = { version = "0.13", optional = true, default-features = false, features = ["hmac"] }
 rand_core = { version = "0.10", optional = true, default-features = false }
-scrypt = { version = "0.12.0-rc.10", optional = true, default-features = false }
+scrypt = { version = "0.12", optional = true, default-features = false }
 sha1 = { version = "0.11", optional = true, default-features = false }
 sha2 = { version = "0.11", optional = true, default-features = false }
 


### PR DESCRIPTION
Release PRs:
- `pbkdf2` v0.13: RustCrypto/password-hashes#885
- `scrypt` v0.12: RustCrypto/password-hashes#897