### PR TITLE
x509-cert: v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1976,7 +1976,7 @@ dependencies = [
 
 [[package]]
 name = "x509-cert"
-version = "0.3.0-rc.4"
+version = "0.3.0"
 dependencies = [
  "arbitrary",
  "const-oid",

--- a/cmpv2/Cargo.toml
+++ b/cmpv2/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.85"
 crmf = "=0.3.0-pre.0"
 der = { version = "0.8", features = ["alloc", "derive", "flagset", "oid"] }
 spki = "0.8"
-x509-cert = { version = "0.3.0-rc.4", default-features = false }
+x509-cert = { version = "0.3", default-features = false }
 
 # optional features
 digest = { version = "0.11", optional = true, default-features = false }

--- a/cms/Cargo.toml
+++ b/cms/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.85"
 const-oid = { version = "0.10", features = ["db"] }
 der = { version = "0.8", features = ["ber", "derive", "oid"] }
 spki = "0.8"
-x509-cert = { version = "0.3.0-rc.4", default-features = false }
+x509-cert = { version = "0.3", default-features = false }
 
 # optional dependencies
 aes = { version = "0.9", optional = true }
@@ -47,7 +47,7 @@ rsa = { version = "0.10.0-rc.18", features = ["sha2"] }
 ecdsa = { version = "0.17", features = ["digest", "pem"] }
 p256 = "0.14"
 tokio = { version = "1.45.1", features = ["macros", "rt"] }
-x509-cert = { version = "0.3.0-rc.4", features = ["pem"] }
+x509-cert = { version = "0.3", features = ["pem"] }
 
 [features]
 default = ["pem"]

--- a/crmf/Cargo.toml
+++ b/crmf/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.85"
 cms = "=0.3.0-pre.2"
 der = { version = "0.8", features = ["alloc", "derive"] }
 spki = "0.8"
-x509-cert = { version = "0.3.0-rc.4", default-features = false }
+x509-cert = { version = "0.3", default-features = false }
 
 [dev-dependencies]
 const-oid = "0.10"

--- a/gss-api/Cargo.toml
+++ b/gss-api/Cargo.toml
@@ -18,12 +18,12 @@ rust-version = "1.85"
 [dependencies]
 der = { version = "0.8", features = ["oid", "alloc"] }
 spki = "0.8"
-x509-cert = { version = "0.3.0-rc.4", default-features = false }
+x509-cert = { version = "0.3", default-features = false }
 
 [dev-dependencies]
 der = { version = "0.8", features = ["oid", "pem", "alloc"] }
 hex-literal = "1"
-x509-cert = { version = "0.3.0-rc.4", default-features = false, features = ["pem"] }
+x509-cert = { version = "0.3", default-features = false, features = ["pem"] }
 
 [features]
 rfc2478 = []

--- a/pkcs12/Cargo.toml
+++ b/pkcs12/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.85"
 [dependencies]
 der = { version = "0.8", features = ["alloc", "derive", "oid"], default-features = false }
 spki = { version = "0.8", default-features = false }
-x509-cert = { version = "0.3.0-rc.4", default-features = false }
+x509-cert = { version = "0.3", default-features = false }
 const-oid = { version = "0.10", features = ["db"], default-features = false }
 cms = { version = "=0.3.0-pre.2", default-features = false }
 

--- a/x509-cert/CHANGELOG.md
+++ b/x509-cert/CHANGELOG.md
@@ -4,6 +4,99 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2026-07-06)
+
+### Added
+
+- Serial number generator ([#1270])
+- `DecodeValue` for `x509_cert::time::Time` ([#1986])
+- `FromStr` for `x509_cert::time::Time` ([#1961])
+- impl `Hash` for `Name` ([#1764])
+- impl `Ord` for `CrlReason` ([#1869])
+- `DirectoryString::BmpString` ([#1794])
+- `Crl` builder ([#1759])
+- `Time::now` method ([#1761])
+- `Validity::infinity` helper ([#1528])
+- `Validity::new` method ([#1529])
+- Re-export `spki` types without `*Owned` suffixes ([#1534])
+- `x509_cert::builder::AsyncBuilder` using `AsyncSigner` ([#1280])
+
+### Changed
+
+- Decompose `AsExtension` into `Criticality + AsExtension` ([#2109])
+- Improve extension API flexibility and ergonomics ([#2120])
+- Expose `Profile` in the `CrlBuilder` ([#1870])
+- Ensure a serial number can be stored in a database ([#1868])
+- Move the CSR builder `x509_cert::request` ([#1581])
+- Rename `x509_cert::builder::Profile` to `BuilderProfile` ([#1514] && [#1517])
+- `Name` is now a new type over `RdnSequence` ([#1499])
+- make `RelativeDistinguishedName` fields private ([#1510])
+- make `RdnSequence` fields private ([#1508])
+- make (Tbs)`CertificateInner` fields private ([#1505])
+- rename helpers to `get_extension`/`filter_extensions` ([#1497])
+- `check_name_encoding` now allow extraneous components ([#1447])
+- Accept RFC-invalid certificates as TrustAnchors ([#1403])
+
+- Edition changed to 2024 and MSRV bumped to 1.85 ([#1689])
+- Bump `rand` to `v0.10` ([#2212])
+- Bump `der` to `v0.8` ([#2234])
+- Bump `digest` to `v0.11` ([#2237])
+- Bump `sha2` to `v0.11` ([#2273])
+- Bump `spki` to `v0.8` ([#2277])
+- Bump `signature` to `v3` ([#2326])
+
+### Fixed
+
+- Converting from `SystemTime` should use `UtcTime` if date <= 2049 ([#1969])
+- Underflow on empty input in `Certificate::load_pem_chain` ([#1965])
+- Domain validated should accept CNs ([#1815])
+- Serialization of email addresses ([#1425])
+
+### Removed
+
+- Std requirement for `x509_cert::builder` ([#1709])
+- `RelativeDistinguishedName::encode_from_string` ([#1509])
+
+[#1270]: https://github.com/RustCrypto/formats/pull/1270
+[#1280]: https://github.com/RustCrypto/formats/pull/1280
+[#1403]: https://github.com/RustCrypto/formats/pull/1403
+[#1425]: https://github.com/RustCrypto/formats/pull/1425
+[#1447]: https://github.com/RustCrypto/formats/pull/1447
+[#1497]: https://github.com/RustCrypto/formats/pull/1497
+[#1499]: https://github.com/RustCrypto/formats/pull/1499
+[#1505]: https://github.com/RustCrypto/formats/pull/1505
+[#1508]: https://github.com/RustCrypto/formats/pull/1508
+[#1509]: https://github.com/RustCrypto/formats/pull/1509
+[#1510]: https://github.com/RustCrypto/formats/pull/1510
+[#1514]: https://github.com/RustCrypto/formats/pull/1514
+[#1517]: https://github.com/RustCrypto/formats/pull/1517
+[#1528]: https://github.com/RustCrypto/formats/pull/1528
+[#1529]: https://github.com/RustCrypto/formats/pull/1529
+[#1534]: https://github.com/RustCrypto/formats/pull/1534
+[#1581]: https://github.com/RustCrypto/formats/pull/1581
+[#1689]: https://github.com/RustCrypto/formats/pull/1689
+[#1709]: https://github.com/RustCrypto/formats/pull/1709
+[#1759]: https://github.com/RustCrypto/formats/pull/1759
+[#1761]: https://github.com/RustCrypto/formats/pull/1761
+[#1764]: https://github.com/RustCrypto/formats/pull/1764
+[#1794]: https://github.com/RustCrypto/formats/pull/1794
+[#1815]: https://github.com/RustCrypto/formats/pull/1815
+[#1868]: https://github.com/RustCrypto/formats/pull/1868
+[#1869]: https://github.com/RustCrypto/formats/pull/1869
+[#1870]: https://github.com/RustCrypto/formats/pull/1870
+[#1961]: https://github.com/RustCrypto/formats/pull/1961
+[#1965]: https://github.com/RustCrypto/formats/pull/1965
+[#1969]: https://github.com/RustCrypto/formats/pull/1969
+[#1986]: https://github.com/RustCrypto/formats/pull/1986
+[#2109]: https://github.com/RustCrypto/formats/pull/2109
+[#2120]: https://github.com/RustCrypto/formats/pull/2120
+[#2212]: https://github.com/RustCrypto/formats/pull/2212
+[#2234]: https://github.com/RustCrypto/formats/pull/2234
+[#2237]: https://github.com/RustCrypto/formats/pull/2237
+[#2273]: https://github.com/RustCrypto/formats/pull/2273
+[#2277]: https://github.com/RustCrypto/formats/pull/2277
+[#2326]: https://github.com/RustCrypto/formats/pull/2326
+
 ## 0.2.5 (2023-12-23)
 
 ### Added

--- a/x509-cert/CHANGELOG.md
+++ b/x509-cert/CHANGELOG.md
@@ -4,8 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.3.0 (2026-07-06)
-
+## 0.3.0 (2026-07-08)
 ### Added
 
 - Serial number generator ([#1270])

--- a/x509-cert/Cargo.toml
+++ b/x509-cert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x509-cert"
-version = "0.3.0-rc.4"
+version = "0.3.0"
 description = """
 Pure Rust implementation of the X.509 Public Key Infrastructure Certificate
 format as described in RFC 5280

--- a/x509-ocsp/Cargo.toml
+++ b/x509-ocsp/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.85"
 const-oid = { version = "0.10", default-features = false, features = ["db"] }
 der = { version = "0.8", features = ["alloc", "derive", "oid"] }
 spki = { version = "0.8", features = ["alloc"] }
-x509-cert = { version = "0.3.0-rc.4", default-features = false }
+x509-cert = { version = "0.3", default-features = false }
 
 # Optional
 digest = { version = "0.11", optional = true, default-features = false, features = ["oid"] }

--- a/x509-tsp/Cargo.toml
+++ b/x509-tsp/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.85"
 der = { version = "0.8", features = ["alloc", "derive", "oid", "pem"] }
 cms = { version = "=0.3.0-pre.2" }
 cmpv2 = { version = "=0.3.0-pre.0", features = ["alloc"] }
-x509-cert = { version = "0.3.0-rc.4", default-features = false }
+x509-cert = { version = "0.3", default-features = false }
 
 [dev-dependencies]
 hex-literal = "1"


### PR DESCRIPTION
### Added

- Serial number generator ([#1270])
- `DecodeValue` for `x509_cert::time::Time` ([#1986])
- `FromStr` for `x509_cert::time::Time` ([#1961])
- impl `Hash` for `Name` ([#1764])
- impl `Ord` for `CrlReason` ([#1869])
- `DirectoryString::BmpString` ([#1794])
- `Crl` builder ([#1759])
- `Time::now` method ([#1761])
- `Validity::infinity` helper ([#1528])
- `Validity::new` method ([#1529])
- Re-export `spki` types without `*Owned` suffixes ([#1534])
- `x509_cert::builder::AsyncBuilder` using `AsyncSigner` ([#1280])

### Changed

- Decompose `AsExtension` into `Criticality + AsExtension` ([#2109])
- Improve extension API flexibility and ergonomics ([#2120])
- Expose `Profile` in the `CrlBuilder` ([#1870])
- Ensure a serial number can be stored in a database ([#1868])
- Move the CSR builder `x509_cert::request` ([#1581])
- Rename `x509_cert::builder::Profile` to `BuilderProfile` ([#1514] && [#1517])
- `Name` is now a new type over `RdnSequence` ([#1499])
- make `RelativeDistinguishedName` fields private ([#1510])
- make `RdnSequence` fields private ([#1508])
- make (Tbs)`CertificateInner` fields private ([#1505])
- rename helpers to `get_extension`/`filter_extensions` ([#1497])
- `check_name_encoding` now allow extraneous components ([#1447])
- Accept RFC-invalid certificates as TrustAnchors ([#1403])
- Edition changed to 2024 and MSRV bumped to 1.85 ([#1689])
- Bump `rand` to `v0.10` ([#2212])
- Bump `der` to `v0.8` ([#2234])
- Bump `digest` to `v0.11` ([#2237])
- Bump `sha2` to `v0.11` ([#2273])
- Bump `spki` to `v0.8` ([#2277])
- Bump `signature` to `v3` ([#2326])

### Fixed

- Converting from `SystemTime` should use `UtcTime` if date <= 2049 ([#1969])
- Underflow on empty input in `Certificate::load_pem_chain` ([#1965])
- Domain validated should accept CNs ([#1815])
- Serialization of email addresses ([#1425])

### Removed

- Std requirement for `x509_cert::builder` ([#1709])
- `RelativeDistinguishedName::encode_from_string` ([#1509])

[#1270]: https://github.com/RustCrypto/formats/pull/1270
[#1280]: https://github.com/RustCrypto/formats/pull/1280
[#1403]: https://github.com/RustCrypto/formats/pull/1403
[#1425]: https://github.com/RustCrypto/formats/pull/1425
[#1447]: https://github.com/RustCrypto/formats/pull/1447
[#1497]: https://github.com/RustCrypto/formats/pull/1497
[#1499]: https://github.com/RustCrypto/formats/pull/1499
[#1505]: https://github.com/RustCrypto/formats/pull/1505
[#1508]: https://github.com/RustCrypto/formats/pull/1508
[#1509]: https://github.com/RustCrypto/formats/pull/1509
[#1510]: https://github.com/RustCrypto/formats/pull/1510
[#1514]: https://github.com/RustCrypto/formats/pull/1514
[#1517]: https://github.com/RustCrypto/formats/pull/1517
[#1528]: https://github.com/RustCrypto/formats/pull/1528
[#1529]: https://github.com/RustCrypto/formats/pull/1529
[#1534]: https://github.com/RustCrypto/formats/pull/1534
[#1581]: https://github.com/RustCrypto/formats/pull/1581
[#1689]: https://github.com/RustCrypto/formats/pull/1689
[#1709]: https://github.com/RustCrypto/formats/pull/1709
[#1759]: https://github.com/RustCrypto/formats/pull/1759
[#1761]: https://github.com/RustCrypto/formats/pull/1761
[#1764]: https://github.com/RustCrypto/formats/pull/1764
[#1794]: https://github.com/RustCrypto/formats/pull/1794
[#1815]: https://github.com/RustCrypto/formats/pull/1815
[#1868]: https://github.com/RustCrypto/formats/pull/1868
[#1869]: https://github.com/RustCrypto/formats/pull/1869
[#1870]: https://github.com/RustCrypto/formats/pull/1870
[#1961]: https://github.com/RustCrypto/formats/pull/1961
[#1965]: https://github.com/RustCrypto/formats/pull/1965
[#1969]: https://github.com/RustCrypto/formats/pull/1969
[#1986]: https://github.com/RustCrypto/formats/pull/1986
[#2109]: https://github.com/RustCrypto/formats/pull/2109
[#2120]: https://github.com/RustCrypto/formats/pull/2120
[#2212]: https://github.com/RustCrypto/formats/pull/2212
[#2234]: https://github.com/RustCrypto/formats/pull/2234
[#2237]: https://github.com/RustCrypto/formats/pull/2237
[#2273]: https://github.com/RustCrypto/formats/pull/2273
[#2277]: https://github.com/RustCrypto/formats/pull/2277
[#2326]: https://github.com/RustCrypto/formats/pull/2326