### PR TITLE
der v0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,7 +477,7 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "arbitrary",
  "bytes",

--- a/der/CHANGELOG.md
+++ b/der/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.1 (2026-07-08)
+### Added
+- `SetOfRef` struct ([#2247])
+
+### Changed
+- Deprecate `ErrorKind::SetDuplicate` ([#2276])
+- Improve `SetOf*` sorting performance ([#2345])
+- Cap maximum number of nested messages at `64` ([#2379])
+
+### Fixed
+- `SET OF` is not supposed to disallow duplicates ([#2272])
+
+[#2247]: https://github.com/RustCrypto/formats/pull/2247
+[#2272]: https://github.com/RustCrypto/formats/pull/2272
+[#2276]: https://github.com/RustCrypto/formats/pull/2276
+[#2345]: https://github.com/RustCrypto/formats/pull/2345
+[#2379]: https://github.com/RustCrypto/formats/pull/2379
+
 ## 0.8.0 (2026-02-13)
 ### Added
 - Custom error types support to the `Decode` and `DecodeValue` traits ([#1055])

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der"
-version = "0.8.0"
+version = "0.8.1"
 description = """
 Pure Rust embedded-friendly implementation of the Distinguished Encoding Rules
 (DER) for Abstract Syntax Notation One (ASN.1) as described in ITU X.690 with

--- a/der/LICENSE-MIT
+++ b/der/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2020-2025 The RustCrypto Project Developers
+Copyright (c) 2020-2026 The RustCrypto Project Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated


### PR DESCRIPTION
## Added
- `SetOfRef` struct ([#2247])

## Changed
- Deprecate `ErrorKind::SetDuplicate` ([#2276])
- Improve `SetOf*` sorting performance ([#2345])
- Cap maximum number of nested messages at `64` ([#2379])

## Fixed
- `SET OF` is not supposed to disallow duplicates ([#2272])

[#2247]: https://github.com/RustCrypto/formats/pull/2247
[#2272]: https://github.com/RustCrypto/formats/pull/2272
[#2276]: https://github.com/RustCrypto/formats/pull/2276
[#2345]: https://github.com/RustCrypto/formats/pull/2345
[#2379]: https://github.com/RustCrypto/formats/pull/2379