### PR TITLE
der: add `AsIntRef` and `AsUintRef` traits

### DIFF
--- a/der/src/asn1.rs
+++ b/der/src/asn1.rs
@@ -42,7 +42,7 @@ pub use self::{
     general_string::GeneralStringRef,
     generalized_time::GeneralizedTime,
     ia5_string::Ia5StringRef,
-    integer::{int::IntRef, uint::UintRef},
+    integer::{AsIntRef, AsUintRef, int::IntRef, uint::UintRef},
     null::Null,
     octet_string::OctetStringRef,
     printable_string::PrintableStringRef,

--- a/der/src/asn1/integer.rs
+++ b/der/src/asn1/integer.rs
@@ -3,6 +3,9 @@
 pub(super) mod int;
 pub(super) mod uint;
 
+use int::IntRef;
+use uint::UintRef;
+
 use core::{cmp::Ordering, mem::size_of};
 
 use crate::{EncodeValue, Result, encode::encode_value_to_slice};
@@ -28,6 +31,20 @@ where
     let buf2 = encode_value_to_slice(&mut buf2, &b)?;
 
     Ok(buf1.cmp(buf2))
+}
+
+/// Borrow the owned or ref `INTEGER` as [`IntRef`]
+pub trait AsIntRef {
+    /// Borrows the owned or ref `INTEGER` as [`IntRef`]
+    #[must_use]
+    fn as_int_ref<'a>(&'a self) -> IntRef<'a>;
+}
+
+/// Borrow the owned or ref `INTEGER` as [`UintRef`]
+pub trait AsUintRef {
+    /// Borrows the owned or ref `INTEGER` as [`UintRef`]
+    #[must_use]
+    fn as_uint_ref<'a>(&'a self) -> UintRef<'a>;
 }
 
 #[cfg(test)]

--- a/der/src/asn1/integer/int.rs
+++ b/der/src/asn1/integer/int.rs
@@ -3,7 +3,7 @@
 use super::{is_highest_bit_set, uint, value_cmp};
 use crate::{
     AnyRef, BytesRef, DecodeValue, EncodeValue, Error, ErrorKind, FixedTag, Header, Length, Reader,
-    Result, Tag, ValueOrd, Writer, ord::OrdIsValueOrd,
+    Result, Tag, ValueOrd, Writer, asn1::integer::AsIntRef, ord::OrdIsValueOrd,
 };
 use core::cmp::Ordering;
 
@@ -180,13 +180,19 @@ impl FixedTag for IntRef<'_> {
 
 impl OrdIsValueOrd for IntRef<'_> {}
 
+impl AsIntRef for IntRef<'_> {
+    fn as_int_ref<'a>(&'a self) -> IntRef<'a> {
+        *self
+    }
+}
+
 #[cfg(feature = "alloc")]
 mod allocating {
     use super::{IntRef, strip_leading_ones, validate_canonical};
     use crate::{
         BytesOwned, DecodeValue, EncodeValue, Error, ErrorKind, FixedTag, Header, Length, Reader,
         Result, Tag, Writer,
-        asn1::Uint,
+        asn1::{Uint, integer::AsIntRef},
         ord::OrdIsValueOrd,
         referenced::{OwnedToRef, RefToOwned},
     };
@@ -234,6 +240,14 @@ mod allocating {
         #[must_use]
         pub fn is_empty(&self) -> bool {
             self.inner.is_empty()
+        }
+    }
+
+    impl AsIntRef for Int {
+        fn as_int_ref<'a>(&'a self) -> IntRef<'a> {
+            let inner = self.inner.as_ref();
+
+            IntRef { inner }
         }
     }
 

--- a/der/src/asn1/integer/uint.rs
+++ b/der/src/asn1/integer/uint.rs
@@ -3,7 +3,7 @@
 use super::value_cmp;
 use crate::{
     AnyRef, BytesRef, DecodeValue, EncodeValue, Error, ErrorKind, FixedTag, Header, Length, Reader,
-    Result, Tag, ValueOrd, Writer, ord::OrdIsValueOrd,
+    Result, Tag, ValueOrd, Writer, asn1::integer::AsUintRef, ord::OrdIsValueOrd,
 };
 use core::cmp::Ordering;
 
@@ -169,12 +169,19 @@ impl FixedTag for UintRef<'_> {
 
 impl OrdIsValueOrd for UintRef<'_> {}
 
+impl AsUintRef for UintRef<'_> {
+    fn as_uint_ref<'a>(&'a self) -> UintRef<'a> {
+        *self
+    }
+}
+
 #[cfg(feature = "alloc")]
 mod allocating {
     use super::{UintRef, decode_to_slice, encoded_len, strip_leading_zeroes};
     use crate::{
         BytesOwned, DecodeValue, EncodeValue, Error, ErrorKind, FixedTag, Header, Length, Reader,
         Result, Tag, Writer,
+        asn1::integer::AsUintRef,
         ord::OrdIsValueOrd,
         referenced::{OwnedToRef, RefToOwned},
     };
@@ -284,6 +291,14 @@ mod allocating {
     impl OwnedToRef for Uint {
         type Borrowed<'a> = UintRef<'a>;
         fn owned_to_ref(&self) -> Self::Borrowed<'_> {
+            let inner = self.inner.as_ref();
+
+            UintRef { inner }
+        }
+    }
+
+    impl AsUintRef for Uint {
+        fn as_uint_ref<'a>(&'a self) -> UintRef<'a> {
             let inner = self.inner.as_ref();
 
             UintRef { inner }


### PR DESCRIPTION
Needed for `pkcs1` split: `Ref` and `Owned` types.

- #2411