### PR TITLE
cms: remove the direct dependency on `std`

### DIFF
--- a/cms/src/builder/kari.rs
+++ b/cms/src/builder/kari.rs
@@ -395,6 +395,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    extern crate std;
+
     use std::eprintln;
 
     use super::*;

--- a/cms/src/enveloped_data.rs
+++ b/cms/src/enveloped_data.rs
@@ -5,6 +5,7 @@ use crate::content_info::CmsVersion;
 use crate::revocation::RevocationInfoChoices;
 use crate::signed_data::CertificateSet;
 
+use alloc::vec;
 use core::cmp::Ordering;
 use der::asn1::{BitString, GeneralizedTime, ObjectIdentifier, OctetString, SetOfVec};
 use der::{Any, Choice, Sequence, ValueOrd};
@@ -88,11 +89,10 @@ pub struct OriginatorInfo {
 pub struct RecipientInfos(pub SetOfVec<RecipientInfo>);
 impl_newtype!(RecipientInfos, SetOfVec<RecipientInfo>);
 
-#[cfg(feature = "std")]
-impl TryFrom<std::vec::Vec<RecipientInfo>> for RecipientInfos {
+impl TryFrom<vec::Vec<RecipientInfo>> for RecipientInfos {
     type Error = der::Error;
 
-    fn try_from(vec: std::vec::Vec<RecipientInfo>) -> der::Result<RecipientInfos> {
+    fn try_from(vec: vec::Vec<RecipientInfo>) -> der::Result<RecipientInfos> {
         Ok(RecipientInfos(SetOfVec::try_from(vec)?))
     }
 }
@@ -268,7 +268,7 @@ pub struct OriginatorPublicKey {
 /// ```
 ///
 /// [RFC 5652 Section 6.2.2]: https://www.rfc-editor.org/rfc/rfc5652#section-6.2.2
-pub type RecipientEncryptedKeys = alloc::vec::Vec<RecipientEncryptedKey>;
+pub type RecipientEncryptedKeys = vec::Vec<RecipientEncryptedKey>;
 
 /// The `RecipientEncryptedKey` type is defined in [RFC 5652 Section 6.2.2].
 ///

--- a/cms/src/lib.rs
+++ b/cms/src/lib.rs
@@ -24,9 +24,6 @@
 
 extern crate alloc;
 
-#[cfg(feature = "std")]
-extern crate std;
-
 pub mod attr;
 pub mod authenticated_data;
 pub mod authenveloped_data;

--- a/cms/src/revocation.rs
+++ b/cms/src/revocation.rs
@@ -1,4 +1,5 @@
 //! Revocation-related types
+use alloc::vec;
 use core::cmp::Ordering;
 
 use der::asn1::SetOfVec;
@@ -47,11 +48,10 @@ impl ValueOrd for RevocationInfoChoice {
     }
 }
 
-#[cfg(feature = "std")]
-impl TryFrom<std::vec::Vec<RevocationInfoChoice>> for RevocationInfoChoices {
+impl TryFrom<vec::Vec<RevocationInfoChoice>> for RevocationInfoChoices {
     type Error = der::Error;
 
-    fn try_from(vec: std::vec::Vec<RevocationInfoChoice>) -> der::Result<RevocationInfoChoices> {
+    fn try_from(vec: vec::Vec<RevocationInfoChoice>) -> der::Result<RevocationInfoChoices> {
         Ok(RevocationInfoChoices(SetOfVec::try_from(vec)?))
     }
 }

--- a/cms/src/signed_data.rs
+++ b/cms/src/signed_data.rs
@@ -4,6 +4,7 @@ use crate::cert::{CertificateChoices, IssuerAndSerialNumber};
 use crate::content_info::CmsVersion;
 use crate::revocation::RevocationInfoChoices;
 
+use alloc::vec;
 use core::cmp::Ordering;
 use der::asn1::{ObjectIdentifier, OctetString, SetOfVec};
 use der::{Any, Choice, DerOrd, Sequence, ValueOrd};
@@ -59,11 +60,10 @@ pub type DigestAlgorithmIdentifiers = SetOfVec<AlgorithmIdentifierOwned>;
 pub struct CertificateSet(pub SetOfVec<CertificateChoices>);
 impl_newtype!(CertificateSet, SetOfVec<CertificateChoices>);
 
-#[cfg(feature = "std")]
-impl TryFrom<std::vec::Vec<CertificateChoices>> for CertificateSet {
+impl TryFrom<vec::Vec<CertificateChoices>> for CertificateSet {
     type Error = der::Error;
 
-    fn try_from(vec: std::vec::Vec<CertificateChoices>) -> der::Result<CertificateSet> {
+    fn try_from(vec: vec::Vec<CertificateChoices>) -> der::Result<CertificateSet> {
         Ok(CertificateSet(SetOfVec::try_from(vec)?))
     }
 }
@@ -79,11 +79,10 @@ impl TryFrom<std::vec::Vec<CertificateChoices>> for CertificateSet {
 pub struct SignerInfos(pub SetOfVec<SignerInfo>);
 impl_newtype!(SignerInfos, SetOfVec<SignerInfo>);
 
-#[cfg(feature = "std")]
-impl TryFrom<std::vec::Vec<SignerInfo>> for SignerInfos {
+impl TryFrom<vec::Vec<SignerInfo>> for SignerInfos {
     type Error = der::Error;
 
-    fn try_from(vec: std::vec::Vec<SignerInfo>) -> der::Result<SignerInfos> {
+    fn try_from(vec: vec::Vec<SignerInfo>) -> der::Result<SignerInfos> {
         Ok(SignerInfos(SetOfVec::try_from(vec)?))
     }
 }


### PR DESCRIPTION
`cms` has a strong dependency on `liballoc`, this replaces the various `std::vec` with `alloc::vec` and drops the std feature.

The `std` feature is kept only to forward the feature to `der`, `spki`, and `x509-cert` crates.