### PR TITLE
pkcs5: build with `all-features = true` on docs.rs

### DIFF
--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -47,4 +47,4 @@ sha1-insecure = ["dep:sha1", "pbes2"]
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = ["--cfg", "docsrs"]
+all-features = true


### PR DESCRIPTION
Looks like the wrong line got deleted from the config, whoops