### PR TITLE
pkcs5: return an error instead of panicking on a short DES/3DES IV

### DIFF
--- a/pkcs5/src/pbes2.rs
+++ b/pkcs5/src/pbes2.rs
@@ -543,15 +543,11 @@ impl TryFrom<AlgorithmIdentifierRef<'_>> for EncryptionScheme {
             }),
             #[cfg(feature = "des-insecure")]
             DES_CBC_OID => Ok(Self::DesCbc {
-                iv: iv[0..DES_BLOCK_SIZE]
-                    .try_into()
-                    .map_err(|_| Tag::OctetString.value_error())?,
+                iv: iv.try_into().map_err(|_| Tag::OctetString.value_error())?,
             }),
             #[cfg(feature = "3des")]
             DES_EDE3_CBC_OID => Ok(Self::DesEde3Cbc {
-                iv: iv[0..DES_BLOCK_SIZE]
-                    .try_into()
-                    .map_err(|_| Tag::OctetString.value_error())?,
+                iv: iv.try_into().map_err(|_| Tag::OctetString.value_error())?,
             }),
             oid => Err(ErrorKind::OidUnknown { oid }.into()),
         }

--- a/pkcs5/tests/pbes2.rs
+++ b/pkcs5/tests/pbes2.rs
@@ -194,6 +194,47 @@ fn decode_pbes2_pbkdf2_sha256_descbc() {
     }
 }
 
+/// A bare DES-EDE3-CBC `AlgorithmIdentifier` whose IV octet string is only 3
+/// bytes long (shorter than the 8-byte DES block). This must decode to an
+/// error rather than panicking.
+#[cfg(feature = "3des")]
+const DESEDE3CBC_SHORT_IV_ALG_ID: &[u8] = &hex!("300f06082a864886f70d03070403010203");
+
+/// A bare DES-CBC `AlgorithmIdentifier` with a 3-byte IV octet string.
+#[cfg(feature = "des-insecure")]
+const DESCBC_SHORT_IV_ALG_ID: &[u8] = &hex!("300c06052b0e0302070403010203");
+
+/// A well-formed DES-EDE3-CBC `AlgorithmIdentifier` with a full 8-byte IV.
+#[cfg(feature = "3des")]
+const DESEDE3CBC_VALID_IV_ALG_ID: &[u8] = &hex!("301406082a864886f70d030704080102030405060708");
+
+#[cfg(feature = "3des")]
+#[test]
+fn desede3cbc_short_iv_is_error_not_panic() {
+    use der::Decode;
+    assert!(pbes2::EncryptionScheme::from_der(DESEDE3CBC_SHORT_IV_ALG_ID).is_err());
+}
+
+#[cfg(feature = "des-insecure")]
+#[test]
+fn descbc_short_iv_is_error_not_panic() {
+    use der::Decode;
+    assert!(pbes2::EncryptionScheme::from_der(DESCBC_SHORT_IV_ALG_ID).is_err());
+}
+
+#[cfg(feature = "3des")]
+#[test]
+fn desede3cbc_valid_iv_still_decodes() {
+    use der::Decode;
+    let scheme = pbes2::EncryptionScheme::from_der(DESEDE3CBC_VALID_IV_ALG_ID).unwrap();
+    match scheme {
+        pbes2::EncryptionScheme::DesEde3Cbc { iv } => {
+            assert_eq!(iv, hex!("0102030405060708"));
+        }
+        other => panic!("unexpected encryption scheme: {other:?}"),
+    }
+}
+
 /// Encoding test for PBES2 + PBKDF2-SHA1 + AES-128-CBC `AlgorithmIdentifier`
 #[test]
 fn encode_pbes2_pbkdf2_sha1_aes128cbc() {


### PR DESCRIPTION
While reading the PBES2 `EncryptionScheme` parser I noticed the DES-CBC and 3DES-EDE3-CBC arms can panic on attacker-controlled input.

Both DES arms do `iv[0..DES_BLOCK_SIZE].try_into()`, so the fixed-size slice happens before the `try_into` length check. If an `AlgorithmIdentifier` carries a DES-CBC or 3DES OID with an IV octet string shorter than 8 bytes, that range slice panics (`range end index 8 out of range for slice of length N`) instead of returning an error. The AES arms already call `try_into` on the whole slice, which reports a wrong length as an error, so this is just an inconsistency between the branches.

The IV comes straight from the DER parameters, so any code path that decodes an untrusted `EncryptionScheme` is affected, including `pkcs8::EncryptedPrivateKeyInfo::decrypt`, where the params are decoded before the password is ever used. A crafted 3DES-encrypted key blob panics regardless of the password.

The fix drops the manual slice and lets `try_into` on the full slice do the length check, matching the AES arms. `DesCbc`/`DesEde3Cbc` both hold `[u8; 8]`, so `TryInto<[u8; 8]>` enforces exactly 8 bytes.

Added regression tests in `pkcs5/tests/pbes2.rs`: a short (3-byte) IV for both DES-CBC and 3DES now decodes to `Err`, and a valid 8-byte 3DES IV still decodes. The 3DES test is behind the `3des` feature and the DES-CBC one behind `des-insecure`; ran with `cargo test -p pkcs5 --features 3des,des-insecure`. Before the change the short-IV cases panicked at pbes2.rs:546 and :552; after it they pass.
