### PR TITLE
tls_codec: return an error instead of panicking on truncated VLBytes

### DIFF
--- a/tls_codec/src/quic_vec.rs
+++ b/tls_codec/src/quic_vec.rs
@@ -366,12 +366,6 @@ impl DeserializeBytes for VLBytes {
             Ok(vec) => Ok((Self { vec: vec.to_vec() }, &remainder[length..])),
             Err(_e) => {
                 let remaining_len = remainder.len();
-                if !cfg!(fuzzing) {
-                    debug_assert_eq!(
-                        remaining_len, length,
-                        "Expected to read {length} bytes but {remaining_len} were read.",
-                    );
-                }
                 Err(Error::DecodingError(format!(
                     "{remaining_len} bytes were read but {length} were expected",
                 )))
@@ -465,12 +459,6 @@ impl DeserializeBytes for VLByteVec {
             Ok(vec) => Ok((Self { vec: vec.to_vec() }, &remainder[length..])),
             Err(_e) => {
                 let remaining_len = remainder.len();
-                if !cfg!(fuzzing) {
-                    debug_assert_eq!(
-                        remaining_len, length,
-                        "Expected to read {length} bytes but {remaining_len} were read.",
-                    );
-                }
                 Err(Error::DecodingError(format!(
                     "{remaining_len} bytes were read but {length} were expected",
                 )))

--- a/tls_codec/tests/decode_bytes.rs
+++ b/tls_codec/tests/decode_bytes.rs
@@ -1,6 +1,7 @@
+#![cfg_attr(feature = "future_deprecations", allow(deprecated))]
 use tls_codec::{
     DeserializeBytes, Error, Size, TlsByteVecU8, TlsByteVecU16, TlsByteVecU24, TlsByteVecU32,
-    TlsVecU8,
+    TlsVecU8, VLByteVec, VLBytes,
 };
 
 #[test]
@@ -193,6 +194,28 @@ fn truncated_byte_vec_reports_end_of_stream() {
             Err(Error::EndOfStream) | Err(Error::InvalidVectorLength)
         ),
         "expected EndOfStream/InvalidVectorLength, got {res:?}"
+    );
+}
+
+// Length 4 + 2 content bytes
+#[test]
+fn truncated_vlbytes_reports_decoding_error() {
+    let input = [4u8, 0xAA, 0xBB];
+    let res = VLBytes::tls_deserialize_bytes(&input);
+    assert!(
+        matches!(res, Err(Error::DecodingError(_))),
+        "expected DecodingError, got {res:?}"
+    );
+}
+
+// Same input, but for `VLByteVec`
+#[test]
+fn truncated_vlbytevec_reports_decoding_error() {
+    let input = [4u8, 0xAA, 0xBB];
+    let res = VLByteVec::tls_deserialize_bytes(&input);
+    assert!(
+        matches!(res, Err(Error::DecodingError(_))),
+        "expected DecodingError, got {res:?}"
     );
 }
 


### PR DESCRIPTION
In debug mode, `VLBytes::tls_deserialize_bytes` and `VLByteVec::tls_deserialize_bytes` panic instead of returning an Err. Panics should happen on invariants, not on untrusted input.