### PR TITLE
tls_codec: bump to 0.5 and change SerializeBytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1738,7 +1738,7 @@ dependencies = [
 
 [[package]]
 name = "tls_codec"
-version = "0.4.3-pre.1"
+version = "0.5.0-pre.1"
 dependencies = [
  "arbitrary",
  "ciborium",
@@ -1746,7 +1746,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
- "tls_codec_derive 0.4.3-pre.1",
+ "tls_codec_derive 0.5.0-pre.1",
  "zeroize",
 ]
 
@@ -1763,12 +1763,12 @@ dependencies = [
 
 [[package]]
 name = "tls_codec_derive"
-version = "0.4.3-pre.1"
+version = "0.5.0-pre.1"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "tls_codec 0.4.3-pre.1",
+ "tls_codec 0.5.0-pre.1",
  "trybuild",
 ]
 

--- a/tls_codec/CHANGELOG.md
+++ b/tls_codec/CHANGELOG.md
@@ -7,10 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## 0.4.3
+## 0.5.0
 
+- BREAKING: Rename `SerializeBytes::tls_serialize` to `SerializeBytes::tls_serialize_bytes` to resolve a method-name collision with `Serialize::tls_serialize` (this matches the existing `DeserializeBytes::tls_deserialize_bytes` convention). Any type using `#[tls_codec(with = "...")]` together with `TlsSerializeBytes` must rename its module's `tls_serialize` function to `tls_serialize_bytes` accordingly.
 - [#2351](https://github.com/RustCrypto/formats/pull/2351): Implement `Size`, `SerializeBytes`, and `DeserializeBytes` for `String` (and `Size`/`SerializeBytes` for `str` / `&str`), encoding the UTF-8 bytes as a `VLByteVec`. Also implement `SerializeBytes` for `ContentLength` and `VLByteSlice`.
-- [#2322](https://github.com/RustCrypto/formats/pull/2322): Add `VLByteVec` and `SecretVLByteVec`, which are `#[serde(transparent)]` wrappers serializing via `serde_bytes`. They produce a much more compact representation in `serde` formats that distinguish byte arrays from sequences of `u8` (e.g. CBOR, MessagePack, bincode). Their `serde` output is not compatible with `VLBytes` / `SecretVLBytes`, but their `Deserialize` impls are backwards-compatible: in self-describing `serde` formats they also accept the legacy `VLBytes` / `SecretVLBytes` encoding (a struct with a `vec` field containing a sequence of `u8`). Deprecate `VLBytes` and `SecretVLBytes` in favour of `VLByteVec` and `SecretVLByteVec`.
+- [#2322](https://github.com/RustCrypto/formats/pull/2322): Add `VLByteVec` and `SecretVLByteVec`, which are `#[serde(transparent)]` wrappers serializing via `serde_bytes`. They produce a much more compact representation in `serde` formats that distinguish byte arrays from sequences of `u8` (e.g. CBOR, MessagePack, bincode). Their `serde` output is not compatible with `VLBytes` / `SecretVLBytes`, but their `Deserialize` impls are backwards-compatible: in self-describing `serde` formats they also accept the legacy `VLBytes` / `SecretVLBytes` encoding (a struct with a `vec` field containing a sequence of `u8`). `VLBytes` and `SecretVLBytes` will be deprecated in future in favour of `VLByteVec` and `SecretVLByteVec`.
 - [#1656](https://github.com/RustCrypto/formats/pull/1656) Add `TlsVarInt` type for variable-length integers.
 
 ### Changed

--- a/tls_codec/Cargo.toml
+++ b/tls_codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tls_codec"
-version = "0.4.3-pre.1"
+version = "0.5.0-pre.1"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/tls_codec/"
@@ -16,7 +16,7 @@ zeroize = { version = "1.9", default-features = false, features = ["alloc"] }
 
 # optional dependencies
 arbitrary = { version = "1.4", features = ["derive"], optional = true }
-tls_codec_derive = { version = "=0.4.3-pre.1", path = "./derive", optional = true }
+tls_codec_derive = { version = "=0.5.0-pre.1", path = "./derive", optional = true }
 serde = { version = "1.0.228", features = ["derive"], optional = true }
 serde_bytes = { version = "0.11.19", optional = true }
 
@@ -36,6 +36,7 @@ conditional_deserialization = [
     "derive",
     "tls_codec_derive/conditional_deserialization",
 ]
+future_deprecations = []
 
 [[bench]]
 name = "tls_vec"

--- a/tls_codec/benches/quic_vec.rs
+++ b/tls_codec/benches/quic_vec.rs
@@ -1,5 +1,4 @@
-// The benches intentionally exercise the deprecated `VLBytes`.
-#![allow(deprecated)]
+#![cfg_attr(feature = "future_deprecations", allow(deprecated))]
 
 use criterion::{BatchSize, Criterion};
 use criterion::{criterion_group, criterion_main};

--- a/tls_codec/derive/Cargo.toml
+++ b/tls_codec/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tls_codec_derive"
-version = "0.4.3-pre.1"
+version = "0.5.0-pre.1"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/tls_codec_derive/"
@@ -27,3 +27,9 @@ trybuild = "1"
 default = ["std"]
 conditional_deserialization = ["syn/full"]
 std = []
+# Declared only so the derive tests can gate their `allow(deprecated)` on
+# `#[cfg_attr(feature = "future_deprecations", ...)]` without tripping the
+# `unexpected_cfgs` lint. It intentionally does not forward to `tls_codec`
+# (which is only a dev-dependency here, so it cannot be forwarded to under
+# `cargo hack --no-dev-deps`).
+future_deprecations = []

--- a/tls_codec/derive/src/lib.rs
+++ b/tls_codec/derive/src/lib.rs
@@ -975,7 +975,7 @@ fn impl_serialize(parsed_ast: TlsStruct, svariant: SerializeVariant) -> TokenStr
                 SerializeVariant::Bytes => {
                     quote! {
                         impl #impl_generics tls_codec::SerializeBytes for #ident #ty_generics #where_clause {
-                            fn tls_serialize(&self) -> core::result::Result<Vec<u8>, tls_codec::Error> {
+                            fn tls_serialize_bytes(&self) -> core::result::Result<Vec<u8>, tls_codec::Error> {
                                 let expected_out = tls_codec::Size::tls_serialized_len(&self);
                                 // On narrow targets `expected_out` saturates when the serialized
                                 // form exceeds `usize::MAX`; reject it before it reaches
@@ -987,7 +987,7 @@ fn impl_serialize(parsed_ast: TlsStruct, svariant: SerializeVariant) -> TokenStr
                                 let mut out = Vec::with_capacity(expected_out);
 
                                 #(
-                                    out.append(&mut #prefixes::tls_serialize(&self.#members)?);
+                                    out.append(&mut #prefixes::tls_serialize_bytes(&self.#members)?);
                                 )*
                                 if cfg!(debug_assertions) {
                                     debug_assert_eq!(out.len(), expected_out, "Expected to serialize {} bytes but only {} were generated.", expected_out, out.len());
@@ -1003,8 +1003,8 @@ fn impl_serialize(parsed_ast: TlsStruct, svariant: SerializeVariant) -> TokenStr
                         }
 
                         impl #impl_generics tls_codec::SerializeBytes for &#ident #ty_generics #where_clause {
-                            fn tls_serialize(&self) -> core::result::Result<Vec<u8>, tls_codec::Error> {
-                                tls_codec::SerializeBytes::tls_serialize(*self)
+                            fn tls_serialize_bytes(&self) -> core::result::Result<Vec<u8>, tls_codec::Error> {
+                                tls_codec::SerializeBytes::tls_serialize_bytes(*self)
                             }
                         }
                     }
@@ -1048,8 +1048,8 @@ fn impl_serialize(parsed_ast: TlsStruct, svariant: SerializeVariant) -> TokenStr
                                 .collect::<Vec<_>>();
                             quote! {
                                 #ident::#variant_id { #(#members: #bindings,)* } => {
-                                    let mut discriminant_out = tls_codec::SerializeBytes::tls_serialize(&#discriminant)?;
-                                    #(discriminant_out.append(&mut #prefixes::tls_serialize(#bindings)?);)*
+                                    let mut discriminant_out = tls_codec::SerializeBytes::tls_serialize_bytes(&#discriminant)?;
+                                    #(discriminant_out.append(&mut #prefixes::tls_serialize_bytes(#bindings)?);)*
                                     Ok(discriminant_out)
                                 },
                             }
@@ -1090,7 +1090,7 @@ fn impl_serialize(parsed_ast: TlsStruct, svariant: SerializeVariant) -> TokenStr
                 SerializeVariant::Bytes => {
                     quote! {
                         impl #impl_generics tls_codec::SerializeBytes for #ident #ty_generics #where_clause {
-                            fn tls_serialize(&self) -> core::result::Result<Vec<u8>, tls_codec::Error> {
+                            fn tls_serialize_bytes(&self) -> core::result::Result<Vec<u8>, tls_codec::Error> {
                                 #discriminant_constants
                                 match self {
                                     #(#arms)*
@@ -1099,8 +1099,8 @@ fn impl_serialize(parsed_ast: TlsStruct, svariant: SerializeVariant) -> TokenStr
                         }
 
                         impl #impl_generics tls_codec::SerializeBytes for &#ident #ty_generics #where_clause {
-                            fn tls_serialize(&self) -> core::result::Result<Vec<u8>, tls_codec::Error> {
-                                tls_codec::SerializeBytes::tls_serialize(*self)
+                            fn tls_serialize_bytes(&self) -> core::result::Result<Vec<u8>, tls_codec::Error> {
+                                tls_codec::SerializeBytes::tls_serialize_bytes(*self)
                             }
                         }
                     }

--- a/tls_codec/derive/tests/decode.rs
+++ b/tls_codec/derive/tests/decode.rs
@@ -1,7 +1,5 @@
 #![cfg(feature = "std")]
-// These tests intentionally exercise the deprecated `VLBytes` for backward
-// compatibility coverage.
-#![allow(deprecated)]
+#![cfg_attr(feature = "future_deprecations", allow(deprecated))]
 use tls_codec::{
     Deserialize, DeserializeBytes, Error, Serialize, Size, TlsSliceU16, TlsVecU8, TlsVecU16,
     TlsVecU32, VLBytes,

--- a/tls_codec/derive/tests/decode_bytes.rs
+++ b/tls_codec/derive/tests/decode_bytes.rs
@@ -30,11 +30,11 @@ struct SomeValue {
 
 #[test]
 fn simple_enum() {
-    let serialized = ExtensionType::KeyId.tls_serialize().unwrap();
+    let serialized = ExtensionType::KeyId.tls_serialize_bytes().unwrap();
     let (deserialized, rest) = ExtensionType::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, ExtensionType::KeyId);
     assert!(rest.is_empty());
-    let serialized = ExtensionType::SomethingElse.tls_serialize().unwrap();
+    let serialized = ExtensionType::SomethingElse.tls_serialize_bytes().unwrap();
     let (deserialized, rest) = ExtensionType::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, ExtensionType::SomethingElse);
     assert!(rest.is_empty());
@@ -47,7 +47,7 @@ fn simple_struct() {
         extension_data: vec![1, 2, 3, 4, 5],
         additional_data: None,
     };
-    let serialized = extension.tls_serialize().unwrap();
+    let serialized = extension.tls_serialize_bytes().unwrap();
     let (deserialized, rest) = ExtensionStruct::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, extension);
     assert!(rest.is_empty());
@@ -61,7 +61,7 @@ fn tuple_struct() {
         additional_data: None,
     };
     let x = TupleStruct(ext, 6);
-    let serialized = x.tls_serialize().unwrap();
+    let serialized = x.tls_serialize_bytes().unwrap();
     let (deserialized, rest) = TupleStruct::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, x);
     assert!(rest.is_empty());
@@ -70,7 +70,7 @@ fn tuple_struct() {
 #[test]
 fn byte_arrays() {
     let x = [0u8, 1, 2, 3];
-    let serialized = x.tls_serialize().unwrap();
+    let serialized = x.tls_serialize_bytes().unwrap();
     let (deserialized, rest) = <[u8; 4]>::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, x);
     assert!(rest.is_empty());
@@ -90,8 +90,8 @@ mod custom {
         v.tls_serialized_len()
     }
 
-    pub fn tls_serialize(v: &[u8]) -> Result<Vec<u8>, tls_codec::Error> {
-        v.tls_serialize()
+    pub fn tls_serialize_bytes(v: &[u8]) -> Result<Vec<u8>, tls_codec::Error> {
+        v.tls_serialize_bytes()
     }
 
     pub fn tls_deserialize_bytes<T: DeserializeBytes>(
@@ -107,7 +107,7 @@ fn custom() {
         values: vec![0, 1, 2],
         a: 3,
     };
-    let serialized = x.tls_serialize().unwrap();
+    let serialized = x.tls_serialize_bytes().unwrap();
     assert_eq!(vec![3, 0, 1, 2, 3], serialized);
     let (deserialized, rest) = Custom::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, x);
@@ -123,7 +123,7 @@ enum EnumWithTupleVariant {
 #[test]
 fn enum_with_tuple_variant() {
     let x = EnumWithTupleVariant::A(3, 4);
-    let serialized = x.tls_serialize().unwrap();
+    let serialized = x.tls_serialize_bytes().unwrap();
     let (deserialized, rest) = EnumWithTupleVariant::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, x);
     assert!(rest.is_empty());
@@ -138,7 +138,7 @@ enum EnumWithStructVariant {
 #[test]
 fn enum_with_struct_variant() {
     let x = EnumWithStructVariant::A { foo: 3, bar: 4 };
-    let serialized = x.tls_serialize().unwrap();
+    let serialized = x.tls_serialize_bytes().unwrap();
     let (deserialized, rest) = EnumWithStructVariant::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, x);
     assert!(rest.is_empty());
@@ -155,7 +155,7 @@ enum EnumWithDataAndDiscriminant {
 #[test]
 fn enum_with_data_and_discriminant() {
     let x = EnumWithDataAndDiscriminant::A(4);
-    let serialized = x.tls_serialize().unwrap();
+    let serialized = x.tls_serialize_bytes().unwrap();
 
     let (deserialized, rest) =
         EnumWithDataAndDiscriminant::tls_deserialize_bytes(&serialized).unwrap();
@@ -166,7 +166,7 @@ fn enum_with_data_and_discriminant() {
 #[test]
 fn discriminant_is_incremented_implicitly() {
     let x = EnumWithDataAndDiscriminant::B;
-    let serialized = x.tls_serialize().unwrap();
+    let serialized = x.tls_serialize_bytes().unwrap();
     let (deserialized, rest) =
         EnumWithDataAndDiscriminant::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, x);
@@ -200,7 +200,7 @@ enum EnumWithDataAndConstDiscriminant {
 #[test]
 fn enum_with_data_and_const_discriminant() {
     let x = EnumWithDataAndConstDiscriminant::A(4);
-    let serialized = x.tls_serialize().unwrap();
+    let serialized = x.tls_serialize_bytes().unwrap();
     assert_eq!(vec![0, 3, 4], serialized);
     let (deserialized, rest) =
         EnumWithDataAndConstDiscriminant::tls_deserialize_bytes(&serialized).unwrap();
@@ -208,14 +208,14 @@ fn enum_with_data_and_const_discriminant() {
     assert!(rest.is_empty());
 
     let x = EnumWithDataAndConstDiscriminant::B;
-    let serialized = x.tls_serialize().unwrap();
+    let serialized = x.tls_serialize_bytes().unwrap();
     let (deserialized, rest) =
         EnumWithDataAndConstDiscriminant::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, x);
     assert!(rest.is_empty());
 
     let x = EnumWithDataAndConstDiscriminant::C;
-    let serialized = x.tls_serialize().unwrap();
+    let serialized = x.tls_serialize_bytes().unwrap();
     let (deserialized, rest) =
         EnumWithDataAndConstDiscriminant::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, x);
@@ -231,7 +231,7 @@ enum EnumWithCustomSerializedField {
 #[test]
 fn enum_with_custom_serialized_field() {
     let x = EnumWithCustomSerializedField::A(vec![1, 2, 3]);
-    let serialized = x.tls_serialize().unwrap();
+    let serialized = x.tls_serialize_bytes().unwrap();
     let (deserialized, rest) =
         EnumWithCustomSerializedField::tls_deserialize_bytes(&serialized).unwrap();
     assert_eq!(deserialized, x);
@@ -244,7 +244,7 @@ fn that_skip_attribute_on_struct_works() {
     where
         T: DeserializeBytes + std::fmt::Debug + PartialEq + SerializeBytes + Size,
     {
-        let serialized = test.tls_serialize().unwrap();
+        let serialized = test.tls_serialize_bytes().unwrap();
         let (deserialized, rest) = T::tls_deserialize_bytes(&serialized).unwrap();
         assert_eq!(deserialized, expected);
         assert!(rest.is_empty());

--- a/tls_codec/derive/tests/encode_bytes.rs
+++ b/tls_codec/derive/tests/encode_bytes.rs
@@ -37,15 +37,15 @@ struct SomeValue {
 fn lifetime_struct() {
     let value = vec![7u8; 33];
     let s = StructWithLifetime { value: &value };
-    let serialized_s = s.tls_serialize().unwrap();
-    assert_eq!(serialized_s, value.tls_serialize().unwrap());
+    let serialized_s = s.tls_serialize_bytes().unwrap();
+    assert_eq!(serialized_s, value.tls_serialize_bytes().unwrap());
 }
 
 #[test]
 fn simple_enum() {
-    let serialized = ExtensionType::KeyId.tls_serialize().unwrap();
+    let serialized = ExtensionType::KeyId.tls_serialize_bytes().unwrap();
     assert_eq!(vec![0, 3], serialized);
-    let serialized = ExtensionType::SomethingElse.tls_serialize().unwrap();
+    let serialized = ExtensionType::SomethingElse.tls_serialize_bytes().unwrap();
     assert_eq!(vec![1, 244], serialized);
 }
 
@@ -56,7 +56,7 @@ fn simple_struct() {
         extension_data: vec![1, 2, 3, 4, 5],
         additional_data: None,
     };
-    let serialized = extension.tls_serialize().unwrap();
+    let serialized = extension.tls_serialize_bytes().unwrap();
     assert_eq!(vec![0, 3, 5, 1, 2, 3, 4, 5, 0], serialized);
 }
 
@@ -68,14 +68,14 @@ fn tuple_struct() {
         additional_data: None,
     };
     let x = TupleStruct(ext, 6);
-    let serialized = x.tls_serialize().unwrap();
+    let serialized = x.tls_serialize_bytes().unwrap();
     assert_eq!(vec![0, 3, 5, 1, 2, 3, 4, 5, 0, 6], serialized);
 }
 
 #[test]
 fn byte_arrays() {
     let x = [0u8, 1, 2, 3];
-    let serialized = x.tls_serialize().unwrap();
+    let serialized = x.tls_serialize_bytes().unwrap();
     assert_eq!(vec![0, 1, 2, 3], serialized);
 }
 
@@ -83,11 +83,11 @@ fn byte_arrays() {
 fn lifetimes() {
     let x = vec![1, 2, 3, 4];
     let s = StructWithLifetime { value: &x };
-    let serialized = s.tls_serialize().unwrap();
+    let serialized = s.tls_serialize_bytes().unwrap();
     assert_eq!(vec![4, 1, 2, 3, 4], serialized);
 
     pub fn do_some_serializing(val: &StructWithLifetime) -> Vec<u8> {
-        val.tls_serialize().unwrap()
+        val.tls_serialize_bytes().unwrap()
     }
     let serialized = do_some_serializing(&s);
     assert_eq!(vec![4, 1, 2, 3, 4], serialized);
@@ -107,8 +107,8 @@ mod custom {
         v.tls_serialized_len()
     }
 
-    pub fn tls_serialize(v: &[u8]) -> Result<Vec<u8>, tls_codec::Error> {
-        v.tls_serialize()
+    pub fn tls_serialize_bytes(v: &[u8]) -> Result<Vec<u8>, tls_codec::Error> {
+        v.tls_serialize_bytes()
     }
 }
 
@@ -118,7 +118,7 @@ fn custom() {
         values: vec![0, 1, 2],
         a: 3,
     };
-    let serialized = x.tls_serialize().unwrap();
+    let serialized = x.tls_serialize_bytes().unwrap();
     assert_eq!(vec![3, 0, 1, 2, 3], serialized);
 }
 
@@ -138,7 +138,7 @@ fn optional_member() {
         ref_optional_member: &None,
         ref_vector: &v,
     };
-    let serialized = x.tls_serialize().unwrap();
+    let serialized = x.tls_serialize_bytes().unwrap();
     assert_eq!(vec![1, 0, 0, 0, 6, 0, 6, 0, 1, 0, 2, 0, 3], serialized);
 }
 
@@ -151,7 +151,7 @@ enum EnumWithTupleVariant {
 #[test]
 fn enum_with_tuple_variant() {
     let x = EnumWithTupleVariant::A(3, 4);
-    let serialized = x.tls_serialize().unwrap();
+    let serialized = x.tls_serialize_bytes().unwrap();
     assert_eq!(vec![0, 3, 0, 0, 0, 4], serialized);
 }
 
@@ -164,7 +164,7 @@ enum EnumWithStructVariant {
 #[test]
 fn enum_with_struct_variant() {
     let x = EnumWithStructVariant::A { foo: 3, bar: 4 };
-    let serialized = x.tls_serialize().unwrap();
+    let serialized = x.tls_serialize_bytes().unwrap();
     assert_eq!(vec![0, 3, 0, 0, 0, 4], serialized);
 }
 
@@ -179,14 +179,14 @@ enum EnumWithDataAndDiscriminant {
 #[test]
 fn enum_with_data_and_discriminant() {
     let x = EnumWithDataAndDiscriminant::A(4);
-    let serialized = x.tls_serialize().unwrap();
+    let serialized = x.tls_serialize_bytes().unwrap();
     assert_eq!(vec![0, 3, 4], serialized);
 }
 
 #[test]
 fn discriminant_is_incremented_implicitly() {
     let x = EnumWithDataAndDiscriminant::B;
-    let serialized = x.tls_serialize().unwrap();
+    let serialized = x.tls_serialize_bytes().unwrap();
     assert_eq!(vec![0, 4], serialized);
 }
 
@@ -217,12 +217,16 @@ enum EnumWithDataAndConstDiscriminant {
 #[test]
 fn enum_with_data_and_const_discriminant() {
     let serialized = EnumWithDataAndConstDiscriminant::A(4)
-        .tls_serialize()
+        .tls_serialize_bytes()
         .unwrap();
     assert_eq!(vec![0, 3, 4], serialized);
-    let serialized = EnumWithDataAndConstDiscriminant::B.tls_serialize().unwrap();
+    let serialized = EnumWithDataAndConstDiscriminant::B
+        .tls_serialize_bytes()
+        .unwrap();
     assert_eq!(vec![0, 4], serialized);
-    let serialized = EnumWithDataAndConstDiscriminant::C.tls_serialize().unwrap();
+    let serialized = EnumWithDataAndConstDiscriminant::C
+        .tls_serialize_bytes()
+        .unwrap();
     assert_eq!(vec![0, 12], serialized);
 }
 
@@ -235,7 +239,7 @@ enum EnumWithCustomSerializedField {
 #[test]
 fn enum_with_custom_serialized_field() {
     let x = EnumWithCustomSerializedField::A(vec![1, 2, 3]);
-    let serialized = x.tls_serialize().unwrap();
+    let serialized = x.tls_serialize_bytes().unwrap();
     assert_eq!(vec![0, 3, 1, 2, 3], serialized);
 }
 
@@ -249,7 +253,7 @@ fn that_skip_attribute_on_struct_works() {
         assert_eq!(test.tls_serialized_len(), expected.len());
 
         // Check serialization.
-        assert_eq!(test.tls_serialize().unwrap(), expected);
+        assert_eq!(test.tls_serialize_bytes().unwrap(), expected);
     }
 
     #[derive(Debug, PartialEq, TlsSerializeBytes, TlsSize)]

--- a/tls_codec/fuzz/Cargo.lock
+++ b/tls_codec/fuzz/Cargo.lock
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "tls_codec"
-version = "0.4.3-pre.1"
+version = "0.5.0-pre.1"
 dependencies = [
  "arbitrary",
  "tls_codec_derive",
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "tls_codec_derive"
-version = "0.4.3-pre.1"
+version = "0.5.0-pre.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/tls_codec/fuzz/Cargo.toml
+++ b/tls_codec/fuzz/Cargo.toml
@@ -14,6 +14,11 @@ libfuzzer-sys = "0.4"
 path = ".."
 features = ["arbitrary"]
 
+[features]
+# Mirror `tls_codec`'s `future_deprecations` so the fuzz targets can gate their
+# `allow(deprecated)` on the same feature.
+future_deprecations = ["tls_codec/future_deprecations"]
+
 # Prevent this from interfering with workspaces
 [workspace]
 members = ["."]

--- a/tls_codec/fuzz/fuzz_targets/bytes_inverse.rs
+++ b/tls_codec/fuzz/fuzz_targets/bytes_inverse.rs
@@ -1,5 +1,5 @@
 #![no_main]
-#![allow(deprecated)]
+#![cfg_attr(feature = "future_deprecations", allow(deprecated))]
 
 //! Round-trip fuzzing of the slice-based [`DeserializeBytes`] path.
 //!

--- a/tls_codec/fuzz/fuzz_targets/deserialize.rs
+++ b/tls_codec/fuzz/fuzz_targets/deserialize.rs
@@ -1,5 +1,5 @@
 #![no_main]
-#![allow(deprecated)]
+#![cfg_attr(feature = "future_deprecations", allow(deprecated))]
 
 //! Robustness + differential fuzzing of the deserializers.
 //!

--- a/tls_codec/fuzz/fuzz_targets/inverse.rs
+++ b/tls_codec/fuzz/fuzz_targets/inverse.rs
@@ -1,5 +1,5 @@
 #![no_main]
-#![allow(deprecated)]
+#![cfg_attr(feature = "future_deprecations", allow(deprecated))]
 
 use libfuzzer_sys::fuzz_target;
 use tls_codec::{Deserialize, Serialize, Size, VLBytes};

--- a/tls_codec/fuzz/fuzz_targets/string.rs
+++ b/tls_codec/fuzz/fuzz_targets/string.rs
@@ -1,5 +1,5 @@
 #![no_main]
-#![allow(deprecated)]
+#![cfg_attr(feature = "future_deprecations", allow(deprecated))]
 
 use libfuzzer_sys::fuzz_target;
 use tls_codec::{Deserialize, Serialize, Size};

--- a/tls_codec/src/arrays.rs
+++ b/tls_codec/src/arrays.rs
@@ -39,7 +39,7 @@ impl<const LEN: usize> DeserializeBytes for [u8; LEN] {
 }
 
 impl<const LEN: usize> SerializeBytes for [u8; LEN] {
-    fn tls_serialize(&self) -> Result<Vec<u8>, Error> {
+    fn tls_serialize_bytes(&self) -> Result<Vec<u8>, Error> {
         Ok(self.to_vec())
     }
 }

--- a/tls_codec/src/lib.rs
+++ b/tls_codec/src/lib.rs
@@ -50,9 +50,9 @@ pub use tls_vec::{
 };
 
 #[cfg(feature = "std")]
-#[allow(deprecated)]
+#[cfg_attr(feature = "future_deprecations", allow(deprecated))]
 pub use quic_vec::SecretVLBytes;
-#[allow(deprecated)]
+#[cfg_attr(feature = "future_deprecations", allow(deprecated))]
 pub use quic_vec::VLBytes;
 #[cfg(feature = "std")]
 pub use quic_vec::{SecretVLByteVec, rw as vlen};
@@ -282,10 +282,10 @@ pub trait Serialize: Size {
 /// The `SerializeBytes` trait provides a function to serialize a struct or enum.
 ///
 /// The trait provides one function:
-/// * `tls_serialize` that returns a byte vector
+/// * `tls_serialize_bytes` that returns a byte vector
 pub trait SerializeBytes: Size {
     /// Serialize `self` and return it as a byte vector.
-    fn tls_serialize(&self) -> Result<Vec<u8>, Error>;
+    fn tls_serialize_bytes(&self) -> Result<Vec<u8>, Error>;
 }
 
 /// The `Deserialize` trait defines functions to deserialize a byte slice to a

--- a/tls_codec/src/primitives.rs
+++ b/tls_codec/src/primitives.rs
@@ -45,13 +45,13 @@ impl<T: Serialize> Serialize for Option<T> {
 
 impl<T: SerializeBytes> SerializeBytes for Option<T> {
     #[inline]
-    fn tls_serialize(&self) -> Result<Vec<u8>, Error> {
+    fn tls_serialize_bytes(&self) -> Result<Vec<u8>, Error> {
         match self {
             Some(e) => {
                 let mut out =
                     Vec::with_capacity(crate::checked_alloc_len(e.tls_serialized_len(), 1)?);
                 out.push(1);
-                out.append(&mut e.tls_serialize()?);
+                out.append(&mut e.tls_serialize_bytes()?);
                 Ok(out)
             }
             None => Ok(vec![0]),
@@ -68,8 +68,8 @@ impl<T: Serialize> Serialize for &Option<T> {
 
 impl<T: SerializeBytes> SerializeBytes for &Option<T> {
     #[inline]
-    fn tls_serialize(&self) -> Result<Vec<u8>, Error> {
-        (*self).tls_serialize()
+    fn tls_serialize_bytes(&self) -> Result<Vec<u8>, Error> {
+        (*self).tls_serialize_bytes()
     }
 }
 
@@ -140,15 +140,15 @@ macro_rules! impl_unsigned {
 
         impl SerializeBytes for &$t {
             #[inline]
-            fn tls_serialize(&self) -> Result<Vec<u8>, Error> {
+            fn tls_serialize_bytes(&self) -> Result<Vec<u8>, Error> {
                 Ok(self.to_be_bytes().to_vec())
             }
         }
 
         impl SerializeBytes for $t {
             #[inline]
-            fn tls_serialize(&self) -> Result<Vec<u8>, Error> {
-                <&Self as SerializeBytes>::tls_serialize(&self)
+            fn tls_serialize_bytes(&self) -> Result<Vec<u8>, Error> {
+                <&Self as SerializeBytes>::tls_serialize_bytes(&self)
             }
         }
 
@@ -368,7 +368,7 @@ impl<T> Serialize for PhantomData<T> {
 
 impl<T> SerializeBytes for PhantomData<T> {
     #[inline(always)]
-    fn tls_serialize(&self) -> Result<Vec<u8>, Error> {
+    fn tls_serialize_bytes(&self) -> Result<Vec<u8>, Error> {
         Ok(vec![])
     }
 }
@@ -390,8 +390,8 @@ impl<T: Serialize> Serialize for Box<T> {
 
 impl<T: SerializeBytes> SerializeBytes for Box<T> {
     #[inline(always)]
-    fn tls_serialize(&self) -> Result<Vec<u8>, Error> {
-        self.as_ref().tls_serialize()
+    fn tls_serialize_bytes(&self) -> Result<Vec<u8>, Error> {
+        self.as_ref().tls_serialize_bytes()
     }
 }
 

--- a/tls_codec/src/quic_vec.rs
+++ b/tls_codec/src/quic_vec.rs
@@ -12,11 +12,12 @@
 //! This is in contrast to the default behaviour defined by RFC 9000 that allows
 //! up to 62-bit length values.
 
-// `VLBytes` and `SecretVLBytes` are kept around as deprecated types. The
-// internal trait impls for them and their use as building blocks for other
-// items in this module would otherwise emit deprecation warnings at every call
-// site within the crate.
-#![allow(deprecated)]
+// `VLBytes` and `SecretVLBytes` are only deprecated when the
+// `future_deprecations` feature is enabled. In that configuration, the internal
+// trait impls for them and their use as building blocks for other items in this
+// module would otherwise emit deprecation warnings at every call site within
+// the crate.
+#![cfg_attr(feature = "future_deprecations", allow(deprecated))]
 
 use super::alloc::vec::Vec;
 use core::fmt;
@@ -130,7 +131,7 @@ impl<T: DeserializeBytes> DeserializeBytes for Vec<T> {
 
 impl SerializeBytes for VLBytes {
     #[inline(always)]
-    fn tls_serialize(&self) -> Result<Vec<u8>, Error> {
+    fn tls_serialize_bytes(&self) -> Result<Vec<u8>, Error> {
         let content_length = self.as_slice().len();
         let length = ContentLength::from_usize(content_length)?;
         let len_len = length.0.bytes_len();
@@ -153,14 +154,14 @@ impl SerializeBytes for VLBytes {
 
 impl SerializeBytes for &VLBytes {
     #[inline(always)]
-    fn tls_serialize(&self) -> Result<Vec<u8>, Error> {
-        (*self).tls_serialize()
+    fn tls_serialize_bytes(&self) -> Result<Vec<u8>, Error> {
+        (*self).tls_serialize_bytes()
     }
 }
 
 impl<T: SerializeBytes> SerializeBytes for &[T] {
     #[inline(always)]
-    fn tls_serialize(&self) -> Result<Vec<u8>, Error> {
+    fn tls_serialize_bytes(&self) -> Result<Vec<u8>, Error> {
         // We need to pre-compute the length of the content.
         // This requires more computations but the other option would be to buffer
         // the entire content, which can end up requiring a lot of memory.
@@ -176,7 +177,7 @@ impl<T: SerializeBytes> SerializeBytes for &[T] {
 
         // Serialize the elements
         for e in self.iter() {
-            out.append(&mut e.tls_serialize()?);
+            out.append(&mut e.tls_serialize_bytes()?);
         }
         #[cfg(debug_assertions)]
         if out.len() - len_len != content_length {
@@ -189,14 +190,14 @@ impl<T: SerializeBytes> SerializeBytes for &[T] {
 
 impl<T: SerializeBytes> SerializeBytes for &Vec<T> {
     #[inline(always)]
-    fn tls_serialize(&self) -> Result<Vec<u8>, Error> {
-        self.as_slice().tls_serialize()
+    fn tls_serialize_bytes(&self) -> Result<Vec<u8>, Error> {
+        self.as_slice().tls_serialize_bytes()
     }
 }
 
 impl<T: SerializeBytes> SerializeBytes for Vec<T> {
-    fn tls_serialize(&self) -> Result<Vec<u8>, Error> {
-        self.as_slice().tls_serialize()
+    fn tls_serialize_bytes(&self) -> Result<Vec<u8>, Error> {
+        self.as_slice().tls_serialize_bytes()
     }
 }
 
@@ -290,10 +291,12 @@ macro_rules! impl_vl_bytes_generic {
 /// This is faster than the generic version.
 #[cfg_attr(feature = "serde", derive(SerdeSerialize, SerdeDeserialize))]
 #[derive(Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
-#[deprecated(
-    since = "0.4.3",
-    note = "Use `VLByteVec` instead. `VLBytes` does not produce a compact serde representation \
+#[cfg_attr(
+    feature = "future_deprecations",
+    deprecated(
+        note = "Use `VLByteVec` instead. `VLBytes` does not produce a compact serde representation \
             of byte vectors. The serde format of `VLByteVec` is not compatible with `VLBytes`."
+    )
 )]
 pub struct VLBytes {
     vec: Vec<u8>,
@@ -595,13 +598,13 @@ impl Size for VLByteSlice<'_> {
 }
 
 impl SerializeBytes for ContentLength {
-    fn tls_serialize(&self) -> Result<Vec<u8>, Error> {
-        SerializeBytes::tls_serialize(&self.0)
+    fn tls_serialize_bytes(&self) -> Result<Vec<u8>, Error> {
+        SerializeBytes::tls_serialize_bytes(&self.0)
     }
 }
 
 impl SerializeBytes for VLByteSlice<'_> {
-    fn tls_serialize(&self) -> Result<Vec<u8>, Error> {
+    fn tls_serialize_bytes(&self) -> Result<Vec<u8>, Error> {
         // Get the byte length of the content and make sure it's not too
         // large (requires `mls` feature, so we also do it explicitly below).
         let content_len = self.0.len();
@@ -611,7 +614,7 @@ impl SerializeBytes for VLByteSlice<'_> {
         let total_len = crate::checked_alloc_len(content_len, len_len)?;
 
         let mut out = alloc::vec::Vec::with_capacity(total_len);
-        out.append(&mut SerializeBytes::tls_serialize(&content_length)?);
+        out.append(&mut SerializeBytes::tls_serialize_bytes(&content_length)?);
         out.extend(self.0);
 
         Ok(out)
@@ -836,10 +839,12 @@ mod secret_bytes {
     /// a [`Vec<u8>`].
     #[cfg_attr(feature = "serde", derive(SerdeSerialize, SerdeDeserialize))]
     #[derive(Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
-    #[deprecated(
-        since = "0.4.3",
-        note = "Use `SecretVLByteVec` instead. The serde format of `SecretVLByteVec` is not \
+    #[cfg_attr(
+        feature = "future_deprecations",
+        deprecated(
+            note = "Use `SecretVLByteVec` instead. The serde format of `SecretVLByteVec` is not \
                 compatible with `SecretVLBytes`."
+        )
     )]
     pub struct SecretVLBytes(VLBytes);
 

--- a/tls_codec/src/string.rs
+++ b/tls_codec/src/string.rs
@@ -24,20 +24,20 @@ impl Size for &str {
 }
 
 impl SerializeBytes for String {
-    fn tls_serialize(&self) -> Result<alloc::vec::Vec<u8>, crate::Error> {
-        SerializeBytes::tls_serialize(&VLByteSlice(self.as_bytes()))
+    fn tls_serialize_bytes(&self) -> Result<alloc::vec::Vec<u8>, crate::Error> {
+        SerializeBytes::tls_serialize_bytes(&VLByteSlice(self.as_bytes()))
     }
 }
 
 impl SerializeBytes for str {
-    fn tls_serialize(&self) -> Result<alloc::vec::Vec<u8>, crate::Error> {
-        SerializeBytes::tls_serialize(&self.as_bytes())
+    fn tls_serialize_bytes(&self) -> Result<alloc::vec::Vec<u8>, crate::Error> {
+        SerializeBytes::tls_serialize_bytes(&self.as_bytes())
     }
 }
 
 impl SerializeBytes for &str {
-    fn tls_serialize(&self) -> Result<alloc::vec::Vec<u8>, crate::Error> {
-        SerializeBytes::tls_serialize(&self.as_bytes())
+    fn tls_serialize_bytes(&self) -> Result<alloc::vec::Vec<u8>, crate::Error> {
+        SerializeBytes::tls_serialize_bytes(&self.as_bytes())
     }
 }
 
@@ -173,7 +173,7 @@ mod tests {
             assert_eq!(s.tls_serialized_len(), 1);
         }
 
-        let buf = SerializeBytes::tls_serialize(&s).unwrap();
+        let buf = SerializeBytes::tls_serialize_bytes(&s).unwrap();
         assert_eq!(buf, [0]);
         assert_eq!(s.tls_serialized_len(), 1);
     }
@@ -190,7 +190,7 @@ mod tests {
             assert_eq!(s.tls_serialized_len(), 6);
         }
 
-        let buf = SerializeBytes::tls_serialize(&s).unwrap();
+        let buf = SerializeBytes::tls_serialize_bytes(&s).unwrap();
         // length prefix (5) + b"hello"
         assert_eq!(buf, [5, b'h', b'e', b'l', b'l', b'o']);
         assert_eq!(s.tls_serialized_len(), 6);
@@ -208,7 +208,7 @@ mod tests {
             assert_eq!(s.tls_serialized_len(), 3);
         }
 
-        let buf = SerializeBytes::tls_serialize(&s).unwrap();
+        let buf = SerializeBytes::tls_serialize_bytes(&s).unwrap();
         assert_eq!(buf, [2, 0xC3, 0xBC]);
         assert_eq!(s.tls_serialized_len(), 3);
     }

--- a/tls_codec/src/tls_vec.rs
+++ b/tls_codec/src/tls_vec.rs
@@ -250,7 +250,7 @@ macro_rules! impl_serialize_bytes_bytes {
             let (tls_serialized_len, byte_length) = $self.get_content_lengths()?;
 
             let mut vec = Vec::<u8>::with_capacity(crate::checked_alloc_len(byte_length, $len_len)?);
-            let length_vec = <$size as SerializeBytes>::tls_serialize(&byte_length.try_into().unwrap())?;
+            let length_vec = <$size as SerializeBytes>::tls_serialize_bytes(&byte_length.try_into().unwrap())?;
             let mut written = length_vec.len();
             vec.extend_from_slice(&length_vec);
 
@@ -354,7 +354,7 @@ macro_rules! impl_tls_vec_codec_bytes {
         }
 
         impl SerializeBytes for $name {
-            fn tls_serialize(&self) -> Result<Vec<u8>, Error> {
+            fn tls_serialize_bytes(&self) -> Result<Vec<u8>, Error> {
                 self.serialize_bytes_bytes()
             }
         }

--- a/tls_codec/src/varint.rs
+++ b/tls_codec/src/varint.rs
@@ -170,7 +170,7 @@ impl Serialize for TlsVarInt {
 
 impl SerializeBytes for TlsVarInt {
     #[inline]
-    fn tls_serialize(&self) -> Result<alloc::vec::Vec<u8>, Error> {
+    fn tls_serialize_bytes(&self) -> Result<alloc::vec::Vec<u8>, Error> {
         let len = self.bytes_len();
         let mut bytes = alloc::vec![0u8; len];
         self.write_bytes(&mut bytes)?;

--- a/tls_codec/tests/decode.rs
+++ b/tls_codec/tests/decode.rs
@@ -1,7 +1,5 @@
 #![cfg(feature = "std")]
-// These tests intentionally exercise the deprecated `VLBytes` for backward
-// compatibility coverage.
-#![allow(deprecated)]
+#![cfg_attr(feature = "future_deprecations", allow(deprecated))]
 
 use tls_codec::{
     Error, Serialize, Size, TlsByteSliceU16, TlsByteVecU8, TlsByteVecU16, TlsByteVecU32,

--- a/tls_codec/tests/decode_bytes.rs
+++ b/tls_codec/tests/decode_bytes.rs
@@ -215,7 +215,7 @@ mod overflow_32bit {
     }
 
     impl SerializeBytes for HugeLen {
-        fn tls_serialize(&self) -> Result<Vec<u8>, tls_codec::Error> {
+        fn tls_serialize_bytes(&self) -> Result<Vec<u8>, tls_codec::Error> {
             // Never actually reached: the length sum overflows before any
             // element is serialized.
             Ok(Vec::new())
@@ -227,7 +227,7 @@ mod overflow_32bit {
     #[test]
     fn serializing_overflowing_length_is_rejected() {
         let v = vec![HugeLen, HugeLen];
-        let res = v.tls_serialize();
+        let res = v.tls_serialize_bytes();
         assert!(
             matches!(res, Err(tls_codec::Error::InvalidVectorLength)),
             "expected InvalidVectorLength, got {res:?}"

--- a/tls_codec/tests/encode.rs
+++ b/tls_codec/tests/encode.rs
@@ -1,7 +1,5 @@
 #![cfg(feature = "std")]
-// These tests intentionally exercise the deprecated `VLBytes` for backward
-// compatibility coverage.
-#![allow(deprecated)]
+#![cfg_attr(feature = "future_deprecations", allow(deprecated))]
 
 use tls_codec::{Serialize, TlsVecU16, TlsVecU24, U24, VLByteSlice, VLBytes};
 
@@ -96,7 +94,7 @@ fn test_matching_vl_bytes_serialization() {
     let byte_vec = VLBytes::new(vec![99u8; 16384]);
     assert_eq!(
         Serialize::tls_serialize_detached(&byte_vec).expect("Error encoding vector"),
-        SerializeBytes::tls_serialize(&byte_vec).expect("Error encoding byte vector")
+        SerializeBytes::tls_serialize_bytes(&byte_vec).expect("Error encoding byte vector")
     );
 }
 

--- a/tls_codec/tests/encode_bytes.rs
+++ b/tls_codec/tests/encode_bytes.rs
@@ -1,4 +1,4 @@
-#![allow(deprecated)]
+#![cfg_attr(feature = "future_deprecations", allow(deprecated))]
 
 use tls_codec::{
     SerializeBytes, TlsByteVecU8, TlsByteVecU16, TlsByteVecU24, TlsByteVecU32, U24, VLBytes,
@@ -7,13 +7,13 @@ use tls_codec::{
 #[test]
 fn serialize_primitives() {
     let mut v = Vec::new();
-    v.append(&mut 77u8.tls_serialize().expect("Error encoding u8"));
-    v.append(&mut 88u8.tls_serialize().expect("Error encoding u8"));
-    v.append(&mut 355u16.tls_serialize().expect("Error encoding u16"));
+    v.append(&mut 77u8.tls_serialize_bytes().expect("Error encoding u8"));
+    v.append(&mut 88u8.tls_serialize_bytes().expect("Error encoding u8"));
+    v.append(&mut 355u16.tls_serialize_bytes().expect("Error encoding u16"));
     v.append(
         &mut U24::try_from(65609usize)
             .unwrap()
-            .tls_serialize()
+            .tls_serialize_bytes()
             .expect("Error encoding U24"),
     );
     let b = [77u8, 88, 1, 99, 1, 0, 73];
@@ -23,11 +23,11 @@ fn serialize_primitives() {
 #[test]
 fn serialize_var_len_vec() {
     let v = vec![9u8, 2, 98, 34, 55, 90, 54];
-    let serialized = v.tls_serialize().expect("Error encoding vector");
+    let serialized = v.tls_serialize_bytes().expect("Error encoding vector");
     assert_eq!(serialized, vec![7, 9, 2, 98, 34, 55, 90, 54]);
 
     let serialized = Vec::<u8>::new()
-        .tls_serialize()
+        .tls_serialize_bytes()
         .expect("Error encoding vector");
     assert_eq!(serialized, vec![0x00]);
 }
@@ -35,19 +35,19 @@ fn serialize_var_len_vec() {
 #[test]
 fn serialize_var_len_boundaries() {
     let v = vec![99u8; 63];
-    let serialized = v.tls_serialize().expect("Error encoding vector");
+    let serialized = v.tls_serialize_bytes().expect("Error encoding vector");
     assert_eq!(&serialized[0..5], &[63, 99, 99, 99, 99]);
 
     let v = vec![99u8; 64];
-    let serialized = v.tls_serialize().expect("Error encoding vector");
+    let serialized = v.tls_serialize_bytes().expect("Error encoding vector");
     assert_eq!(&serialized[0..5], &[0x40, 64, 99, 99, 99]);
 
     let v = vec![99u8; 16383];
-    let serialized = v.tls_serialize().expect("Error encoding vector");
+    let serialized = v.tls_serialize_bytes().expect("Error encoding vector");
     assert_eq!(&serialized[0..5], &[0x7f, 0xff, 99, 99, 99]);
 
     let v = vec![99u8; 16384];
-    let serialized = v.tls_serialize().expect("Error encoding vector");
+    let serialized = v.tls_serialize_bytes().expect("Error encoding vector");
     assert_eq!(&serialized[0..5], &[0x80, 0, 0x40, 0, 99]);
 }
 
@@ -55,7 +55,7 @@ fn serialize_var_len_boundaries() {
 fn serialize_tls_byte_vec_u8() {
     let byte_vec = TlsByteVecU8::from_slice(&[1, 2, 3]);
     let actual_result = byte_vec
-        .tls_serialize()
+        .tls_serialize_bytes()
         .expect("Error encoding byte vector");
     assert_eq!(actual_result, vec![3, 1, 2, 3]);
 }
@@ -64,7 +64,7 @@ fn serialize_tls_byte_vec_u8() {
 fn serialize_tls_byte_vec_u16() {
     let byte_vec = TlsByteVecU16::from_slice(&[1, 2, 3]);
     let actual_result = byte_vec
-        .tls_serialize()
+        .tls_serialize_bytes()
         .expect("Error encoding byte vector");
     assert_eq!(actual_result, vec![0, 3, 1, 2, 3]);
 }
@@ -73,7 +73,7 @@ fn serialize_tls_byte_vec_u16() {
 fn serialize_tls_byte_vec_u24() {
     let byte_vec = TlsByteVecU24::from_slice(&[1, 2, 3]);
     let actual_result = byte_vec
-        .tls_serialize()
+        .tls_serialize_bytes()
         .expect("Error encoding byte vector");
     assert_eq!(actual_result, vec![0, 0, 3, 1, 2, 3]);
 }
@@ -82,7 +82,7 @@ fn serialize_tls_byte_vec_u24() {
 fn serialize_tls_byte_vec_u32() {
     let byte_vec = TlsByteVecU32::from_slice(&[1, 2, 3]);
     let actual_result = byte_vec
-        .tls_serialize()
+        .tls_serialize_bytes()
         .expect("Error encoding byte vector");
     assert_eq!(actual_result, vec![0, 0, 0, 3, 1, 2, 3]);
 }
@@ -91,7 +91,7 @@ fn serialize_tls_byte_vec_u32() {
 fn serialize_vlbytes() {
     let byte_vec = VLBytes::new(vec![1, 2, 3]);
     let actual_result = byte_vec
-        .tls_serialize()
+        .tls_serialize_bytes()
         .expect("Error encoding byte vector");
     assert_eq!(actual_result, vec![3, 1, 2, 3]);
 }

--- a/tls_codec/tests/serde_impls.rs
+++ b/tls_codec/tests/serde_impls.rs
@@ -1,5 +1,5 @@
 #![cfg(feature = "serde")]
-#![allow(deprecated)]
+#![cfg_attr(feature = "future_deprecations", allow(deprecated))]
 
 use tls_codec::{SecretVLByteVec, VLByteVec, VLBytes};
 


### PR DESCRIPTION
`SerializeBytes::tls_serialize` -> `SerializeBytes::tls_serialize_bytes`

The `DeserializeBytes` fixed this early one but for some reason we never changed the serialize to disambiguate. Because we implement this for more structs like `VLBytes` now, this makes trouble in too many places. This PR changes the name of this function to be in line with the deserialize and don't force users to go through the trait. This is a breaking change and consumers need to update their function calls.

Add `future_deprecations` and don't deprecate `VLBytes`

Deprecating `VLBytes` is a bit premature. It's used in too many places. Instead of deprecating right away, it's deprecated only when the `future_deprecations` feature is enabled.