### PR TITLE
pkcs1: split der objects into `*Ref` and `*Owned`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,10 @@ x509-tsp = { path = "./x509-tsp" }
 x509-cert = { path = "./x509-cert" }
 x509-ocsp = { path = "./x509-ocsp" }
 
+# RSA: refactor: use *Ref (or *Owned) der types from RustCrypto/formats - #706
+rsa = { git = "https://github.com/dishmaker/RSA.git", rev = "96c97ec3e8b2bedde44f5954334618bec87a19c3" }
+
+
 [workspace.lints.clippy]
 borrow_as_ptr = "warn"
 cast_lossless = "warn"

--- a/pkcs1/Cargo.toml
+++ b/pkcs1/Cargo.toml
@@ -25,7 +25,7 @@ hex-literal = "1"
 tempfile = "3"
 
 [features]
-alloc = ["der/alloc", "zeroize"]
+alloc = ["der/alloc", "spki/alloc", "zeroize"]
 std = ["der/std", "alloc"]
 
 pem = ["alloc", "der/pem"]

--- a/pkcs1/src/lib.rs
+++ b/pkcs1/src/lib.rs
@@ -34,16 +34,18 @@ pub use der::{
 
 pub use crate::{
     error::{Error, Result},
-    params::{RsaOaepParams, RsaPssParams, TrailerField},
-    private_key::RsaPrivateKey,
-    public_key::RsaPublicKey,
+    params::{RsaOaepParams, RsaOaepParamsRef, RsaPssParams, RsaPssParamsRef, TrailerField},
+    private_key::{RsaPrivateKey, RsaPrivateKeyRef},
+    public_key::{RsaPublicKey, RsaPublicKeyRef},
     traits::{DecodeRsaPrivateKey, DecodeRsaPublicKey},
     version::Version,
 };
 
 #[cfg(feature = "alloc")]
 pub use crate::{
-    private_key::{OtherPrimeInfos, other_prime_info::OtherPrimeInfo},
+    params::{RsaOaepParamsOwned, RsaPssParamsOwned},
+    private_key::{OtherPrimeInfos, RsaPrivateKeyOwned, other_prime_info::OtherPrimeInfo},
+    public_key::RsaPublicKeyOwned,
     traits::{EncodeRsaPrivateKey, EncodeRsaPublicKey},
 };
 

--- a/pkcs1/src/params.rs
+++ b/pkcs1/src/params.rs
@@ -1,13 +1,15 @@
 //! PKCS#1 RSA parameters.
 
 use crate::{Error, Result};
+#[cfg(feature = "alloc")]
+use der::Any;
 use der::{
     Decode, DecodeValue, Encode, EncodeValue, FixedTag, Length, Reader, Sequence, Tag, TagMode,
     TagNumber, Writer,
     asn1::{AnyRef, ContextSpecificRef, ObjectIdentifier},
     oid::AssociatedOid,
 };
-use spki::{AlgorithmIdentifier, AlgorithmIdentifierRef};
+use spki::{AlgorithmIdentifier, AlgorithmIdentifierRef, AsAlgorithmIdentifierRef};
 
 const OID_SHA_1: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.14.3.2.26");
 const OID_MGF_1: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.8");
@@ -58,6 +60,13 @@ impl FixedTag for TrailerField {
 }
 
 /// PKCS#1 RSASSA-PSS parameters as defined in [RFC 8017 Appendix 2.3]
+pub type RsaPssParamsRef<'a> = RsaPssParams<AnyRef<'a>>;
+
+/// PKCS#1 RSASSA-PSS parameters as defined in [RFC 8017 Appendix 2.3]
+#[cfg(feature = "alloc")]
+pub type RsaPssParamsOwned = RsaPssParams<Any>;
+
+/// PKCS#1 RSASSA-PSS parameters as defined in [RFC 8017 Appendix 2.3]
 ///
 /// ASN.1 structure containing a serialized RSASSA-PSS parameters:
 /// ```text
@@ -73,12 +82,12 @@ impl FixedTag for TrailerField {
 ///
 /// [RFC 8017 Appendix 2.3]: https://datatracker.ietf.org/doc/html/rfc8017#appendix-A.2.3
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct RsaPssParams<'a> {
+pub struct RsaPssParams<Params> {
     /// Hash Algorithm
-    pub hash: AlgorithmIdentifierRef<'a>,
+    pub hash: AlgorithmIdentifier<Params>,
 
     /// Mask Generation Function (MGF)
-    pub mask_gen: AlgorithmIdentifier<AlgorithmIdentifierRef<'a>>,
+    pub mask_gen: AlgorithmIdentifier<AlgorithmIdentifier<Params>>,
 
     /// Salt length
     pub salt_len: u8,
@@ -87,60 +96,12 @@ pub struct RsaPssParams<'a> {
     pub trailer_field: TrailerField,
 }
 
-impl<'a> RsaPssParams<'a> {
+impl<Params> RsaPssParams<Params> {
     /// Default RSA PSS Salt length in RsaPssParams
     pub const SALT_LEN_DEFAULT: u8 = 20;
 
-    /// Create new RsaPssParams for the provided digest and salt len
-    pub fn new<D>(salt_len: u8) -> Self
-    where
-        D: AssociatedOid,
-    {
-        Self {
-            hash: AlgorithmIdentifierRef {
-                oid: D::OID,
-                parameters: Some(AnyRef::NULL),
-            },
-            mask_gen: AlgorithmIdentifier {
-                oid: OID_MGF_1,
-                parameters: Some(AlgorithmIdentifierRef {
-                    oid: D::OID,
-                    parameters: Some(AnyRef::NULL),
-                }),
-            },
-            salt_len,
-            trailer_field: Default::default(),
-        }
-    }
-
-    fn context_specific_hash(&self) -> Option<ContextSpecificRef<'_, AlgorithmIdentifierRef<'a>>> {
-        if self.hash == SHA_1_AI {
-            None
-        } else {
-            Some(ContextSpecificRef {
-                tag_number: TagNumber(0),
-                tag_mode: TagMode::Explicit,
-                value: &self.hash,
-            })
-        }
-    }
-
-    fn context_specific_mask_gen(
-        &self,
-    ) -> Option<ContextSpecificRef<'_, AlgorithmIdentifier<AlgorithmIdentifierRef<'a>>>> {
-        if self.mask_gen == default_mgf1_sha1() {
-            None
-        } else {
-            Some(ContextSpecificRef {
-                tag_number: TagNumber(1),
-                tag_mode: TagMode::Explicit,
-                value: &self.mask_gen,
-            })
-        }
-    }
-
     fn context_specific_salt_len(&self) -> Option<ContextSpecificRef<'_, u8>> {
-        if self.salt_len == RsaPssParams::SALT_LEN_DEFAULT {
+        if self.salt_len == Self::SALT_LEN_DEFAULT {
             None
         } else {
             Some(ContextSpecificRef {
@@ -164,31 +125,98 @@ impl<'a> RsaPssParams<'a> {
     }
 }
 
-impl Default for RsaPssParams<'_> {
-    fn default() -> Self {
+impl<'a> RsaPssParamsRef<'a> {
+    /// Create new [`RsaPssParams`] for the provided digest and salt len
+    pub fn new<D>(salt_len: u8) -> Self
+    where
+        D: AssociatedOid,
+    {
         Self {
-            hash: SHA_1_AI,
-            mask_gen: default_mgf1_sha1(),
-            salt_len: RsaPssParams::SALT_LEN_DEFAULT,
+            hash: AlgorithmIdentifierRef {
+                oid: D::OID,
+                parameters: Some(AnyRef::NULL),
+            },
+            mask_gen: AlgorithmIdentifier {
+                oid: OID_MGF_1,
+                parameters: Some(AlgorithmIdentifierRef {
+                    oid: D::OID,
+                    parameters: Some(AnyRef::NULL),
+                }),
+            },
+            salt_len,
             trailer_field: Default::default(),
         }
     }
 }
 
-impl<'a> DecodeValue<'a> for RsaPssParams<'a> {
+impl<Params> RsaPssParams<Params>
+where
+    AlgorithmIdentifier<Params>: AsAlgorithmIdentifierRef,
+    AlgorithmIdentifier<Params>: From<AlgorithmIdentifier<AnyRef<'static>>>,
+    Params: PartialEq,
+{
+    fn context_specific_hash(&self) -> Option<ContextSpecificRef<'_, AlgorithmIdentifier<Params>>> {
+        if self.hash.as_algo_ref() == SHA_1_AI {
+            None
+        } else {
+            Some(ContextSpecificRef {
+                tag_number: TagNumber(0),
+                tag_mode: TagMode::Explicit,
+                value: &self.hash,
+            })
+        }
+    }
+
+    fn context_specific_mask_gen(
+        &self,
+    ) -> Option<ContextSpecificRef<'_, AlgorithmIdentifier<AlgorithmIdentifier<Params>>>> {
+        if self.mask_gen == default_mgf1_sha1::<Params>() {
+            None
+        } else {
+            Some(ContextSpecificRef {
+                tag_number: TagNumber(1),
+                tag_mode: TagMode::Explicit,
+                value: &self.mask_gen,
+            })
+        }
+    }
+}
+
+impl<Params> Default for RsaPssParams<Params>
+where
+    AlgorithmIdentifier<Params>: From<AlgorithmIdentifierRef<'static>>,
+{
+    fn default() -> Self {
+        Self {
+            hash: SHA_1_AI.into(),
+            mask_gen: default_mgf1_sha1(),
+            salt_len: RsaPssParams::<Params>::SALT_LEN_DEFAULT,
+            trailer_field: Default::default(),
+        }
+    }
+}
+
+impl<'a, Params> DecodeValue<'a> for RsaPssParams<Params>
+where
+    AlgorithmIdentifier<Params>: DecodeValue<'a, Error = der::Error> + FixedTag,
+    AlgorithmIdentifier<AlgorithmIdentifier<Params>>:
+        DecodeValue<'a, Error = der::Error> + FixedTag,
+    AlgorithmIdentifier<Params>: From<AlgorithmIdentifierRef<'static>>,
+    Params: 'a,
+{
     type Error = der::Error;
 
     fn decode_value<R: Reader<'a>>(reader: &mut R, _header: der::Header) -> der::Result<Self> {
         Ok(Self {
             hash: reader
                 .context_specific(TagNumber(0), TagMode::Explicit)?
-                .unwrap_or(SHA_1_AI),
+                .unwrap_or_else(|| SHA_1_AI.into()),
             mask_gen: reader
                 .context_specific(TagNumber(1), TagMode::Explicit)?
                 .unwrap_or_else(default_mgf1_sha1),
             salt_len: reader
                 .context_specific(TagNumber(2), TagMode::Explicit)?
-                .unwrap_or(RsaPssParams::SALT_LEN_DEFAULT),
+                .unwrap_or(RsaPssParams::<Params>::SALT_LEN_DEFAULT),
             trailer_field: reader
                 .context_specific(TagNumber(3), TagMode::Explicit)?
                 .unwrap_or_default(),
@@ -196,7 +224,15 @@ impl<'a> DecodeValue<'a> for RsaPssParams<'a> {
     }
 }
 
-impl EncodeValue for RsaPssParams<'_> {
+impl<Params> EncodeValue for RsaPssParams<Params>
+where
+    AlgorithmIdentifier<Params>: AsAlgorithmIdentifierRef,
+    for<'b> Option<ContextSpecificRef<'b, AlgorithmIdentifier<Params>>>: Encode,
+    for<'b> Option<ContextSpecificRef<'b, AlgorithmIdentifier<AlgorithmIdentifier<Params>>>>:
+        Encode,
+    AlgorithmIdentifier<Params>: From<AlgorithmIdentifierRef<'static>>,
+    Params: PartialEq,
+{
     fn value_len(&self) -> der::Result<Length> {
         self.context_specific_hash().encoded_len()?
             + self.context_specific_mask_gen().encoded_len()?
@@ -213,9 +249,16 @@ impl EncodeValue for RsaPssParams<'_> {
     }
 }
 
-impl<'a> Sequence<'a> for RsaPssParams<'a> {}
+impl<'a, Params> Sequence<'a> for RsaPssParams<Params> {}
 
-impl<'a> TryFrom<&'a [u8]> for RsaPssParams<'a> {
+impl<'a, Params> TryFrom<&'a [u8]> for RsaPssParams<Params>
+where
+    AlgorithmIdentifier<Params>: DecodeValue<'a, Error = der::Error> + FixedTag,
+    AlgorithmIdentifier<AlgorithmIdentifier<Params>>:
+        DecodeValue<'a, Error = der::Error> + FixedTag,
+    AlgorithmIdentifier<Params>: From<AlgorithmIdentifierRef<'static>>,
+    Params: 'a,
+{
     type Error = Error;
 
     fn try_from(bytes: &'a [u8]) -> Result<Self> {
@@ -224,12 +267,22 @@ impl<'a> TryFrom<&'a [u8]> for RsaPssParams<'a> {
 }
 
 /// Default Mask Generation Function (MGF): SHA-1.
-fn default_mgf1_sha1<'a>() -> AlgorithmIdentifier<AlgorithmIdentifierRef<'a>> {
-    AlgorithmIdentifier::<AlgorithmIdentifierRef<'a>> {
+fn default_mgf1_sha1<Params>() -> AlgorithmIdentifier<AlgorithmIdentifier<Params>>
+where
+    AlgorithmIdentifier<Params>: From<AlgorithmIdentifierRef<'static>>,
+{
+    AlgorithmIdentifier::<AlgorithmIdentifier<Params>> {
         oid: OID_MGF_1,
-        parameters: Some(SHA_1_AI),
+        parameters: Some(SHA_1_AI.into()),
     }
 }
+
+/// [`RsaOaepParams`] with [`AlgorithmIdentifier<AnyRef>`]
+pub type RsaOaepParamsRef<'a> = RsaOaepParams<AnyRef<'a>>;
+
+/// [`RsaOaepParams`] with allocating [`AlgorithmIdentifier<Any>`]
+#[cfg(feature = "alloc")]
+pub type RsaOaepParamsOwned = RsaOaepParams<Any>;
 
 /// PKCS#1 RSAES-OAEP parameters as defined in [RFC 8017 Appendix 2.1]
 ///
@@ -247,49 +300,23 @@ fn default_mgf1_sha1<'a>() -> AlgorithmIdentifier<AlgorithmIdentifierRef<'a>> {
 ///
 /// [RFC 8017 Appendix 2.1]: https://datatracker.ietf.org/doc/html/rfc8017#appendix-A.2.1
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct RsaOaepParams<'a> {
+pub struct RsaOaepParams<Params> {
     /// Hash Algorithm
-    pub hash: AlgorithmIdentifierRef<'a>,
+    pub hash: AlgorithmIdentifier<Params>,
 
     /// Mask Generation Function (MGF)
-    pub mask_gen: AlgorithmIdentifier<AlgorithmIdentifierRef<'a>>,
+    pub mask_gen: AlgorithmIdentifier<AlgorithmIdentifier<Params>>,
 
     /// The source (and possibly the value) of the label L
-    pub p_source: AlgorithmIdentifierRef<'a>,
+    pub p_source: AlgorithmIdentifier<Params>,
 }
 
-impl<'a> RsaOaepParams<'a> {
-    /// Create new RsaPssParams for the provided digest and default (empty) label
-    pub fn new<D>() -> Self
-    where
-        D: AssociatedOid,
-    {
-        Self::new_with_label::<D>(&[])
-    }
-
-    /// Create new RsaPssParams for the provided digest and specified label
-    pub fn new_with_label<D>(label: &'a impl AsRef<[u8]>) -> Self
-    where
-        D: AssociatedOid,
-    {
-        Self {
-            hash: AlgorithmIdentifierRef {
-                oid: D::OID,
-                parameters: Some(AnyRef::NULL),
-            },
-            mask_gen: AlgorithmIdentifier {
-                oid: OID_MGF_1,
-                parameters: Some(AlgorithmIdentifierRef {
-                    oid: D::OID,
-                    parameters: Some(AnyRef::NULL),
-                }),
-            },
-            p_source: pspecified_algorithm_identifier(label),
-        }
-    }
-
-    fn context_specific_hash(&self) -> Option<ContextSpecificRef<'_, AlgorithmIdentifierRef<'a>>> {
-        if self.hash == SHA_1_AI {
+impl<Params> RsaOaepParams<Params>
+where
+    AlgorithmIdentifier<Params>: AsAlgorithmIdentifierRef,
+{
+    fn context_specific_hash(&self) -> Option<ContextSpecificRef<'_, AlgorithmIdentifier<Params>>> {
+        if self.hash.as_algo_ref() == SHA_1_AI {
             None
         } else {
             Some(ContextSpecificRef {
@@ -300,24 +327,10 @@ impl<'a> RsaOaepParams<'a> {
         }
     }
 
-    fn context_specific_mask_gen(
-        &self,
-    ) -> Option<ContextSpecificRef<'_, AlgorithmIdentifier<AlgorithmIdentifierRef<'a>>>> {
-        if self.mask_gen == default_mgf1_sha1() {
-            None
-        } else {
-            Some(ContextSpecificRef {
-                tag_number: TagNumber(1),
-                tag_mode: TagMode::Explicit,
-                value: &self.mask_gen,
-            })
-        }
-    }
-
     fn context_specific_p_source(
         &self,
-    ) -> Option<ContextSpecificRef<'_, AlgorithmIdentifierRef<'a>>> {
-        if self.p_source == default_pempty_string() {
+    ) -> Option<ContextSpecificRef<'_, AlgorithmIdentifier<Params>>> {
+        if self.p_source.as_algo_ref() == default_pempty_string() {
             None
         } else {
             Some(ContextSpecificRef {
@@ -329,35 +342,105 @@ impl<'a> RsaOaepParams<'a> {
     }
 }
 
-impl Default for RsaOaepParams<'_> {
-    fn default() -> Self {
-        Self {
-            hash: SHA_1_AI,
-            mask_gen: default_mgf1_sha1(),
-            p_source: default_pempty_string(),
+impl<Params> RsaOaepParams<Params>
+where
+    AlgorithmIdentifier<Params>: AsAlgorithmIdentifierRef,
+    AlgorithmIdentifier<Params>: From<AlgorithmIdentifierRef<'static>>,
+    Params: PartialEq,
+{
+    fn context_specific_mask_gen(
+        &self,
+    ) -> Option<ContextSpecificRef<'_, AlgorithmIdentifier<AlgorithmIdentifier<Params>>>> {
+        if self.mask_gen == default_mgf1_sha1::<Params>() {
+            None
+        } else {
+            Some(ContextSpecificRef {
+                tag_number: TagNumber(1),
+                tag_mode: TagMode::Explicit,
+                value: &self.mask_gen,
+            })
         }
     }
 }
 
-impl<'a> DecodeValue<'a> for RsaOaepParams<'a> {
+impl<'a> RsaOaepParamsRef<'a> {
+    /// Create new [`RsaOaepParams`] for the provided digest and default (empty) label
+    pub fn new<D>() -> Self
+    where
+        D: AssociatedOid,
+    {
+        Self::new_with_label::<D>(&[])
+    }
+
+    /// Create new [`RsaOaepParams`] for the provided digest and specified label
+    pub fn new_with_label<D>(label: &'a impl AsRef<[u8]>) -> RsaOaepParamsRef<'a>
+    where
+        D: AssociatedOid,
+    {
+        Self {
+            hash: AlgorithmIdentifier {
+                oid: D::OID,
+                parameters: Some(AnyRef::NULL),
+            },
+            mask_gen: AlgorithmIdentifier {
+                oid: OID_MGF_1,
+                parameters: Some(AlgorithmIdentifier {
+                    oid: D::OID,
+                    parameters: Some(AnyRef::NULL),
+                }),
+            },
+            p_source: pspecified_algorithm_identifier(label),
+        }
+    }
+}
+
+impl<Params> Default for RsaOaepParams<Params>
+where
+    AlgorithmIdentifier<Params>: From<AlgorithmIdentifierRef<'static>>,
+{
+    fn default() -> Self {
+        Self {
+            hash: SHA_1_AI.into(),
+            mask_gen: default_mgf1_sha1(),
+            p_source: default_pempty_string().into(),
+        }
+    }
+}
+
+impl<'a, Params> DecodeValue<'a> for RsaOaepParams<Params>
+where
+    AlgorithmIdentifier<Params>: DecodeValue<'a, Error = der::Error> + FixedTag,
+    AlgorithmIdentifier<AlgorithmIdentifier<Params>>:
+        DecodeValue<'a, Error = der::Error> + FixedTag,
+    AlgorithmIdentifier<Params>: From<AlgorithmIdentifierRef<'static>>,
+    Params: 'a,
+{
     type Error = der::Error;
 
     fn decode_value<R: Reader<'a>>(reader: &mut R, _header: der::Header) -> der::Result<Self> {
         Ok(Self {
             hash: reader
                 .context_specific(TagNumber(0), TagMode::Explicit)?
-                .unwrap_or(SHA_1_AI),
+                .unwrap_or_else(|| SHA_1_AI.into()),
             mask_gen: reader
                 .context_specific(TagNumber(1), TagMode::Explicit)?
                 .unwrap_or_else(default_mgf1_sha1),
             p_source: reader
                 .context_specific(TagNumber(2), TagMode::Explicit)?
-                .unwrap_or_else(default_pempty_string),
+                .unwrap_or_else(|| default_pempty_string().into()),
         })
     }
 }
 
-impl EncodeValue for RsaOaepParams<'_> {
+impl<Params> EncodeValue for RsaOaepParams<Params>
+where
+    AlgorithmIdentifier<Params>: AsAlgorithmIdentifierRef,
+    for<'b> Option<ContextSpecificRef<'b, AlgorithmIdentifier<Params>>>: Encode,
+    for<'b> Option<ContextSpecificRef<'b, AlgorithmIdentifier<AlgorithmIdentifier<Params>>>>:
+        Encode,
+    AlgorithmIdentifier<Params>: From<AlgorithmIdentifierRef<'static>>,
+    Params: PartialEq,
+{
     fn value_len(&self) -> der::Result<Length> {
         self.context_specific_hash().encoded_len()?
             + self.context_specific_mask_gen().encoded_len()?
@@ -372,9 +455,16 @@ impl EncodeValue for RsaOaepParams<'_> {
     }
 }
 
-impl<'a> Sequence<'a> for RsaOaepParams<'a> {}
+impl<'a, Params> Sequence<'a> for RsaOaepParams<Params> {}
 
-impl<'a> TryFrom<&'a [u8]> for RsaOaepParams<'a> {
+impl<'a, Params> TryFrom<&'a [u8]> for RsaOaepParams<Params>
+where
+    AlgorithmIdentifier<Params>: DecodeValue<'a, Error = der::Error> + FixedTag,
+    AlgorithmIdentifier<AlgorithmIdentifier<Params>>:
+        DecodeValue<'a, Error = der::Error> + FixedTag,
+    AlgorithmIdentifier<Params>: From<AlgorithmIdentifierRef<'static>>,
+    Params: 'a,
+{
     type Error = Error;
 
     fn try_from(bytes: &'a [u8]) -> Result<Self> {

--- a/pkcs1/src/private_key.rs
+++ b/pkcs1/src/private_key.rs
@@ -3,18 +3,28 @@
 #[cfg(feature = "alloc")]
 pub(crate) mod other_prime_info;
 
-use crate::{Error, Result, RsaPublicKey, Version};
+use crate::{Error, Result, RsaPublicKeyRef, Version};
 use core::fmt;
 use der::{
     Decode, DecodeValue, Encode, EncodeValue, Header, Length, Reader, Sequence, Tag, Writer,
-    asn1::{OctetStringRef, UintRef},
+    asn1::{AsUintRef, OctetStringRef, UintRef},
 };
 
 #[cfg(feature = "alloc")]
 use {self::other_prime_info::OtherPrimeInfo, alloc::vec::Vec, der::SecretDocument};
 
+#[cfg(feature = "alloc")]
+use der::asn1::Uint;
+
 #[cfg(feature = "pem")]
 use der::pem::PemLabel;
+
+/// PKCS#1 RSA Private Keys as defined in [RFC 8017 Appendix 1.2].
+pub type RsaPrivateKeyRef<'a> = RsaPrivateKey<UintRef<'a>>;
+
+/// PKCS#1 RSA Private Keys as defined in [RFC 8017 Appendix 1.2].
+#[cfg(feature = "alloc")]
+pub type RsaPrivateKeyOwned = RsaPrivateKey<Uint>;
 
 /// PKCS#1 RSA Private Keys as defined in [RFC 8017 Appendix 1.2].
 ///
@@ -40,45 +50,50 @@ use der::pem::PemLabel;
 ///
 /// [RFC 8017 Appendix 1.2]: https://datatracker.ietf.org/doc/html/rfc8017#appendix-A.1.2
 #[derive(Clone)]
-pub struct RsaPrivateKey<'a> {
+pub struct RsaPrivateKey<U> {
     /// `n`: RSA modulus.
-    pub modulus: UintRef<'a>,
+    pub modulus: U,
 
     /// `e`: RSA public exponent.
-    pub public_exponent: UintRef<'a>,
+    pub public_exponent: U,
 
     /// `d`: RSA private exponent.
-    pub private_exponent: UintRef<'a>,
+    pub private_exponent: U,
 
     /// `p`: first prime factor of `n`.
-    pub prime1: UintRef<'a>,
+    pub prime1: U,
 
     /// `q`: Second prime factor of `n`.
-    pub prime2: UintRef<'a>,
+    pub prime2: U,
 
     /// First exponent: `d mod (p-1)`.
-    pub exponent1: UintRef<'a>,
+    pub exponent1: U,
 
     /// Second exponent: `d mod (q-1)`.
-    pub exponent2: UintRef<'a>,
+    pub exponent2: U,
 
     /// CRT coefficient: `(inverse of q) mod p`.
-    pub coefficient: UintRef<'a>,
+    pub coefficient: U,
 
     /// Additional primes `r_3`, ..., `r_u`, in order, if this is a multi-prime
     /// RSA key (i.e. `version` is `multi`).
-    pub other_prime_infos: Option<OtherPrimeInfos<'a>>,
+    pub other_prime_infos: Option<OtherPrimeInfos<U>>,
 }
 
-impl<'a> RsaPrivateKey<'a> {
+impl<U> RsaPrivateKey<U>
+where
+    U: AsUintRef,
+{
     /// Get the public key that corresponds to this [`RsaPrivateKey`].
-    pub fn public_key(&self) -> RsaPublicKey<'a> {
-        RsaPublicKey {
-            modulus: self.modulus,
-            public_exponent: self.public_exponent,
+    pub fn public_key<'a>(&'a self) -> RsaPublicKeyRef<'a> {
+        RsaPublicKeyRef {
+            modulus: self.modulus.as_uint_ref(),
+            public_exponent: self.public_exponent.as_uint_ref(),
         }
     }
+}
 
+impl<U> RsaPrivateKey<U> {
     /// Get the [`Version`] for this key.
     ///
     /// Determined by the presence or absence of the
@@ -92,7 +107,10 @@ impl<'a> RsaPrivateKey<'a> {
     }
 }
 
-impl<'a> DecodeValue<'a> for RsaPrivateKey<'a> {
+impl<'a, U> DecodeValue<'a> for RsaPrivateKey<U>
+where
+    U: Decode<'a, Error = der::Error>,
+{
     type Error = der::Error;
 
     fn decode_value<R: Reader<'a>>(reader: &mut R, _header: Header) -> der::Result<Self> {
@@ -119,7 +137,10 @@ impl<'a> DecodeValue<'a> for RsaPrivateKey<'a> {
     }
 }
 
-impl EncodeValue for RsaPrivateKey<'_> {
+impl<U> EncodeValue for RsaPrivateKey<U>
+where
+    U: Encode,
+{
     fn value_len(&self) -> der::Result<Length> {
         self.version().encoded_len()?
             + self.modulus.encoded_len()?
@@ -148,21 +169,21 @@ impl EncodeValue for RsaPrivateKey<'_> {
     }
 }
 
-impl<'a> Sequence<'a> for RsaPrivateKey<'a> {}
+impl<U> Sequence<'_> for RsaPrivateKey<U> {}
 
-impl<'a> From<RsaPrivateKey<'a>> for RsaPublicKey<'a> {
-    fn from(private_key: RsaPrivateKey<'a>) -> RsaPublicKey<'a> {
+impl<'a, U> From<&'a RsaPrivateKey<U>> for RsaPublicKeyRef<'a>
+where
+    U: AsUintRef,
+{
+    fn from(private_key: &'a RsaPrivateKey<U>) -> RsaPublicKeyRef<'a> {
         private_key.public_key()
     }
 }
 
-impl<'a> From<&RsaPrivateKey<'a>> for RsaPublicKey<'a> {
-    fn from(private_key: &RsaPrivateKey<'a>) -> RsaPublicKey<'a> {
-        private_key.public_key()
-    }
-}
-
-impl<'a> TryFrom<&'a [u8]> for RsaPrivateKey<'a> {
+impl<'a, U> TryFrom<&'a [u8]> for RsaPrivateKey<U>
+where
+    U: Decode<'a, Error = der::Error>,
+{
     type Error = Error;
 
     fn try_from(bytes: &'a [u8]) -> Result<Self> {
@@ -170,7 +191,10 @@ impl<'a> TryFrom<&'a [u8]> for RsaPrivateKey<'a> {
     }
 }
 
-impl<'a> TryFrom<&'a OctetStringRef> for RsaPrivateKey<'a> {
+impl<'a, U> TryFrom<&'a OctetStringRef> for RsaPrivateKey<U>
+where
+    U: Decode<'a, Error = der::Error>,
+{
     type Error = Error;
 
     fn try_from(bytes: &'a OctetStringRef) -> Result<Self> {
@@ -178,7 +202,10 @@ impl<'a> TryFrom<&'a OctetStringRef> for RsaPrivateKey<'a> {
     }
 }
 
-impl fmt::Debug for RsaPrivateKey<'_> {
+impl<U> fmt::Debug for RsaPrivateKey<U>
+where
+    U: fmt::Debug,
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RsaPrivateKey")
             .field("version", &self.version())
@@ -189,25 +216,31 @@ impl fmt::Debug for RsaPrivateKey<'_> {
 }
 
 #[cfg(feature = "alloc")]
-impl TryFrom<RsaPrivateKey<'_>> for SecretDocument {
+impl<U> TryFrom<RsaPrivateKey<U>> for SecretDocument
+where
+    U: Encode,
+{
     type Error = Error;
 
-    fn try_from(private_key: RsaPrivateKey<'_>) -> Result<SecretDocument> {
+    fn try_from(private_key: RsaPrivateKey<U>) -> Result<SecretDocument> {
         SecretDocument::try_from(&private_key)
     }
 }
 
 #[cfg(feature = "alloc")]
-impl TryFrom<&RsaPrivateKey<'_>> for SecretDocument {
+impl<U> TryFrom<&RsaPrivateKey<U>> for SecretDocument
+where
+    U: Encode,
+{
     type Error = Error;
 
-    fn try_from(private_key: &RsaPrivateKey<'_>) -> Result<SecretDocument> {
+    fn try_from(private_key: &RsaPrivateKey<U>) -> Result<SecretDocument> {
         Ok(Self::encode_msg(private_key)?)
     }
 }
 
 #[cfg(feature = "pem")]
-impl PemLabel for RsaPrivateKey<'_> {
+impl<U> PemLabel for RsaPrivateKey<U> {
     const PEM_LABEL: &'static str = "RSA PRIVATE KEY";
 }
 
@@ -217,12 +250,12 @@ impl PemLabel for RsaPrivateKey<'_> {
 #[cfg(not(feature = "alloc"))]
 #[derive(Clone)]
 #[non_exhaustive]
-pub struct OtherPrimeInfos<'a> {
-    _lifetime: core::marker::PhantomData<&'a ()>,
+pub struct OtherPrimeInfos<U> {
+    _marker: core::marker::PhantomData<U>,
 }
 
 #[cfg(not(feature = "alloc"))]
-impl<'a> DecodeValue<'a> for OtherPrimeInfos<'a> {
+impl<'a, U> DecodeValue<'a> for OtherPrimeInfos<U> {
     type Error = der::Error;
 
     fn decode_value<R: Reader<'a>>(reader: &mut R, _header: Header) -> der::Result<Self> {
@@ -233,7 +266,7 @@ impl<'a> DecodeValue<'a> for OtherPrimeInfos<'a> {
 }
 
 #[cfg(not(feature = "alloc"))]
-impl EncodeValue for OtherPrimeInfos<'_> {
+impl<U> EncodeValue for OtherPrimeInfos<U> {
     fn value_len(&self) -> der::Result<Length> {
         // Placeholder decoder that always returns an error.
         // Uses `Tag::Integer` to signal an unsupported version.
@@ -248,10 +281,10 @@ impl EncodeValue for OtherPrimeInfos<'_> {
 }
 
 #[cfg(not(feature = "alloc"))]
-impl der::FixedTag for OtherPrimeInfos<'_> {
+impl<U> der::FixedTag for OtherPrimeInfos<U> {
     const TAG: Tag = Tag::Sequence;
 }
 
 /// Additional RSA prime info in a multi-prime RSA key.
 #[cfg(feature = "alloc")]
-pub type OtherPrimeInfos<'a> = Vec<OtherPrimeInfo<'a>>;
+pub type OtherPrimeInfos<U> = Vec<OtherPrimeInfo<U>>;

--- a/pkcs1/src/private_key/other_prime_info.rs
+++ b/pkcs1/src/private_key/other_prime_info.rs
@@ -1,8 +1,6 @@
 //! PKCS#1 OtherPrimeInfo support.
 
-use der::{
-    DecodeValue, Encode, EncodeValue, Header, Length, Reader, Sequence, Writer, asn1::UintRef,
-};
+use der::{Decode, DecodeValue, Encode, EncodeValue, Header, Length, Reader, Sequence, Writer};
 
 /// PKCS#1 OtherPrimeInfo as defined in [RFC 8017 Appendix 1.2].
 ///
@@ -18,18 +16,21 @@ use der::{
 ///
 /// [RFC 8017 Appendix 1.2]: https://datatracker.ietf.org/doc/html/rfc8017#appendix-A.1.2
 #[derive(Clone)]
-pub struct OtherPrimeInfo<'a> {
+pub struct OtherPrimeInfo<U> {
     /// Prime factor `r_i` of `n`, where `i` >= 3.
-    pub prime: UintRef<'a>,
+    pub prime: U,
 
     /// Exponent: `d_i = d mod (r_i - 1)`.
-    pub exponent: UintRef<'a>,
+    pub exponent: U,
 
     /// CRT coefficient: `t_i = (r_1 * r_2 * ... * r_(i-1))^(-1) mod r_i`.
-    pub coefficient: UintRef<'a>,
+    pub coefficient: U,
 }
 
-impl<'a> DecodeValue<'a> for OtherPrimeInfo<'a> {
+impl<'a, U> DecodeValue<'a> for OtherPrimeInfo<U>
+where
+    U: Decode<'a, Error = der::Error>,
+{
     type Error = der::Error;
 
     fn decode_value<R: Reader<'a>>(reader: &mut R, _header: Header) -> der::Result<Self> {
@@ -41,7 +42,10 @@ impl<'a> DecodeValue<'a> for OtherPrimeInfo<'a> {
     }
 }
 
-impl EncodeValue for OtherPrimeInfo<'_> {
+impl<U> EncodeValue for OtherPrimeInfo<U>
+where
+    U: Encode,
+{
     fn value_len(&self) -> der::Result<Length> {
         self.prime.encoded_len()? + self.exponent.encoded_len()? + self.coefficient.encoded_len()?
     }
@@ -54,4 +58,4 @@ impl EncodeValue for OtherPrimeInfo<'_> {
     }
 }
 
-impl<'a> Sequence<'a> for OtherPrimeInfo<'a> {}
+impl<U> Sequence<'_> for OtherPrimeInfo<U> {}

--- a/pkcs1/src/public_key.rs
+++ b/pkcs1/src/public_key.rs
@@ -2,15 +2,22 @@
 
 use crate::{Error, Result};
 use der::{
-    Decode, DecodeValue, Encode, EncodeValue, Header, Length, Reader, Sequence, Writer,
+    Decode, DecodeValue, Encode, EncodeValue, FixedTag, Header, Length, Reader, Sequence, Writer,
     asn1::UintRef,
 };
 
 #[cfg(feature = "alloc")]
-use der::Document;
+use der::{Document, asn1::Uint};
 
 #[cfg(feature = "pem")]
 use der::pem::PemLabel;
+
+/// [`RsaPublicKey`] with [`UintRef`] INTEGERs.
+pub type RsaPublicKeyRef<'a> = RsaPublicKey<UintRef<'a>>;
+
+/// [`RsaPublicKey`] with allocating [`Uint`] INTEGERs.
+#[cfg(feature = "alloc")]
+pub type RsaPublicKeyOwned = RsaPublicKey<Uint>;
 
 /// PKCS#1 RSA Public Keys as defined in [RFC 8017 Appendix 1.1].
 ///
@@ -25,15 +32,18 @@ use der::pem::PemLabel;
 ///
 /// [RFC 8017 Appendix 1.1]: https://datatracker.ietf.org/doc/html/rfc8017#appendix-A.1.1
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub struct RsaPublicKey<'a> {
+pub struct RsaPublicKey<U> {
     /// `n`: RSA modulus
-    pub modulus: UintRef<'a>,
+    pub modulus: U,
 
     /// `e`: RSA public exponent
-    pub public_exponent: UintRef<'a>,
+    pub public_exponent: U,
 }
 
-impl<'a> DecodeValue<'a> for RsaPublicKey<'a> {
+impl<'a, U> DecodeValue<'a> for RsaPublicKey<U>
+where
+    U: DecodeValue<'a, Error = der::Error> + FixedTag + 'a,
+{
     type Error = der::Error;
     fn decode_value<R: Reader<'a>>(reader: &mut R, _header: Header) -> der::Result<Self> {
         Ok(Self {
@@ -43,7 +53,10 @@ impl<'a> DecodeValue<'a> for RsaPublicKey<'a> {
     }
 }
 
-impl EncodeValue for RsaPublicKey<'_> {
+impl<U> EncodeValue for RsaPublicKey<U>
+where
+    U: EncodeValue + FixedTag,
+{
     fn value_len(&self) -> der::Result<Length> {
         self.modulus.encoded_len()? + self.public_exponent.encoded_len()?
     }
@@ -55,9 +68,13 @@ impl EncodeValue for RsaPublicKey<'_> {
     }
 }
 
-impl<'a> Sequence<'a> for RsaPublicKey<'a> {}
+impl<'a, U> Sequence<'a> for RsaPublicKey<U> {}
 
-impl<'a> TryFrom<&'a [u8]> for RsaPublicKey<'a> {
+impl<'a, U> TryFrom<&'a [u8]> for RsaPublicKey<U>
+where
+    RsaPublicKey<U>: Decode<'a>,
+    Error: From<<RsaPublicKey<U> as Decode<'a>>::Error>,
+{
     type Error = Error;
 
     fn try_from(bytes: &'a [u8]) -> Result<Self> {
@@ -66,24 +83,30 @@ impl<'a> TryFrom<&'a [u8]> for RsaPublicKey<'a> {
 }
 
 #[cfg(feature = "alloc")]
-impl TryFrom<RsaPublicKey<'_>> for Document {
+impl<U> TryFrom<RsaPublicKey<U>> for Document
+where
+    RsaPublicKey<U>: EncodeValue,
+{
     type Error = Error;
 
-    fn try_from(spki: RsaPublicKey<'_>) -> Result<Document> {
+    fn try_from(spki: RsaPublicKey<U>) -> Result<Document> {
         Self::try_from(&spki)
     }
 }
 
 #[cfg(feature = "alloc")]
-impl TryFrom<&RsaPublicKey<'_>> for Document {
+impl<U> TryFrom<&RsaPublicKey<U>> for Document
+where
+    RsaPublicKey<U>: EncodeValue,
+{
     type Error = Error;
 
-    fn try_from(spki: &RsaPublicKey<'_>) -> Result<Document> {
+    fn try_from(spki: &RsaPublicKey<U>) -> Result<Document> {
         Ok(Self::encode_msg(spki)?)
     }
 }
 
 #[cfg(feature = "pem")]
-impl PemLabel for RsaPublicKey<'_> {
+impl<U> PemLabel for RsaPublicKey<U> {
     const PEM_LABEL: &'static str = "RSA PUBLIC KEY";
 }

--- a/pkcs1/src/traits.rs
+++ b/pkcs1/src/traits.rs
@@ -16,6 +16,9 @@ use {
 use std::path::Path;
 
 #[cfg(all(feature = "alloc", feature = "pem"))]
+use crate::{RsaPrivateKeyRef, RsaPublicKeyRef};
+
+#[cfg(doc)]
 use crate::{RsaPrivateKey, RsaPublicKey};
 
 /// Parse an [`RsaPrivateKey`] from a PKCS#1-encoded document.
@@ -34,7 +37,7 @@ pub trait DecodeRsaPrivateKey: Sized {
     #[cfg(feature = "pem")]
     fn from_pkcs1_pem(s: &str) -> Result<Self> {
         let (label, doc) = SecretDocument::from_pem(s)?;
-        RsaPrivateKey::validate_pem_label(label)?;
+        RsaPrivateKeyRef::validate_pem_label(label)?;
         Self::from_pkcs1_der(doc.as_bytes())
     }
 
@@ -49,7 +52,7 @@ pub trait DecodeRsaPrivateKey: Sized {
     #[cfg(all(feature = "pem", feature = "std"))]
     fn read_pkcs1_pem_file(path: impl AsRef<Path>) -> Result<Self> {
         let (label, doc) = SecretDocument::read_pem_file(path)?;
-        RsaPrivateKey::validate_pem_label(&label)?;
+        RsaPrivateKeyRef::validate_pem_label(&label)?;
         Self::from_pkcs1_der(doc.as_bytes())
     }
 }
@@ -70,7 +73,7 @@ pub trait DecodeRsaPublicKey: Sized {
     #[cfg(feature = "pem")]
     fn from_pkcs1_pem(s: &str) -> Result<Self> {
         let (label, doc) = Document::from_pem(s)?;
-        RsaPublicKey::validate_pem_label(label)?;
+        RsaPublicKeyRef::validate_pem_label(label)?;
         Self::from_pkcs1_der(doc.as_bytes())
     }
 
@@ -86,7 +89,7 @@ pub trait DecodeRsaPublicKey: Sized {
     #[cfg(all(feature = "pem", feature = "std"))]
     fn read_pkcs1_pem_file(path: impl AsRef<Path>) -> Result<Self> {
         let (label, doc) = Document::read_pem_file(path)?;
-        RsaPublicKey::validate_pem_label(&label)?;
+        RsaPublicKeyRef::validate_pem_label(&label)?;
         Self::from_pkcs1_der(doc.as_bytes())
     }
 }
@@ -101,7 +104,7 @@ pub trait EncodeRsaPrivateKey {
     #[cfg(feature = "pem")]
     fn to_pkcs1_pem(&self, line_ending: LineEnding) -> Result<Zeroizing<String>> {
         let doc = self.to_pkcs1_der()?;
-        Ok(doc.to_pem(RsaPrivateKey::PEM_LABEL, line_ending)?)
+        Ok(doc.to_pem(RsaPrivateKeyRef::PEM_LABEL, line_ending)?)
     }
 
     /// Write ASN.1 DER-encoded PKCS#1 private key to the given path.
@@ -114,7 +117,7 @@ pub trait EncodeRsaPrivateKey {
     #[cfg(all(feature = "pem", feature = "std"))]
     fn write_pkcs1_pem_file(&self, path: impl AsRef<Path>, line_ending: LineEnding) -> Result<()> {
         let doc = self.to_pkcs1_der()?;
-        Ok(doc.write_pem_file(path, RsaPrivateKey::PEM_LABEL, line_ending)?)
+        Ok(doc.write_pem_file(path, RsaPrivateKeyRef::PEM_LABEL, line_ending)?)
     }
 }
 
@@ -128,7 +131,7 @@ pub trait EncodeRsaPublicKey {
     #[cfg(feature = "pem")]
     fn to_pkcs1_pem(&self, line_ending: LineEnding) -> Result<String> {
         let doc = self.to_pkcs1_der()?;
-        Ok(doc.to_pem(RsaPublicKey::PEM_LABEL, line_ending)?)
+        Ok(doc.to_pem(RsaPublicKeyRef::PEM_LABEL, line_ending)?)
     }
 
     /// Write ASN.1 DER-encoded public key to the given path.
@@ -141,6 +144,6 @@ pub trait EncodeRsaPublicKey {
     #[cfg(all(feature = "pem", feature = "std"))]
     fn write_pkcs1_pem_file(&self, path: impl AsRef<Path>, line_ending: LineEnding) -> Result<()> {
         let doc = self.to_pkcs1_der()?;
-        Ok(doc.write_pem_file(path, RsaPublicKey::PEM_LABEL, line_ending)?)
+        Ok(doc.write_pem_file(path, RsaPublicKeyRef::PEM_LABEL, line_ending)?)
     }
 }

--- a/pkcs1/tests/params.rs
+++ b/pkcs1/tests/params.rs
@@ -7,7 +7,7 @@ use der::{
     oid::AssociatedOid,
 };
 use hex_literal::hex;
-use pkcs1::{RsaOaepParams, RsaPssParams, TrailerField};
+use pkcs1::{RsaOaepParamsRef, RsaPssParamsRef, TrailerField};
 
 /// Default PSS parameters using all default values (SHA1, MGF1)
 const RSA_PSS_PARAMETERS_DEFAULTS: &[u8] = &hex!("3000");
@@ -35,7 +35,7 @@ impl AssociatedOid for Sha256Mock {
 
 #[test]
 fn decode_pss_param() {
-    let param = RsaPssParams::try_from(RSA_PSS_PARAMETERS_SHA2_256).unwrap();
+    let param = RsaPssParamsRef::try_from(RSA_PSS_PARAMETERS_SHA2_256).unwrap();
 
     assert!(
         param
@@ -65,7 +65,7 @@ fn decode_pss_param() {
 #[test]
 fn encode_pss_param() {
     let mut buf = [0_u8; 256];
-    let param = RsaPssParams::try_from(RSA_PSS_PARAMETERS_SHA2_256).unwrap();
+    let param = RsaPssParamsRef::try_from(RSA_PSS_PARAMETERS_SHA2_256).unwrap();
     assert_eq!(
         param.encode_to_slice(&mut buf).unwrap(),
         RSA_PSS_PARAMETERS_SHA2_256
@@ -74,7 +74,7 @@ fn encode_pss_param() {
 
 #[test]
 fn decode_pss_param_default() {
-    let param = RsaPssParams::try_from(RSA_PSS_PARAMETERS_DEFAULTS).unwrap();
+    let param = RsaPssParamsRef::try_from(RSA_PSS_PARAMETERS_DEFAULTS).unwrap();
 
     assert!(
         param
@@ -110,7 +110,9 @@ fn decode_pss_param_default() {
 fn encode_pss_param_default() {
     let mut buf = [0_u8; 256];
     assert_eq!(
-        RsaPssParams::default().encode_to_slice(&mut buf).unwrap(),
+        RsaPssParamsRef::default()
+            .encode_to_slice(&mut buf)
+            .unwrap(),
         RSA_PSS_PARAMETERS_DEFAULTS
     );
 }
@@ -119,13 +121,13 @@ fn encode_pss_param_default() {
 fn new_pss_param() {
     let mut buf = [0_u8; 256];
 
-    let param = RsaPssParams::new::<Sha1Mock>(20);
+    let param = RsaPssParamsRef::new::<Sha1Mock>(20);
     assert_eq!(
         param.encode_to_slice(&mut buf).unwrap(),
         RSA_PSS_PARAMETERS_DEFAULTS
     );
 
-    let param = RsaPssParams::new::<Sha256Mock>(32);
+    let param = RsaPssParamsRef::new::<Sha256Mock>(32);
     assert_eq!(
         param.encode_to_slice(&mut buf).unwrap(),
         RSA_PSS_PARAMETERS_SHA2_256
@@ -134,7 +136,7 @@ fn new_pss_param() {
 
 #[test]
 fn decode_oaep_param() {
-    let param = RsaOaepParams::try_from(RSA_OAEP_PARAMETERS_SHA2_256).unwrap();
+    let param = RsaOaepParamsRef::try_from(RSA_OAEP_PARAMETERS_SHA2_256).unwrap();
 
     assert!(
         param
@@ -177,7 +179,7 @@ fn decode_oaep_param() {
 #[test]
 fn encode_oaep_param() {
     let mut buf = [0_u8; 256];
-    let param = RsaOaepParams::try_from(RSA_OAEP_PARAMETERS_SHA2_256).unwrap();
+    let param = RsaOaepParamsRef::try_from(RSA_OAEP_PARAMETERS_SHA2_256).unwrap();
     assert_eq!(
         param.encode_to_slice(&mut buf).unwrap(),
         RSA_OAEP_PARAMETERS_SHA2_256
@@ -186,7 +188,7 @@ fn encode_oaep_param() {
 
 #[test]
 fn decode_oaep_param_default() {
-    let param = RsaOaepParams::try_from(RSA_OAEP_PARAMETERS_DEFAULTS).unwrap();
+    let param = RsaOaepParamsRef::try_from(RSA_OAEP_PARAMETERS_DEFAULTS).unwrap();
 
     assert!(
         param
@@ -235,7 +237,9 @@ fn decode_oaep_param_default() {
 fn encode_oaep_param_default() {
     let mut buf = [0_u8; 256];
     assert_eq!(
-        RsaOaepParams::default().encode_to_slice(&mut buf).unwrap(),
+        RsaOaepParamsRef::default()
+            .encode_to_slice(&mut buf)
+            .unwrap(),
         RSA_OAEP_PARAMETERS_DEFAULTS
     );
 }
@@ -244,16 +248,40 @@ fn encode_oaep_param_default() {
 fn new_oaep_param() {
     let mut buf = [0_u8; 256];
 
-    let param = RsaOaepParams::new::<Sha1Mock>();
+    let param = RsaOaepParamsRef::new::<Sha1Mock>();
     assert_eq!(
         param.encode_to_slice(&mut buf).unwrap(),
         RSA_OAEP_PARAMETERS_DEFAULTS
     );
 
-    let param = RsaOaepParams::new::<Sha256Mock>();
+    let param = RsaOaepParamsRef::new::<Sha256Mock>();
     println!("{:02x?}", param.encode_to_slice(&mut buf).unwrap());
     assert_eq!(
         param.encode_to_slice(&mut buf).unwrap(),
         RSA_OAEP_PARAMETERS_SHA2_256
     );
+}
+
+#[cfg(feature = "alloc")]
+mod test_alloc_trait_bounds {
+    use der::{Decode, Encode};
+    use pkcs1::{RsaOaepParamsOwned, RsaPssParamsOwned};
+
+    #[test]
+    fn rsapssparamsowned_trait_bounds_from_der() {
+        let _ = RsaPssParamsOwned::from_der(&[]);
+    }
+    #[test]
+    fn rsapssparamsowned_trait_bounds_to_der() {
+        let _ = RsaPssParamsOwned::default().encode_to_slice(&mut []);
+    }
+
+    #[test]
+    fn rsaoaepparamsowned_trait_bounds_from_der() {
+        let _ = RsaOaepParamsOwned::from_der(&[]);
+    }
+    #[test]
+    fn rsaoaepparamsowned_trait_bounds_to_der() {
+        let _ = RsaOaepParamsOwned::default().encode_to_slice(&mut []);
+    }
 }

--- a/pkcs1/tests/private_key.rs
+++ b/pkcs1/tests/private_key.rs
@@ -1,7 +1,7 @@
 //! PKCS#1 private key tests
 
 use hex_literal::hex;
-use pkcs1::{RsaPrivateKey, Version};
+use pkcs1::{RsaPrivateKeyRef, Version};
 
 /// RSA-2048 PKCS#1 private key encoded as ASN.1 DER.
 ///
@@ -17,7 +17,7 @@ const RSA_2048_MULTI_PRIME_DER_EXAMPLE: &[u8] = include_bytes!("examples/rsa2048
 
 #[test]
 fn decode_rsa2048_der() {
-    let key = RsaPrivateKey::try_from(RSA_2048_DER_EXAMPLE).unwrap();
+    let key = RsaPrivateKeyRef::try_from(RSA_2048_DER_EXAMPLE).unwrap();
     assert_eq!(key.version(), Version::TwoPrime);
 
     // Extracted using:
@@ -70,7 +70,7 @@ fn decode_rsa2048_der() {
 
 #[test]
 fn decode_rsa4096_der() {
-    let key = RsaPrivateKey::try_from(RSA_4096_DER_EXAMPLE).unwrap();
+    let key = RsaPrivateKeyRef::try_from(RSA_4096_DER_EXAMPLE).unwrap();
     assert_eq!(key.version(), Version::TwoPrime);
 
     // Extracted using:
@@ -125,13 +125,13 @@ fn decode_rsa4096_der() {
 #[test]
 fn decode_rsa2048_multi_prime_der() {
     // Multi-prime RSA keys are unsupported when the alloc feature is disabled
-    assert!(RsaPrivateKey::try_from(RSA_2048_MULTI_PRIME_DER_EXAMPLE).is_err());
+    assert!(RsaPrivateKeyRef::try_from(RSA_2048_MULTI_PRIME_DER_EXAMPLE).is_err());
 }
 
 #[cfg(feature = "alloc")]
 #[test]
 fn decode_rsa2048_multi_prime_der() {
-    let key = RsaPrivateKey::try_from(RSA_2048_MULTI_PRIME_DER_EXAMPLE).unwrap();
+    let key = RsaPrivateKeyRef::try_from(RSA_2048_MULTI_PRIME_DER_EXAMPLE).unwrap();
     assert_eq!(key.version(), Version::Multi);
 
     // Extracted using:
@@ -204,7 +204,7 @@ fn decode_rsa2048_multi_prime_der() {
 
 #[test]
 fn private_key_to_public_key() {
-    let private_key = RsaPrivateKey::try_from(RSA_2048_DER_EXAMPLE).unwrap();
+    let private_key = RsaPrivateKeyRef::try_from(RSA_2048_DER_EXAMPLE).unwrap();
     let public_key = private_key.public_key();
 
     // Extracted using:

--- a/pkcs1/tests/public_key.rs
+++ b/pkcs1/tests/public_key.rs
@@ -1,7 +1,7 @@
 //! PKCS#1 public key tests
 
 use hex_literal::hex;
-use pkcs1::RsaPublicKey;
+use pkcs1::RsaPublicKeyRef;
 
 /// RSA-2048 PKCS#1 public key encoded as ASN.1 DER.
 ///
@@ -22,7 +22,7 @@ const RSA_4096_DER_EXAMPLE: &[u8] = include_bytes!("examples/rsa4096-pub.der");
 
 #[test]
 fn decode_rsa2048_der() {
-    let key = RsaPublicKey::try_from(RSA_2048_DER_EXAMPLE).unwrap();
+    let key = RsaPublicKeyRef::try_from(RSA_2048_DER_EXAMPLE).unwrap();
 
     // Extracted using:
     // $ openssl asn1parse -in tests/examples/rsa2048-pub.pem
@@ -37,7 +37,7 @@ fn decode_rsa2048_der() {
 
 #[test]
 fn decode_rsa4096_der() {
-    let key = RsaPublicKey::try_from(RSA_4096_DER_EXAMPLE).unwrap();
+    let key = RsaPublicKeyRef::try_from(RSA_4096_DER_EXAMPLE).unwrap();
 
     // Extracted using:
     // $ openssl asn1parse -in tests/examples/rsa4096-pub.pem

--- a/spki/src/algorithm.rs
+++ b/spki/src/algorithm.rs
@@ -186,6 +186,18 @@ impl<'a> AlgorithmIdentifierRef<'a> {
     }
 }
 
+/// Borrow the owned or ref `AlgorithmIdentifier` as [`AlgorithmIdentifierRef`].
+pub trait AsAlgorithmIdentifierRef {
+    /// Borrow the owned or ref `AlgorithmIdentifier` as [`AlgorithmIdentifierRef`].
+    fn as_algo_ref<'a>(&'a self) -> AlgorithmIdentifierRef<'a>;
+}
+
+impl<'a> AsAlgorithmIdentifierRef for AlgorithmIdentifierRef<'a> {
+    fn as_algo_ref(&self) -> AlgorithmIdentifierRef<'a> {
+        *self
+    }
+}
+
 #[cfg(feature = "alloc")]
 mod allocating {
     use super::*;
@@ -207,6 +219,33 @@ mod allocating {
             AlgorithmIdentifier {
                 oid: self.oid,
                 parameters: self.parameters.owned_to_ref(),
+            }
+        }
+    }
+
+    impl AsAlgorithmIdentifierRef for AlgorithmIdentifierOwned {
+        fn as_algo_ref<'a>(&'a self) -> AlgorithmIdentifierRef<'a> {
+            AlgorithmIdentifier {
+                oid: self.oid,
+                parameters: self.parameters.owned_to_ref(),
+            }
+        }
+    }
+
+    impl<'a> From<AlgorithmIdentifierRef<'a>> for AlgorithmIdentifierOwned {
+        fn from(value: AlgorithmIdentifierRef) -> Self {
+            Self {
+                oid: value.oid,
+                parameters: value.parameters.map(Into::into),
+            }
+        }
+    }
+
+    impl<'a> From<&'a AlgorithmIdentifierOwned> for AlgorithmIdentifierRef<'a> {
+        fn from(value: &'a AlgorithmIdentifierOwned) -> Self {
+            Self {
+                oid: value.oid,
+                parameters: value.parameters.as_ref().map(|p| p.to_ref()),
             }
         }
     }

--- a/spki/src/lib.rs
+++ b/spki/src/lib.rs
@@ -40,7 +40,10 @@ mod traits;
 mod digest;
 
 pub use crate::{
-    algorithm::{AlgorithmIdentifier, AlgorithmIdentifierRef, AlgorithmIdentifierWithOid},
+    algorithm::{
+        AlgorithmIdentifier, AlgorithmIdentifierRef, AlgorithmIdentifierWithOid,
+        AsAlgorithmIdentifierRef,
+    },
     error::{Error, Result},
     spki::{SubjectPublicKeyInfo, SubjectPublicKeyInfoRef},
     traits::{AssociatedAlgorithmIdentifier, DecodePublicKey, SignatureAlgorithmIdentifier},


### PR DESCRIPTION
Generic `Ref` and `Owned` aliases of `der` objects

- [x] `pkcs1` progress:
  - [x] `OtherPrimeInfo`
  - [x] `RsaOaepParams`
  - [x] `RsaPrivateKey`
  - [x] `RsaPssParams`
  - [x] `RsaPublicKey`

Related issue:
- #2385