### PR TITLE
der: add impl `OwnedToRef` for `UintRef` and `IntRef`

### DIFF
--- a/der/src/asn1/integer/int.rs
+++ b/der/src/asn1/integer/int.rs
@@ -3,7 +3,7 @@
 use super::{is_highest_bit_set, uint, value_cmp};
 use crate::{
     AnyRef, BytesRef, DecodeValue, EncodeValue, Error, ErrorKind, FixedTag, Header, Length, Reader,
-    Result, Tag, ValueOrd, Writer, ord::OrdIsValueOrd,
+    Result, Tag, ValueOrd, Writer, ord::OrdIsValueOrd, referenced::OwnedToRef,
 };
 use core::cmp::Ordering;
 
@@ -179,6 +179,16 @@ impl FixedTag for IntRef<'_> {
 }
 
 impl OrdIsValueOrd for IntRef<'_> {}
+
+impl<'a> OwnedToRef for IntRef<'a> {
+    type Borrowed<'b>
+        = IntRef<'a>
+    where
+        'a: 'b;
+    fn owned_to_ref(&self) -> Self::Borrowed<'a> {
+        *self
+    }
+}
 
 #[cfg(feature = "alloc")]
 mod allocating {

--- a/der/src/asn1/integer/uint.rs
+++ b/der/src/asn1/integer/uint.rs
@@ -3,7 +3,7 @@
 use super::value_cmp;
 use crate::{
     AnyRef, BytesRef, DecodeValue, EncodeValue, Error, ErrorKind, FixedTag, Header, Length, Reader,
-    Result, Tag, ValueOrd, Writer, ord::OrdIsValueOrd,
+    Result, Tag, ValueOrd, Writer, ord::OrdIsValueOrd, referenced::OwnedToRef,
 };
 use core::cmp::Ordering;
 
@@ -168,6 +168,16 @@ impl FixedTag for UintRef<'_> {
 }
 
 impl OrdIsValueOrd for UintRef<'_> {}
+
+impl<'a> OwnedToRef for UintRef<'a> {
+    type Borrowed<'b>
+        = UintRef<'a>
+    where
+        'a: 'b;
+    fn owned_to_ref(&self) -> Self::Borrowed<'a> {
+        *self
+    }
+}
 
 #[cfg(feature = "alloc")]
 mod allocating {


### PR DESCRIPTION
Edit: This might be useful. But looks like `AsUintRef` solves the problem.
```rust
impl<U> RsaPrivateKey<U>
where
    U: AsUintRef,
{
    pub fn public_key(&'u self) -> RsaPublicKeyRef<'u> {
        RsaPublicKeyRef {
            modulus: self.modulus.as_uint_ref(),
            public_exponent: self.public_exponent.as_uint_ref(),
        }
    }
}
```


https://github.com/RustCrypto/formats/pull/2411/changes/5d46ec0c1064d54b2524ad1ef11022da87382665#diff-65c869a52db3faff4591aacf0874b552096a0ac7ad0bd4b0908c7fb82ada6c98R90

