### PR TITLE
pkcs5 v0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1034,7 +1034,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs5"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/pkcs5/CHANGELOG.md
+++ b/pkcs5/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.1 (2026-06-28)
+### Added
+- Support for using AES-GCM with PBES2 ([#1433], [#2313])
+
+[#1433]: https://github.com/RustCrypto/formats/pull/1433
+[#2313]: https://github.com/RustCrypto/formats/pull/2313
+
 ## 0.8.0 (2026-04-24)
 ### Added
 - `pbes2::Params` constructors ([#1207])

--- a/pkcs5/Cargo.toml
+++ b/pkcs5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs5"
-version = "0.8.0"
+version = "0.8.1"
 description = """
 Pure Rust implementation of Public-Key Cryptography Standards (PKCS) #5:
 Password-Based Cryptography Specification Version 2.1 (RFC 8018)

--- a/pkcs5/src/pbes2.rs
+++ b/pkcs5/src/pbes2.rs
@@ -63,10 +63,7 @@ pub const PBES2_OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.11
 /// AES cipher block size
 const AES_BLOCK_SIZE: usize = 16;
 
-/// GCM nonce size
-///
-/// We could use any value here but GCM is most efficient
-/// with 96 bit nonces
+/// Recommended GCM nonce size.
 const GCM_NONCE_SIZE: usize = 12;
 
 /// DES / Triple DES block size


### PR DESCRIPTION
## Added
- Support for using AES-GCM with PBES2 ([#1433], [#2313])

[#1433]: https://github.com/RustCrypto/formats/pull/1433
[#2313]: https://github.com/RustCrypto/formats/pull/2313