### PR TITLE
serdect: `no_alloc` implementation of `serialize_hex`

### DIFF
--- a/serdect/src/common.rs
+++ b/serdect/src/common.rs
@@ -1,16 +1,13 @@
+use base16ct::HexDisplay;
 use core::fmt;
 use core::marker::PhantomData;
-
 use serde::{
     Serializer,
     de::{Error, Unexpected, Visitor},
 };
 
 #[cfg(feature = "alloc")]
-use {alloc::vec::Vec, serde::Serialize};
-
-#[cfg(not(feature = "alloc"))]
-use serde::ser::Error as SerError;
+use alloc::vec::Vec;
 
 pub(crate) fn serialize_hex<S, T, const UPPERCASE: bool>(
     value: &T,
@@ -20,19 +17,12 @@ where
     S: Serializer,
     T: AsRef<[u8]>,
 {
-    #[cfg(feature = "alloc")]
+    let hex = HexDisplay(value.as_ref());
+
     if UPPERCASE {
-        base16ct::upper::encode_string(value.as_ref()).serialize(serializer)
+        serializer.collect_str(&format_args!("{:X}", hex))
     } else {
-        base16ct::lower::encode_string(value.as_ref()).serialize(serializer)
-    }
-    #[cfg(not(feature = "alloc"))]
-    {
-        let _ = value;
-        let _ = serializer;
-        Err(S::Error::custom(
-            "serializer is human readable, which requires the `alloc` crate feature",
-        ))
+        serializer.collect_str(&format_args!("{:x}", hex))
     }
 }
 


### PR DESCRIPTION
This previously mandated use of `alloc` and would simply return an error when used without the feature enabled.

This uses `serde`'s built-in integration with `core::fmt` along with the `base16ct::HexDisplay` type to implement a simple `no_alloc` serializer.