### PR TITLE
pkcs5 v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1030,7 +1030,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs5"
-version = "0.8.0-rc.13"
+version = "0.8.0"
 dependencies = [
  "aes",
  "cbc",

--- a/cms/Cargo.toml
+++ b/cms/Cargo.toml
@@ -40,7 +40,7 @@ aes = "0.9"
 getrandom = "0.4"
 hex-literal = "1"
 pem-rfc7468 = "1"
-pkcs5 = "0.8.0-rc.13"
+pkcs5 = "0.8"
 pbkdf2 = "0.13.0-rc.9"
 rand = "0.10"
 rsa = { version = "0.10.0-rc.17", features = ["sha2"] }

--- a/pkcs12/Cargo.toml
+++ b/pkcs12/Cargo.toml
@@ -28,8 +28,8 @@ zeroize = { version = "1.8.1", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "1"
+pkcs5 = { version = "0.8", features = ["pbes2", "3des"] }
 pkcs8 = { version = "0.11.0-rc.10", features = ["pkcs5"] }
-pkcs5 = { version = "0.8.0-rc.13", features = ["pbes2", "3des"] }
 sha2 = "0.11"
 whirlpool = "0.11"
 

--- a/pkcs5/CHANGELOG.md
+++ b/pkcs5/CHANGELOG.md
@@ -4,6 +4,46 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.0 (2026-04-24)
+### Added
+- `pbes2::Params` constructors ([#1207])
+- `EncryptionScheme::generate` method gated on `getrandom` feature ([#2297])
+- `pbes2::Parameters::generate` method gated on `getrandom` feature ([#2297])
+
+### Changed
+- All types now own rather than borrow their data ([#1195])
+- Upgrade to the 2024 edition; MSRV 1.85 ([#1670])
+- Bump `rand_core` to v0.10 ([#2198])
+- Bump `getrandom` to v0.4 ([#2198])
+- Bump `der` to v0.8 ([#2234])
+- Bump `sha2` to v0.11 ([#2273])
+- Bump `aes` to v0.9 ([#2281])
+- Bump `cbc` to v0.2 ([#2282])
+- Bump `des` to v0.9 ([#2282])
+- Bump `pbkdf2` to v0.13 ([#2291])
+- Bump `scrypt` to v0.12 ([#2291])
+
+### Fixed
+- Allow empty `algId` PRF parameter for PBES2 params ([#1521])
+- Incorrect error was being returned from CBC decryption ([#1678])
+
+### Removed
+- `std` feature ([#2294])
+
+[#1195]: https://github.com/RustCrypto/formats/pull/1195
+[#1207]: https://github.com/RustCrypto/formats/pull/1207
+[#1521]: https://github.com/RustCrypto/formats/pull/1521
+[#1670]: https://github.com/RustCrypto/formats/pull/1670
+[#1678]: https://github.com/RustCrypto/formats/pull/1678
+[#2198]: https://github.com/RustCrypto/formats/pull/2198
+[#2234]: https://github.com/RustCrypto/formats/pull/2234
+[#2273]: https://github.com/RustCrypto/formats/pull/2273
+[#2281]: https://github.com/RustCrypto/formats/pull/2281
+[#2282]: https://github.com/RustCrypto/formats/pull/2282
+[#2291]: https://github.com/RustCrypto/formats/pull/2291
+[#2294]: https://github.com/RustCrypto/formats/pull/2294
+[#2297]: https://github.com/RustCrypto/formats/pull/2297
+
 ## 0.7.1 (2023-03-05)
 ### Changed
 - Bump `pbkdf2` to v0.12 ([#913])

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs5"
-version = "0.8.0-rc.13"
+version = "0.8.0"
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #5:
 Password-Based Cryptography Specification Version 2.1 (RFC 8018)

--- a/pkcs5/LICENSE-MIT
+++ b/pkcs5/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2021-2025 The RustCrypto Project Developers
+Copyright (c) 2021-2026 The RustCrypto Project Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/pkcs5/README.md
+++ b/pkcs5/README.md
@@ -12,6 +12,13 @@ Password-Based Cryptography Specification Version 2.1 ([RFC 8018]).
 
 [Documentation][docs-link]
 
+## About
+
+PKCS#5 is a standard for deriving cryptographic keys from a password using a variety of supported
+algorithms, and then encrypting/decrypting data (e.g. PKCS#8 private keys) using that derived key.
+
+This crate supports deriving keys from passwords using either the `scrypt` or `pbkdf2` algorithms.
+
 ## Minimum Supported Rust Version (MSRV) Policy
 
 MSRV increases are not considered breaking changes and can happen in patch releases.

--- a/pkcs8/Cargo.toml
+++ b/pkcs8/Cargo.toml
@@ -22,7 +22,7 @@ spki = "0.8"
 
 # optional dependencies
 rand_core = { version = "0.10", optional = true, default-features = false }
-pkcs5 = { version = "0.8.0-rc.13", optional = true, features = ["rand_core"] }
+pkcs5 = { version = "0.8", optional = true, features = ["rand_core"] }
 subtle = { version = "2", optional = true, default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
## Added
- `pbes2::Params` constructors ([#1207])
- `EncryptionScheme::generate` method gated on `getrandom` feature ([#2297])
- `pbes2::Parameters::generate` method gated on `getrandom` feature ([#2297])

## Changed
- All types now own rather than borrow their data ([#1195])
- Upgrade to the 2024 edition; MSRV 1.85 ([#1670])
- Bump `rand_core` to v0.10 ([#2198])
- Bump `getrandom` to v0.4 ([#2198])
- Bump `der` to v0.8 ([#2234])
- Bump `sha2` to v0.11 ([#2273])
- Bump `aes` to v0.9 ([#2281])
- Bump `cbc` to v0.2 ([#2282])
- Bump `des` to v0.9 ([#2282])
- Bump `pbkdf2` to v0.13 ([#2291])
- Bump `scrypt` to v0.12 ([#2291])

## Fixed
- Allow empty `algId` PRF parameter for PBES2 params ([#1521])
- Incorrect error was being returned from CBC decryption ([#1678])

## Removed
- `std` feature ([#2294])

[#1195]: https://github.com/RustCrypto/formats/pull/1195
[#1207]: https://github.com/RustCrypto/formats/pull/1207
[#1521]: https://github.com/RustCrypto/formats/pull/1521
[#1670]: https://github.com/RustCrypto/formats/pull/1670
[#1678]: https://github.com/RustCrypto/formats/pull/1678
[#2198]: https://github.com/RustCrypto/formats/pull/2198
[#2234]: https://github.com/RustCrypto/formats/pull/2234
[#2273]: https://github.com/RustCrypto/formats/pull/2273
[#2281]: https://github.com/RustCrypto/formats/pull/2281
[#2282]: https://github.com/RustCrypto/formats/pull/2282
[#2291]: https://github.com/RustCrypto/formats/pull/2291
[#2294]: https://github.com/RustCrypto/formats/pull/2294
[#2297]: https://github.com/RustCrypto/formats/pull/2297