### PR TITLE
serdect v0.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "serdect"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "base16ct",
  "ciborium",

--- a/serdect/CHANGELOG.md
+++ b/serdect/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.3 (2026-05-03)
+### Added
+- `no_alloc` implementation of `serialize_hex` ([#2327])
+
+[#2327]: https://github.com/RustCrypto/formats/pull/2327
+
 ## 0.4.2 (2026-01-03)
 ### Changed
 - Bump `base16ct` to v1 ([#2145])

--- a/serdect/Cargo.toml
+++ b/serdect/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Constant-time serde serializer/deserializer helpers for data that potentially
 contains secrets (e.g. cryptographic keys)
 """
-version = "0.4.2"
+version = "0.4.3"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 homepage = "https://github.com/RustCrypto/formats/tree/master/serdect"


### PR DESCRIPTION
## Added
- `no_alloc` implementation of `serialize_hex` ([#2327])

[#2327]: https://github.com/RustCrypto/formats/pull/2327