### PR TITLE
base32ct: comments and constants

### DIFF
--- a/base32ct/src/alphabet.rs
+++ b/base32ct/src/alphabet.rs
@@ -4,9 +4,9 @@ pub(crate) mod rfc4648;
 
 use core::{fmt::Debug, ops::RangeInclusive};
 
-/// Core encoder/decoder functions for a particular Base64 alphabet
+/// Core encoder/decoder functions for a particular Base32 alphabet
 pub trait Alphabet: 'static + Copy + Debug + Eq + Send + Sized + Sync {
-    /// First character in this Base64 alphabet
+    /// First character in this Base32 alphabet
     const BASE: u8;
 
     /// Decoder passes

--- a/base32ct/src/alphabet/rfc4648.rs
+++ b/base32ct/src/alphabet/rfc4648.rs
@@ -37,7 +37,7 @@ impl Alphabet for Base32Unpadded {
 /// Lower-case Base32 decoder.
 const DECODE_LOWER: &[DecodeStep] = &[DecodeStep(b'a'..=b'z', -96), DecodeStep(b'2'..=b'7', -23)];
 
-/// Standard Base64 encoder
+/// Lower-case Base32 encoder
 const ENCODE_LOWER: &[EncodeStep] = &[EncodeStep(25, 73)];
 
 /// RFC4648 upper case Base32 encoding with `=` padding.
@@ -51,9 +51,8 @@ pub struct Base32Upper;
 
 impl Alphabet for Base32Upper {
     const BASE: u8 = b'A';
-    const DECODER: &'static [DecodeStep] =
-        &[DecodeStep(b'A'..=b'Z', -64), DecodeStep(b'2'..=b'7', -23)];
-    const ENCODER: &'static [EncodeStep] = &[EncodeStep(25, 41)];
+    const DECODER: &'static [DecodeStep] = DECODE_UPPER;
+    const ENCODER: &'static [EncodeStep] = ENCODE_UPPER;
     const PADDED: bool = true;
 }
 
@@ -68,8 +67,13 @@ pub struct Base32UpperUnpadded;
 
 impl Alphabet for Base32UpperUnpadded {
     const BASE: u8 = b'A';
-    const DECODER: &'static [DecodeStep] =
-        &[DecodeStep(b'A'..=b'Z', -64), DecodeStep(b'2'..=b'7', -23)];
-    const ENCODER: &'static [EncodeStep] = &[EncodeStep(25, 41)];
+    const DECODER: &'static [DecodeStep] = DECODE_UPPER;
+    const ENCODER: &'static [EncodeStep] = ENCODE_UPPER;
     const PADDED: bool = false;
 }
+
+/// Lower-case Base32 decoder.
+const DECODE_UPPER: &[DecodeStep] = &[DecodeStep(b'A'..=b'Z', -64), DecodeStep(b'2'..=b'7', -23)];
+
+/// Upper-case Base32 encoder
+const ENCODE_UPPER: &[EncodeStep] = &[EncodeStep(25, 41)];


### PR DESCRIPTION
BTW, when reading https://www.rfc-editor.org/rfc/rfc4648.html#section-6 I noticed that both Base32 encoding should use upper-case alphabet characters. But changing this would be a breaking change, any idea why we use lower-case characters for `Base32`?