### PR TITLE
der,spki: fixup minimal-versions CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,6 +457,7 @@ dependencies = [
  "bytes",
  "const-oid",
  "der_derive",
+ "derive_arbitrary",
  "flagset",
  "heapless 0.9.3",
  "hex-literal",

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -17,7 +17,8 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-arbitrary = { version = "1.4", features = ["derive"], optional = true }
+arbitrary = { version = "1.4.2", features = ["derive"], optional = true }
+derive_arbitrary = { version = "1.4.2", optional = true } # Fixup for minimal-versions
 bytes = { version = "1", optional = true, default-features = false }
 const-oid = { version = "0.10", optional = true }
 der_derive = { version = "0.8", optional = true }
@@ -36,7 +37,7 @@ proptest = "1.10"
 alloc = ["zeroize?/alloc"]
 std = ["alloc"]
 
-arbitrary = ["dep:arbitrary", "const-oid?/arbitrary", "std"]
+arbitrary = ["dep:arbitrary", "dep:derive_arbitrary", "const-oid?/arbitrary", "std"]
 ber = []
 bytes = ["dep:bytes", "alloc"]
 derive = ["dep:der_derive"]


### PR DESCRIPTION
arbitrary derive 1.4.0 can generate invalid code (does not use the full path for Result, so it will use  a locally define Result alias)

I believe the commit that fixes that behavior is https://github.com/rust-fuzz/arbitrary/commit/6cbaf485632cc8eb7e50af78f8f9f68261f6bf00

This is fixed in 1.4.2. This commit sets arbitrary 1.4.2 as the floor.