### PR TITLE
der: add negative test for `SequenceOf` shorter than inner data

### DIFF
--- a/der/src/asn1/sequence_of.rs
+++ b/der/src/asn1/sequence_of.rs
@@ -287,7 +287,8 @@ where
 #[cfg(all(test, feature = "heapless"))]
 mod tests {
     use super::SequenceOf;
-    use crate::ord::DerOrd;
+    use crate::{Decode, DerOrd, ErrorKind, Length};
+    use hex_literal::hex;
 
     #[test]
     fn sequenceof_valueord_value_cmp() {
@@ -306,5 +307,23 @@ mod tests {
             arr
         };
         assert_eq!(arr1.der_cmp(&arr2), Ok(Ordering::Greater));
+    }
+
+    #[test]
+    fn sequenceof_data_too_short() {
+        let invalid_data = &hex!(
+            "30 02" // SEQUENCE tag and length (shorter than actual data)
+                "02 01" // INTEGER tag and length
+                    "05"
+        );
+        let err = SequenceOf::<u16, 5>::from_der(invalid_data)
+            .expect_err("read_nested should narrow down the data slice");
+        assert_eq!(
+            ErrorKind::Incomplete {
+                expected_len: Length::new(5),
+                actual_len: Length::new(4)
+            },
+            err.kind()
+        );
     }
 }


### PR DESCRIPTION
Reopened `read_nested` test:
- #2009