### PR TITLE
Implement PemLabel for ContentInfo

### DIFF
--- a/cms/Cargo.toml
+++ b/cms/Cargo.toml
@@ -50,6 +50,7 @@ tokio = { version = "1.45.1", features = ["macros", "rt"] }
 x509-cert = { version = "0.3.0-rc.4", features = ["pem"] }
 
 [features]
+default = ["pem"]
 std = ["der/std", "x509-cert/std", "spki/std"]
 builder = [
     "dep:aes",
@@ -70,6 +71,7 @@ builder = [
     "x509-cert/builder",
     "dep:zeroize"
 ]
+pem = ["der/pem"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/cms/src/content_info.rs
+++ b/cms/src/content_info.rs
@@ -129,15 +129,15 @@ impl der::pem::PemLabel for ContentInfo {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "pem")]
     use super::ContentInfo;
-    use der::Any;
 
     #[cfg(feature = "pem")]
     #[test]
     fn test_pem_encode_decode() {
         let content_info = ContentInfo {
             content_type: const_oid::db::rfc5911::ID_SIGNED_DATA,
-            content: Any::null(),
+            content: der::Any::null(),
         };
 
         // Encode to PEM and check that it's come out looking plausible

--- a/cms/src/content_info.rs
+++ b/cms/src/content_info.rs
@@ -118,3 +118,39 @@ impl TryFrom<PkiPath> for ContentInfo {
         })
     }
 }
+
+#[cfg(feature = "pem")]
+impl der::pem::PemLabel for ContentInfo {
+    /// Per [RFC7468], ContentInfo can be encoded into PEM with a label of "CMS".
+    ///
+    /// [RFC7468]: https://www.rfc-editor.org/info/rfc7468/#section-9
+    const PEM_LABEL: &'static str = "CMS";
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ContentInfo;
+    use der::Any;
+
+    #[cfg(feature = "pem")]
+    #[test]
+    fn test_pem_encode_decode() {
+        let content_info = ContentInfo {
+            content_type: const_oid::db::rfc5911::ID_SIGNED_DATA,
+            content: Any::null(),
+        };
+
+        // Encode to PEM and check that it's come out looking plausible
+        use der::EncodePem;
+        let pem_encoding = content_info
+            .to_pem(der::pem::LineEnding::LF)
+            .expect("Failed to encode ContentInfo as PEM");
+        assert!(pem_encoding.starts_with("-----BEGIN CMS-----\n"));
+        assert!(pem_encoding.ends_with("\n-----END CMS-----\n"));
+
+        // Parse back into ContentInfo, and check we end up with what we started with.
+        use der::DecodePem;
+        let parsed = ContentInfo::from_pem(pem_encoding).expect("Failed to decode ContentInfo PEM");
+        assert_eq!(parsed, content_info);
+    }
+}


### PR DESCRIPTION
We should be able to encode and decode ContentInfo objects encoded as PEM strings.

Fixes: https://github.com/RustCrypto/formats/issues/2352