### PR TITLE
Bump `rsa` to v0.10.0-rc.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1306,8 +1306,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.10.0-rc.17"
-source = "git+https://github.com/RustCrypto/RSA#ecd32e3e53f5c413d831c3721b13156edc113f75"
+version = "0.10.0-rc.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b2aa4ba0d89f73d1e332df05be0eeab8840351c36ca5654341dfdb57bb3caf"
 dependencies = [
  "const-oid",
  "crypto-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,8 +61,6 @@ x509-tsp = { path = "./x509-tsp" }
 x509-cert = { path = "./x509-cert" }
 x509-ocsp = { path = "./x509-ocsp" }
 
-rsa = { git = "https://github.com/RustCrypto/RSA" }
-
 [workspace.lints.clippy]
 borrow_as_ptr = "warn"
 cast_lossless = "warn"

--- a/cms/Cargo.toml
+++ b/cms/Cargo.toml
@@ -28,7 +28,7 @@ cbc = { version = "0.2", optional = true }
 cipher = { version = "0.5", features = ["alloc", "block-padding", "rand_core"], optional = true }
 digest = { version = "0.11", optional = true }
 elliptic-curve = { version = "0.14.0-rc.30", optional = true }
-rsa = { version = "0.10.0-rc.17", optional = true }
+rsa = { version = "0.10.0-rc.18", optional = true }
 sha1 = { version = "0.11", optional = true }
 sha2 = { version = "0.11", optional = true }
 sha3 = { version = "0.11", optional = true }
@@ -43,7 +43,7 @@ pem-rfc7468 = "1"
 pkcs5 = "0.8"
 pbkdf2 = "0.13.0-rc.9"
 rand = "0.10"
-rsa = { version = "0.10.0-rc.17", features = ["sha2"] }
+rsa = { version = "0.10.0-rc.18", features = ["sha2"] }
 ecdsa = { version = "0.17.0-rc.16", features = ["digest", "pem"] }
 p256 = "0.14.0-rc.7"
 tokio = { version = "1.45.1", features = ["macros", "rt"] }

--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -30,7 +30,7 @@ tls_codec = { version = "0.4", default-features = false, features = ["derive"], 
 [dev-dependencies]
 hex-literal = "1"
 rand = "0.10"
-rsa = { version = "0.10.0-rc.17", features = ["sha2"] }
+rsa = { version = "0.10.0-rc.18", features = ["sha2"] }
 ecdsa = { version = "0.17.0-rc.16", features = ["digest", "pem"] }
 p256 = "0.14.0-rc.7"
 rstest = "0.26"

--- a/x509-ocsp/Cargo.toml
+++ b/x509-ocsp/Cargo.toml
@@ -30,7 +30,7 @@ signature = { version = "3.0.0-rc.10", optional = true, default-features = false
 hex-literal = "1"
 lazy_static = "1.5.0"
 rand = "0.10"
-rsa = { version = "0.10.0-rc.17", default-features = false, features = ["encoding", "sha2"] }
+rsa = { version = "0.10.0-rc.18", default-features = false, features = ["encoding", "sha2"] }
 sha1 = { version = "0.11", default-features = false, features = ["oid"] }
 sha2 = { version = "0.11", default-features = false, features = ["oid"] }
 


### PR DESCRIPTION
This is the first crate release that's compatible with `pkcs8` v0.11.