### PR TITLE
tls_codec: implement `SerializeBytes` for `VLBytes`

### DIFF
--- a/tls_codec/src/quic_vec.rs
+++ b/tls_codec/src/quic_vec.rs
@@ -672,7 +672,23 @@ mod rw_bytes {
     impl Serialize for &VLBytes {
         #[inline(always)]
         fn tls_serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, Error> {
-            (*self).tls_serialize(writer)
+            Serialize::tls_serialize(*self, writer)
+        }
+    }
+
+    impl SerializeBytes for VLBytes {
+        #[inline(always)]
+        fn tls_serialize(&self) -> Result<Vec<u8>, Error> {
+            let mut bytes = Vec::with_capacity(self.tls_serialized_len());
+            Serialize::tls_serialize(&self, &mut bytes).map(|_| bytes)
+        }
+    }
+
+    impl SerializeBytes for &VLBytes {
+        #[inline(always)]
+        fn tls_serialize(&self) -> Result<Vec<u8>, Error> {
+            let mut bytes = Vec::with_capacity(self.tls_serialized_len());
+            Serialize::tls_serialize(self, &mut bytes).map(|_| bytes)
         }
     }
 
@@ -802,7 +818,7 @@ mod secret_bytes {
 
     impl Serialize for SecretVLBytes {
         fn tls_serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, Error> {
-            self.0.tls_serialize(writer)
+            Serialize::tls_serialize(&self.0, writer)
         }
     }
 

--- a/tls_codec/src/quic_vec.rs
+++ b/tls_codec/src/quic_vec.rs
@@ -112,6 +112,36 @@ impl<T: DeserializeBytes> DeserializeBytes for Vec<T> {
     }
 }
 
+impl SerializeBytes for VLBytes {
+    #[inline(always)]
+    fn tls_serialize(&self) -> Result<Vec<u8>, Error> {
+        let content_length = self.as_slice().len();
+        let length = ContentLength::from_usize(content_length)?;
+        let len_len = length.0.bytes_len();
+
+        let mut out = Vec::with_capacity(content_length + len_len);
+        out.resize(len_len, 0);
+        length.0.write_bytes(&mut out)?;
+
+        // Extend with the data
+        out.extend(self.as_slice());
+
+        #[cfg(debug_assertions)]
+        if out.len() - len_len != content_length {
+            return Err(Error::LibraryError);
+        }
+
+        Ok(out)
+    }
+}
+
+impl SerializeBytes for &VLBytes {
+    #[inline(always)]
+    fn tls_serialize(&self) -> Result<Vec<u8>, Error> {
+        (*self).tls_serialize()
+    }
+}
+
 impl<T: SerializeBytes> SerializeBytes for &[T] {
     #[inline(always)]
     fn tls_serialize(&self) -> Result<Vec<u8>, Error> {
@@ -673,22 +703,6 @@ mod rw_bytes {
         #[inline(always)]
         fn tls_serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, Error> {
             Serialize::tls_serialize(*self, writer)
-        }
-    }
-
-    impl SerializeBytes for VLBytes {
-        #[inline(always)]
-        fn tls_serialize(&self) -> Result<Vec<u8>, Error> {
-            let mut bytes = Vec::with_capacity(self.tls_serialized_len());
-            Serialize::tls_serialize(&self, &mut bytes).map(|_| bytes)
-        }
-    }
-
-    impl SerializeBytes for &VLBytes {
-        #[inline(always)]
-        fn tls_serialize(&self) -> Result<Vec<u8>, Error> {
-            let mut bytes = Vec::with_capacity(self.tls_serialized_len());
-            Serialize::tls_serialize(self, &mut bytes).map(|_| bytes)
         }
     }
 

--- a/tls_codec/tests/encode.rs
+++ b/tls_codec/tests/encode.rs
@@ -87,3 +87,15 @@ fn serialize_var_len_boundaries() {
     let serialized = v.tls_serialize_detached().expect("Error encoding vector");
     assert_eq!(&serialized[0..5], &[0x80, 0, 0x40, 0, 99]);
 }
+
+#[test]
+/// Test that serializations of [`VLBytes`] match for [`tls_codec::Serialize`]
+/// and [`tls_codec::SerializeBytes`].
+fn test_matching_vl_bytes_serialization() {
+    use tls_codec::SerializeBytes;
+    let byte_vec = VLBytes::new(vec![99u8; 16384]);
+    assert_eq!(
+        Serialize::tls_serialize_detached(&byte_vec).expect("Error encoding vector"),
+        SerializeBytes::tls_serialize(&byte_vec).expect("Error encoding byte vector")
+    );
+}

--- a/tls_codec/tests/encode_bytes.rs
+++ b/tls_codec/tests/encode_bytes.rs
@@ -1,5 +1,8 @@
 use tls_codec::{SerializeBytes, TlsByteVecU8, TlsByteVecU16, TlsByteVecU24, TlsByteVecU32, U24};
 
+#[allow(deprecated)]
+use tls_codec::VLBytes;
+
 #[test]
 fn serialize_primitives() {
     let mut v = Vec::new();
@@ -81,4 +84,13 @@ fn serialize_tls_byte_vec_u32() {
         .tls_serialize()
         .expect("Error encoding byte vector");
     assert_eq!(actual_result, vec![0, 0, 0, 3, 1, 2, 3]);
+}
+
+#[test]
+fn serialize_vlbytes() {
+    let byte_vec = VLBytes::new(vec![1, 2, 3]);
+    let actual_result = byte_vec
+        .tls_serialize()
+        .expect("Error encoding byte vector");
+    assert_eq!(actual_result, vec![3, 1, 2, 3]);
 }

--- a/tls_codec/tests/encode_bytes.rs
+++ b/tls_codec/tests/encode_bytes.rs
@@ -1,7 +1,8 @@
-use tls_codec::{SerializeBytes, TlsByteVecU8, TlsByteVecU16, TlsByteVecU24, TlsByteVecU32, U24};
+#![allow(deprecated)]
 
-#[allow(deprecated)]
-use tls_codec::VLBytes;
+use tls_codec::{
+    SerializeBytes, TlsByteVecU8, TlsByteVecU16, TlsByteVecU24, TlsByteVecU32, U24, VLBytes,
+};
 
 #[test]
 fn serialize_primitives() {


### PR DESCRIPTION
This PR implements `SerializeBytes` for `VLBytes`. Since the `SerializeBytes::tls_serialize()` method is now implemented for `VLBytes` in addition to the existing `Serialize::tls_serialize()` method, this PR also updates the calls to `Serialize::tls_serialize()` in this module to explicitly use the method from the `Serialize` trait.