### PR TITLE
der v0.8.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,7 +477,7 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "arbitrary",
  "bytes",

--- a/der/CHANGELOG.md
+++ b/der/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.2 (2026-09-05)
+### Added
+- `AsIntRef` and `AsUintRef` traits ([#2415])
+
+### Fixed
+- Return error on nested trailing data ([#2401])
+
+[#2415]: https://github.com/RustCrypto/formats/pull/2415
+[#2401]: https://github.com/RustCrypto/formats/pull/2401
+
 ## 0.8.1 (2026-07-08)
 ### Added
 - `SetOfRef` struct ([#2247])
@@ -22,7 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2345]: https://github.com/RustCrypto/formats/pull/2345
 [#2379]: https://github.com/RustCrypto/formats/pull/2379
 
-## 0.8.0 (2026-02-13)
+## 0.8.0 (2026-02-13) [YANKED]
+
+NOTE: this release was yanked to fix a `minimal-versions` check in CI.
+
 ### Added
 - Custom error types support to the `Decode` and `DecodeValue` traits ([#1055])
 - `EncodingRules` enum ([#1321])

--- a/der/Cargo.toml
+++ b/der/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "der"
-version = "0.8.1"
+version = "0.8.2"
 description = """
 Pure Rust embedded-friendly implementation of the Distinguished Encoding Rules
 (DER) for Abstract Syntax Notation One (ASN.1) as described in ITU X.690 with


### PR DESCRIPTION
## Added
- `AsIntRef` and `AsUintRef` traits ([#2415])

## Fixed
- Return error on nested trailing data ([#2401])

[#2415]: https://github.com/RustCrypto/formats/pull/2415
[#2401]: https://github.com/RustCrypto/formats/pull/2401