### PR TITLE
x509-tsp: provide a to_datetime for `GeneralizedTimeNanos`

### DIFF
--- a/x509-tsp/src/generalized_time_nanos.rs
+++ b/x509-tsp/src/generalized_time_nanos.rs
@@ -49,6 +49,14 @@ impl GeneralizedTimeNanos {
             nanoseconds: unix_duration.subsec_nanos(),
         })
     }
+
+    /// Convert this [`GeneralizedTimeNanos`] into a [`DateTime`].
+    ///
+    /// Note: This looses the nanoseconds precision.
+    #[must_use]
+    pub const fn to_date_time(&self) -> DateTime {
+        self.datetime
+    }
 }
 
 impl From<GeneralizedTime> for GeneralizedTimeNanos {


### PR DESCRIPTION
This is mostly useful for human-readable messages.